### PR TITLE
Changed to export SSym and SNat

### DIFF
--- a/src/Data/Singletons/TypeLits.hs
+++ b/src/Data/Singletons/TypeLits.hs
@@ -22,7 +22,7 @@ module Data.Singletons.TypeLits (
   SNat, SSymbol, withKnownNat, withKnownSymbol,
   Error, ErrorSym0, sError,
   KnownNat, natVal, KnownSymbol, symbolVal,
-  Sing(SSym), Sing(SNat),
+  Sing(SSym, SNat),
 
   (:^), (:^$), (:^$$), (:^$$$)
   ) where


### PR DESCRIPTION
`SSym` and `SNat` is currently not exported so we can't make any use of `sError` or comparison with type-level natural. So I changed to export both from `Data.Singletons.TypeLits` module.
