### PR TITLE
WIP: build on GHC 8

### DIFF
--- a/singletons.cabal
+++ b/singletons.cabal
@@ -46,7 +46,7 @@ library
                       mtl >= 2.1.2,
                       template-haskell,
                       containers >= 0.5,
-                      th-desugar >= 1.5.4.1 && < 1.6,
+                      th-desugar >= 1.5.4.1 && < 1.7,
                       syb >= 0.4
   default-language:   Haskell2010
   other-extensions:   TemplateHaskell

--- a/src/Data/Singletons/CustomStar.hs
+++ b/src/Data/Singletons/CustomStar.hs
@@ -124,10 +124,10 @@ singletonStar names = do
           return $ DCon (map DPlainTV vars) [] dataName
 #if MIN_VERSION_th_desugar(1,6,0)
                    (DNormalC (map (\ty -> (Bang NoSourceUnpackedness NoSourceStrictness, ty)) types))
+                   Nothing
 #else
                    (DNormalC (map (\ty -> (NotStrict, ty)) types))
 #endif
-                   Nothing
 
         -- demote a kind back to a type, accumulating any unbound parameters
         kindToType :: DsMonad q => DKind -> QWithAux [Name] q DType

--- a/src/Data/Singletons/Deriving/Enum.hs
+++ b/src/Data/Singletons/Deriving/Enum.hs
@@ -11,6 +11,8 @@
 --
 ----------------------------------------------------------------------------
 
+{-# LANGUAGE CPP #-}
+
 module Data.Singletons.Deriving.Enum ( mkEnumInstance ) where
 
 import Language.Haskell.TH.Syntax
@@ -25,14 +27,22 @@ import Control.Monad
 mkEnumInstance :: Quasi q => DType -> [DCon] -> q UInstDecl
 mkEnumInstance ty cons = do
   when (null cons ||
+#if MIN_VERSION_th_desugar(1,6,0)
+        any (\(DCon tvbs cxt _ f _) -> or [ not $ null $ tysOfConFields f
+#else
         any (\(DCon tvbs cxt _ f) -> or [ not $ null $ tysOfConFields f
+#endif
                                         , not $ null tvbs
                                         , not $ null cxt ]) cons) $
     fail ("Can't derive Enum instance for " ++ pprint (typeToTH ty) ++ ".")
   n <- qNewName "n"
   let to_enum = UFunction [DClause [DVarPa n] (to_enum_rhs cons [0..])]
       to_enum_rhs [] _ = DVarE errorName `DAppE` DLitE (StringL "toEnum: bad argument")
+#if MIN_VERSION_th_desugar(1,6,0)
+      to_enum_rhs (DCon _ _ name _ _ : rest) (num:nums) =
+#else
       to_enum_rhs (DCon _ _ name _ : rest) (num:nums) =
+#endif
         DCaseE (DVarE equalsName `DAppE` DVarE n `DAppE` DLitE (IntegerL num))
           [ DMatch (DConPa trueName []) (DConE name)
           , DMatch (DConPa falseName []) (to_enum_rhs rest nums) ]

--- a/src/Data/Singletons/Deriving/Infer.hs
+++ b/src/Data/Singletons/Deriving/Infer.hs
@@ -11,6 +11,8 @@
 --
 ----------------------------------------------------------------------------
 
+{-# LANGUAGE CPP #-}
+
 module Data.Singletons.Deriving.Infer ( inferConstraints ) where
 
 import Language.Haskell.TH.Desugar
@@ -21,4 +23,8 @@ import Data.Generics.Twins
 inferConstraints :: DPred -> [DCon] -> DCxt
 inferConstraints pr = nubBy geq . concatMap infer_ct
   where
+#if MIN_VERSION_th_desugar(1,6,0)
+    infer_ct (DCon _ _ _ fields _) = map (pr `DAppPr`) (tysOfConFields fields)
+#else
     infer_ct (DCon _ _ _ fields) = map (pr `DAppPr`) (tysOfConFields fields)
+#endif

--- a/src/Data/Singletons/Deriving/Ord.hs
+++ b/src/Data/Singletons/Deriving/Ord.hs
@@ -11,6 +11,8 @@
 --
 ----------------------------------------------------------------------------
 
+{-# LANGUAGE CPP #-}
+
 module Data.Singletons.Deriving.Ord ( mkOrdInstance ) where
 
 import Language.Haskell.TH.Desugar
@@ -39,7 +41,11 @@ mkOrdInstance ty cons = do
                                               compare_noneq_clauses) )] })
 
 mk_equal_clause :: Quasi q => DCon -> q DClause
+#if MIN_VERSION_th_desugar(1,6,0)
+mk_equal_clause (DCon _tvbs _cxt name fields _m_kind) = do
+#else
 mk_equal_clause (DCon _tvbs _cxt name fields) = do
+#endif
   let tys = tysOfConFields fields
   a_names <- mapM (const $ newUniqueName "a") tys
   b_names <- mapM (const $ newUniqueName "b") tys
@@ -54,8 +60,13 @@ mk_equal_clause (DCon _tvbs _cxt name fields) = do
                                           a_names b_names))
 
 mk_nonequal_clause :: (DCon, Int) -> (DCon, Int) -> DClause
+#if MIN_VERSION_th_desugar(1,6,0)
+mk_nonequal_clause (DCon _tvbs1 _cxt1 name1 fields1 _m_kind1, n1)
+                   (DCon _tvbs2 _cxt2 name2 fields2 _m_kind2, n2) =
+#else
 mk_nonequal_clause (DCon _tvbs1 _cxt1 name1 fields1, n1)
                    (DCon _tvbs2 _cxt2 name2 fields2, n2) =
+#endif
   DClause [pat1, pat2] (case n1 `compare` n2 of
                           LT -> DConE cmpLTName
                           EQ -> DConE cmpEQName

--- a/src/Data/Singletons/Partition.hs
+++ b/src/Data/Singletons/Partition.hs
@@ -56,7 +56,7 @@ partitionDec (DDataD nd _cxt name tvbs cons derivings) = do
                   , pd_instance_decs = derived_instances }
   where
     ty = foldType (DConT name) (map tvbToType tvbs)
-#if MIN_VERSION_th_desugar(1,6,0) && __GLASGOW_HASKELL__ < 711
+#if MIN_VERSION_th_desugar(1,6,0)
     part_derivings :: Quasi m => DPred -> m (Either Name UInstDecl)
     part_derivings (DConPr deriv_name)
       | deriv_name == ordName

--- a/src/Data/Singletons/Partition.hs
+++ b/src/Data/Singletons/Partition.hs
@@ -11,6 +11,8 @@
 --
 ----------------------------------------------------------------------------
 
+{-# LANGUAGE CPP #-}
+
 module Data.Singletons.Partition where
 
 import Prelude hiding ( exp )
@@ -54,6 +56,19 @@ partitionDec (DDataD nd _cxt name tvbs cons derivings) = do
                   , pd_instance_decs = derived_instances }
   where
     ty = foldType (DConT name) (map tvbToType tvbs)
+#if MIN_VERSION_th_desugar(1,6,0) && __GLASGOW_HASKELL__ < 711
+    part_derivings :: Quasi m => DPred -> m (Either Name UInstDecl)
+    part_derivings (DConPr deriv_name)
+      | deriv_name == ordName
+      = Right <$> mkOrdInstance ty cons
+      | deriv_name == boundedName
+      = Right <$> mkBoundedInstance ty cons
+      | deriv_name == enumName
+      = Right <$> mkEnumInstance ty cons
+      | otherwise
+      = return (Left deriv_name)
+    part_derivings p = fail $ "Illegal deriving construct: " ++ show p
+#else
     part_derivings :: Quasi m => Name -> m (Either Name UInstDecl)
     part_derivings deriv_name
       | deriv_name == ordName
@@ -64,6 +79,7 @@ partitionDec (DDataD nd _cxt name tvbs cons derivings) = do
       = Right <$> mkEnumInstance ty cons
       | otherwise
       = return (Left deriv_name)
+#endif
 
 partitionDec (DClassD cxt name tvbs fds decs) = do
   env <- concatMapM partitionClassDec decs

--- a/src/Data/Singletons/Promote/Monad.hs
+++ b/src/Data/Singletons/Promote/Monad.hs
@@ -20,6 +20,9 @@ module Data.Singletons.Promote.Monad (
 
 import Control.Monad.Reader
 import Control.Monad.Writer
+#if __GLASGOW_HASKELL__ > 710
+import Control.Monad.Fail ( MonadFail )
+#endif
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict ( Map )
 import Language.Haskell.TH.Syntax hiding ( lift )
@@ -44,6 +47,9 @@ emptyPrEnv = PrEnv { pr_lambda_bound = Map.empty
 -- the promotion monad
 newtype PrM a = PrM (ReaderT PrEnv (WriterT [DDec] Q) a)
   deriving ( Functor, Applicative, Monad, Quasi
+#if __GLASGOW_HASKELL__ > 710
+           , MonadFail
+#endif
            , MonadReader PrEnv, MonadWriter [DDec] )
 
 instance DsMonad PrM where

--- a/src/Data/Singletons/Single/Monad.hs
+++ b/src/Data/Singletons/Single/Monad.hs
@@ -175,7 +175,11 @@ lookup_var_con mk_sing_name mk_exp name = do
       m_dinfo <- liftM2 (<|>) (dsReify sName) (dsReify name)
         -- try the unrefined name too -- it's needed to bootstrap Enum
       case m_dinfo of
+#if MIN_VERSION_th_desugar(1,6,0)
+        Just (DVarI _ ty _) ->
+#else
         Just (DVarI _ ty _ _) ->
+#endif
           let num_args = countArgs ty in
           return $ wrapSingFun num_args (promoteValRhs name) (mk_exp name)
         _ -> return $ mk_exp name   -- lambda-bound

--- a/src/Data/Singletons/Single/Type.hs
+++ b/src/Data/Singletons/Single/Type.hs
@@ -6,6 +6,8 @@ eir@cis.upenn.edu
 Singletonizes types.
 -}
 
+{-# LANGUAGE CPP #-}
+
 module Data.Singletons.Single.Type where
 
 import Language.Haskell.TH.Desugar
@@ -52,3 +54,6 @@ singPredRec ctx (DConPr n)
     kis <- mapM promoteType ctx
     let sName = singClassName n
     return $ foldl DAppPr (DConPr sName) (map kindParam kis)
+#if MIN_VERSION_th_desugar(1,6,0)
+singPredRec _ DWildCardPr = fail "Singling of type wildcard constraint not yet supported"
+#endif

--- a/src/Data/Singletons/Util.hs
+++ b/src/Data/Singletons/Util.hs
@@ -352,7 +352,7 @@ unfoldArrowT _ = Nothing
 unfoldDConTApp :: DType -> Maybe (Name,[DType])
 unfoldDConTApp = go []
   where
-    go args (DConT n)     = Just (n,reverse args)
+    go args (DConT n)     = Just (n, args)
     go args (DAppT t1 t2) = go (t2:args) t1
     go _    _             = Nothing
 #endif

--- a/src/Data/Singletons/Util.hs
+++ b/src/Data/Singletons/Util.hs
@@ -84,10 +84,18 @@ extractNameArgs = liftSnd length . extractNameTypes
 
 -- extract the name and types of constructor arguments
 extractNameTypes :: DCon -> (Name, [DType])
+#if MIN_VERSION_th_desugar(1,6,0)
+extractNameTypes (DCon _ _ n fields _) = (n, tysOfConFields fields)
+#else
 extractNameTypes (DCon _ _ n fields) = (n, tysOfConFields fields)
+#endif
 
 extractName :: DCon -> Name
+#if MIN_VERSION_th_desugar(1,6,0)
+extractName (DCon _ _ n _ _) = n
+#else
 extractName (DCon _ _ n _) = n
+#endif
 
 -- is an identifier uppercase?
 isUpcase :: Name -> Bool
@@ -220,6 +228,7 @@ countArgs :: DType -> Int
 countArgs ty = length args
   where (_, _, args, _) = unravel ty
 
+#if !MIN_VERSION_th_desugar(1,6,0)
 substKind :: Map Name DKind -> DKind -> DKind
 substKind _ (DForallK {}) =
   error "Higher-rank kind encountered in instance method promotion."
@@ -230,6 +239,7 @@ substKind subst (DVarK n) =
 substKind subst (DConK con kis) = DConK con (map (substKind subst) kis)
 substKind subst (DArrowK k1 k2) = DArrowK (substKind subst k1) (substKind subst k2)
 substKind _ DStarK = DStarK
+#endif
 
 substType :: Map Name DType -> DType -> DType
 substType subst ty | Map.null subst = ty
@@ -248,6 +258,10 @@ substType subst (DVarT n) =
 substType _ ty@(DConT {}) = ty
 substType _ ty@(DArrowT)  = ty
 substType _ ty@(DLitT {}) = ty
+#if MIN_VERSION_th_desugar(1,6,0)
+substType _ ty@(DWildCardT {}) = ty
+substType _ ty@(DStarT {}) = ty
+#endif
 
 substPred :: Map Name DType -> DPred -> DPred
 substPred subst pred | Map.null subst = pred
@@ -256,6 +270,9 @@ substPred subst (DAppPr pred ty) =
 substPred subst (DSigPr pred ki) = DSigPr (substPred subst pred) ki
 substPred _ pred@(DVarPr {}) = pred
 substPred _ pred@(DConPr {}) = pred
+#if MIN_VERSION_th_desugar(1,6,0)
+substPred _ pred@(DWildCardPr {}) = pred
+#endif
 
 substKindInType :: Map Name DKind -> DType -> DType
 substKindInType subst ty | Map.null subst = ty
@@ -267,30 +284,57 @@ substKindInType subst (DForallT tvbs cxt inner_ty) =
   DForallT tvbs' cxt' inner_ty'
 substKindInType subst (DAppT ty1 ty2)
   = substKindInType subst ty1 `DAppT` substKindInType subst ty2
+#if MIN_VERSION_th_desugar(1,6,0)
+substKindInType subst (DSigT ty ki) = substKindInType subst ty `DSigT` substType subst ki
+#else
 substKindInType subst (DSigT ty ki) = substKindInType subst ty `DSigT` substKind subst ki
+#endif
 substKindInType _ ty@(DVarT {}) = ty
 substKindInType _ ty@(DConT {}) = ty
 substKindInType _ ty@(DArrowT)  = ty
 substKindInType _ ty@(DLitT {}) = ty
+#if MIN_VERSION_th_desugar(1,6,0)
+substKindInType _ ty@(DWildCardT {}) = ty
+substKindInType _ ty@(DStarT {}) = ty
+#endif
 
 substKindInPred :: Map Name DKind -> DPred -> DPred
 substKindInPred subst pred | Map.null subst = pred
 substKindInPred subst (DAppPr pred ty) =
   DAppPr (substKindInPred subst pred) (substKindInType subst ty)
 substKindInPred subst (DSigPr pred ki) = DSigPr (substKindInPred subst pred)
+#if MIN_VERSION_th_desugar(1,6,0)
+                                                (substType subst ki)
+#else
                                                 (substKind subst ki)
+#endif
 substKindInPred _ pred@(DVarPr {}) = pred
 substKindInPred _ pred@(DConPr {}) = pred
+#if MIN_VERSION_th_desugar(1,6,0)
+substKindInPred _ pred@(DWildCardPr {}) = pred
+#endif
 
 substKindInTvb :: Map Name DKind -> DTyVarBndr -> DTyVarBndr
 substKindInTvb _ tvb@(DPlainTV _) = tvb
+#if MIN_VERSION_th_desugar(1,6,0)
+substKindInTvb subst (DKindedTV n ki) = DKindedTV n (substType subst ki)
+#else
 substKindInTvb subst (DKindedTV n ki) = DKindedTV n (substKind subst ki)
+#endif
 
 addStar :: DKind -> DKind
+#if MIN_VERSION_th_desugar(1,6,0)
+addStar t = DAppT (DAppT DArrowT t) DStarT
+#else
 addStar t = DArrowK t DStarK
+#endif
 
 addStar_maybe :: Maybe DKind -> Maybe DKind
+#if MIN_VERSION_th_desugar(1,6,0)
+addStar_maybe t = DAppT <$> (DAppT DArrowT <$> t) <*> pure DStarT
+#else
 addStar_maybe t = DArrowK <$> t <*> pure DStarK
+#endif
 
 -- apply a type to a list of types
 foldType :: DType -> [DType] -> DType
@@ -300,9 +344,26 @@ foldType = foldl DAppT
 foldExp :: DExp -> [DExp] -> DExp
 foldExp = foldl DAppE
 
+#if MIN_VERSION_th_desugar(1,6,0)
+unfoldArrowT :: DType -> Maybe (DType,DType)
+unfoldArrowT (DAppT (DAppT DArrowT t1) t2) = Just (t1,t2)
+unfoldArrowT _ = Nothing
+
+unfoldDConTApp :: DType -> Maybe (Name,[DType])
+unfoldDConTApp = go []
+  where
+    go args (DConT n)     = Just (n,reverse args)
+    go args (DAppT t1 t2) = go (t2:args) t1
+    go _    _             = Nothing
+#endif
+
 -- is a kind a variable?
 isVarK :: DKind -> Bool
+#if MIN_VERSION_th_desugar(1,6,0)
+isVarK (DVarT _) = True
+#else
 isVarK (DVarK _) = True
+#endif
 isVarK _ = False
 
 -- is a function type?


### PR DESCRIPTION
This is just a work in progress (WIP) where I'm trying to build `singletons` on GHC8-rc2, against [th-desugar-1.6(~~ghc8~~master branch)](https://github.com/goldfirere/th-desugar/tree/master)

~~I'm building it using the following `stack.yaml`: https://gist.github.com/christiaanb/a77ad004bdb72dd4bdb2~~
I'm building in a normal `cabal` sandbox

Until now I got as far as the following GHC panic:

```
~/devel/singletons(ghc8) $ stack --stack-yaml stack-ghc8.yaml build
singletons-2.0.1: build

--  While building package singletons-2.0.1 using:
      /home/baaijcpr/.stack/setup-exe-cache/x86_64-linux/setup-Simple-Cabal-1.23.1.0-ghc-8.0.0.20160204 --builddir=.stack-work/dist/x86_64-linux/Cabal-1.23.1.0 build lib:singletons --ghc-options " -ddump-hi -ddump-to-file"
    Process exited with code: ExitFailure 1
    Logs have been written to: /home/baaijcpr/devel/singletons/.stack-work/logs/singletons-2.0.1.log

    Preprocessing library singletons-2.0.1...
    [22 of 50] Compiling Data.Singletons.Prelude.Instances ( src/Data/Singletons/Prelude/Instances.hs, .stack-work/dist/x86_64-linux/Cabal-1.23.1.0/build/Data/Singletons/Prelude/Instances.o )
    ghc: panic! (the 'impossible' happened)
      (GHC version 8.0.0.20160204 for x86_64-unknown-linux):
    	tyConsOfType hit a hole {adve}
    
    Please report this as a GHC bug:  http://www.haskell.org/ghc/reportabug
```

I don't think I'll be able to reduce it to a minimal example so I can post in on GHC Trac.


Just to be extra clear, this is a WIP branch and is not meant to be merged (right now). See it more as a notification that I'm working on porting `singletons` to ghc8.