### PR TITLE
Depend on base >=4.8.0.0 && <5

### DIFF
--- a/singletons.cabal
+++ b/singletons.cabal
@@ -42,7 +42,7 @@ source-repository this
 
 library
   hs-source-dirs:     src
-  build-depends:      base >= 4.8.1.0 && < 5,
+  build-depends:      base >= 4.8.0.0 && < 5,
                       mtl >= 2.1.2,
                       template-haskell,
                       containers >= 0.5,


### PR DESCRIPTION
It builds fine with GHC 7.10.2 and GHCJS. 

GHCJS is still using `base-4.8.0.0`, that is why I suggest this change.