### PR TITLE
Bump lower bound for base, to avoid trying to build 2.x with 7.8.x.

### DIFF
--- a/singletons.cabal
+++ b/singletons.cabal
@@ -42,7 +42,7 @@ source-repository this
 
 library
   hs-source-dirs:     src
-  build-depends:      base >= 4.7.0.1 && < 5,
+  build-depends:      base >= 4.8.1.0 && < 5,
                       mtl >= 2.1.2,
                       template-haskell,
                       containers >= 0.5,


### PR DESCRIPTION
At least since https://github.com/goldfirere/singletons/pull/125, singletons 2.x no longer compiles with 7.8 but the current lower bound for `base` still results in picking a build plan with 7.8 and singletons 2.x which is doomed to fail. Hence I hereby suggest to bump the lower bound for `base`, in order to avoid build plans being selected with 7.8 and singletons 2.x.