### PR TITLE
Remove lingering references to KProxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,18 +146,18 @@ generated for every new singleton type.
 A class used to pass singleton values implicitly. The `sing` method produces
 an explicit singleton value.
 
-    data SomeSing (kproxy :: KProxy k) where
-      SomeSing :: Sing (a :: k) -> SomeSing ('KProxy :: KProxy k)
+    data SomeSing k where
+      SomeSing :: Sing (a :: k) -> SomeSing k
 
 The `SomeSing` type wraps up an _existentially-quantified_ singleton. Note that
 the type parameter `a` does not appear in the `SomeSing` type. Thus, this type
 can be used when you have a singleton, but you don't know at compile time what
-it will be. `SomeSing ('KProxy :: KProxy Thing)` is isomorphic to `Thing`.
+it will be. `SomeSing Thing` is isomorphic to `Thing`.
 
-    class (kparam ~ 'KProxy) => SingKind (kparam :: KProxy k) where
-      type DemoteRep kparam :: *
-      fromSing :: Sing (a :: k) -> DemoteRep kparam
-      toSing   :: DemoteRep kparam -> SomeSing kparam
+    class SingKind k where
+      type DemoteRep k :: *
+      fromSing :: Sing (a :: k) -> DemoteRep k
+      toSing   :: DemoteRep k -> SomeSing k
 
 This class is used to convert a singleton value back to a value in the
 original, unrefined ADT. The `fromSing` method converts, say, a
@@ -281,7 +281,7 @@ class Eq a => Ord a where
 This class gets promoted to a "kind class" thus:
 
 ```haskell
-class (kproxy ~ 'KProxy, PEq kproxy) => POrd (kproxy :: KProxy a) where
+class (kproxy ~ 'Proxy, PEq kproxy) => POrd (kproxy :: Proxy a) where
   type Compare (x :: a) (y :: a) :: Ordering
   type (:<)    (x :: a) (y :: a) :: Bool
   type x :< y = ... -- promoting `case` is yucky.
@@ -293,7 +293,7 @@ instances. This works out quite nicely.
 We also get this singleton class:
 
 ```haskell
-class (kproxy ~ 'KProxy, SEq kproxy) => SOrd (kproxy :: KProxy a) where
+class SEq a => SOrd a where
   sCompare :: forall (x :: a) (y :: a). Sing x -> Sing y -> Sing (Compare x y)
   (%:<)    :: forall (x :: a) (y :: a). Sing x -> Sing y -> Sing (x :< y)
 
@@ -317,13 +317,13 @@ instance Ord Bool where
   compare True  False = GT
   compare True  True  = EQ
 
-instance POrd ('KProxy :: KProxy Bool) where
+instance POrd ('Proxy :: Proxy Bool) where
   type Compare 'False 'False = 'EQ
   type Compare 'False 'True  = 'LT
   type Compare 'True  'False = 'GT
   type Compare 'True  'True  = 'EQ
 
-instance SOrd ('KProxy :: KProxy Bool) where
+instance SOrd Bool where
   sCompare :: forall (x :: a) (y :: a). Sing x -> Sing y -> Sing (Compare x y)
   sCompare SFalse SFalse = SEQ
   sCompare SFalse STrue  = SLT

--- a/README.md
+++ b/README.md
@@ -164,8 +164,7 @@ original, unrefined ADT. The `fromSing` method converts, say, a
 singleton `Nat` back to an ordinary `Nat`. The `toSing` method produces
 an existentially-quantified singleton, wrapped up in a `SomeSing`.
 The `DemoteRep` associated
-kind-indexed type family maps a proxy of the kind `Nat`
-back to the type `Nat`.
+kind-indexed type family maps the kind `Nat` back to the type `Nat`.
 
     data SingInstance (a :: k) where
       SingInstance :: SingI a => SingInstance a

--- a/src/Data/Promotion/Prelude/Enum.hs
+++ b/src/Data/Promotion/Prelude/Enum.hs
@@ -1,10 +1,6 @@
 {-# LANGUAGE TemplateHaskell, PolyKinds, DataKinds, TypeFamilies,
              UndecidableInstances, GADTs #-}
 
--- Suppress orphan instance warning for PEnum KProxy. This will go away once #25
--- is fixed and instance declaration for Enum Nat is moved to
--- Data.Singletons.Prelude.Enum module.
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Promotion.Prelude.Enum

--- a/src/Data/Singletons/Names.hs
+++ b/src/Data/Singletons/Names.hs
@@ -246,7 +246,7 @@ foldApply = foldl apply
 mkEqPred :: DType -> DType -> DPred
 mkEqPred ty1 ty2 = foldl DAppPr (DConPr equalityName) [ty1, ty2]
 
--- create a bunch of kproxy vars, and constrain them all to be 'KProxy
+-- create a bunch of kproxy vars, and constrain them all to be 'Proxy
 mkKProxies :: Quasi q
            => [Name]   -- for the kinds of the kproxies
            -> q ([DTyVarBndr], DCxt)


### PR DESCRIPTION
#148 removed uses of `KProxy` from the codebase, but it's still lurking in a couple of places:

* The `ByHand2` test
* An outdated comment about orphan instances in `Data.Promotion.Prelude.Enum`. Since it's outdated, I opted to remove the whole comment (and the unnecessary `-fno-warn-orphans` flag).
* The `README`. But see my inline comment.