### PR TITLE
Relaxed version dependency for mtl

### DIFF
--- a/singletons.cabal
+++ b/singletons.cabal
@@ -41,7 +41,7 @@ source-repository this
 library
   hs-source-dirs:     src
   build-depends:      base >= 4.7 && < 5,
-                      mtl >= 2.2.1,
+                      mtl >= 2.1 && < 2.2,
                       template-haskell,
                       containers >= 0.5,
                       th-desugar >= 1.4.1


### PR DESCRIPTION
Git HEAD version dependency for `mtl` requires `>= 2.2.1`. Haskell Platform 2014.2.0.0 is shipped with `mtl-2.1.1` so we can't use with it.
