### PR TITLE
Remove Proxy in KindOf

### DIFF
--- a/src/Data/Singletons.hs
+++ b/src/Data/Singletons.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE MagicHash, RankNTypes, PolyKinds, GADTs, DataKinds,
              FlexibleContexts, FlexibleInstances,
              TypeFamilies, TypeOperators, TypeFamilyDependencies,
-             UndecidableInstances, TypeInType #-}
+             UndecidableInstances, TypeInType, ConstraintKinds #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -32,7 +32,7 @@ module Data.Singletons (
   SingI(..), SingKind(..),
 
   -- * Working with singletons
-  KindOf,
+  KindOf, SameKind,
   SingInstance(..), SomeSing(..),
   singInstance, withSingI, withSomeSing, singByProxy,
 
@@ -64,11 +64,17 @@ module Data.Singletons (
 import Data.Kind
 import Unsafe.Coerce
 import Data.Proxy ( Proxy(..) )
-import GHC.Exts ( Proxy# )
+import GHC.Exts ( Proxy#, Constraint )
 
 -- | Convenient synonym to refer to the kind of a type variable:
--- @type KindOf (a :: k) = ('Proxy :: Proxy k)@
-type KindOf (a :: k) = ('Proxy :: Proxy k)
+-- @type KindOf (a :: k) = k@
+type KindOf (a :: k) = k
+
+-- | Force GHC to unify the kinds of @a@ and @b@. Note that @SameKind a b@ is
+-- different from @KindOf a ~ KindOf b@ in that the former makes the kinds
+-- unify immediately, whereas the latter is a proposition that GHC considers
+-- as possibly false.
+type SameKind (a :: k) (b :: k) = (() :: Constraint)
 
 ----------------------------------------------------------------------
 ---- Sing & friends --------------------------------------------------

--- a/src/Data/Singletons/Names.hs
+++ b/src/Data/Singletons/Names.hs
@@ -35,7 +35,7 @@ anyTypeName, boolName, andName, tyEqName, compareName, minBoundName,
   provedName, disprovedName, reflName, toSingName, fromSingName,
   equalityName, applySingName, suppressClassName, suppressMethodName,
   thenCmpName,
-  kindOfName, tyFromIntegerName, tyNegateName, sFromIntegerName,
+  sameKindName, tyFromIntegerName, tyNegateName, sFromIntegerName,
   sNegateName, errorName, foldlName, cmpEQName, cmpLTName, cmpGTName,
   singletonsToEnumName, singletonsFromEnumName, enumName, singletonsEnumName,
   equalsName :: Name
@@ -88,7 +88,7 @@ applySingName = 'applySing
 suppressClassName = ''SuppressUnusedWarnings
 suppressMethodName = 'suppressUnusedWarnings
 thenCmpName = mk_name_v "Data.Singletons.Prelude.Ord" "thenCmp"
-kindOfName = ''KindOf
+sameKindName = ''SameKind
 tyFromIntegerName = mk_name_tc "Data.Singletons.Prelude.Num" "FromInteger"
 tyNegateName = mk_name_tc "Data.Singletons.Prelude.Num" "Negate"
 sFromIntegerName = mk_name_v "Data.Singletons.Prelude.Num" "sFromInteger"

--- a/tests/compile-and-dump/GradingClient/Database.ghc80.template
+++ b/tests/compile-and-dump/GradingClient/Database.ghc80.template
@@ -19,7 +19,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) SuccSym0KindInference GHC.Tuple.())
     data SuccSym0 (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply SuccSym0 arg) ~ KindOf (SuccSym1 arg) =>
+      = forall arg. SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
         SuccSym0KindInference
     type instance Apply SuccSym0 l = SuccSym1 l
     type family Compare_0123456789 (a :: Nat)
@@ -35,7 +35,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Compare_0123456789Sym1KindInference GHC.Tuple.())
     data Compare_0123456789Sym1 (l :: Nat) (l :: TyFun Nat Ordering)
-      = forall arg. KindOf (Apply (Compare_0123456789Sym1 l) arg) ~ KindOf (Compare_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Compare_0123456789Sym1 l) arg) (Compare_0123456789Sym2 l arg) =>
         Compare_0123456789Sym1KindInference
     type instance Apply (Compare_0123456789Sym1 l) l = Compare_0123456789Sym2 l l
     instance SuppressUnusedWarnings Compare_0123456789Sym0 where
@@ -44,7 +44,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,) Compare_0123456789Sym0KindInference GHC.Tuple.())
     data Compare_0123456789Sym0 (l :: TyFun Nat (TyFun Nat Ordering
                                                  -> Type))
-      = forall arg. KindOf (Apply Compare_0123456789Sym0 arg) ~ KindOf (Compare_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Compare_0123456789Sym0 arg) (Compare_0123456789Sym1 arg) =>
         Compare_0123456789Sym0KindInference
     type instance Apply Compare_0123456789Sym0 l = Compare_0123456789Sym1 l
     instance POrd (Proxy :: Proxy Nat) where
@@ -274,14 +274,14 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) VECSym1KindInference GHC.Tuple.())
     data VECSym1 (l :: U) (l :: TyFun Nat U)
-      = forall arg. KindOf (Apply (VECSym1 l) arg) ~ KindOf (VECSym2 l arg) =>
+      = forall arg. SameKind (Apply (VECSym1 l) arg) (VECSym2 l arg) =>
         VECSym1KindInference
     type instance Apply (VECSym1 l) l = VECSym2 l l
     instance SuppressUnusedWarnings VECSym0 where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) VECSym0KindInference GHC.Tuple.())
     data VECSym0 (l :: TyFun U (TyFun Nat U -> Type))
-      = forall arg. KindOf (Apply VECSym0 arg) ~ KindOf (VECSym1 arg) =>
+      = forall arg. SameKind (Apply VECSym0 arg) (VECSym1 arg) =>
         VECSym0KindInference
     type instance Apply VECSym0 l = VECSym1 l
     type family Equals_0123456789 (a :: AChar)
@@ -346,14 +346,14 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) AttrSym1KindInference GHC.Tuple.())
     data AttrSym1 (l :: [AChar]) (l :: TyFun U Attribute)
-      = forall arg. KindOf (Apply (AttrSym1 l) arg) ~ KindOf (AttrSym2 l arg) =>
+      = forall arg. SameKind (Apply (AttrSym1 l) arg) (AttrSym2 l arg) =>
         AttrSym1KindInference
     type instance Apply (AttrSym1 l) l = AttrSym2 l l
     instance SuppressUnusedWarnings AttrSym0 where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) AttrSym0KindInference GHC.Tuple.())
     data AttrSym0 (l :: TyFun [AChar] (TyFun U Attribute -> Type))
-      = forall arg. KindOf (Apply AttrSym0 arg) ~ KindOf (AttrSym1 arg) =>
+      = forall arg. SameKind (Apply AttrSym0 arg) (AttrSym1 arg) =>
         AttrSym0KindInference
     type instance Apply AttrSym0 l = AttrSym1 l
     type SchSym1 (t :: [Attribute]) = Sch t
@@ -361,7 +361,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) SchSym0KindInference GHC.Tuple.())
     data SchSym0 (l :: TyFun [Attribute] Schema)
-      = forall arg. KindOf (Apply SchSym0 arg) ~ KindOf (SchSym1 arg) =>
+      = forall arg. SameKind (Apply SchSym0 arg) (SchSym1 arg) =>
         SchSym0KindInference
     type instance Apply SchSym0 l = SchSym1 l
     type Let0123456789Scrutinee_0123456789Sym4 t t t t =
@@ -372,7 +372,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,)
                Let0123456789Scrutinee_0123456789Sym3KindInference GHC.Tuple.())
     data Let0123456789Scrutinee_0123456789Sym3 l l l l
-      = forall arg. KindOf (Apply (Let0123456789Scrutinee_0123456789Sym3 l l l) arg) ~ KindOf (Let0123456789Scrutinee_0123456789Sym4 l l l arg) =>
+      = forall arg. SameKind (Apply (Let0123456789Scrutinee_0123456789Sym3 l l l) arg) (Let0123456789Scrutinee_0123456789Sym4 l l l arg) =>
         Let0123456789Scrutinee_0123456789Sym3KindInference
     type instance Apply (Let0123456789Scrutinee_0123456789Sym3 l l l) l = Let0123456789Scrutinee_0123456789Sym4 l l l l
     instance SuppressUnusedWarnings Let0123456789Scrutinee_0123456789Sym2 where
@@ -381,7 +381,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,)
                Let0123456789Scrutinee_0123456789Sym2KindInference GHC.Tuple.())
     data Let0123456789Scrutinee_0123456789Sym2 l l l
-      = forall arg. KindOf (Apply (Let0123456789Scrutinee_0123456789Sym2 l l) arg) ~ KindOf (Let0123456789Scrutinee_0123456789Sym3 l l arg) =>
+      = forall arg. SameKind (Apply (Let0123456789Scrutinee_0123456789Sym2 l l) arg) (Let0123456789Scrutinee_0123456789Sym3 l l arg) =>
         Let0123456789Scrutinee_0123456789Sym2KindInference
     type instance Apply (Let0123456789Scrutinee_0123456789Sym2 l l) l = Let0123456789Scrutinee_0123456789Sym3 l l l
     instance SuppressUnusedWarnings Let0123456789Scrutinee_0123456789Sym1 where
@@ -390,7 +390,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,)
                Let0123456789Scrutinee_0123456789Sym1KindInference GHC.Tuple.())
     data Let0123456789Scrutinee_0123456789Sym1 l l
-      = forall arg. KindOf (Apply (Let0123456789Scrutinee_0123456789Sym1 l) arg) ~ KindOf (Let0123456789Scrutinee_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Let0123456789Scrutinee_0123456789Sym1 l) arg) (Let0123456789Scrutinee_0123456789Sym2 l arg) =>
         Let0123456789Scrutinee_0123456789Sym1KindInference
     type instance Apply (Let0123456789Scrutinee_0123456789Sym1 l) l = Let0123456789Scrutinee_0123456789Sym2 l l
     instance SuppressUnusedWarnings Let0123456789Scrutinee_0123456789Sym0 where
@@ -399,7 +399,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,)
                Let0123456789Scrutinee_0123456789Sym0KindInference GHC.Tuple.())
     data Let0123456789Scrutinee_0123456789Sym0 l
-      = forall arg. KindOf (Apply Let0123456789Scrutinee_0123456789Sym0 arg) ~ KindOf (Let0123456789Scrutinee_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789Scrutinee_0123456789Sym0 arg) (Let0123456789Scrutinee_0123456789Sym1 arg) =>
         Let0123456789Scrutinee_0123456789Sym0KindInference
     type instance Apply Let0123456789Scrutinee_0123456789Sym0 l = Let0123456789Scrutinee_0123456789Sym1 l
     type family Let0123456789Scrutinee_0123456789 name
@@ -415,14 +415,14 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) LookupSym1KindInference GHC.Tuple.())
     data LookupSym1 (l :: [AChar]) (l :: TyFun Schema U)
-      = forall arg. KindOf (Apply (LookupSym1 l) arg) ~ KindOf (LookupSym2 l arg) =>
+      = forall arg. SameKind (Apply (LookupSym1 l) arg) (LookupSym2 l arg) =>
         LookupSym1KindInference
     type instance Apply (LookupSym1 l) l = LookupSym2 l l
     instance SuppressUnusedWarnings LookupSym0 where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) LookupSym0KindInference GHC.Tuple.())
     data LookupSym0 (l :: TyFun [AChar] (TyFun Schema U -> Type))
-      = forall arg. KindOf (Apply LookupSym0 arg) ~ KindOf (LookupSym1 arg) =>
+      = forall arg. SameKind (Apply LookupSym0 arg) (LookupSym1 arg) =>
         LookupSym0KindInference
     type instance Apply LookupSym0 l = LookupSym1 l
     type OccursSym2 (t :: [AChar]) (t :: Schema) = Occurs t t
@@ -430,14 +430,14 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) OccursSym1KindInference GHC.Tuple.())
     data OccursSym1 (l :: [AChar]) (l :: TyFun Schema Bool)
-      = forall arg. KindOf (Apply (OccursSym1 l) arg) ~ KindOf (OccursSym2 l arg) =>
+      = forall arg. SameKind (Apply (OccursSym1 l) arg) (OccursSym2 l arg) =>
         OccursSym1KindInference
     type instance Apply (OccursSym1 l) l = OccursSym2 l l
     instance SuppressUnusedWarnings OccursSym0 where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) OccursSym0KindInference GHC.Tuple.())
     data OccursSym0 (l :: TyFun [AChar] (TyFun Schema Bool -> Type))
-      = forall arg. KindOf (Apply OccursSym0 arg) ~ KindOf (OccursSym1 arg) =>
+      = forall arg. SameKind (Apply OccursSym0 arg) (OccursSym1 arg) =>
         OccursSym0KindInference
     type instance Apply OccursSym0 l = OccursSym1 l
     type AttrNotInSym2 (t :: Attribute) (t :: Schema) = AttrNotIn t t
@@ -445,7 +445,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) AttrNotInSym1KindInference GHC.Tuple.())
     data AttrNotInSym1 (l :: Attribute) (l :: TyFun Schema Bool)
-      = forall arg. KindOf (Apply (AttrNotInSym1 l) arg) ~ KindOf (AttrNotInSym2 l arg) =>
+      = forall arg. SameKind (Apply (AttrNotInSym1 l) arg) (AttrNotInSym2 l arg) =>
         AttrNotInSym1KindInference
     type instance Apply (AttrNotInSym1 l) l = AttrNotInSym2 l l
     instance SuppressUnusedWarnings AttrNotInSym0 where
@@ -453,7 +453,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) AttrNotInSym0KindInference GHC.Tuple.())
     data AttrNotInSym0 (l :: TyFun Attribute (TyFun Schema Bool
                                               -> Type))
-      = forall arg. KindOf (Apply AttrNotInSym0 arg) ~ KindOf (AttrNotInSym1 arg) =>
+      = forall arg. SameKind (Apply AttrNotInSym0 arg) (AttrNotInSym1 arg) =>
         AttrNotInSym0KindInference
     type instance Apply AttrNotInSym0 l = AttrNotInSym1 l
     type DisjointSym2 (t :: Schema) (t :: Schema) = Disjoint t t
@@ -461,14 +461,14 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) DisjointSym1KindInference GHC.Tuple.())
     data DisjointSym1 (l :: Schema) (l :: TyFun Schema Bool)
-      = forall arg. KindOf (Apply (DisjointSym1 l) arg) ~ KindOf (DisjointSym2 l arg) =>
+      = forall arg. SameKind (Apply (DisjointSym1 l) arg) (DisjointSym2 l arg) =>
         DisjointSym1KindInference
     type instance Apply (DisjointSym1 l) l = DisjointSym2 l l
     instance SuppressUnusedWarnings DisjointSym0 where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) DisjointSym0KindInference GHC.Tuple.())
     data DisjointSym0 (l :: TyFun Schema (TyFun Schema Bool -> Type))
-      = forall arg. KindOf (Apply DisjointSym0 arg) ~ KindOf (DisjointSym1 arg) =>
+      = forall arg. SameKind (Apply DisjointSym0 arg) (DisjointSym1 arg) =>
         DisjointSym0KindInference
     type instance Apply DisjointSym0 l = DisjointSym1 l
     type AppendSym2 (t :: Schema) (t :: Schema) = Append t t
@@ -476,14 +476,14 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) AppendSym1KindInference GHC.Tuple.())
     data AppendSym1 (l :: Schema) (l :: TyFun Schema Schema)
-      = forall arg. KindOf (Apply (AppendSym1 l) arg) ~ KindOf (AppendSym2 l arg) =>
+      = forall arg. SameKind (Apply (AppendSym1 l) arg) (AppendSym2 l arg) =>
         AppendSym1KindInference
     type instance Apply (AppendSym1 l) l = AppendSym2 l l
     instance SuppressUnusedWarnings AppendSym0 where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) AppendSym0KindInference GHC.Tuple.())
     data AppendSym0 (l :: TyFun Schema (TyFun Schema Schema -> Type))
-      = forall arg. KindOf (Apply AppendSym0 arg) ~ KindOf (AppendSym1 arg) =>
+      = forall arg. SameKind (Apply AppendSym0 arg) (AppendSym1 arg) =>
         AppendSym0KindInference
     type instance Apply AppendSym0 l = AppendSym1 l
     type family Lookup (a :: [AChar]) (a :: Schema) :: U where

--- a/tests/compile-and-dump/InsertionSort/InsertionSortImp.ghc80.template
+++ b/tests/compile-and-dump/InsertionSort/InsertionSortImp.ghc80.template
@@ -8,7 +8,7 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) SuccSym0KindInference GHC.Tuple.())
     data SuccSym0 (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply SuccSym0 arg) ~ KindOf (SuccSym1 arg) =>
+      = forall arg. SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
         SuccSym0KindInference
     type instance Apply SuccSym0 l = SuccSym1 l
     data instance Sing (z :: Nat)
@@ -63,7 +63,7 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,)
                Let0123456789Scrutinee_0123456789Sym2KindInference GHC.Tuple.())
     data Let0123456789Scrutinee_0123456789Sym2 l l l
-      = forall arg. KindOf (Apply (Let0123456789Scrutinee_0123456789Sym2 l l) arg) ~ KindOf (Let0123456789Scrutinee_0123456789Sym3 l l arg) =>
+      = forall arg. SameKind (Apply (Let0123456789Scrutinee_0123456789Sym2 l l) arg) (Let0123456789Scrutinee_0123456789Sym3 l l arg) =>
         Let0123456789Scrutinee_0123456789Sym2KindInference
     type instance Apply (Let0123456789Scrutinee_0123456789Sym2 l l) l = Let0123456789Scrutinee_0123456789Sym3 l l l
     instance SuppressUnusedWarnings Let0123456789Scrutinee_0123456789Sym1 where
@@ -72,7 +72,7 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,)
                Let0123456789Scrutinee_0123456789Sym1KindInference GHC.Tuple.())
     data Let0123456789Scrutinee_0123456789Sym1 l l
-      = forall arg. KindOf (Apply (Let0123456789Scrutinee_0123456789Sym1 l) arg) ~ KindOf (Let0123456789Scrutinee_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Let0123456789Scrutinee_0123456789Sym1 l) arg) (Let0123456789Scrutinee_0123456789Sym2 l arg) =>
         Let0123456789Scrutinee_0123456789Sym1KindInference
     type instance Apply (Let0123456789Scrutinee_0123456789Sym1 l) l = Let0123456789Scrutinee_0123456789Sym2 l l
     instance SuppressUnusedWarnings Let0123456789Scrutinee_0123456789Sym0 where
@@ -81,7 +81,7 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,)
                Let0123456789Scrutinee_0123456789Sym0KindInference GHC.Tuple.())
     data Let0123456789Scrutinee_0123456789Sym0 l
-      = forall arg. KindOf (Apply Let0123456789Scrutinee_0123456789Sym0 arg) ~ KindOf (Let0123456789Scrutinee_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789Scrutinee_0123456789Sym0 arg) (Let0123456789Scrutinee_0123456789Sym1 arg) =>
         Let0123456789Scrutinee_0123456789Sym0KindInference
     type instance Apply Let0123456789Scrutinee_0123456789Sym0 l = Let0123456789Scrutinee_0123456789Sym1 l
     type family Let0123456789Scrutinee_0123456789 n h t where
@@ -94,14 +94,14 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) LeqSym1KindInference GHC.Tuple.())
     data LeqSym1 (l :: Nat) (l :: TyFun Nat Bool)
-      = forall arg. KindOf (Apply (LeqSym1 l) arg) ~ KindOf (LeqSym2 l arg) =>
+      = forall arg. SameKind (Apply (LeqSym1 l) arg) (LeqSym2 l arg) =>
         LeqSym1KindInference
     type instance Apply (LeqSym1 l) l = LeqSym2 l l
     instance SuppressUnusedWarnings LeqSym0 where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) LeqSym0KindInference GHC.Tuple.())
     data LeqSym0 (l :: TyFun Nat (TyFun Nat Bool -> GHC.Types.Type))
-      = forall arg. KindOf (Apply LeqSym0 arg) ~ KindOf (LeqSym1 arg) =>
+      = forall arg. SameKind (Apply LeqSym0 arg) (LeqSym1 arg) =>
         LeqSym0KindInference
     type instance Apply LeqSym0 l = LeqSym1 l
     type InsertSym2 (t :: Nat) (t :: [Nat]) = Insert t t
@@ -109,7 +109,7 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) InsertSym1KindInference GHC.Tuple.())
     data InsertSym1 (l :: Nat) (l :: TyFun [Nat] [Nat])
-      = forall arg. KindOf (Apply (InsertSym1 l) arg) ~ KindOf (InsertSym2 l arg) =>
+      = forall arg. SameKind (Apply (InsertSym1 l) arg) (InsertSym2 l arg) =>
         InsertSym1KindInference
     type instance Apply (InsertSym1 l) l = InsertSym2 l l
     instance SuppressUnusedWarnings InsertSym0 where
@@ -117,7 +117,7 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) InsertSym0KindInference GHC.Tuple.())
     data InsertSym0 (l :: TyFun Nat (TyFun [Nat] [Nat]
                                      -> GHC.Types.Type))
-      = forall arg. KindOf (Apply InsertSym0 arg) ~ KindOf (InsertSym1 arg) =>
+      = forall arg. SameKind (Apply InsertSym0 arg) (InsertSym1 arg) =>
         InsertSym0KindInference
     type instance Apply InsertSym0 l = InsertSym1 l
     type InsertionSortSym1 (t :: [Nat]) = InsertionSort t
@@ -125,7 +125,7 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) InsertionSortSym0KindInference GHC.Tuple.())
     data InsertionSortSym0 (l :: TyFun [Nat] [Nat])
-      = forall arg. KindOf (Apply InsertionSortSym0 arg) ~ KindOf (InsertionSortSym1 arg) =>
+      = forall arg. SameKind (Apply InsertionSortSym0 arg) (InsertionSortSym1 arg) =>
         InsertionSortSym0KindInference
     type instance Apply InsertionSortSym0 l = InsertionSortSym1 l
     type family Leq (a :: Nat) (a :: Nat) :: Bool where

--- a/tests/compile-and-dump/Promote/Constructors.ghc80.template
+++ b/tests/compile-and-dump/Promote/Constructors.ghc80.template
@@ -11,15 +11,14 @@ Promote/Constructors.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) (:+$$###) GHC.Tuple.())
     data (:+$$) (l :: Foo) (l :: TyFun Foo Foo)
-      = forall arg. KindOf (Apply ((:+$$) l) arg) ~ KindOf ((:+$$$) l arg) =>
+      = forall arg. SameKind (Apply ((:+$$) l) arg) ((:+$$$) l arg) =>
         (:+$$###)
     type instance Apply ((:+$$) l) l = (:+$$$) l l
     instance SuppressUnusedWarnings (:+$) where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) (:+$###) GHC.Tuple.())
     data (:+$) (l :: TyFun Foo (TyFun Foo Foo -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (:+$) arg) ~ KindOf ((:+$$) arg) =>
-        (:+$###)
+      = forall arg. SameKind (Apply (:+$) arg) ((:+$$) arg) => (:+$###)
     type instance Apply (:+$) l = (:+$$) l
     type BarSym5 (t :: Bar)
                  (t :: Bar)
@@ -35,7 +34,7 @@ Promote/Constructors.hs:(0,0)-(0,0): Splicing declarations
                  (l :: Bar)
                  (l :: Bar)
                  (l :: TyFun Foo Bar)
-      = forall arg. KindOf (Apply (BarSym4 l l l l) arg) ~ KindOf (BarSym5 l l l l arg) =>
+      = forall arg. SameKind (Apply (BarSym4 l l l l) arg) (BarSym5 l l l l arg) =>
         BarSym4KindInference
     type instance Apply (BarSym4 l l l l) l = BarSym5 l l l l l
     instance SuppressUnusedWarnings BarSym3 where
@@ -45,7 +44,7 @@ Promote/Constructors.hs:(0,0)-(0,0): Splicing declarations
                  (l :: Bar)
                  (l :: Bar)
                  (l :: TyFun Bar (TyFun Foo Bar -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (BarSym3 l l l) arg) ~ KindOf (BarSym4 l l l arg) =>
+      = forall arg. SameKind (Apply (BarSym3 l l l) arg) (BarSym4 l l l arg) =>
         BarSym3KindInference
     type instance Apply (BarSym3 l l l) l = BarSym4 l l l l
     instance SuppressUnusedWarnings BarSym2 where
@@ -55,7 +54,7 @@ Promote/Constructors.hs:(0,0)-(0,0): Splicing declarations
                  (l :: Bar)
                  (l :: TyFun Bar (TyFun Bar (TyFun Foo Bar -> GHC.Types.Type)
                                   -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (BarSym2 l l) arg) ~ KindOf (BarSym3 l l arg) =>
+      = forall arg. SameKind (Apply (BarSym2 l l) arg) (BarSym3 l l arg) =>
         BarSym2KindInference
     type instance Apply (BarSym2 l l) l = BarSym3 l l l
     instance SuppressUnusedWarnings BarSym1 where
@@ -66,7 +65,7 @@ Promote/Constructors.hs:(0,0)-(0,0): Splicing declarations
                                                         -> GHC.Types.Type)
                                              -> GHC.Types.Type)
                                   -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (BarSym1 l) arg) ~ KindOf (BarSym2 l arg) =>
+      = forall arg. SameKind (Apply (BarSym1 l) arg) (BarSym2 l arg) =>
         BarSym1KindInference
     type instance Apply (BarSym1 l) l = BarSym2 l l
     instance SuppressUnusedWarnings BarSym0 where
@@ -77,6 +76,6 @@ Promote/Constructors.hs:(0,0)-(0,0): Splicing declarations
                                                         -> GHC.Types.Type)
                                              -> GHC.Types.Type)
                                   -> GHC.Types.Type))
-      = forall arg. KindOf (Apply BarSym0 arg) ~ KindOf (BarSym1 arg) =>
+      = forall arg. SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
         BarSym0KindInference
     type instance Apply BarSym0 l = BarSym1 l

--- a/tests/compile-and-dump/Promote/GenDefunSymbols.ghc80.template
+++ b/tests/compile-and-dump/Promote/GenDefunSymbols.ghc80.template
@@ -9,7 +9,7 @@ Promote/GenDefunSymbols.hs:0:0:: Splicing declarations
         = snd (GHC.Tuple.(,) LiftMaybeSym1KindInference GHC.Tuple.())
     data LiftMaybeSym1 (l :: TyFun a0123456789 b0123456789 -> Type)
                        (l :: TyFun (Maybe a0123456789) (Maybe b0123456789))
-      = forall arg. Data.Singletons.KindOf (Apply (LiftMaybeSym1 l) arg) ~ Data.Singletons.KindOf (LiftMaybeSym2 l arg) =>
+      = forall arg. Data.Singletons.SameKind (Apply (LiftMaybeSym1 l) arg) (LiftMaybeSym2 l arg) =>
         LiftMaybeSym1KindInference
     type instance Apply (LiftMaybeSym1 l) l = LiftMaybeSym2 l l
     instance SuppressUnusedWarnings LiftMaybeSym0 where
@@ -18,7 +18,7 @@ Promote/GenDefunSymbols.hs:0:0:: Splicing declarations
     data LiftMaybeSym0 (l :: TyFun (TyFun a0123456789 b0123456789
                                     -> Type) (TyFun (Maybe a0123456789) (Maybe b0123456789)
                                               -> Type))
-      = forall arg. Data.Singletons.KindOf (Apply LiftMaybeSym0 arg) ~ Data.Singletons.KindOf (LiftMaybeSym1 arg) =>
+      = forall arg. Data.Singletons.SameKind (Apply LiftMaybeSym0 arg) (LiftMaybeSym1 arg) =>
         LiftMaybeSym0KindInference
     type instance Apply LiftMaybeSym0 l = LiftMaybeSym1 l
     type ZeroSym0 = Zero
@@ -27,7 +27,7 @@ Promote/GenDefunSymbols.hs:0:0:: Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) SuccSym0KindInference GHC.Tuple.())
     data SuccSym0 (l :: TyFun NatT NatT)
-      = forall arg. Data.Singletons.KindOf (Apply SuccSym0 arg) ~ Data.Singletons.KindOf (SuccSym1 arg) =>
+      = forall arg. Data.Singletons.SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
         SuccSym0KindInference
     type instance Apply SuccSym0 l = SuccSym1 l
     type (:+$$$) (t :: Nat) (t :: Nat) = (:+) t t
@@ -35,13 +35,13 @@ Promote/GenDefunSymbols.hs:0:0:: Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) (:+$$###) GHC.Tuple.())
     data (:+$$) (l :: Nat) l
-      = forall arg. Data.Singletons.KindOf (Apply ((:+$$) l) arg) ~ Data.Singletons.KindOf ((:+$$$) l arg) =>
+      = forall arg. Data.Singletons.SameKind (Apply ((:+$$) l) arg) ((:+$$$) l arg) =>
         (:+$$###)
     type instance Apply ((:+$$) l) l = (:+$$$) l l
     instance SuppressUnusedWarnings (:+$) where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) (:+$###) GHC.Tuple.())
     data (:+$) l
-      = forall arg. Data.Singletons.KindOf (Apply (:+$) arg) ~ Data.Singletons.KindOf ((:+$$) arg) =>
+      = forall arg. Data.Singletons.SameKind (Apply (:+$) arg) ((:+$$) arg) =>
         (:+$###)
     type instance Apply (:+$) l = (:+$$) l

--- a/tests/compile-and-dump/Promote/Newtypes.ghc80.template
+++ b/tests/compile-and-dump/Promote/Newtypes.ghc80.template
@@ -14,7 +14,7 @@ Promote/Newtypes.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) UnBarSym0KindInference GHC.Tuple.())
     data UnBarSym0 (l :: TyFun Bar Nat)
-      = forall arg. KindOf (Apply UnBarSym0 arg) ~ KindOf (UnBarSym1 arg) =>
+      = forall arg. SameKind (Apply UnBarSym0 arg) (UnBarSym1 arg) =>
         UnBarSym0KindInference
     type instance Apply UnBarSym0 l = UnBarSym1 l
     type family UnBar (a :: Bar) :: Nat where
@@ -29,7 +29,7 @@ Promote/Newtypes.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) FooSym0KindInference GHC.Tuple.())
     data FooSym0 (l :: TyFun Nat Foo)
-      = forall arg. KindOf (Apply FooSym0 arg) ~ KindOf (FooSym1 arg) =>
+      = forall arg. SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
         FooSym0KindInference
     type instance Apply FooSym0 l = FooSym1 l
     type BarSym1 (t :: Nat) = Bar t
@@ -37,6 +37,6 @@ Promote/Newtypes.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) BarSym0KindInference GHC.Tuple.())
     data BarSym0 (l :: TyFun Nat Bar)
-      = forall arg. KindOf (Apply BarSym0 arg) ~ KindOf (BarSym1 arg) =>
+      = forall arg. SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
         BarSym0KindInference
     type instance Apply BarSym0 l = BarSym1 l

--- a/tests/compile-and-dump/Promote/Prelude.ghc80.template
+++ b/tests/compile-and-dump/Promote/Prelude.ghc80.template
@@ -9,7 +9,7 @@ Promote/Prelude.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) OddSym0KindInference GHC.Tuple.())
     data OddSym0 (l :: TyFun Nat Bool)
-      = forall arg. Data.Singletons.KindOf (Apply OddSym0 arg) ~ Data.Singletons.KindOf (OddSym1 arg) =>
+      = forall arg. Data.Singletons.SameKind (Apply OddSym0 arg) (OddSym1 arg) =>
         OddSym0KindInference
     type instance Apply OddSym0 l = OddSym1 l
     type family Odd (a :: Nat) :: Bool where

--- a/tests/compile-and-dump/Singletons/AsPattern.ghc80.template
+++ b/tests/compile-and-dump/Singletons/AsPattern.ghc80.template
@@ -39,7 +39,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) BazSym2KindInference GHC.Tuple.())
     data BazSym2 (l :: Nat) (l :: Nat) (l :: TyFun Nat Baz)
-      = forall arg. KindOf (Apply (BazSym2 l l) arg) ~ KindOf (BazSym3 l l arg) =>
+      = forall arg. SameKind (Apply (BazSym2 l l) arg) (BazSym3 l l arg) =>
         BazSym2KindInference
     type instance Apply (BazSym2 l l) l = BazSym3 l l l
     instance SuppressUnusedWarnings BazSym1 where
@@ -47,7 +47,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) BazSym1KindInference GHC.Tuple.())
     data BazSym1 (l :: Nat)
                  (l :: TyFun Nat (TyFun Nat Baz -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (BazSym1 l) arg) ~ KindOf (BazSym2 l arg) =>
+      = forall arg. SameKind (Apply (BazSym1 l) arg) (BazSym2 l arg) =>
         BazSym1KindInference
     type instance Apply (BazSym1 l) l = BazSym2 l l
     instance SuppressUnusedWarnings BazSym0 where
@@ -56,7 +56,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
     data BazSym0 (l :: TyFun Nat (TyFun Nat (TyFun Nat Baz
                                              -> GHC.Types.Type)
                                   -> GHC.Types.Type))
-      = forall arg. KindOf (Apply BazSym0 arg) ~ KindOf (BazSym1 arg) =>
+      = forall arg. SameKind (Apply BazSym0 arg) (BazSym1 arg) =>
         BazSym0KindInference
     type instance Apply BazSym0 l = BazSym1 l
     type Let0123456789PSym0 = Let0123456789P
@@ -67,7 +67,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789PSym0KindInference GHC.Tuple.())
     data Let0123456789PSym0 l
-      = forall arg. KindOf (Apply Let0123456789PSym0 arg) ~ KindOf (Let0123456789PSym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789PSym0 arg) (Let0123456789PSym1 arg) =>
         Let0123456789PSym0KindInference
     type instance Apply Let0123456789PSym0 l = Let0123456789PSym1 l
     type family Let0123456789P wild_0123456789 where
@@ -77,21 +77,21 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789PSym2KindInference GHC.Tuple.())
     data Let0123456789PSym2 l l l
-      = forall arg. KindOf (Apply (Let0123456789PSym2 l l) arg) ~ KindOf (Let0123456789PSym3 l l arg) =>
+      = forall arg. SameKind (Apply (Let0123456789PSym2 l l) arg) (Let0123456789PSym3 l l arg) =>
         Let0123456789PSym2KindInference
     type instance Apply (Let0123456789PSym2 l l) l = Let0123456789PSym3 l l l
     instance SuppressUnusedWarnings Let0123456789PSym1 where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789PSym1KindInference GHC.Tuple.())
     data Let0123456789PSym1 l l
-      = forall arg. KindOf (Apply (Let0123456789PSym1 l) arg) ~ KindOf (Let0123456789PSym2 l arg) =>
+      = forall arg. SameKind (Apply (Let0123456789PSym1 l) arg) (Let0123456789PSym2 l arg) =>
         Let0123456789PSym1KindInference
     type instance Apply (Let0123456789PSym1 l) l = Let0123456789PSym2 l l
     instance SuppressUnusedWarnings Let0123456789PSym0 where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789PSym0KindInference GHC.Tuple.())
     data Let0123456789PSym0 l
-      = forall arg. KindOf (Apply Let0123456789PSym0 arg) ~ KindOf (Let0123456789PSym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789PSym0 arg) (Let0123456789PSym1 arg) =>
         Let0123456789PSym0KindInference
     type instance Apply Let0123456789PSym0 l = Let0123456789PSym1 l
     type family Let0123456789P wild_0123456789
@@ -103,14 +103,14 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789PSym1KindInference GHC.Tuple.())
     data Let0123456789PSym1 l l
-      = forall arg. KindOf (Apply (Let0123456789PSym1 l) arg) ~ KindOf (Let0123456789PSym2 l arg) =>
+      = forall arg. SameKind (Apply (Let0123456789PSym1 l) arg) (Let0123456789PSym2 l arg) =>
         Let0123456789PSym1KindInference
     type instance Apply (Let0123456789PSym1 l) l = Let0123456789PSym2 l l
     instance SuppressUnusedWarnings Let0123456789PSym0 where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789PSym0KindInference GHC.Tuple.())
     data Let0123456789PSym0 l
-      = forall arg. KindOf (Apply Let0123456789PSym0 arg) ~ KindOf (Let0123456789PSym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789PSym0 arg) (Let0123456789PSym1 arg) =>
         Let0123456789PSym0KindInference
     type instance Apply Let0123456789PSym0 l = Let0123456789PSym1 l
     type family Let0123456789P wild_0123456789 wild_0123456789 where
@@ -123,21 +123,21 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789PSym2KindInference GHC.Tuple.())
     data Let0123456789PSym2 l l l
-      = forall arg. KindOf (Apply (Let0123456789PSym2 l l) arg) ~ KindOf (Let0123456789PSym3 l l arg) =>
+      = forall arg. SameKind (Apply (Let0123456789PSym2 l l) arg) (Let0123456789PSym3 l l arg) =>
         Let0123456789PSym2KindInference
     type instance Apply (Let0123456789PSym2 l l) l = Let0123456789PSym3 l l l
     instance SuppressUnusedWarnings Let0123456789PSym1 where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789PSym1KindInference GHC.Tuple.())
     data Let0123456789PSym1 l l
-      = forall arg. KindOf (Apply (Let0123456789PSym1 l) arg) ~ KindOf (Let0123456789PSym2 l arg) =>
+      = forall arg. SameKind (Apply (Let0123456789PSym1 l) arg) (Let0123456789PSym2 l arg) =>
         Let0123456789PSym1KindInference
     type instance Apply (Let0123456789PSym1 l) l = Let0123456789PSym2 l l
     instance SuppressUnusedWarnings Let0123456789PSym0 where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789PSym0KindInference GHC.Tuple.())
     data Let0123456789PSym0 l
-      = forall arg. KindOf (Apply Let0123456789PSym0 arg) ~ KindOf (Let0123456789PSym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789PSym0 arg) (Let0123456789PSym1 arg) =>
         Let0123456789PSym0KindInference
     type instance Apply Let0123456789PSym0 l = Let0123456789PSym1 l
     type family Let0123456789P wild_0123456789
@@ -149,7 +149,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789XSym0KindInference GHC.Tuple.())
     data Let0123456789XSym0 l
-      = forall arg. KindOf (Apply Let0123456789XSym0 arg) ~ KindOf (Let0123456789XSym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789XSym0 arg) (Let0123456789XSym1 arg) =>
         Let0123456789XSym0KindInference
     type instance Apply Let0123456789XSym0 l = Let0123456789XSym1 l
     type family Let0123456789X wild_0123456789 where
@@ -162,7 +162,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) FooSym0KindInference GHC.Tuple.())
     data FooSym0 (l :: TyFun [Nat] [Nat])
-      = forall arg. KindOf (Apply FooSym0 arg) ~ KindOf (FooSym1 arg) =>
+      = forall arg. SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
         FooSym0KindInference
     type instance Apply FooSym0 l = FooSym1 l
     type TupSym1 (t :: (Nat, Nat)) = Tup t
@@ -170,7 +170,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) TupSym0KindInference GHC.Tuple.())
     data TupSym0 (l :: TyFun (Nat, Nat) (Nat, Nat))
-      = forall arg. KindOf (Apply TupSym0 arg) ~ KindOf (TupSym1 arg) =>
+      = forall arg. SameKind (Apply TupSym0 arg) (TupSym1 arg) =>
         TupSym0KindInference
     type instance Apply TupSym0 l = TupSym1 l
     type Baz_Sym1 (t :: Maybe Baz) = Baz_ t
@@ -178,7 +178,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Baz_Sym0KindInference GHC.Tuple.())
     data Baz_Sym0 (l :: TyFun (Maybe Baz) (Maybe Baz))
-      = forall arg. KindOf (Apply Baz_Sym0 arg) ~ KindOf (Baz_Sym1 arg) =>
+      = forall arg. SameKind (Apply Baz_Sym0 arg) (Baz_Sym1 arg) =>
         Baz_Sym0KindInference
     type instance Apply Baz_Sym0 l = Baz_Sym1 l
     type BarSym1 (t :: Maybe Nat) = Bar t
@@ -186,7 +186,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) BarSym0KindInference GHC.Tuple.())
     data BarSym0 (l :: TyFun (Maybe Nat) (Maybe Nat))
-      = forall arg. KindOf (Apply BarSym0 arg) ~ KindOf (BarSym1 arg) =>
+      = forall arg. SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
         BarSym0KindInference
     type instance Apply BarSym0 l = BarSym1 l
     type MaybePlusSym1 (t :: Maybe Nat) = MaybePlus t
@@ -194,7 +194,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) MaybePlusSym0KindInference GHC.Tuple.())
     data MaybePlusSym0 (l :: TyFun (Maybe Nat) (Maybe Nat))
-      = forall arg. KindOf (Apply MaybePlusSym0 arg) ~ KindOf (MaybePlusSym1 arg) =>
+      = forall arg. SameKind (Apply MaybePlusSym0 arg) (MaybePlusSym1 arg) =>
         MaybePlusSym0KindInference
     type instance Apply MaybePlusSym0 l = MaybePlusSym1 l
     type family Foo (a :: [Nat]) :: [Nat] where

--- a/tests/compile-and-dump/Singletons/BoundedDeriving.ghc80.template
+++ b/tests/compile-and-dump/Singletons/BoundedDeriving.ghc80.template
@@ -42,7 +42,7 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Foo3Sym0KindInference GHC.Tuple.())
     data Foo3Sym0 (l :: TyFun a0123456789 (Foo3 a0123456789))
-      = forall arg. KindOf (Apply Foo3Sym0 arg) ~ KindOf (Foo3Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
         Foo3Sym0KindInference
     type instance Apply Foo3Sym0 l = Foo3Sym1 l
     type Foo41Sym0 = Foo41
@@ -52,14 +52,14 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) PairSym1KindInference GHC.Tuple.())
     data PairSym1 (l :: Bool) (l :: TyFun Bool Pair)
-      = forall arg. KindOf (Apply (PairSym1 l) arg) ~ KindOf (PairSym2 l arg) =>
+      = forall arg. SameKind (Apply (PairSym1 l) arg) (PairSym2 l arg) =>
         PairSym1KindInference
     type instance Apply (PairSym1 l) l = PairSym2 l l
     instance SuppressUnusedWarnings PairSym0 where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) PairSym0KindInference GHC.Tuple.())
     data PairSym0 (l :: TyFun Bool (TyFun Bool Pair -> Type))
-      = forall arg. KindOf (Apply PairSym0 arg) ~ KindOf (PairSym1 arg) =>
+      = forall arg. SameKind (Apply PairSym0 arg) (PairSym1 arg) =>
         PairSym0KindInference
     type instance Apply PairSym0 l = PairSym1 l
     type family MinBound_0123456789 :: Foo1 where

--- a/tests/compile-and-dump/Singletons/BoxUnBox.ghc80.template
+++ b/tests/compile-and-dump/Singletons/BoxUnBox.ghc80.template
@@ -13,7 +13,7 @@ Singletons/BoxUnBox.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) FBoxSym0KindInference GHC.Tuple.())
     data FBoxSym0 (l :: TyFun a0123456789 (Box a0123456789))
-      = forall arg. KindOf (Apply FBoxSym0 arg) ~ KindOf (FBoxSym1 arg) =>
+      = forall arg. SameKind (Apply FBoxSym0 arg) (FBoxSym1 arg) =>
         FBoxSym0KindInference
     type instance Apply FBoxSym0 l = FBoxSym1 l
     type UnBoxSym1 (t :: Box a0123456789) = UnBox t
@@ -21,7 +21,7 @@ Singletons/BoxUnBox.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) UnBoxSym0KindInference GHC.Tuple.())
     data UnBoxSym0 (l :: TyFun (Box a0123456789) a0123456789)
-      = forall arg. KindOf (Apply UnBoxSym0 arg) ~ KindOf (UnBoxSym1 arg) =>
+      = forall arg. SameKind (Apply UnBoxSym0 arg) (UnBoxSym1 arg) =>
         UnBoxSym0KindInference
     type instance Apply UnBoxSym0 l = UnBoxSym1 l
     type family UnBox (a :: Box a) :: a where

--- a/tests/compile-and-dump/Singletons/CaseExpressions.ghc80.template
+++ b/tests/compile-and-dump/Singletons/CaseExpressions.ghc80.template
@@ -47,7 +47,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym2KindInference GHC.Tuple.())
     data Lambda_0123456789Sym2 l l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym2 l l) arg) ~ KindOf (Lambda_0123456789Sym3 l l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym2 l l) arg) (Lambda_0123456789Sym3 l l arg) =>
         Lambda_0123456789Sym2KindInference
     type instance Apply (Lambda_0123456789Sym2 l l) l = Lambda_0123456789Sym3 l l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym1 where
@@ -55,7 +55,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym1KindInference GHC.Tuple.())
     data Lambda_0123456789Sym1 l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym1 l) arg) ~ KindOf (Lambda_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym1 l) arg) (Lambda_0123456789Sym2 l arg) =>
         Lambda_0123456789Sym1KindInference
     type instance Apply (Lambda_0123456789Sym1 l) l = Lambda_0123456789Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym0 where
@@ -63,7 +63,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym0KindInference GHC.Tuple.())
     data Lambda_0123456789Sym0 l
-      = forall arg. KindOf (Apply Lambda_0123456789Sym0 arg) ~ KindOf (Lambda_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Lambda_0123456789Sym0 arg) (Lambda_0123456789Sym1 arg) =>
         Lambda_0123456789Sym0KindInference
     type instance Apply Lambda_0123456789Sym0 l = Lambda_0123456789Sym1 l
     type family Case_0123456789 x t where
@@ -73,14 +73,14 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789ZSym1KindInference GHC.Tuple.())
     data Let0123456789ZSym1 l l
-      = forall arg. KindOf (Apply (Let0123456789ZSym1 l) arg) ~ KindOf (Let0123456789ZSym2 l arg) =>
+      = forall arg. SameKind (Apply (Let0123456789ZSym1 l) arg) (Let0123456789ZSym2 l arg) =>
         Let0123456789ZSym1KindInference
     type instance Apply (Let0123456789ZSym1 l) l = Let0123456789ZSym2 l l
     instance SuppressUnusedWarnings Let0123456789ZSym0 where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789ZSym0KindInference GHC.Tuple.())
     data Let0123456789ZSym0 l
-      = forall arg. KindOf (Apply Let0123456789ZSym0 arg) ~ KindOf (Let0123456789ZSym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789ZSym0 arg) (Let0123456789ZSym1 arg) =>
         Let0123456789ZSym0KindInference
     type instance Apply Let0123456789ZSym0 l = Let0123456789ZSym1 l
     type family Let0123456789Z x y :: a where
@@ -95,7 +95,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,)
                Let0123456789Scrutinee_0123456789Sym1KindInference GHC.Tuple.())
     data Let0123456789Scrutinee_0123456789Sym1 l l
-      = forall arg. KindOf (Apply (Let0123456789Scrutinee_0123456789Sym1 l) arg) ~ KindOf (Let0123456789Scrutinee_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Let0123456789Scrutinee_0123456789Sym1 l) arg) (Let0123456789Scrutinee_0123456789Sym2 l arg) =>
         Let0123456789Scrutinee_0123456789Sym1KindInference
     type instance Apply (Let0123456789Scrutinee_0123456789Sym1 l) l = Let0123456789Scrutinee_0123456789Sym2 l l
     instance SuppressUnusedWarnings Let0123456789Scrutinee_0123456789Sym0 where
@@ -104,7 +104,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,)
                Let0123456789Scrutinee_0123456789Sym0KindInference GHC.Tuple.())
     data Let0123456789Scrutinee_0123456789Sym0 l
-      = forall arg. KindOf (Apply Let0123456789Scrutinee_0123456789Sym0 arg) ~ KindOf (Let0123456789Scrutinee_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789Scrutinee_0123456789Sym0 arg) (Let0123456789Scrutinee_0123456789Sym1 arg) =>
         Let0123456789Scrutinee_0123456789Sym0KindInference
     type instance Apply Let0123456789Scrutinee_0123456789Sym0 l = Let0123456789Scrutinee_0123456789Sym1 l
     type family Let0123456789Scrutinee_0123456789 a b where
@@ -119,7 +119,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,)
                Let0123456789Scrutinee_0123456789Sym1KindInference GHC.Tuple.())
     data Let0123456789Scrutinee_0123456789Sym1 l l
-      = forall arg. KindOf (Apply (Let0123456789Scrutinee_0123456789Sym1 l) arg) ~ KindOf (Let0123456789Scrutinee_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Let0123456789Scrutinee_0123456789Sym1 l) arg) (Let0123456789Scrutinee_0123456789Sym2 l arg) =>
         Let0123456789Scrutinee_0123456789Sym1KindInference
     type instance Apply (Let0123456789Scrutinee_0123456789Sym1 l) l = Let0123456789Scrutinee_0123456789Sym2 l l
     instance SuppressUnusedWarnings Let0123456789Scrutinee_0123456789Sym0 where
@@ -128,7 +128,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,)
                Let0123456789Scrutinee_0123456789Sym0KindInference GHC.Tuple.())
     data Let0123456789Scrutinee_0123456789Sym0 l
-      = forall arg. KindOf (Apply Let0123456789Scrutinee_0123456789Sym0 arg) ~ KindOf (Let0123456789Scrutinee_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789Scrutinee_0123456789Sym0 arg) (Let0123456789Scrutinee_0123456789Sym1 arg) =>
         Let0123456789Scrutinee_0123456789Sym0KindInference
     type instance Apply Let0123456789Scrutinee_0123456789Sym0 l = Let0123456789Scrutinee_0123456789Sym1 l
     type family Let0123456789Scrutinee_0123456789 d _z_0123456789 where
@@ -143,7 +143,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Foo5Sym0KindInference GHC.Tuple.())
     data Foo5Sym0 (l :: TyFun a0123456789 a0123456789)
-      = forall arg. KindOf (Apply Foo5Sym0 arg) ~ KindOf (Foo5Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo5Sym0 arg) (Foo5Sym1 arg) =>
         Foo5Sym0KindInference
     type instance Apply Foo5Sym0 l = Foo5Sym1 l
     type Foo4Sym1 (t :: a0123456789) = Foo4 t
@@ -151,7 +151,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Foo4Sym0KindInference GHC.Tuple.())
     data Foo4Sym0 (l :: TyFun a0123456789 a0123456789)
-      = forall arg. KindOf (Apply Foo4Sym0 arg) ~ KindOf (Foo4Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo4Sym0 arg) (Foo4Sym1 arg) =>
         Foo4Sym0KindInference
     type instance Apply Foo4Sym0 l = Foo4Sym1 l
     type Foo3Sym2 (t :: a0123456789) (t :: b0123456789) = Foo3 t t
@@ -160,7 +160,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) Foo3Sym1KindInference GHC.Tuple.())
     data Foo3Sym1 (l :: a0123456789)
                   (l :: TyFun b0123456789 a0123456789)
-      = forall arg. KindOf (Apply (Foo3Sym1 l) arg) ~ KindOf (Foo3Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Foo3Sym1 l) arg) (Foo3Sym2 l arg) =>
         Foo3Sym1KindInference
     type instance Apply (Foo3Sym1 l) l = Foo3Sym2 l l
     instance SuppressUnusedWarnings Foo3Sym0 where
@@ -168,7 +168,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) Foo3Sym0KindInference GHC.Tuple.())
     data Foo3Sym0 (l :: TyFun a0123456789 (TyFun b0123456789 a0123456789
                                            -> GHC.Types.Type))
-      = forall arg. KindOf (Apply Foo3Sym0 arg) ~ KindOf (Foo3Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
         Foo3Sym0KindInference
     type instance Apply Foo3Sym0 l = Foo3Sym1 l
     type Foo2Sym2 (t :: a0123456789) (t :: Maybe a0123456789) =
@@ -178,7 +178,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) Foo2Sym1KindInference GHC.Tuple.())
     data Foo2Sym1 (l :: a0123456789)
                   (l :: TyFun (Maybe a0123456789) a0123456789)
-      = forall arg. KindOf (Apply (Foo2Sym1 l) arg) ~ KindOf (Foo2Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Foo2Sym1 l) arg) (Foo2Sym2 l arg) =>
         Foo2Sym1KindInference
     type instance Apply (Foo2Sym1 l) l = Foo2Sym2 l l
     instance SuppressUnusedWarnings Foo2Sym0 where
@@ -186,7 +186,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) Foo2Sym0KindInference GHC.Tuple.())
     data Foo2Sym0 (l :: TyFun a0123456789 (TyFun (Maybe a0123456789) a0123456789
                                            -> GHC.Types.Type))
-      = forall arg. KindOf (Apply Foo2Sym0 arg) ~ KindOf (Foo2Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) =>
         Foo2Sym0KindInference
     type instance Apply Foo2Sym0 l = Foo2Sym1 l
     type Foo1Sym2 (t :: a0123456789) (t :: Maybe a0123456789) =
@@ -196,7 +196,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) Foo1Sym1KindInference GHC.Tuple.())
     data Foo1Sym1 (l :: a0123456789)
                   (l :: TyFun (Maybe a0123456789) a0123456789)
-      = forall arg. KindOf (Apply (Foo1Sym1 l) arg) ~ KindOf (Foo1Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Foo1Sym1 l) arg) (Foo1Sym2 l arg) =>
         Foo1Sym1KindInference
     type instance Apply (Foo1Sym1 l) l = Foo1Sym2 l l
     instance SuppressUnusedWarnings Foo1Sym0 where
@@ -204,7 +204,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) Foo1Sym0KindInference GHC.Tuple.())
     data Foo1Sym0 (l :: TyFun a0123456789 (TyFun (Maybe a0123456789) a0123456789
                                            -> GHC.Types.Type))
-      = forall arg. KindOf (Apply Foo1Sym0 arg) ~ KindOf (Foo1Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
         Foo1Sym0KindInference
     type instance Apply Foo1Sym0 l = Foo1Sym1 l
     type family Foo5 (a :: a) :: a where

--- a/tests/compile-and-dump/Singletons/Classes.ghc80.template
+++ b/tests/compile-and-dump/Singletons/Classes.ghc80.template
@@ -70,7 +70,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) FooCompareSym1KindInference GHC.Tuple.())
     data FooCompareSym1 (l :: Foo) (l :: TyFun Foo Ordering)
-      = forall arg. KindOf (Apply (FooCompareSym1 l) arg) ~ KindOf (FooCompareSym2 l arg) =>
+      = forall arg. SameKind (Apply (FooCompareSym1 l) arg) (FooCompareSym2 l arg) =>
         FooCompareSym1KindInference
     type instance Apply (FooCompareSym1 l) l = FooCompareSym2 l l
     instance SuppressUnusedWarnings FooCompareSym0 where
@@ -78,7 +78,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) FooCompareSym0KindInference GHC.Tuple.())
     data FooCompareSym0 (l :: TyFun Foo (TyFun Foo Ordering
                                          -> GHC.Types.Type))
-      = forall arg. KindOf (Apply FooCompareSym0 arg) ~ KindOf (FooCompareSym1 arg) =>
+      = forall arg. SameKind (Apply FooCompareSym0 arg) (FooCompareSym1 arg) =>
         FooCompareSym0KindInference
     type instance Apply FooCompareSym0 l = FooCompareSym1 l
     type ConstSym2 (t :: a0123456789) (t :: b0123456789) = Const t t
@@ -87,7 +87,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) ConstSym1KindInference GHC.Tuple.())
     data ConstSym1 (l :: a0123456789)
                    (l :: TyFun b0123456789 a0123456789)
-      = forall arg. KindOf (Apply (ConstSym1 l) arg) ~ KindOf (ConstSym2 l arg) =>
+      = forall arg. SameKind (Apply (ConstSym1 l) arg) (ConstSym2 l arg) =>
         ConstSym1KindInference
     type instance Apply (ConstSym1 l) l = ConstSym2 l l
     instance SuppressUnusedWarnings ConstSym0 where
@@ -95,7 +95,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) ConstSym0KindInference GHC.Tuple.())
     data ConstSym0 (l :: TyFun a0123456789 (TyFun b0123456789 a0123456789
                                             -> GHC.Types.Type))
-      = forall arg. KindOf (Apply ConstSym0 arg) ~ KindOf (ConstSym1 arg) =>
+      = forall arg. SameKind (Apply ConstSym0 arg) (ConstSym1 arg) =>
         ConstSym0KindInference
     type instance Apply ConstSym0 l = ConstSym1 l
     type family FooCompare (a :: Foo) (a :: Foo) :: Ordering where
@@ -113,7 +113,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) MycompareSym1KindInference GHC.Tuple.())
     data MycompareSym1 (l :: a0123456789)
                        (l :: TyFun a0123456789 Ordering)
-      = forall arg. KindOf (Apply (MycompareSym1 l) arg) ~ KindOf (MycompareSym2 l arg) =>
+      = forall arg. SameKind (Apply (MycompareSym1 l) arg) (MycompareSym2 l arg) =>
         MycompareSym1KindInference
     type instance Apply (MycompareSym1 l) l = MycompareSym2 l l
     instance SuppressUnusedWarnings MycompareSym0 where
@@ -121,7 +121,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) MycompareSym0KindInference GHC.Tuple.())
     data MycompareSym0 (l :: TyFun a0123456789 (TyFun a0123456789 Ordering
                                                 -> GHC.Types.Type))
-      = forall arg. KindOf (Apply MycompareSym0 arg) ~ KindOf (MycompareSym1 arg) =>
+      = forall arg. SameKind (Apply MycompareSym0 arg) (MycompareSym1 arg) =>
         MycompareSym0KindInference
     type instance Apply MycompareSym0 l = MycompareSym1 l
     type (:<=>$$$) (t :: a0123456789) (t :: a0123456789) = (:<=>) t t
@@ -129,7 +129,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) (:<=>$$###) GHC.Tuple.())
     data (:<=>$$) (l :: a0123456789) (l :: TyFun a0123456789 Ordering)
-      = forall arg. KindOf (Apply ((:<=>$$) l) arg) ~ KindOf ((:<=>$$$) l arg) =>
+      = forall arg. SameKind (Apply ((:<=>$$) l) arg) ((:<=>$$$) l arg) =>
         (:<=>$$###)
     type instance Apply ((:<=>$$) l) l = (:<=>$$$) l l
     instance SuppressUnusedWarnings (:<=>$) where
@@ -137,7 +137,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) (:<=>$###) GHC.Tuple.())
     data (:<=>$) (l :: TyFun a0123456789 (TyFun a0123456789 Ordering
                                           -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (:<=>$) arg) ~ KindOf ((:<=>$$) arg) =>
+      = forall arg. SameKind (Apply (:<=>$) arg) ((:<=>$$) arg) =>
         (:<=>$###)
     type instance Apply (:<=>$) l = (:<=>$$) l
     type family TFHelper_0123456789 (a :: a) (a :: a) :: Ordering where
@@ -151,7 +151,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,) TFHelper_0123456789Sym1KindInference GHC.Tuple.())
     data TFHelper_0123456789Sym1 (l :: a0123456789)
                                  (l :: TyFun a0123456789 Ordering)
-      = forall arg. KindOf (Apply (TFHelper_0123456789Sym1 l) arg) ~ KindOf (TFHelper_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (TFHelper_0123456789Sym1 l) arg) (TFHelper_0123456789Sym2 l arg) =>
         TFHelper_0123456789Sym1KindInference
     type instance Apply (TFHelper_0123456789Sym1 l) l = TFHelper_0123456789Sym2 l l
     instance SuppressUnusedWarnings TFHelper_0123456789Sym0 where
@@ -160,7 +160,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,) TFHelper_0123456789Sym0KindInference GHC.Tuple.())
     data TFHelper_0123456789Sym0 (l :: TyFun a0123456789 (TyFun a0123456789 Ordering
                                                           -> GHC.Types.Type))
-      = forall arg. KindOf (Apply TFHelper_0123456789Sym0 arg) ~ KindOf (TFHelper_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply TFHelper_0123456789Sym0 arg) (TFHelper_0123456789Sym1 arg) =>
         TFHelper_0123456789Sym0KindInference
     type instance Apply TFHelper_0123456789Sym0 l = TFHelper_0123456789Sym1 l
     class kproxy ~ Proxy => PMyOrd (kproxy :: Proxy a) where
@@ -180,7 +180,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Mycompare_0123456789Sym1KindInference GHC.Tuple.())
     data Mycompare_0123456789Sym1 (l :: Nat) (l :: TyFun Nat Ordering)
-      = forall arg. KindOf (Apply (Mycompare_0123456789Sym1 l) arg) ~ KindOf (Mycompare_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Mycompare_0123456789Sym1 l) arg) (Mycompare_0123456789Sym2 l arg) =>
         Mycompare_0123456789Sym1KindInference
     type instance Apply (Mycompare_0123456789Sym1 l) l = Mycompare_0123456789Sym2 l l
     instance SuppressUnusedWarnings Mycompare_0123456789Sym0 where
@@ -189,7 +189,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,) Mycompare_0123456789Sym0KindInference GHC.Tuple.())
     data Mycompare_0123456789Sym0 (l :: TyFun Nat (TyFun Nat Ordering
                                                    -> GHC.Types.Type))
-      = forall arg. KindOf (Apply Mycompare_0123456789Sym0 arg) ~ KindOf (Mycompare_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Mycompare_0123456789Sym0 arg) (Mycompare_0123456789Sym1 arg) =>
         Mycompare_0123456789Sym0KindInference
     type instance Apply Mycompare_0123456789Sym0 l = Mycompare_0123456789Sym1 l
     instance PMyOrd (Proxy :: Proxy Nat) where
@@ -204,7 +204,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Mycompare_0123456789Sym1KindInference GHC.Tuple.())
     data Mycompare_0123456789Sym1 (l :: ()) (l :: TyFun () Ordering)
-      = forall arg. KindOf (Apply (Mycompare_0123456789Sym1 l) arg) ~ KindOf (Mycompare_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Mycompare_0123456789Sym1 l) arg) (Mycompare_0123456789Sym2 l arg) =>
         Mycompare_0123456789Sym1KindInference
     type instance Apply (Mycompare_0123456789Sym1 l) l = Mycompare_0123456789Sym2 l l
     instance SuppressUnusedWarnings Mycompare_0123456789Sym0 where
@@ -213,7 +213,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,) Mycompare_0123456789Sym0KindInference GHC.Tuple.())
     data Mycompare_0123456789Sym0 (l :: TyFun () (TyFun () Ordering
                                                   -> GHC.Types.Type))
-      = forall arg. KindOf (Apply Mycompare_0123456789Sym0 arg) ~ KindOf (Mycompare_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Mycompare_0123456789Sym0 arg) (Mycompare_0123456789Sym1 arg) =>
         Mycompare_0123456789Sym0KindInference
     type instance Apply Mycompare_0123456789Sym0 l = Mycompare_0123456789Sym1 l
     instance PMyOrd (Proxy :: Proxy ()) where
@@ -228,7 +228,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Mycompare_0123456789Sym1KindInference GHC.Tuple.())
     data Mycompare_0123456789Sym1 (l :: Foo) (l :: TyFun Foo Ordering)
-      = forall arg. KindOf (Apply (Mycompare_0123456789Sym1 l) arg) ~ KindOf (Mycompare_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Mycompare_0123456789Sym1 l) arg) (Mycompare_0123456789Sym2 l arg) =>
         Mycompare_0123456789Sym1KindInference
     type instance Apply (Mycompare_0123456789Sym1 l) l = Mycompare_0123456789Sym2 l l
     instance SuppressUnusedWarnings Mycompare_0123456789Sym0 where
@@ -237,7 +237,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,) Mycompare_0123456789Sym0KindInference GHC.Tuple.())
     data Mycompare_0123456789Sym0 (l :: TyFun Foo (TyFun Foo Ordering
                                                    -> GHC.Types.Type))
-      = forall arg. KindOf (Apply Mycompare_0123456789Sym0 arg) ~ KindOf (Mycompare_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Mycompare_0123456789Sym0 arg) (Mycompare_0123456789Sym1 arg) =>
         Mycompare_0123456789Sym0KindInference
     type instance Apply Mycompare_0123456789Sym0 l = Mycompare_0123456789Sym1 l
     instance PMyOrd (Proxy :: Proxy Foo) where
@@ -255,7 +255,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) TFHelper_0123456789Sym1KindInference GHC.Tuple.())
     data TFHelper_0123456789Sym1 (l :: Foo2) (l :: TyFun Foo2 Bool)
-      = forall arg. KindOf (Apply (TFHelper_0123456789Sym1 l) arg) ~ KindOf (TFHelper_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (TFHelper_0123456789Sym1 l) arg) (TFHelper_0123456789Sym2 l arg) =>
         TFHelper_0123456789Sym1KindInference
     type instance Apply (TFHelper_0123456789Sym1 l) l = TFHelper_0123456789Sym2 l l
     instance SuppressUnusedWarnings TFHelper_0123456789Sym0 where
@@ -264,7 +264,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,) TFHelper_0123456789Sym0KindInference GHC.Tuple.())
     data TFHelper_0123456789Sym0 (l :: TyFun Foo2 (TyFun Foo2 Bool
                                                    -> GHC.Types.Type))
-      = forall arg. KindOf (Apply TFHelper_0123456789Sym0 arg) ~ KindOf (TFHelper_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply TFHelper_0123456789Sym0 arg) (TFHelper_0123456789Sym1 arg) =>
         TFHelper_0123456789Sym0KindInference
     type instance Apply TFHelper_0123456789Sym0 l = TFHelper_0123456789Sym1 l
     instance PEq (Proxy :: Proxy Foo2) where
@@ -500,7 +500,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,) Mycompare_0123456789Sym1KindInference GHC.Tuple.())
     data Mycompare_0123456789Sym1 (l :: Foo2)
                                   (l :: TyFun Foo2 Ordering)
-      = forall arg. KindOf (Apply (Mycompare_0123456789Sym1 l) arg) ~ KindOf (Mycompare_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Mycompare_0123456789Sym1 l) arg) (Mycompare_0123456789Sym2 l arg) =>
         Mycompare_0123456789Sym1KindInference
     type instance Apply (Mycompare_0123456789Sym1 l) l = Mycompare_0123456789Sym2 l l
     instance SuppressUnusedWarnings Mycompare_0123456789Sym0 where
@@ -509,7 +509,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,) Mycompare_0123456789Sym0KindInference GHC.Tuple.())
     data Mycompare_0123456789Sym0 (l :: TyFun Foo2 (TyFun Foo2 Ordering
                                                     -> GHC.Types.Type))
-      = forall arg. KindOf (Apply Mycompare_0123456789Sym0 arg) ~ KindOf (Mycompare_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Mycompare_0123456789Sym0 arg) (Mycompare_0123456789Sym1 arg) =>
         Mycompare_0123456789Sym0KindInference
     type instance Apply Mycompare_0123456789Sym0 l = Mycompare_0123456789Sym1 l
     instance PMyOrd (Proxy :: Proxy Foo2) where
@@ -526,7 +526,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Compare_0123456789Sym1KindInference GHC.Tuple.())
     data Compare_0123456789Sym1 (l :: Foo2) (l :: TyFun Foo2 Ordering)
-      = forall arg. KindOf (Apply (Compare_0123456789Sym1 l) arg) ~ KindOf (Compare_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Compare_0123456789Sym1 l) arg) (Compare_0123456789Sym2 l arg) =>
         Compare_0123456789Sym1KindInference
     type instance Apply (Compare_0123456789Sym1 l) l = Compare_0123456789Sym2 l l
     instance SuppressUnusedWarnings Compare_0123456789Sym0 where
@@ -535,7 +535,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,) Compare_0123456789Sym0KindInference GHC.Tuple.())
     data Compare_0123456789Sym0 (l :: TyFun Foo2 (TyFun Foo2 Ordering
                                                   -> GHC.Types.Type))
-      = forall arg. KindOf (Apply Compare_0123456789Sym0 arg) ~ KindOf (Compare_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Compare_0123456789Sym0 arg) (Compare_0123456789Sym1 arg) =>
         Compare_0123456789Sym0KindInference
     type instance Apply Compare_0123456789Sym0 l = Compare_0123456789Sym1 l
     instance POrd (Proxy :: Proxy Foo2) where
@@ -562,7 +562,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Succ'Sym0KindInference GHC.Tuple.())
     data Succ'Sym0 (l :: TyFun Nat' Nat')
-      = forall arg. KindOf (Apply Succ'Sym0 arg) ~ KindOf (Succ'Sym1 arg) =>
+      = forall arg. SameKind (Apply Succ'Sym0 arg) (Succ'Sym1 arg) =>
         Succ'Sym0KindInference
     type instance Apply Succ'Sym0 l = Succ'Sym1 l
     type family Mycompare_0123456789 (a :: Nat')
@@ -579,7 +579,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,) Mycompare_0123456789Sym1KindInference GHC.Tuple.())
     data Mycompare_0123456789Sym1 (l :: Nat')
                                   (l :: TyFun Nat' Ordering)
-      = forall arg. KindOf (Apply (Mycompare_0123456789Sym1 l) arg) ~ KindOf (Mycompare_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Mycompare_0123456789Sym1 l) arg) (Mycompare_0123456789Sym2 l arg) =>
         Mycompare_0123456789Sym1KindInference
     type instance Apply (Mycompare_0123456789Sym1 l) l = Mycompare_0123456789Sym2 l l
     instance SuppressUnusedWarnings Mycompare_0123456789Sym0 where
@@ -588,7 +588,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,) Mycompare_0123456789Sym0KindInference GHC.Tuple.())
     data Mycompare_0123456789Sym0 (l :: TyFun Nat' (TyFun Nat' Ordering
                                                     -> GHC.Types.Type))
-      = forall arg. KindOf (Apply Mycompare_0123456789Sym0 arg) ~ KindOf (Mycompare_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Mycompare_0123456789Sym0 arg) (Mycompare_0123456789Sym1 arg) =>
         Mycompare_0123456789Sym0KindInference
     type instance Apply Mycompare_0123456789Sym0 l = Mycompare_0123456789Sym1 l
     instance PMyOrd (Proxy :: Proxy Nat') where

--- a/tests/compile-and-dump/Singletons/Classes2.ghc80.template
+++ b/tests/compile-and-dump/Singletons/Classes2.ghc80.template
@@ -20,7 +20,7 @@ Singletons/Classes2.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) SuccFooSym0KindInference GHC.Tuple.())
     data SuccFooSym0 (l :: TyFun NatFoo NatFoo)
-      = forall arg. KindOf (Apply SuccFooSym0 arg) ~ KindOf (SuccFooSym1 arg) =>
+      = forall arg. SameKind (Apply SuccFooSym0 arg) (SuccFooSym1 arg) =>
         SuccFooSym0KindInference
     type instance Apply SuccFooSym0 l = SuccFooSym1 l
     type family Mycompare_0123456789 (a :: NatFoo)
@@ -37,7 +37,7 @@ Singletons/Classes2.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,) Mycompare_0123456789Sym1KindInference GHC.Tuple.())
     data Mycompare_0123456789Sym1 (l :: NatFoo)
                                   (l :: TyFun NatFoo Ordering)
-      = forall arg. KindOf (Apply (Mycompare_0123456789Sym1 l) arg) ~ KindOf (Mycompare_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Mycompare_0123456789Sym1 l) arg) (Mycompare_0123456789Sym2 l arg) =>
         Mycompare_0123456789Sym1KindInference
     type instance Apply (Mycompare_0123456789Sym1 l) l = Mycompare_0123456789Sym2 l l
     instance SuppressUnusedWarnings Mycompare_0123456789Sym0 where
@@ -46,7 +46,7 @@ Singletons/Classes2.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,) Mycompare_0123456789Sym0KindInference GHC.Tuple.())
     data Mycompare_0123456789Sym0 (l :: TyFun NatFoo (TyFun NatFoo Ordering
                                                       -> GHC.Types.Type))
-      = forall arg. KindOf (Apply Mycompare_0123456789Sym0 arg) ~ KindOf (Mycompare_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Mycompare_0123456789Sym0 arg) (Mycompare_0123456789Sym1 arg) =>
         Mycompare_0123456789Sym0KindInference
     type instance Apply Mycompare_0123456789Sym0 l = Mycompare_0123456789Sym1 l
     instance PMyOrd (Proxy :: Proxy NatFoo) where

--- a/tests/compile-and-dump/Singletons/Contains.ghc80.template
+++ b/tests/compile-and-dump/Singletons/Contains.ghc80.template
@@ -14,7 +14,7 @@ Singletons/Contains.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) ContainsSym1KindInference GHC.Tuple.())
     data ContainsSym1 (l :: a0123456789)
                       (l :: TyFun [a0123456789] Bool)
-      = forall arg. KindOf (Apply (ContainsSym1 l) arg) ~ KindOf (ContainsSym2 l arg) =>
+      = forall arg. SameKind (Apply (ContainsSym1 l) arg) (ContainsSym2 l arg) =>
         ContainsSym1KindInference
     type instance Apply (ContainsSym1 l) l = ContainsSym2 l l
     instance SuppressUnusedWarnings ContainsSym0 where
@@ -22,7 +22,7 @@ Singletons/Contains.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) ContainsSym0KindInference GHC.Tuple.())
     data ContainsSym0 (l :: TyFun a0123456789 (TyFun [a0123456789] Bool
                                                -> GHC.Types.Type))
-      = forall arg. KindOf (Apply ContainsSym0 arg) ~ KindOf (ContainsSym1 arg) =>
+      = forall arg. SameKind (Apply ContainsSym0 arg) (ContainsSym1 arg) =>
         ContainsSym0KindInference
     type instance Apply ContainsSym0 l = ContainsSym1 l
     type family Contains (a :: a) (a :: [a]) :: Bool where

--- a/tests/compile-and-dump/Singletons/DataValues.ghc80.template
+++ b/tests/compile-and-dump/Singletons/DataValues.ghc80.template
@@ -22,7 +22,7 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) PairSym1KindInference GHC.Tuple.())
     data PairSym1 (l :: a0123456789)
                   (l :: TyFun b0123456789 (Pair a0123456789 b0123456789))
-      = forall arg. KindOf (Apply (PairSym1 l) arg) ~ KindOf (PairSym2 l arg) =>
+      = forall arg. SameKind (Apply (PairSym1 l) arg) (PairSym2 l arg) =>
         PairSym1KindInference
     type instance Apply (PairSym1 l) l = PairSym2 l l
     instance SuppressUnusedWarnings PairSym0 where
@@ -30,7 +30,7 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) PairSym0KindInference GHC.Tuple.())
     data PairSym0 (l :: TyFun a0123456789 (TyFun b0123456789 (Pair a0123456789 b0123456789)
                                            -> GHC.Types.Type))
-      = forall arg. KindOf (Apply PairSym0 arg) ~ KindOf (PairSym1 arg) =>
+      = forall arg. SameKind (Apply PairSym0 arg) (PairSym1 arg) =>
         PairSym0KindInference
     type instance Apply PairSym0 l = PairSym1 l
     type AListSym0 = AList

--- a/tests/compile-and-dump/Singletons/EnumDeriving.ghc80.template
+++ b/tests/compile-and-dump/Singletons/EnumDeriving.ghc80.template
@@ -32,7 +32,7 @@ Singletons/EnumDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) ToEnum_0123456789Sym0KindInference GHC.Tuple.())
     data ToEnum_0123456789Sym0 (l :: TyFun GHC.Types.Nat Foo)
-      = forall arg. KindOf (Apply ToEnum_0123456789Sym0 arg) ~ KindOf (ToEnum_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply ToEnum_0123456789Sym0 arg) (ToEnum_0123456789Sym1 arg) =>
         ToEnum_0123456789Sym0KindInference
     type instance Apply ToEnum_0123456789Sym0 l = ToEnum_0123456789Sym1 l
     type family FromEnum_0123456789 (a :: Foo) :: GHC.Types.Nat where
@@ -45,7 +45,7 @@ Singletons/EnumDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) FromEnum_0123456789Sym0KindInference GHC.Tuple.())
     data FromEnum_0123456789Sym0 (l :: TyFun Foo GHC.Types.Nat)
-      = forall arg. KindOf (Apply FromEnum_0123456789Sym0 arg) ~ KindOf (FromEnum_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply FromEnum_0123456789Sym0 arg) (FromEnum_0123456789Sym1 arg) =>
         FromEnum_0123456789Sym0KindInference
     type instance Apply FromEnum_0123456789Sym0 l = FromEnum_0123456789Sym1 l
     instance PEnum (Proxy :: Proxy Foo) where
@@ -195,7 +195,7 @@ Singletons/EnumDeriving.hs:0:0:: Splicing declarations
         = snd
             (GHC.Tuple.(,) ToEnum_0123456789Sym0KindInference GHC.Tuple.())
     data ToEnum_0123456789Sym0 (l :: TyFun GHC.Types.Nat Quux)
-      = forall arg. KindOf (Apply ToEnum_0123456789Sym0 arg) ~ KindOf (ToEnum_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply ToEnum_0123456789Sym0 arg) (ToEnum_0123456789Sym1 arg) =>
         ToEnum_0123456789Sym0KindInference
     type instance Apply ToEnum_0123456789Sym0 l = ToEnum_0123456789Sym1 l
     type family FromEnum_0123456789 (a :: Quux) :: GHC.Types.Nat where
@@ -207,7 +207,7 @@ Singletons/EnumDeriving.hs:0:0:: Splicing declarations
         = snd
             (GHC.Tuple.(,) FromEnum_0123456789Sym0KindInference GHC.Tuple.())
     data FromEnum_0123456789Sym0 (l :: TyFun Quux GHC.Types.Nat)
-      = forall arg. KindOf (Apply FromEnum_0123456789Sym0 arg) ~ KindOf (FromEnum_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply FromEnum_0123456789Sym0 arg) (FromEnum_0123456789Sym1 arg) =>
         FromEnum_0123456789Sym0KindInference
     type instance Apply FromEnum_0123456789Sym0 l = FromEnum_0123456789Sym1 l
     instance PEnum (Proxy :: Proxy Quux) where

--- a/tests/compile-and-dump/Singletons/Error.ghc80.template
+++ b/tests/compile-and-dump/Singletons/Error.ghc80.template
@@ -12,7 +12,7 @@ Singletons/Error.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) HeadSym0KindInference GHC.Tuple.())
     data HeadSym0 (l :: TyFun [a0123456789] a0123456789)
-      = forall arg. KindOf (Apply HeadSym0 arg) ~ KindOf (HeadSym1 arg) =>
+      = forall arg. SameKind (Apply HeadSym0 arg) (HeadSym1 arg) =>
         HeadSym0KindInference
     type instance Apply HeadSym0 l = HeadSym1 l
     type family Head (a :: [a]) :: a where

--- a/tests/compile-and-dump/Singletons/Fixity.ghc80.template
+++ b/tests/compile-and-dump/Singletons/Fixity.ghc80.template
@@ -22,7 +22,7 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) (:====$$###) GHC.Tuple.())
     data (:====$$) (l :: a0123456789)
                    (l :: TyFun a0123456789 a0123456789)
-      = forall arg. KindOf (Apply ((:====$$) l) arg) ~ KindOf ((:====$$$) l arg) =>
+      = forall arg. SameKind (Apply ((:====$$) l) arg) ((:====$$$) l arg) =>
         (:====$$###)
     type instance Apply ((:====$$) l) l = (:====$$$) l l
     instance SuppressUnusedWarnings (:====$) where
@@ -30,7 +30,7 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) (:====$###) GHC.Tuple.())
     data (:====$) (l :: TyFun a0123456789 (TyFun a0123456789 a0123456789
                                            -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (:====$) arg) ~ KindOf ((:====$$) arg) =>
+      = forall arg. SameKind (Apply (:====$) arg) ((:====$$) arg) =>
         (:====$###)
     type instance Apply (:====$) l = (:====$$) l
     type family (:====) (a :: a) (a :: a) :: a where
@@ -42,7 +42,7 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) (:<=>$$###) GHC.Tuple.())
     data (:<=>$$) (l :: a0123456789) (l :: TyFun a0123456789 Ordering)
-      = forall arg. KindOf (Apply ((:<=>$$) l) arg) ~ KindOf ((:<=>$$$) l arg) =>
+      = forall arg. SameKind (Apply ((:<=>$$) l) arg) ((:<=>$$$) l arg) =>
         (:<=>$$###)
     type instance Apply ((:<=>$$) l) l = (:<=>$$$) l l
     instance SuppressUnusedWarnings (:<=>$) where
@@ -50,7 +50,7 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) (:<=>$###) GHC.Tuple.())
     data (:<=>$) (l :: TyFun a0123456789 (TyFun a0123456789 Ordering
                                           -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (:<=>$) arg) ~ KindOf ((:<=>$$) arg) =>
+      = forall arg. SameKind (Apply (:<=>$) arg) ((:<=>$$) arg) =>
         (:<=>$###)
     type instance Apply (:<=>$) l = (:<=>$$) l
     class kproxy ~ Proxy => PMyOrd (kproxy :: Proxy a) where

--- a/tests/compile-and-dump/Singletons/FunDeps.ghc80.template
+++ b/tests/compile-and-dump/Singletons/FunDeps.ghc80.template
@@ -27,7 +27,7 @@ Singletons/FunDeps.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) MethSym0KindInference GHC.Tuple.())
     data MethSym0 (l :: TyFun a0123456789 a0123456789)
-      = forall arg. KindOf (Apply MethSym0 arg) ~ KindOf (MethSym1 arg) =>
+      = forall arg. SameKind (Apply MethSym0 arg) (MethSym1 arg) =>
         MethSym0KindInference
     type instance Apply MethSym0 l = MethSym1 l
     type L2rSym1 (t :: a0123456789) = L2r t
@@ -35,7 +35,7 @@ Singletons/FunDeps.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) L2rSym0KindInference GHC.Tuple.())
     data L2rSym0 (l :: TyFun a0123456789 b0123456789)
-      = forall arg. KindOf (Apply L2rSym0 arg) ~ KindOf (L2rSym1 arg) =>
+      = forall arg. SameKind (Apply L2rSym0 arg) (L2rSym1 arg) =>
         L2rSym0KindInference
     type instance Apply L2rSym0 l = L2rSym1 l
     class (kproxy ~ Proxy, kproxy ~ Proxy) => PFD (kproxy :: Proxy a)
@@ -49,7 +49,7 @@ Singletons/FunDeps.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Meth_0123456789Sym0KindInference GHC.Tuple.())
     data Meth_0123456789Sym0 (l :: TyFun Bool Bool)
-      = forall arg. KindOf (Apply Meth_0123456789Sym0 arg) ~ KindOf (Meth_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Meth_0123456789Sym0 arg) (Meth_0123456789Sym1 arg) =>
         Meth_0123456789Sym0KindInference
     type instance Apply Meth_0123456789Sym0 l = Meth_0123456789Sym1 l
     type family L2r_0123456789 (a :: Bool) :: Nat where
@@ -60,7 +60,7 @@ Singletons/FunDeps.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) L2r_0123456789Sym0KindInference GHC.Tuple.())
     data L2r_0123456789Sym0 (l :: TyFun Bool Nat)
-      = forall arg. KindOf (Apply L2r_0123456789Sym0 arg) ~ KindOf (L2r_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply L2r_0123456789Sym0 arg) (L2r_0123456789Sym1 arg) =>
         L2r_0123456789Sym0KindInference
     type instance Apply L2r_0123456789Sym0 l = L2r_0123456789Sym1 l
     instance PFD (Proxy :: Proxy Bool) (Proxy :: Proxy Nat) where

--- a/tests/compile-and-dump/Singletons/HigherOrder.ghc80.template
+++ b/tests/compile-and-dump/Singletons/HigherOrder.ghc80.template
@@ -46,7 +46,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) LeftSym0KindInference GHC.Tuple.())
     data LeftSym0 (l :: TyFun a0123456789 (Either a0123456789 b0123456789))
-      = forall arg. KindOf (Apply LeftSym0 arg) ~ KindOf (LeftSym1 arg) =>
+      = forall arg. SameKind (Apply LeftSym0 arg) (LeftSym1 arg) =>
         LeftSym0KindInference
     type instance Apply LeftSym0 l = LeftSym1 l
     type RightSym1 (t :: b0123456789) = Right t
@@ -54,7 +54,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) RightSym0KindInference GHC.Tuple.())
     data RightSym0 (l :: TyFun b0123456789 (Either a0123456789 b0123456789))
-      = forall arg. KindOf (Apply RightSym0 arg) ~ KindOf (RightSym1 arg) =>
+      = forall arg. SameKind (Apply RightSym0 arg) (RightSym1 arg) =>
         RightSym0KindInference
     type instance Apply RightSym0 l = RightSym1 l
     type family Case_0123456789 ns bs n b t where
@@ -68,7 +68,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym3KindInference GHC.Tuple.())
     data Lambda_0123456789Sym3 l l l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym3 l l l) arg) ~ KindOf (Lambda_0123456789Sym4 l l l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym3 l l l) arg) (Lambda_0123456789Sym4 l l l arg) =>
         Lambda_0123456789Sym3KindInference
     type instance Apply (Lambda_0123456789Sym3 l l l) l = Lambda_0123456789Sym4 l l l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym2 where
@@ -76,7 +76,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym2KindInference GHC.Tuple.())
     data Lambda_0123456789Sym2 l l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym2 l l) arg) ~ KindOf (Lambda_0123456789Sym3 l l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym2 l l) arg) (Lambda_0123456789Sym3 l l arg) =>
         Lambda_0123456789Sym2KindInference
     type instance Apply (Lambda_0123456789Sym2 l l) l = Lambda_0123456789Sym3 l l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym1 where
@@ -84,7 +84,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym1KindInference GHC.Tuple.())
     data Lambda_0123456789Sym1 l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym1 l) arg) ~ KindOf (Lambda_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym1 l) arg) (Lambda_0123456789Sym2 l arg) =>
         Lambda_0123456789Sym1KindInference
     type instance Apply (Lambda_0123456789Sym1 l) l = Lambda_0123456789Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym0 where
@@ -92,7 +92,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym0KindInference GHC.Tuple.())
     data Lambda_0123456789Sym0 l
-      = forall arg. KindOf (Apply Lambda_0123456789Sym0 arg) ~ KindOf (Lambda_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Lambda_0123456789Sym0 arg) (Lambda_0123456789Sym1 arg) =>
         Lambda_0123456789Sym0KindInference
     type instance Apply Lambda_0123456789Sym0 l = Lambda_0123456789Sym1 l
     type family Case_0123456789 n b a_0123456789 a_0123456789 t where
@@ -106,7 +106,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym3KindInference GHC.Tuple.())
     data Lambda_0123456789Sym3 l l l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym3 l l l) arg) ~ KindOf (Lambda_0123456789Sym4 l l l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym3 l l l) arg) (Lambda_0123456789Sym4 l l l arg) =>
         Lambda_0123456789Sym3KindInference
     type instance Apply (Lambda_0123456789Sym3 l l l) l = Lambda_0123456789Sym4 l l l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym2 where
@@ -114,7 +114,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym2KindInference GHC.Tuple.())
     data Lambda_0123456789Sym2 l l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym2 l l) arg) ~ KindOf (Lambda_0123456789Sym3 l l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym2 l l) arg) (Lambda_0123456789Sym3 l l arg) =>
         Lambda_0123456789Sym2KindInference
     type instance Apply (Lambda_0123456789Sym2 l l) l = Lambda_0123456789Sym3 l l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym1 where
@@ -122,7 +122,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym1KindInference GHC.Tuple.())
     data Lambda_0123456789Sym1 l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym1 l) arg) ~ KindOf (Lambda_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym1 l) arg) (Lambda_0123456789Sym2 l arg) =>
         Lambda_0123456789Sym1KindInference
     type instance Apply (Lambda_0123456789Sym1 l) l = Lambda_0123456789Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym0 where
@@ -130,7 +130,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym0KindInference GHC.Tuple.())
     data Lambda_0123456789Sym0 l
-      = forall arg. KindOf (Apply Lambda_0123456789Sym0 arg) ~ KindOf (Lambda_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Lambda_0123456789Sym0 arg) (Lambda_0123456789Sym1 arg) =>
         Lambda_0123456789Sym0KindInference
     type instance Apply Lambda_0123456789Sym0 l = Lambda_0123456789Sym1 l
     type FooSym3 (t :: TyFun (TyFun a0123456789 b0123456789
@@ -149,7 +149,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
                        -> GHC.Types.Type)
                  (l :: TyFun a0123456789 b0123456789 -> GHC.Types.Type)
                  (l :: TyFun a0123456789 b0123456789)
-      = forall arg. KindOf (Apply (FooSym2 l l) arg) ~ KindOf (FooSym3 l l arg) =>
+      = forall arg. SameKind (Apply (FooSym2 l l) arg) (FooSym3 l l arg) =>
         FooSym2KindInference
     type instance Apply (FooSym2 l l) l = FooSym3 l l l
     instance SuppressUnusedWarnings FooSym1 where
@@ -162,7 +162,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
                  (l :: TyFun (TyFun a0123456789 b0123456789
                               -> GHC.Types.Type) (TyFun a0123456789 b0123456789
                                                   -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (FooSym1 l) arg) ~ KindOf (FooSym2 l arg) =>
+      = forall arg. SameKind (Apply (FooSym1 l) arg) (FooSym2 l arg) =>
         FooSym1KindInference
     type instance Apply (FooSym1 l) l = FooSym2 l l
     instance SuppressUnusedWarnings FooSym0 where
@@ -175,7 +175,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
                                                          -> GHC.Types.Type) (TyFun a0123456789 b0123456789
                                                                              -> GHC.Types.Type)
                                                   -> GHC.Types.Type))
-      = forall arg. KindOf (Apply FooSym0 arg) ~ KindOf (FooSym1 arg) =>
+      = forall arg. SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
         FooSym0KindInference
     type instance Apply FooSym0 l = FooSym1 l
     type ZipWithSym3 (t :: TyFun a0123456789 (TyFun b0123456789 c0123456789
@@ -192,7 +192,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
                            -> GHC.Types.Type)
                      (l :: [a0123456789])
                      (l :: TyFun [b0123456789] [c0123456789])
-      = forall arg. KindOf (Apply (ZipWithSym2 l l) arg) ~ KindOf (ZipWithSym3 l l arg) =>
+      = forall arg. SameKind (Apply (ZipWithSym2 l l) arg) (ZipWithSym3 l l arg) =>
         ZipWithSym2KindInference
     type instance Apply (ZipWithSym2 l l) l = ZipWithSym3 l l l
     instance SuppressUnusedWarnings ZipWithSym1 where
@@ -203,7 +203,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
                            -> GHC.Types.Type)
                      (l :: TyFun [a0123456789] (TyFun [b0123456789] [c0123456789]
                                                 -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (ZipWithSym1 l) arg) ~ KindOf (ZipWithSym2 l arg) =>
+      = forall arg. SameKind (Apply (ZipWithSym1 l) arg) (ZipWithSym2 l arg) =>
         ZipWithSym1KindInference
     type instance Apply (ZipWithSym1 l) l = ZipWithSym2 l l
     instance SuppressUnusedWarnings ZipWithSym0 where
@@ -214,7 +214,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
                                   -> GHC.Types.Type) (TyFun [a0123456789] (TyFun [b0123456789] [c0123456789]
                                                                            -> GHC.Types.Type)
                                                       -> GHC.Types.Type))
-      = forall arg. KindOf (Apply ZipWithSym0 arg) ~ KindOf (ZipWithSym1 arg) =>
+      = forall arg. SameKind (Apply ZipWithSym0 arg) (ZipWithSym1 arg) =>
         ZipWithSym0KindInference
     type instance Apply ZipWithSym0 l = ZipWithSym1 l
     type SplungeSym2 (t :: [Nat]) (t :: [Bool]) = Splunge t t
@@ -222,7 +222,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) SplungeSym1KindInference GHC.Tuple.())
     data SplungeSym1 (l :: [Nat]) (l :: TyFun [Bool] [Nat])
-      = forall arg. KindOf (Apply (SplungeSym1 l) arg) ~ KindOf (SplungeSym2 l arg) =>
+      = forall arg. SameKind (Apply (SplungeSym1 l) arg) (SplungeSym2 l arg) =>
         SplungeSym1KindInference
     type instance Apply (SplungeSym1 l) l = SplungeSym2 l l
     instance SuppressUnusedWarnings SplungeSym0 where
@@ -230,7 +230,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) SplungeSym0KindInference GHC.Tuple.())
     data SplungeSym0 (l :: TyFun [Nat] (TyFun [Bool] [Nat]
                                         -> GHC.Types.Type))
-      = forall arg. KindOf (Apply SplungeSym0 arg) ~ KindOf (SplungeSym1 arg) =>
+      = forall arg. SameKind (Apply SplungeSym0 arg) (SplungeSym1 arg) =>
         SplungeSym0KindInference
     type instance Apply SplungeSym0 l = SplungeSym1 l
     type EtadSym2 (t :: [Nat]) (t :: [Bool]) = Etad t t
@@ -238,7 +238,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) EtadSym1KindInference GHC.Tuple.())
     data EtadSym1 (l :: [Nat]) (l :: TyFun [Bool] [Nat])
-      = forall arg. KindOf (Apply (EtadSym1 l) arg) ~ KindOf (EtadSym2 l arg) =>
+      = forall arg. SameKind (Apply (EtadSym1 l) arg) (EtadSym2 l arg) =>
         EtadSym1KindInference
     type instance Apply (EtadSym1 l) l = EtadSym2 l l
     instance SuppressUnusedWarnings EtadSym0 where
@@ -246,7 +246,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) EtadSym0KindInference GHC.Tuple.())
     data EtadSym0 (l :: TyFun [Nat] (TyFun [Bool] [Nat]
                                      -> GHC.Types.Type))
-      = forall arg. KindOf (Apply EtadSym0 arg) ~ KindOf (EtadSym1 arg) =>
+      = forall arg. SameKind (Apply EtadSym0 arg) (EtadSym1 arg) =>
         EtadSym0KindInference
     type instance Apply EtadSym0 l = EtadSym1 l
     type LiftMaybeSym2 (t :: TyFun a0123456789 b0123456789
@@ -259,7 +259,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     data LiftMaybeSym1 (l :: TyFun a0123456789 b0123456789
                              -> GHC.Types.Type)
                        (l :: TyFun (Maybe a0123456789) (Maybe b0123456789))
-      = forall arg. KindOf (Apply (LiftMaybeSym1 l) arg) ~ KindOf (LiftMaybeSym2 l arg) =>
+      = forall arg. SameKind (Apply (LiftMaybeSym1 l) arg) (LiftMaybeSym2 l arg) =>
         LiftMaybeSym1KindInference
     type instance Apply (LiftMaybeSym1 l) l = LiftMaybeSym2 l l
     instance SuppressUnusedWarnings LiftMaybeSym0 where
@@ -268,7 +268,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     data LiftMaybeSym0 (l :: TyFun (TyFun a0123456789 b0123456789
                                     -> GHC.Types.Type) (TyFun (Maybe a0123456789) (Maybe b0123456789)
                                                         -> GHC.Types.Type))
-      = forall arg. KindOf (Apply LiftMaybeSym0 arg) ~ KindOf (LiftMaybeSym1 arg) =>
+      = forall arg. SameKind (Apply LiftMaybeSym0 arg) (LiftMaybeSym1 arg) =>
         LiftMaybeSym0KindInference
     type instance Apply LiftMaybeSym0 l = LiftMaybeSym1 l
     type MapSym2 (t :: TyFun a0123456789 b0123456789 -> GHC.Types.Type)
@@ -279,7 +279,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) MapSym1KindInference GHC.Tuple.())
     data MapSym1 (l :: TyFun a0123456789 b0123456789 -> GHC.Types.Type)
                  (l :: TyFun [a0123456789] [b0123456789])
-      = forall arg. KindOf (Apply (MapSym1 l) arg) ~ KindOf (MapSym2 l arg) =>
+      = forall arg. SameKind (Apply (MapSym1 l) arg) (MapSym2 l arg) =>
         MapSym1KindInference
     type instance Apply (MapSym1 l) l = MapSym2 l l
     instance SuppressUnusedWarnings MapSym0 where
@@ -288,7 +288,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     data MapSym0 (l :: TyFun (TyFun a0123456789 b0123456789
                               -> GHC.Types.Type) (TyFun [a0123456789] [b0123456789]
                                                   -> GHC.Types.Type))
-      = forall arg. KindOf (Apply MapSym0 arg) ~ KindOf (MapSym1 arg) =>
+      = forall arg. SameKind (Apply MapSym0 arg) (MapSym1 arg) =>
         MapSym0KindInference
     type instance Apply MapSym0 l = MapSym1 l
     type family Foo (a :: TyFun (TyFun a b

--- a/tests/compile-and-dump/Singletons/LambdaCase.ghc80.template
+++ b/tests/compile-and-dump/Singletons/LambdaCase.ghc80.template
@@ -39,7 +39,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym2KindInference GHC.Tuple.())
     data Lambda_0123456789Sym2 l l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym2 l l) arg) ~ KindOf (Lambda_0123456789Sym3 l l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym2 l l) arg) (Lambda_0123456789Sym3 l l arg) =>
         Lambda_0123456789Sym2KindInference
     type instance Apply (Lambda_0123456789Sym2 l l) l = Lambda_0123456789Sym3 l l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym1 where
@@ -47,7 +47,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym1KindInference GHC.Tuple.())
     data Lambda_0123456789Sym1 l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym1 l) arg) ~ KindOf (Lambda_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym1 l) arg) (Lambda_0123456789Sym2 l arg) =>
         Lambda_0123456789Sym1KindInference
     type instance Apply (Lambda_0123456789Sym1 l) l = Lambda_0123456789Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym0 where
@@ -55,7 +55,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym0KindInference GHC.Tuple.())
     data Lambda_0123456789Sym0 l
-      = forall arg. KindOf (Apply Lambda_0123456789Sym0 arg) ~ KindOf (Lambda_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Lambda_0123456789Sym0 arg) (Lambda_0123456789Sym1 arg) =>
         Lambda_0123456789Sym0KindInference
     type instance Apply Lambda_0123456789Sym0 l = Lambda_0123456789Sym1 l
     type family Case_0123456789 d x_0123456789 _z_0123456789 t where
@@ -69,7 +69,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym2KindInference GHC.Tuple.())
     data Lambda_0123456789Sym2 l l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym2 l l) arg) ~ KindOf (Lambda_0123456789Sym3 l l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym2 l l) arg) (Lambda_0123456789Sym3 l l arg) =>
         Lambda_0123456789Sym2KindInference
     type instance Apply (Lambda_0123456789Sym2 l l) l = Lambda_0123456789Sym3 l l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym1 where
@@ -77,7 +77,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym1KindInference GHC.Tuple.())
     data Lambda_0123456789Sym1 l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym1 l) arg) ~ KindOf (Lambda_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym1 l) arg) (Lambda_0123456789Sym2 l arg) =>
         Lambda_0123456789Sym1KindInference
     type instance Apply (Lambda_0123456789Sym1 l) l = Lambda_0123456789Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym0 where
@@ -85,7 +85,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym0KindInference GHC.Tuple.())
     data Lambda_0123456789Sym0 l
-      = forall arg. KindOf (Apply Lambda_0123456789Sym0 arg) ~ KindOf (Lambda_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Lambda_0123456789Sym0 arg) (Lambda_0123456789Sym1 arg) =>
         Lambda_0123456789Sym0KindInference
     type instance Apply Lambda_0123456789Sym0 l = Lambda_0123456789Sym1 l
     type family Case_0123456789 d x x_0123456789 t where
@@ -99,7 +99,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym2KindInference GHC.Tuple.())
     data Lambda_0123456789Sym2 l l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym2 l l) arg) ~ KindOf (Lambda_0123456789Sym3 l l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym2 l l) arg) (Lambda_0123456789Sym3 l l arg) =>
         Lambda_0123456789Sym2KindInference
     type instance Apply (Lambda_0123456789Sym2 l l) l = Lambda_0123456789Sym3 l l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym1 where
@@ -107,7 +107,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym1KindInference GHC.Tuple.())
     data Lambda_0123456789Sym1 l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym1 l) arg) ~ KindOf (Lambda_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym1 l) arg) (Lambda_0123456789Sym2 l arg) =>
         Lambda_0123456789Sym1KindInference
     type instance Apply (Lambda_0123456789Sym1 l) l = Lambda_0123456789Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym0 where
@@ -115,7 +115,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym0KindInference GHC.Tuple.())
     data Lambda_0123456789Sym0 l
-      = forall arg. KindOf (Apply Lambda_0123456789Sym0 arg) ~ KindOf (Lambda_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Lambda_0123456789Sym0 arg) (Lambda_0123456789Sym1 arg) =>
         Lambda_0123456789Sym0KindInference
     type instance Apply Lambda_0123456789Sym0 l = Lambda_0123456789Sym1 l
     type Foo3Sym2 (t :: a0123456789) (t :: b0123456789) = Foo3 t t
@@ -124,7 +124,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) Foo3Sym1KindInference GHC.Tuple.())
     data Foo3Sym1 (l :: a0123456789)
                   (l :: TyFun b0123456789 a0123456789)
-      = forall arg. KindOf (Apply (Foo3Sym1 l) arg) ~ KindOf (Foo3Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Foo3Sym1 l) arg) (Foo3Sym2 l arg) =>
         Foo3Sym1KindInference
     type instance Apply (Foo3Sym1 l) l = Foo3Sym2 l l
     instance SuppressUnusedWarnings Foo3Sym0 where
@@ -132,7 +132,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) Foo3Sym0KindInference GHC.Tuple.())
     data Foo3Sym0 (l :: TyFun a0123456789 (TyFun b0123456789 a0123456789
                                            -> GHC.Types.Type))
-      = forall arg. KindOf (Apply Foo3Sym0 arg) ~ KindOf (Foo3Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
         Foo3Sym0KindInference
     type instance Apply Foo3Sym0 l = Foo3Sym1 l
     type Foo2Sym2 (t :: a0123456789) (t :: Maybe a0123456789) =
@@ -142,7 +142,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) Foo2Sym1KindInference GHC.Tuple.())
     data Foo2Sym1 (l :: a0123456789)
                   (l :: TyFun (Maybe a0123456789) a0123456789)
-      = forall arg. KindOf (Apply (Foo2Sym1 l) arg) ~ KindOf (Foo2Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Foo2Sym1 l) arg) (Foo2Sym2 l arg) =>
         Foo2Sym1KindInference
     type instance Apply (Foo2Sym1 l) l = Foo2Sym2 l l
     instance SuppressUnusedWarnings Foo2Sym0 where
@@ -150,7 +150,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) Foo2Sym0KindInference GHC.Tuple.())
     data Foo2Sym0 (l :: TyFun a0123456789 (TyFun (Maybe a0123456789) a0123456789
                                            -> GHC.Types.Type))
-      = forall arg. KindOf (Apply Foo2Sym0 arg) ~ KindOf (Foo2Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) =>
         Foo2Sym0KindInference
     type instance Apply Foo2Sym0 l = Foo2Sym1 l
     type Foo1Sym2 (t :: a0123456789) (t :: Maybe a0123456789) =
@@ -160,7 +160,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) Foo1Sym1KindInference GHC.Tuple.())
     data Foo1Sym1 (l :: a0123456789)
                   (l :: TyFun (Maybe a0123456789) a0123456789)
-      = forall arg. KindOf (Apply (Foo1Sym1 l) arg) ~ KindOf (Foo1Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Foo1Sym1 l) arg) (Foo1Sym2 l arg) =>
         Foo1Sym1KindInference
     type instance Apply (Foo1Sym1 l) l = Foo1Sym2 l l
     instance SuppressUnusedWarnings Foo1Sym0 where
@@ -168,7 +168,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) Foo1Sym0KindInference GHC.Tuple.())
     data Foo1Sym0 (l :: TyFun a0123456789 (TyFun (Maybe a0123456789) a0123456789
                                            -> GHC.Types.Type))
-      = forall arg. KindOf (Apply Foo1Sym0 arg) ~ KindOf (Foo1Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
         Foo1Sym0KindInference
     type instance Apply Foo1Sym0 l = Foo1Sym1 l
     type family Foo3 (a :: a) (a :: b) :: a where

--- a/tests/compile-and-dump/Singletons/Lambdas.ghc80.template
+++ b/tests/compile-and-dump/Singletons/Lambdas.ghc80.template
@@ -46,7 +46,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) FooSym1KindInference GHC.Tuple.())
     data FooSym1 (l :: a0123456789)
                  (l :: TyFun b0123456789 (Foo a0123456789 b0123456789))
-      = forall arg. KindOf (Apply (FooSym1 l) arg) ~ KindOf (FooSym2 l arg) =>
+      = forall arg. SameKind (Apply (FooSym1 l) arg) (FooSym2 l arg) =>
         FooSym1KindInference
     type instance Apply (FooSym1 l) l = FooSym2 l l
     instance SuppressUnusedWarnings FooSym0 where
@@ -54,7 +54,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) FooSym0KindInference GHC.Tuple.())
     data FooSym0 (l :: TyFun a0123456789 (TyFun b0123456789 (Foo a0123456789 b0123456789)
                                           -> GHC.Types.Type))
-      = forall arg. KindOf (Apply FooSym0 arg) ~ KindOf (FooSym1 arg) =>
+      = forall arg. SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
         FooSym0KindInference
     type instance Apply FooSym0 l = FooSym1 l
     type family Case_0123456789 x arg_0123456789 t where
@@ -67,7 +67,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym1KindInference GHC.Tuple.())
     data Lambda_0123456789Sym1 l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym1 l) arg) ~ KindOf (Lambda_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym1 l) arg) (Lambda_0123456789Sym2 l arg) =>
         Lambda_0123456789Sym1KindInference
     type instance Apply (Lambda_0123456789Sym1 l) l = Lambda_0123456789Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym0 where
@@ -75,7 +75,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym0KindInference GHC.Tuple.())
     data Lambda_0123456789Sym0 l
-      = forall arg. KindOf (Apply Lambda_0123456789Sym0 arg) ~ KindOf (Lambda_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Lambda_0123456789Sym0 arg) (Lambda_0123456789Sym1 arg) =>
         Lambda_0123456789Sym0KindInference
     type instance Apply Lambda_0123456789Sym0 l = Lambda_0123456789Sym1 l
     type family Case_0123456789 x y arg_0123456789 t where
@@ -88,7 +88,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym2KindInference GHC.Tuple.())
     data Lambda_0123456789Sym2 l l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym2 l l) arg) ~ KindOf (Lambda_0123456789Sym3 l l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym2 l l) arg) (Lambda_0123456789Sym3 l l arg) =>
         Lambda_0123456789Sym2KindInference
     type instance Apply (Lambda_0123456789Sym2 l l) l = Lambda_0123456789Sym3 l l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym1 where
@@ -96,7 +96,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym1KindInference GHC.Tuple.())
     data Lambda_0123456789Sym1 l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym1 l) arg) ~ KindOf (Lambda_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym1 l) arg) (Lambda_0123456789Sym2 l arg) =>
         Lambda_0123456789Sym1KindInference
     type instance Apply (Lambda_0123456789Sym1 l) l = Lambda_0123456789Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym0 where
@@ -104,7 +104,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym0KindInference GHC.Tuple.())
     data Lambda_0123456789Sym0 l
-      = forall arg. KindOf (Apply Lambda_0123456789Sym0 arg) ~ KindOf (Lambda_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Lambda_0123456789Sym0 arg) (Lambda_0123456789Sym1 arg) =>
         Lambda_0123456789Sym0KindInference
     type instance Apply Lambda_0123456789Sym0 l = Lambda_0123456789Sym1 l
     type family Case_0123456789 a b x arg_0123456789 t where
@@ -117,7 +117,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym3KindInference GHC.Tuple.())
     data Lambda_0123456789Sym3 l l l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym3 l l l) arg) ~ KindOf (Lambda_0123456789Sym4 l l l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym3 l l l) arg) (Lambda_0123456789Sym4 l l l arg) =>
         Lambda_0123456789Sym3KindInference
     type instance Apply (Lambda_0123456789Sym3 l l l) l = Lambda_0123456789Sym4 l l l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym2 where
@@ -125,7 +125,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym2KindInference GHC.Tuple.())
     data Lambda_0123456789Sym2 l l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym2 l l) arg) ~ KindOf (Lambda_0123456789Sym3 l l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym2 l l) arg) (Lambda_0123456789Sym3 l l arg) =>
         Lambda_0123456789Sym2KindInference
     type instance Apply (Lambda_0123456789Sym2 l l) l = Lambda_0123456789Sym3 l l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym1 where
@@ -133,7 +133,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym1KindInference GHC.Tuple.())
     data Lambda_0123456789Sym1 l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym1 l) arg) ~ KindOf (Lambda_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym1 l) arg) (Lambda_0123456789Sym2 l arg) =>
         Lambda_0123456789Sym1KindInference
     type instance Apply (Lambda_0123456789Sym1 l) l = Lambda_0123456789Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym0 where
@@ -141,7 +141,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym0KindInference GHC.Tuple.())
     data Lambda_0123456789Sym0 l
-      = forall arg. KindOf (Apply Lambda_0123456789Sym0 arg) ~ KindOf (Lambda_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Lambda_0123456789Sym0 arg) (Lambda_0123456789Sym1 arg) =>
         Lambda_0123456789Sym0KindInference
     type instance Apply Lambda_0123456789Sym0 l = Lambda_0123456789Sym1 l
     type family Lambda_0123456789 a b t where
@@ -152,7 +152,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym2KindInference GHC.Tuple.())
     data Lambda_0123456789Sym2 l l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym2 l l) arg) ~ KindOf (Lambda_0123456789Sym3 l l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym2 l l) arg) (Lambda_0123456789Sym3 l l arg) =>
         Lambda_0123456789Sym2KindInference
     type instance Apply (Lambda_0123456789Sym2 l l) l = Lambda_0123456789Sym3 l l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym1 where
@@ -160,7 +160,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym1KindInference GHC.Tuple.())
     data Lambda_0123456789Sym1 l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym1 l) arg) ~ KindOf (Lambda_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym1 l) arg) (Lambda_0123456789Sym2 l arg) =>
         Lambda_0123456789Sym1KindInference
     type instance Apply (Lambda_0123456789Sym1 l) l = Lambda_0123456789Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym0 where
@@ -168,7 +168,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym0KindInference GHC.Tuple.())
     data Lambda_0123456789Sym0 l
-      = forall arg. KindOf (Apply Lambda_0123456789Sym0 arg) ~ KindOf (Lambda_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Lambda_0123456789Sym0 arg) (Lambda_0123456789Sym1 arg) =>
         Lambda_0123456789Sym0KindInference
     type instance Apply Lambda_0123456789Sym0 l = Lambda_0123456789Sym1 l
     type family Lambda_0123456789 x y t where
@@ -179,7 +179,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym2KindInference GHC.Tuple.())
     data Lambda_0123456789Sym2 l l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym2 l l) arg) ~ KindOf (Lambda_0123456789Sym3 l l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym2 l l) arg) (Lambda_0123456789Sym3 l l arg) =>
         Lambda_0123456789Sym2KindInference
     type instance Apply (Lambda_0123456789Sym2 l l) l = Lambda_0123456789Sym3 l l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym1 where
@@ -187,7 +187,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym1KindInference GHC.Tuple.())
     data Lambda_0123456789Sym1 l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym1 l) arg) ~ KindOf (Lambda_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym1 l) arg) (Lambda_0123456789Sym2 l arg) =>
         Lambda_0123456789Sym1KindInference
     type instance Apply (Lambda_0123456789Sym1 l) l = Lambda_0123456789Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym0 where
@@ -195,7 +195,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym0KindInference GHC.Tuple.())
     data Lambda_0123456789Sym0 l
-      = forall arg. KindOf (Apply Lambda_0123456789Sym0 arg) ~ KindOf (Lambda_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Lambda_0123456789Sym0 arg) (Lambda_0123456789Sym1 arg) =>
         Lambda_0123456789Sym0KindInference
     type instance Apply Lambda_0123456789Sym0 l = Lambda_0123456789Sym1 l
     type family Case_0123456789 x
@@ -214,7 +214,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym4KindInference GHC.Tuple.())
     data Lambda_0123456789Sym4 l l l l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym4 l l l l) arg) ~ KindOf (Lambda_0123456789Sym5 l l l l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym4 l l l l) arg) (Lambda_0123456789Sym5 l l l l arg) =>
         Lambda_0123456789Sym4KindInference
     type instance Apply (Lambda_0123456789Sym4 l l l l) l = Lambda_0123456789Sym5 l l l l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym3 where
@@ -222,7 +222,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym3KindInference GHC.Tuple.())
     data Lambda_0123456789Sym3 l l l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym3 l l l) arg) ~ KindOf (Lambda_0123456789Sym4 l l l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym3 l l l) arg) (Lambda_0123456789Sym4 l l l arg) =>
         Lambda_0123456789Sym3KindInference
     type instance Apply (Lambda_0123456789Sym3 l l l) l = Lambda_0123456789Sym4 l l l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym2 where
@@ -230,7 +230,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym2KindInference GHC.Tuple.())
     data Lambda_0123456789Sym2 l l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym2 l l) arg) ~ KindOf (Lambda_0123456789Sym3 l l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym2 l l) arg) (Lambda_0123456789Sym3 l l arg) =>
         Lambda_0123456789Sym2KindInference
     type instance Apply (Lambda_0123456789Sym2 l l) l = Lambda_0123456789Sym3 l l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym1 where
@@ -238,7 +238,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym1KindInference GHC.Tuple.())
     data Lambda_0123456789Sym1 l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym1 l) arg) ~ KindOf (Lambda_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym1 l) arg) (Lambda_0123456789Sym2 l arg) =>
         Lambda_0123456789Sym1KindInference
     type instance Apply (Lambda_0123456789Sym1 l) l = Lambda_0123456789Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym0 where
@@ -246,7 +246,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym0KindInference GHC.Tuple.())
     data Lambda_0123456789Sym0 l
-      = forall arg. KindOf (Apply Lambda_0123456789Sym0 arg) ~ KindOf (Lambda_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Lambda_0123456789Sym0 arg) (Lambda_0123456789Sym1 arg) =>
         Lambda_0123456789Sym0KindInference
     type instance Apply Lambda_0123456789Sym0 l = Lambda_0123456789Sym1 l
     type family Lambda_0123456789 x t where
@@ -257,7 +257,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym1KindInference GHC.Tuple.())
     data Lambda_0123456789Sym1 l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym1 l) arg) ~ KindOf (Lambda_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym1 l) arg) (Lambda_0123456789Sym2 l arg) =>
         Lambda_0123456789Sym1KindInference
     type instance Apply (Lambda_0123456789Sym1 l) l = Lambda_0123456789Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym0 where
@@ -265,7 +265,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym0KindInference GHC.Tuple.())
     data Lambda_0123456789Sym0 l
-      = forall arg. KindOf (Apply Lambda_0123456789Sym0 arg) ~ KindOf (Lambda_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Lambda_0123456789Sym0 arg) (Lambda_0123456789Sym1 arg) =>
         Lambda_0123456789Sym0KindInference
     type instance Apply Lambda_0123456789Sym0 l = Lambda_0123456789Sym1 l
     type family Case_0123456789 x y arg_0123456789 t where
@@ -278,7 +278,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym2KindInference GHC.Tuple.())
     data Lambda_0123456789Sym2 l l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym2 l l) arg) ~ KindOf (Lambda_0123456789Sym3 l l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym2 l l) arg) (Lambda_0123456789Sym3 l l arg) =>
         Lambda_0123456789Sym2KindInference
     type instance Apply (Lambda_0123456789Sym2 l l) l = Lambda_0123456789Sym3 l l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym1 where
@@ -286,7 +286,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym1KindInference GHC.Tuple.())
     data Lambda_0123456789Sym1 l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym1 l) arg) ~ KindOf (Lambda_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym1 l) arg) (Lambda_0123456789Sym2 l arg) =>
         Lambda_0123456789Sym1KindInference
     type instance Apply (Lambda_0123456789Sym1 l) l = Lambda_0123456789Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym0 where
@@ -294,7 +294,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym0KindInference GHC.Tuple.())
     data Lambda_0123456789Sym0 l
-      = forall arg. KindOf (Apply Lambda_0123456789Sym0 arg) ~ KindOf (Lambda_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Lambda_0123456789Sym0 arg) (Lambda_0123456789Sym1 arg) =>
         Lambda_0123456789Sym0KindInference
     type instance Apply Lambda_0123456789Sym0 l = Lambda_0123456789Sym1 l
     type family Case_0123456789 x arg_0123456789 a_0123456789 t where
@@ -307,7 +307,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym2KindInference GHC.Tuple.())
     data Lambda_0123456789Sym2 l l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym2 l l) arg) ~ KindOf (Lambda_0123456789Sym3 l l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym2 l l) arg) (Lambda_0123456789Sym3 l l arg) =>
         Lambda_0123456789Sym2KindInference
     type instance Apply (Lambda_0123456789Sym2 l l) l = Lambda_0123456789Sym3 l l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym1 where
@@ -315,7 +315,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym1KindInference GHC.Tuple.())
     data Lambda_0123456789Sym1 l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym1 l) arg) ~ KindOf (Lambda_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym1 l) arg) (Lambda_0123456789Sym2 l arg) =>
         Lambda_0123456789Sym1KindInference
     type instance Apply (Lambda_0123456789Sym1 l) l = Lambda_0123456789Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym0 where
@@ -323,7 +323,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym0KindInference GHC.Tuple.())
     data Lambda_0123456789Sym0 l
-      = forall arg. KindOf (Apply Lambda_0123456789Sym0 arg) ~ KindOf (Lambda_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Lambda_0123456789Sym0 arg) (Lambda_0123456789Sym1 arg) =>
         Lambda_0123456789Sym0KindInference
     type instance Apply Lambda_0123456789Sym0 l = Lambda_0123456789Sym1 l
     type family Lambda_0123456789 a_0123456789 a_0123456789 t t where
@@ -334,7 +334,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym3KindInference GHC.Tuple.())
     data Lambda_0123456789Sym3 l l l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym3 l l l) arg) ~ KindOf (Lambda_0123456789Sym4 l l l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym3 l l l) arg) (Lambda_0123456789Sym4 l l l arg) =>
         Lambda_0123456789Sym3KindInference
     type instance Apply (Lambda_0123456789Sym3 l l l) l = Lambda_0123456789Sym4 l l l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym2 where
@@ -342,7 +342,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym2KindInference GHC.Tuple.())
     data Lambda_0123456789Sym2 l l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym2 l l) arg) ~ KindOf (Lambda_0123456789Sym3 l l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym2 l l) arg) (Lambda_0123456789Sym3 l l arg) =>
         Lambda_0123456789Sym2KindInference
     type instance Apply (Lambda_0123456789Sym2 l l) l = Lambda_0123456789Sym3 l l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym1 where
@@ -350,7 +350,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym1KindInference GHC.Tuple.())
     data Lambda_0123456789Sym1 l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym1 l) arg) ~ KindOf (Lambda_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym1 l) arg) (Lambda_0123456789Sym2 l arg) =>
         Lambda_0123456789Sym1KindInference
     type instance Apply (Lambda_0123456789Sym1 l) l = Lambda_0123456789Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym0 where
@@ -358,7 +358,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym0KindInference GHC.Tuple.())
     data Lambda_0123456789Sym0 l
-      = forall arg. KindOf (Apply Lambda_0123456789Sym0 arg) ~ KindOf (Lambda_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Lambda_0123456789Sym0 arg) (Lambda_0123456789Sym1 arg) =>
         Lambda_0123456789Sym0KindInference
     type instance Apply Lambda_0123456789Sym0 l = Lambda_0123456789Sym1 l
     type Foo8Sym1 (t :: Foo a0123456789 b0123456789) = Foo8 t
@@ -366,7 +366,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Foo8Sym0KindInference GHC.Tuple.())
     data Foo8Sym0 (l :: TyFun (Foo a0123456789 b0123456789) a0123456789)
-      = forall arg. KindOf (Apply Foo8Sym0 arg) ~ KindOf (Foo8Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo8Sym0 arg) (Foo8Sym1 arg) =>
         Foo8Sym0KindInference
     type instance Apply Foo8Sym0 l = Foo8Sym1 l
     type Foo7Sym2 (t :: a0123456789) (t :: b0123456789) = Foo7 t t
@@ -375,7 +375,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) Foo7Sym1KindInference GHC.Tuple.())
     data Foo7Sym1 (l :: a0123456789)
                   (l :: TyFun b0123456789 b0123456789)
-      = forall arg. KindOf (Apply (Foo7Sym1 l) arg) ~ KindOf (Foo7Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Foo7Sym1 l) arg) (Foo7Sym2 l arg) =>
         Foo7Sym1KindInference
     type instance Apply (Foo7Sym1 l) l = Foo7Sym2 l l
     instance SuppressUnusedWarnings Foo7Sym0 where
@@ -383,7 +383,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) Foo7Sym0KindInference GHC.Tuple.())
     data Foo7Sym0 (l :: TyFun a0123456789 (TyFun b0123456789 b0123456789
                                            -> GHC.Types.Type))
-      = forall arg. KindOf (Apply Foo7Sym0 arg) ~ KindOf (Foo7Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo7Sym0 arg) (Foo7Sym1 arg) =>
         Foo7Sym0KindInference
     type instance Apply Foo7Sym0 l = Foo7Sym1 l
     type Foo6Sym2 (t :: a0123456789) (t :: b0123456789) = Foo6 t t
@@ -392,7 +392,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) Foo6Sym1KindInference GHC.Tuple.())
     data Foo6Sym1 (l :: a0123456789)
                   (l :: TyFun b0123456789 a0123456789)
-      = forall arg. KindOf (Apply (Foo6Sym1 l) arg) ~ KindOf (Foo6Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Foo6Sym1 l) arg) (Foo6Sym2 l arg) =>
         Foo6Sym1KindInference
     type instance Apply (Foo6Sym1 l) l = Foo6Sym2 l l
     instance SuppressUnusedWarnings Foo6Sym0 where
@@ -400,7 +400,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) Foo6Sym0KindInference GHC.Tuple.())
     data Foo6Sym0 (l :: TyFun a0123456789 (TyFun b0123456789 a0123456789
                                            -> GHC.Types.Type))
-      = forall arg. KindOf (Apply Foo6Sym0 arg) ~ KindOf (Foo6Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo6Sym0 arg) (Foo6Sym1 arg) =>
         Foo6Sym0KindInference
     type instance Apply Foo6Sym0 l = Foo6Sym1 l
     type Foo5Sym2 (t :: a0123456789) (t :: b0123456789) = Foo5 t t
@@ -409,7 +409,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) Foo5Sym1KindInference GHC.Tuple.())
     data Foo5Sym1 (l :: a0123456789)
                   (l :: TyFun b0123456789 b0123456789)
-      = forall arg. KindOf (Apply (Foo5Sym1 l) arg) ~ KindOf (Foo5Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Foo5Sym1 l) arg) (Foo5Sym2 l arg) =>
         Foo5Sym1KindInference
     type instance Apply (Foo5Sym1 l) l = Foo5Sym2 l l
     instance SuppressUnusedWarnings Foo5Sym0 where
@@ -417,7 +417,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) Foo5Sym0KindInference GHC.Tuple.())
     data Foo5Sym0 (l :: TyFun a0123456789 (TyFun b0123456789 b0123456789
                                            -> GHC.Types.Type))
-      = forall arg. KindOf (Apply Foo5Sym0 arg) ~ KindOf (Foo5Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo5Sym0 arg) (Foo5Sym1 arg) =>
         Foo5Sym0KindInference
     type instance Apply Foo5Sym0 l = Foo5Sym1 l
     type Foo4Sym3 (t :: a0123456789)
@@ -430,7 +430,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     data Foo4Sym2 (l :: a0123456789)
                   (l :: b0123456789)
                   (l :: TyFun c0123456789 a0123456789)
-      = forall arg. KindOf (Apply (Foo4Sym2 l l) arg) ~ KindOf (Foo4Sym3 l l arg) =>
+      = forall arg. SameKind (Apply (Foo4Sym2 l l) arg) (Foo4Sym3 l l arg) =>
         Foo4Sym2KindInference
     type instance Apply (Foo4Sym2 l l) l = Foo4Sym3 l l l
     instance SuppressUnusedWarnings Foo4Sym1 where
@@ -439,7 +439,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     data Foo4Sym1 (l :: a0123456789)
                   (l :: TyFun b0123456789 (TyFun c0123456789 a0123456789
                                            -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (Foo4Sym1 l) arg) ~ KindOf (Foo4Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Foo4Sym1 l) arg) (Foo4Sym2 l arg) =>
         Foo4Sym1KindInference
     type instance Apply (Foo4Sym1 l) l = Foo4Sym2 l l
     instance SuppressUnusedWarnings Foo4Sym0 where
@@ -448,7 +448,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     data Foo4Sym0 (l :: TyFun a0123456789 (TyFun b0123456789 (TyFun c0123456789 a0123456789
                                                               -> GHC.Types.Type)
                                            -> GHC.Types.Type))
-      = forall arg. KindOf (Apply Foo4Sym0 arg) ~ KindOf (Foo4Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo4Sym0 arg) (Foo4Sym1 arg) =>
         Foo4Sym0KindInference
     type instance Apply Foo4Sym0 l = Foo4Sym1 l
     type Foo3Sym1 (t :: a0123456789) = Foo3 t
@@ -456,7 +456,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Foo3Sym0KindInference GHC.Tuple.())
     data Foo3Sym0 (l :: TyFun a0123456789 a0123456789)
-      = forall arg. KindOf (Apply Foo3Sym0 arg) ~ KindOf (Foo3Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
         Foo3Sym0KindInference
     type instance Apply Foo3Sym0 l = Foo3Sym1 l
     type Foo2Sym2 (t :: a0123456789) (t :: b0123456789) = Foo2 t t
@@ -465,7 +465,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) Foo2Sym1KindInference GHC.Tuple.())
     data Foo2Sym1 (l :: a0123456789)
                   (l :: TyFun b0123456789 a0123456789)
-      = forall arg. KindOf (Apply (Foo2Sym1 l) arg) ~ KindOf (Foo2Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Foo2Sym1 l) arg) (Foo2Sym2 l arg) =>
         Foo2Sym1KindInference
     type instance Apply (Foo2Sym1 l) l = Foo2Sym2 l l
     instance SuppressUnusedWarnings Foo2Sym0 where
@@ -473,7 +473,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) Foo2Sym0KindInference GHC.Tuple.())
     data Foo2Sym0 (l :: TyFun a0123456789 (TyFun b0123456789 a0123456789
                                            -> GHC.Types.Type))
-      = forall arg. KindOf (Apply Foo2Sym0 arg) ~ KindOf (Foo2Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) =>
         Foo2Sym0KindInference
     type instance Apply Foo2Sym0 l = Foo2Sym1 l
     type Foo1Sym2 (t :: a0123456789) (t :: b0123456789) = Foo1 t t
@@ -482,7 +482,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) Foo1Sym1KindInference GHC.Tuple.())
     data Foo1Sym1 (l :: a0123456789)
                   (l :: TyFun b0123456789 a0123456789)
-      = forall arg. KindOf (Apply (Foo1Sym1 l) arg) ~ KindOf (Foo1Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Foo1Sym1 l) arg) (Foo1Sym2 l arg) =>
         Foo1Sym1KindInference
     type instance Apply (Foo1Sym1 l) l = Foo1Sym2 l l
     instance SuppressUnusedWarnings Foo1Sym0 where
@@ -490,7 +490,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) Foo1Sym0KindInference GHC.Tuple.())
     data Foo1Sym0 (l :: TyFun a0123456789 (TyFun b0123456789 a0123456789
                                            -> GHC.Types.Type))
-      = forall arg. KindOf (Apply Foo1Sym0 arg) ~ KindOf (Foo1Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
         Foo1Sym0KindInference
     type instance Apply Foo1Sym0 l = Foo1Sym1 l
     type Foo0Sym2 (t :: a0123456789) (t :: b0123456789) = Foo0 t t
@@ -499,7 +499,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) Foo0Sym1KindInference GHC.Tuple.())
     data Foo0Sym1 (l :: a0123456789)
                   (l :: TyFun b0123456789 a0123456789)
-      = forall arg. KindOf (Apply (Foo0Sym1 l) arg) ~ KindOf (Foo0Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Foo0Sym1 l) arg) (Foo0Sym2 l arg) =>
         Foo0Sym1KindInference
     type instance Apply (Foo0Sym1 l) l = Foo0Sym2 l l
     instance SuppressUnusedWarnings Foo0Sym0 where
@@ -507,7 +507,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) Foo0Sym0KindInference GHC.Tuple.())
     data Foo0Sym0 (l :: TyFun a0123456789 (TyFun b0123456789 a0123456789
                                            -> GHC.Types.Type))
-      = forall arg. KindOf (Apply Foo0Sym0 arg) ~ KindOf (Foo0Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo0Sym0 arg) (Foo0Sym1 arg) =>
         Foo0Sym0KindInference
     type instance Apply Foo0Sym0 l = Foo0Sym1 l
     type family Foo8 (a :: Foo a b) :: a where

--- a/tests/compile-and-dump/Singletons/LambdasComprehensive.ghc80.template
+++ b/tests/compile-and-dump/Singletons/LambdasComprehensive.ghc80.template
@@ -19,7 +19,7 @@ Singletons/LambdasComprehensive.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym0KindInference GHC.Tuple.())
     data Lambda_0123456789Sym0 l
-      = forall arg. KindOf (Apply Lambda_0123456789Sym0 arg) ~ KindOf (Lambda_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Lambda_0123456789Sym0 arg) (Lambda_0123456789Sym1 arg) =>
         Lambda_0123456789Sym0KindInference
     type instance Apply Lambda_0123456789Sym0 l = Lambda_0123456789Sym1 l
     type BarSym0 = Bar

--- a/tests/compile-and-dump/Singletons/LetStatements.ghc80.template
+++ b/tests/compile-and-dump/Singletons/LetStatements.ghc80.template
@@ -198,7 +198,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789YSym0KindInference GHC.Tuple.())
     data Let0123456789YSym0 l
-      = forall arg. KindOf (Apply Let0123456789YSym0 arg) ~ KindOf (Let0123456789YSym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789YSym0 arg) (Let0123456789YSym1 arg) =>
         Let0123456789YSym0KindInference
     type instance Apply Let0123456789YSym0 l = Let0123456789YSym1 l
     type Let0123456789ZSym1 t = Let0123456789Z t
@@ -206,7 +206,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789ZSym0KindInference GHC.Tuple.())
     data Let0123456789ZSym0 l
-      = forall arg. KindOf (Apply Let0123456789ZSym0 arg) ~ KindOf (Let0123456789ZSym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789ZSym0 arg) (Let0123456789ZSym1 arg) =>
         Let0123456789ZSym0KindInference
     type instance Apply Let0123456789ZSym0 l = Let0123456789ZSym1 l
     type Let0123456789X_0123456789Sym1 t = Let0123456789X_0123456789 t
@@ -216,7 +216,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,)
                Let0123456789X_0123456789Sym0KindInference GHC.Tuple.())
     data Let0123456789X_0123456789Sym0 l
-      = forall arg. KindOf (Apply Let0123456789X_0123456789Sym0 arg) ~ KindOf (Let0123456789X_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789X_0123456789Sym0 arg) (Let0123456789X_0123456789Sym1 arg) =>
         Let0123456789X_0123456789Sym0KindInference
     type instance Apply Let0123456789X_0123456789Sym0 l = Let0123456789X_0123456789Sym1 l
     type family Let0123456789Y x where
@@ -231,7 +231,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Let0123456789BarSym0KindInference GHC.Tuple.())
     data Let0123456789BarSym0 l
-      = forall arg. KindOf (Apply Let0123456789BarSym0 arg) ~ KindOf (Let0123456789BarSym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789BarSym0 arg) (Let0123456789BarSym1 arg) =>
         Let0123456789BarSym0KindInference
     type instance Apply Let0123456789BarSym0 l = Let0123456789BarSym1 l
     type family Let0123456789Bar x :: a where
@@ -242,7 +242,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) (:<<<%%%%%%%%%%:+$$$###) GHC.Tuple.())
     data (:<<<%%%%%%%%%%:+$$$) l (l :: Nat) (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply ((:<<<%%%%%%%%%%:+$$$) l l) arg) ~ KindOf ((:<<<%%%%%%%%%%:+$$$$) l l arg) =>
+      = forall arg. SameKind (Apply ((:<<<%%%%%%%%%%:+$$$) l l) arg) ((:<<<%%%%%%%%%%:+$$$$) l l arg) =>
         (:<<<%%%%%%%%%%:+$$$###)
     type instance Apply ((:<<<%%%%%%%%%%:+$$$) l l) l = (:<<<%%%%%%%%%%:+$$$$) l l l
     instance SuppressUnusedWarnings (:<<<%%%%%%%%%%:+$$) where
@@ -250,14 +250,14 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) (:<<<%%%%%%%%%%:+$$###) GHC.Tuple.())
     data (:<<<%%%%%%%%%%:+$$) l
                               (l :: TyFun Nat (TyFun Nat Nat -> GHC.Types.Type))
-      = forall arg. KindOf (Apply ((:<<<%%%%%%%%%%:+$$) l) arg) ~ KindOf ((:<<<%%%%%%%%%%:+$$$) l arg) =>
+      = forall arg. SameKind (Apply ((:<<<%%%%%%%%%%:+$$) l) arg) ((:<<<%%%%%%%%%%:+$$$) l arg) =>
         (:<<<%%%%%%%%%%:+$$###)
     type instance Apply ((:<<<%%%%%%%%%%:+$$) l) l = (:<<<%%%%%%%%%%:+$$$) l l
     instance SuppressUnusedWarnings (:<<<%%%%%%%%%%:+$) where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) (:<<<%%%%%%%%%%:+$###) GHC.Tuple.())
     data (:<<<%%%%%%%%%%:+$) l
-      = forall arg. KindOf (Apply (:<<<%%%%%%%%%%:+$) arg) ~ KindOf ((:<<<%%%%%%%%%%:+$$) arg) =>
+      = forall arg. SameKind (Apply (:<<<%%%%%%%%%%:+$) arg) ((:<<<%%%%%%%%%%:+$$) arg) =>
         (:<<<%%%%%%%%%%:+$###)
     type instance Apply (:<<<%%%%%%%%%%:+$) l = (:<<<%%%%%%%%%%:+$$) l
     type family (:<<<%%%%%%%%%%:+) x (a :: Nat) (a :: Nat) :: Nat where
@@ -268,7 +268,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789ZSym0KindInference GHC.Tuple.())
     data Let0123456789ZSym0 l
-      = forall arg. KindOf (Apply Let0123456789ZSym0 arg) ~ KindOf (Let0123456789ZSym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789ZSym0 arg) (Let0123456789ZSym1 arg) =>
         Let0123456789ZSym0KindInference
     type instance Apply Let0123456789ZSym0 l = Let0123456789ZSym1 l
     type (:<<<%%%%%%%%%%:+$$$$) t (t :: Nat) (t :: Nat) =
@@ -277,7 +277,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) (:<<<%%%%%%%%%%:+$$$###) GHC.Tuple.())
     data (:<<<%%%%%%%%%%:+$$$) l (l :: Nat) (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply ((:<<<%%%%%%%%%%:+$$$) l l) arg) ~ KindOf ((:<<<%%%%%%%%%%:+$$$$) l l arg) =>
+      = forall arg. SameKind (Apply ((:<<<%%%%%%%%%%:+$$$) l l) arg) ((:<<<%%%%%%%%%%:+$$$$) l l arg) =>
         (:<<<%%%%%%%%%%:+$$$###)
     type instance Apply ((:<<<%%%%%%%%%%:+$$$) l l) l = (:<<<%%%%%%%%%%:+$$$$) l l l
     instance SuppressUnusedWarnings (:<<<%%%%%%%%%%:+$$) where
@@ -285,14 +285,14 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) (:<<<%%%%%%%%%%:+$$###) GHC.Tuple.())
     data (:<<<%%%%%%%%%%:+$$) l
                               (l :: TyFun Nat (TyFun Nat Nat -> GHC.Types.Type))
-      = forall arg. KindOf (Apply ((:<<<%%%%%%%%%%:+$$) l) arg) ~ KindOf ((:<<<%%%%%%%%%%:+$$$) l arg) =>
+      = forall arg. SameKind (Apply ((:<<<%%%%%%%%%%:+$$) l) arg) ((:<<<%%%%%%%%%%:+$$$) l arg) =>
         (:<<<%%%%%%%%%%:+$$###)
     type instance Apply ((:<<<%%%%%%%%%%:+$$) l) l = (:<<<%%%%%%%%%%:+$$$) l l
     instance SuppressUnusedWarnings (:<<<%%%%%%%%%%:+$) where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) (:<<<%%%%%%%%%%:+$###) GHC.Tuple.())
     data (:<<<%%%%%%%%%%:+$) l
-      = forall arg. KindOf (Apply (:<<<%%%%%%%%%%:+$) arg) ~ KindOf ((:<<<%%%%%%%%%%:+$$) arg) =>
+      = forall arg. SameKind (Apply (:<<<%%%%%%%%%%:+$) arg) ((:<<<%%%%%%%%%%:+$$) arg) =>
         (:<<<%%%%%%%%%%:+$###)
     type instance Apply (:<<<%%%%%%%%%%:+$) l = (:<<<%%%%%%%%%%:+$$) l
     type family Let0123456789Z x :: Nat where
@@ -306,7 +306,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) (:<<<%%%%%%%%%%:+$$$###) GHC.Tuple.())
     data (:<<<%%%%%%%%%%:+$$$) l (l :: Nat) (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply ((:<<<%%%%%%%%%%:+$$$) l l) arg) ~ KindOf ((:<<<%%%%%%%%%%:+$$$$) l l arg) =>
+      = forall arg. SameKind (Apply ((:<<<%%%%%%%%%%:+$$$) l l) arg) ((:<<<%%%%%%%%%%:+$$$$) l l arg) =>
         (:<<<%%%%%%%%%%:+$$$###)
     type instance Apply ((:<<<%%%%%%%%%%:+$$$) l l) l = (:<<<%%%%%%%%%%:+$$$$) l l l
     instance SuppressUnusedWarnings (:<<<%%%%%%%%%%:+$$) where
@@ -314,14 +314,14 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) (:<<<%%%%%%%%%%:+$$###) GHC.Tuple.())
     data (:<<<%%%%%%%%%%:+$$) l
                               (l :: TyFun Nat (TyFun Nat Nat -> GHC.Types.Type))
-      = forall arg. KindOf (Apply ((:<<<%%%%%%%%%%:+$$) l) arg) ~ KindOf ((:<<<%%%%%%%%%%:+$$$) l arg) =>
+      = forall arg. SameKind (Apply ((:<<<%%%%%%%%%%:+$$) l) arg) ((:<<<%%%%%%%%%%:+$$$) l arg) =>
         (:<<<%%%%%%%%%%:+$$###)
     type instance Apply ((:<<<%%%%%%%%%%:+$$) l) l = (:<<<%%%%%%%%%%:+$$$) l l
     instance SuppressUnusedWarnings (:<<<%%%%%%%%%%:+$) where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) (:<<<%%%%%%%%%%:+$###) GHC.Tuple.())
     data (:<<<%%%%%%%%%%:+$) l
-      = forall arg. KindOf (Apply (:<<<%%%%%%%%%%:+$) arg) ~ KindOf ((:<<<%%%%%%%%%%:+$$) arg) =>
+      = forall arg. SameKind (Apply (:<<<%%%%%%%%%%:+$) arg) ((:<<<%%%%%%%%%%:+$$) arg) =>
         (:<<<%%%%%%%%%%:+$###)
     type instance Apply (:<<<%%%%%%%%%%:+$) l = (:<<<%%%%%%%%%%:+$$) l
     type family (:<<<%%%%%%%%%%:+) x (a :: Nat) (a :: Nat) :: Nat where
@@ -335,7 +335,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym2KindInference GHC.Tuple.())
     data Lambda_0123456789Sym2 l l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym2 l l) arg) ~ KindOf (Lambda_0123456789Sym3 l l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym2 l l) arg) (Lambda_0123456789Sym3 l l arg) =>
         Lambda_0123456789Sym2KindInference
     type instance Apply (Lambda_0123456789Sym2 l l) l = Lambda_0123456789Sym3 l l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym1 where
@@ -343,7 +343,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym1KindInference GHC.Tuple.())
     data Lambda_0123456789Sym1 l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym1 l) arg) ~ KindOf (Lambda_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym1 l) arg) (Lambda_0123456789Sym2 l arg) =>
         Lambda_0123456789Sym1KindInference
     type instance Apply (Lambda_0123456789Sym1 l) l = Lambda_0123456789Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym0 where
@@ -351,7 +351,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym0KindInference GHC.Tuple.())
     data Lambda_0123456789Sym0 l
-      = forall arg. KindOf (Apply Lambda_0123456789Sym0 arg) ~ KindOf (Lambda_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Lambda_0123456789Sym0 arg) (Lambda_0123456789Sym1 arg) =>
         Lambda_0123456789Sym0KindInference
     type instance Apply Lambda_0123456789Sym0 l = Lambda_0123456789Sym1 l
     type Let0123456789ZSym2 t (t :: Nat) = Let0123456789Z t t
@@ -359,14 +359,14 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789ZSym1KindInference GHC.Tuple.())
     data Let0123456789ZSym1 l (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply (Let0123456789ZSym1 l) arg) ~ KindOf (Let0123456789ZSym2 l arg) =>
+      = forall arg. SameKind (Apply (Let0123456789ZSym1 l) arg) (Let0123456789ZSym2 l arg) =>
         Let0123456789ZSym1KindInference
     type instance Apply (Let0123456789ZSym1 l) l = Let0123456789ZSym2 l l
     instance SuppressUnusedWarnings Let0123456789ZSym0 where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789ZSym0KindInference GHC.Tuple.())
     data Let0123456789ZSym0 l
-      = forall arg. KindOf (Apply Let0123456789ZSym0 arg) ~ KindOf (Let0123456789ZSym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789ZSym0 arg) (Let0123456789ZSym1 arg) =>
         Let0123456789ZSym0KindInference
     type instance Apply Let0123456789ZSym0 l = Let0123456789ZSym1 l
     type family Let0123456789Z x (a :: Nat) :: Nat where
@@ -379,7 +379,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym1KindInference GHC.Tuple.())
     data Lambda_0123456789Sym1 l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym1 l) arg) ~ KindOf (Lambda_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym1 l) arg) (Lambda_0123456789Sym2 l arg) =>
         Lambda_0123456789Sym1KindInference
     type instance Apply (Lambda_0123456789Sym1 l) l = Lambda_0123456789Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym0 where
@@ -387,7 +387,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym0KindInference GHC.Tuple.())
     data Lambda_0123456789Sym0 l
-      = forall arg. KindOf (Apply Lambda_0123456789Sym0 arg) ~ KindOf (Lambda_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Lambda_0123456789Sym0 arg) (Lambda_0123456789Sym1 arg) =>
         Lambda_0123456789Sym0KindInference
     type instance Apply Lambda_0123456789Sym0 l = Lambda_0123456789Sym1 l
     type Let0123456789ZSym1 t = Let0123456789Z t
@@ -395,7 +395,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789ZSym0KindInference GHC.Tuple.())
     data Let0123456789ZSym0 l
-      = forall arg. KindOf (Apply Let0123456789ZSym0 arg) ~ KindOf (Let0123456789ZSym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789ZSym0 arg) (Let0123456789ZSym1 arg) =>
         Let0123456789ZSym0KindInference
     type instance Apply Let0123456789ZSym0 l = Let0123456789ZSym1 l
     type family Let0123456789Z x :: Nat where
@@ -405,7 +405,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789XSym0KindInference GHC.Tuple.())
     data Let0123456789XSym0 l
-      = forall arg. KindOf (Apply Let0123456789XSym0 arg) ~ KindOf (Let0123456789XSym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789XSym0 arg) (Let0123456789XSym1 arg) =>
         Let0123456789XSym0KindInference
     type instance Apply Let0123456789XSym0 l = Let0123456789XSym1 l
     type family Let0123456789X x :: Nat where
@@ -415,14 +415,14 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789FSym1KindInference GHC.Tuple.())
     data Let0123456789FSym1 l (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply (Let0123456789FSym1 l) arg) ~ KindOf (Let0123456789FSym2 l arg) =>
+      = forall arg. SameKind (Apply (Let0123456789FSym1 l) arg) (Let0123456789FSym2 l arg) =>
         Let0123456789FSym1KindInference
     type instance Apply (Let0123456789FSym1 l) l = Let0123456789FSym2 l l
     instance SuppressUnusedWarnings Let0123456789FSym0 where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789FSym0KindInference GHC.Tuple.())
     data Let0123456789FSym0 l
-      = forall arg. KindOf (Apply Let0123456789FSym0 arg) ~ KindOf (Let0123456789FSym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789FSym0 arg) (Let0123456789FSym1 arg) =>
         Let0123456789FSym0KindInference
     type instance Apply Let0123456789FSym0 l = Let0123456789FSym1 l
     type family Let0123456789F x (a :: Nat) :: Nat where
@@ -432,7 +432,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789ZSym0KindInference GHC.Tuple.())
     data Let0123456789ZSym0 l
-      = forall arg. KindOf (Apply Let0123456789ZSym0 arg) ~ KindOf (Let0123456789ZSym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789ZSym0 arg) (Let0123456789ZSym1 arg) =>
         Let0123456789ZSym0KindInference
     type instance Apply Let0123456789ZSym0 l = Let0123456789ZSym1 l
     type family Let0123456789Z x :: Nat where
@@ -442,14 +442,14 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789ZSym1KindInference GHC.Tuple.())
     data Let0123456789ZSym1 l l
-      = forall arg. KindOf (Apply (Let0123456789ZSym1 l) arg) ~ KindOf (Let0123456789ZSym2 l arg) =>
+      = forall arg. SameKind (Apply (Let0123456789ZSym1 l) arg) (Let0123456789ZSym2 l arg) =>
         Let0123456789ZSym1KindInference
     type instance Apply (Let0123456789ZSym1 l) l = Let0123456789ZSym2 l l
     instance SuppressUnusedWarnings Let0123456789ZSym0 where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789ZSym0KindInference GHC.Tuple.())
     data Let0123456789ZSym0 l
-      = forall arg. KindOf (Apply Let0123456789ZSym0 arg) ~ KindOf (Let0123456789ZSym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789ZSym0 arg) (Let0123456789ZSym1 arg) =>
         Let0123456789ZSym0KindInference
     type instance Apply Let0123456789ZSym0 l = Let0123456789ZSym1 l
     type family Let0123456789Z x y :: Nat where
@@ -459,14 +459,14 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789FSym1KindInference GHC.Tuple.())
     data Let0123456789FSym1 l (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply (Let0123456789FSym1 l) arg) ~ KindOf (Let0123456789FSym2 l arg) =>
+      = forall arg. SameKind (Apply (Let0123456789FSym1 l) arg) (Let0123456789FSym2 l arg) =>
         Let0123456789FSym1KindInference
     type instance Apply (Let0123456789FSym1 l) l = Let0123456789FSym2 l l
     instance SuppressUnusedWarnings Let0123456789FSym0 where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789FSym0KindInference GHC.Tuple.())
     data Let0123456789FSym0 l
-      = forall arg. KindOf (Apply Let0123456789FSym0 arg) ~ KindOf (Let0123456789FSym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789FSym0 arg) (Let0123456789FSym1 arg) =>
         Let0123456789FSym0KindInference
     type instance Apply Let0123456789FSym0 l = Let0123456789FSym1 l
     type family Let0123456789F x (a :: Nat) :: Nat where
@@ -476,14 +476,14 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789FSym1KindInference GHC.Tuple.())
     data Let0123456789FSym1 l (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply (Let0123456789FSym1 l) arg) ~ KindOf (Let0123456789FSym2 l arg) =>
+      = forall arg. SameKind (Apply (Let0123456789FSym1 l) arg) (Let0123456789FSym2 l arg) =>
         Let0123456789FSym1KindInference
     type instance Apply (Let0123456789FSym1 l) l = Let0123456789FSym2 l l
     instance SuppressUnusedWarnings Let0123456789FSym0 where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789FSym0KindInference GHC.Tuple.())
     data Let0123456789FSym0 l
-      = forall arg. KindOf (Apply Let0123456789FSym0 arg) ~ KindOf (Let0123456789FSym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789FSym0 arg) (Let0123456789FSym1 arg) =>
         Let0123456789FSym0KindInference
     type instance Apply Let0123456789FSym0 l = Let0123456789FSym1 l
     type family Let0123456789F x (a :: Nat) :: Nat where
@@ -493,7 +493,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789YSym0KindInference GHC.Tuple.())
     data Let0123456789YSym0 l
-      = forall arg. KindOf (Apply Let0123456789YSym0 arg) ~ KindOf (Let0123456789YSym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789YSym0 arg) (Let0123456789YSym1 arg) =>
         Let0123456789YSym0KindInference
     type instance Apply Let0123456789YSym0 l = Let0123456789YSym1 l
     type family Let0123456789Y x :: Nat where
@@ -509,7 +509,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789YSym0KindInference GHC.Tuple.())
     data Let0123456789YSym0 l
-      = forall arg. KindOf (Apply Let0123456789YSym0 arg) ~ KindOf (Let0123456789YSym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789YSym0 arg) (Let0123456789YSym1 arg) =>
         Let0123456789YSym0KindInference
     type instance Apply Let0123456789YSym0 l = Let0123456789YSym1 l
     type family Let0123456789Y x :: Nat where
@@ -519,7 +519,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Foo14Sym0KindInference GHC.Tuple.())
     data Foo14Sym0 (l :: TyFun Nat (Nat, Nat))
-      = forall arg. KindOf (Apply Foo14Sym0 arg) ~ KindOf (Foo14Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo14Sym0 arg) (Foo14Sym1 arg) =>
         Foo14Sym0KindInference
     type instance Apply Foo14Sym0 l = Foo14Sym1 l
     type Foo13_Sym1 (t :: a0123456789) = Foo13_ t
@@ -527,7 +527,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Foo13_Sym0KindInference GHC.Tuple.())
     data Foo13_Sym0 (l :: TyFun a0123456789 a0123456789)
-      = forall arg. KindOf (Apply Foo13_Sym0 arg) ~ KindOf (Foo13_Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo13_Sym0 arg) (Foo13_Sym1 arg) =>
         Foo13_Sym0KindInference
     type instance Apply Foo13_Sym0 l = Foo13_Sym1 l
     type Foo13Sym1 (t :: a0123456789) = Foo13 t
@@ -535,7 +535,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Foo13Sym0KindInference GHC.Tuple.())
     data Foo13Sym0 (l :: TyFun a0123456789 a0123456789)
-      = forall arg. KindOf (Apply Foo13Sym0 arg) ~ KindOf (Foo13Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo13Sym0 arg) (Foo13Sym1 arg) =>
         Foo13Sym0KindInference
     type instance Apply Foo13Sym0 l = Foo13Sym1 l
     type Foo12Sym1 (t :: Nat) = Foo12 t
@@ -543,7 +543,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Foo12Sym0KindInference GHC.Tuple.())
     data Foo12Sym0 (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply Foo12Sym0 arg) ~ KindOf (Foo12Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo12Sym0 arg) (Foo12Sym1 arg) =>
         Foo12Sym0KindInference
     type instance Apply Foo12Sym0 l = Foo12Sym1 l
     type Foo11Sym1 (t :: Nat) = Foo11 t
@@ -551,7 +551,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Foo11Sym0KindInference GHC.Tuple.())
     data Foo11Sym0 (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply Foo11Sym0 arg) ~ KindOf (Foo11Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo11Sym0 arg) (Foo11Sym1 arg) =>
         Foo11Sym0KindInference
     type instance Apply Foo11Sym0 l = Foo11Sym1 l
     type Foo10Sym1 (t :: Nat) = Foo10 t
@@ -559,7 +559,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Foo10Sym0KindInference GHC.Tuple.())
     data Foo10Sym0 (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply Foo10Sym0 arg) ~ KindOf (Foo10Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo10Sym0 arg) (Foo10Sym1 arg) =>
         Foo10Sym0KindInference
     type instance Apply Foo10Sym0 l = Foo10Sym1 l
     type Foo9Sym1 (t :: Nat) = Foo9 t
@@ -567,7 +567,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Foo9Sym0KindInference GHC.Tuple.())
     data Foo9Sym0 (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply Foo9Sym0 arg) ~ KindOf (Foo9Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo9Sym0 arg) (Foo9Sym1 arg) =>
         Foo9Sym0KindInference
     type instance Apply Foo9Sym0 l = Foo9Sym1 l
     type Foo8Sym1 (t :: Nat) = Foo8 t
@@ -575,7 +575,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Foo8Sym0KindInference GHC.Tuple.())
     data Foo8Sym0 (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply Foo8Sym0 arg) ~ KindOf (Foo8Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo8Sym0 arg) (Foo8Sym1 arg) =>
         Foo8Sym0KindInference
     type instance Apply Foo8Sym0 l = Foo8Sym1 l
     type Foo7Sym1 (t :: Nat) = Foo7 t
@@ -583,7 +583,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Foo7Sym0KindInference GHC.Tuple.())
     data Foo7Sym0 (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply Foo7Sym0 arg) ~ KindOf (Foo7Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo7Sym0 arg) (Foo7Sym1 arg) =>
         Foo7Sym0KindInference
     type instance Apply Foo7Sym0 l = Foo7Sym1 l
     type Foo6Sym1 (t :: Nat) = Foo6 t
@@ -591,7 +591,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Foo6Sym0KindInference GHC.Tuple.())
     data Foo6Sym0 (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply Foo6Sym0 arg) ~ KindOf (Foo6Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo6Sym0 arg) (Foo6Sym1 arg) =>
         Foo6Sym0KindInference
     type instance Apply Foo6Sym0 l = Foo6Sym1 l
     type Foo5Sym1 (t :: Nat) = Foo5 t
@@ -599,7 +599,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Foo5Sym0KindInference GHC.Tuple.())
     data Foo5Sym0 (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply Foo5Sym0 arg) ~ KindOf (Foo5Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo5Sym0 arg) (Foo5Sym1 arg) =>
         Foo5Sym0KindInference
     type instance Apply Foo5Sym0 l = Foo5Sym1 l
     type Foo4Sym1 (t :: Nat) = Foo4 t
@@ -607,7 +607,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Foo4Sym0KindInference GHC.Tuple.())
     data Foo4Sym0 (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply Foo4Sym0 arg) ~ KindOf (Foo4Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo4Sym0 arg) (Foo4Sym1 arg) =>
         Foo4Sym0KindInference
     type instance Apply Foo4Sym0 l = Foo4Sym1 l
     type Foo3Sym1 (t :: Nat) = Foo3 t
@@ -615,7 +615,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Foo3Sym0KindInference GHC.Tuple.())
     data Foo3Sym0 (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply Foo3Sym0 arg) ~ KindOf (Foo3Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
         Foo3Sym0KindInference
     type instance Apply Foo3Sym0 l = Foo3Sym1 l
     type Foo2Sym0 = Foo2
@@ -624,7 +624,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Foo1Sym0KindInference GHC.Tuple.())
     data Foo1Sym0 (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply Foo1Sym0 arg) ~ KindOf (Foo1Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
         Foo1Sym0KindInference
     type instance Apply Foo1Sym0 l = Foo1Sym1 l
     type family Foo14 (a :: Nat) :: (Nat, Nat) where

--- a/tests/compile-and-dump/Singletons/Maybe.ghc80.template
+++ b/tests/compile-and-dump/Singletons/Maybe.ghc80.template
@@ -20,7 +20,7 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) JustSym0KindInference GHC.Tuple.())
     data JustSym0 (l :: TyFun a0123456789 (Maybe a0123456789))
-      = forall arg. KindOf (Apply JustSym0 arg) ~ KindOf (JustSym1 arg) =>
+      = forall arg. SameKind (Apply JustSym0 arg) (JustSym1 arg) =>
         JustSym0KindInference
     type instance Apply JustSym0 l = JustSym1 l
     data instance Sing (z :: Maybe a)

--- a/tests/compile-and-dump/Singletons/Nat.ghc80.template
+++ b/tests/compile-and-dump/Singletons/Nat.ghc80.template
@@ -36,7 +36,7 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) SuccSym0KindInference GHC.Tuple.())
     data SuccSym0 (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply SuccSym0 arg) ~ KindOf (SuccSym1 arg) =>
+      = forall arg. SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
         SuccSym0KindInference
     type instance Apply SuccSym0 l = SuccSym1 l
     type PredSym1 (t :: Nat) = Pred t
@@ -44,7 +44,7 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) PredSym0KindInference GHC.Tuple.())
     data PredSym0 (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply PredSym0 arg) ~ KindOf (PredSym1 arg) =>
+      = forall arg. SameKind (Apply PredSym0 arg) (PredSym1 arg) =>
         PredSym0KindInference
     type instance Apply PredSym0 l = PredSym1 l
     type PlusSym2 (t :: Nat) (t :: Nat) = Plus t t
@@ -52,14 +52,14 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) PlusSym1KindInference GHC.Tuple.())
     data PlusSym1 (l :: Nat) (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply (PlusSym1 l) arg) ~ KindOf (PlusSym2 l arg) =>
+      = forall arg. SameKind (Apply (PlusSym1 l) arg) (PlusSym2 l arg) =>
         PlusSym1KindInference
     type instance Apply (PlusSym1 l) l = PlusSym2 l l
     instance SuppressUnusedWarnings PlusSym0 where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) PlusSym0KindInference GHC.Tuple.())
     data PlusSym0 (l :: TyFun Nat (TyFun Nat Nat -> GHC.Types.Type))
-      = forall arg. KindOf (Apply PlusSym0 arg) ~ KindOf (PlusSym1 arg) =>
+      = forall arg. SameKind (Apply PlusSym0 arg) (PlusSym1 arg) =>
         PlusSym0KindInference
     type instance Apply PlusSym0 l = PlusSym1 l
     type family Pred (a :: Nat) :: Nat where

--- a/tests/compile-and-dump/Singletons/Operators.ghc80.template
+++ b/tests/compile-and-dump/Singletons/Operators.ghc80.template
@@ -28,14 +28,14 @@ Singletons/Operators.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) (:+:$$###) GHC.Tuple.())
     data (:+:$$) (l :: Foo) (l :: TyFun Foo Foo)
-      = forall arg. KindOf (Apply ((:+:$$) l) arg) ~ KindOf ((:+:$$$) l arg) =>
+      = forall arg. SameKind (Apply ((:+:$$) l) arg) ((:+:$$$) l arg) =>
         (:+:$$###)
     type instance Apply ((:+:$$) l) l = (:+:$$$) l l
     instance SuppressUnusedWarnings (:+:$) where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) (:+:$###) GHC.Tuple.())
     data (:+:$) (l :: TyFun Foo (TyFun Foo Foo -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (:+:$) arg) ~ KindOf ((:+:$$) arg) =>
+      = forall arg. SameKind (Apply (:+:$) arg) ((:+:$$) arg) =>
         (:+:$###)
     type instance Apply (:+:$) l = (:+:$$) l
     type (:+$$$) (t :: Nat) (t :: Nat) = (:+) t t
@@ -43,22 +43,21 @@ Singletons/Operators.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) (:+$$###) GHC.Tuple.())
     data (:+$$) (l :: Nat) (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply ((:+$$) l) arg) ~ KindOf ((:+$$$) l arg) =>
+      = forall arg. SameKind (Apply ((:+$$) l) arg) ((:+$$$) l arg) =>
         (:+$$###)
     type instance Apply ((:+$$) l) l = (:+$$$) l l
     instance SuppressUnusedWarnings (:+$) where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) (:+$###) GHC.Tuple.())
     data (:+$) (l :: TyFun Nat (TyFun Nat Nat -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (:+$) arg) ~ KindOf ((:+$$) arg) =>
-        (:+$###)
+      = forall arg. SameKind (Apply (:+$) arg) ((:+$$) arg) => (:+$###)
     type instance Apply (:+$) l = (:+$$) l
     type ChildSym1 (t :: Foo) = Child t
     instance SuppressUnusedWarnings ChildSym0 where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) ChildSym0KindInference GHC.Tuple.())
     data ChildSym0 (l :: TyFun Foo Foo)
-      = forall arg. KindOf (Apply ChildSym0 arg) ~ KindOf (ChildSym1 arg) =>
+      = forall arg. SameKind (Apply ChildSym0 arg) (ChildSym1 arg) =>
         ChildSym0KindInference
     type instance Apply ChildSym0 l = ChildSym1 l
     type family (:+) (a :: Nat) (a :: Nat) :: Nat where

--- a/tests/compile-and-dump/Singletons/OrdDeriving.ghc80.template
+++ b/tests/compile-and-dump/Singletons/OrdDeriving.ghc80.template
@@ -35,7 +35,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) SuccSym0KindInference GHC.Tuple.())
     data SuccSym0 (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply SuccSym0 arg) ~ KindOf (SuccSym1 arg) =>
+      = forall arg. SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
         SuccSym0KindInference
     type instance Apply SuccSym0 l = SuccSym1 l
     type family Equals_0123456789 (a :: Foo k k k k)
@@ -61,7 +61,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                (l :: b0123456789)
                (l :: c0123456789)
                (l :: TyFun d0123456789 (Foo a0123456789 b0123456789 c0123456789 d0123456789))
-      = forall arg. KindOf (Apply (ASym3 l l l) arg) ~ KindOf (ASym4 l l l arg) =>
+      = forall arg. SameKind (Apply (ASym3 l l l) arg) (ASym4 l l l arg) =>
         ASym3KindInference
     type instance Apply (ASym3 l l l) l = ASym4 l l l l
     instance SuppressUnusedWarnings ASym2 where
@@ -71,7 +71,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                (l :: b0123456789)
                (l :: TyFun c0123456789 (TyFun d0123456789 (Foo a0123456789 b0123456789 c0123456789 d0123456789)
                                         -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (ASym2 l l) arg) ~ KindOf (ASym3 l l arg) =>
+      = forall arg. SameKind (Apply (ASym2 l l) arg) (ASym3 l l arg) =>
         ASym2KindInference
     type instance Apply (ASym2 l l) l = ASym3 l l l
     instance SuppressUnusedWarnings ASym1 where
@@ -81,7 +81,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                (l :: TyFun b0123456789 (TyFun c0123456789 (TyFun d0123456789 (Foo a0123456789 b0123456789 c0123456789 d0123456789)
                                                            -> GHC.Types.Type)
                                         -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (ASym1 l) arg) ~ KindOf (ASym2 l arg) =>
+      = forall arg. SameKind (Apply (ASym1 l) arg) (ASym2 l arg) =>
         ASym1KindInference
     type instance Apply (ASym1 l) l = ASym2 l l
     instance SuppressUnusedWarnings ASym0 where
@@ -91,7 +91,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                                                                               -> GHC.Types.Type)
                                                            -> GHC.Types.Type)
                                         -> GHC.Types.Type))
-      = forall arg. KindOf (Apply ASym0 arg) ~ KindOf (ASym1 arg) =>
+      = forall arg. SameKind (Apply ASym0 arg) (ASym1 arg) =>
         ASym0KindInference
     type instance Apply ASym0 l = ASym1 l
     type BSym4 (t :: a0123456789)
@@ -106,7 +106,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                (l :: b0123456789)
                (l :: c0123456789)
                (l :: TyFun d0123456789 (Foo a0123456789 b0123456789 c0123456789 d0123456789))
-      = forall arg. KindOf (Apply (BSym3 l l l) arg) ~ KindOf (BSym4 l l l arg) =>
+      = forall arg. SameKind (Apply (BSym3 l l l) arg) (BSym4 l l l arg) =>
         BSym3KindInference
     type instance Apply (BSym3 l l l) l = BSym4 l l l l
     instance SuppressUnusedWarnings BSym2 where
@@ -116,7 +116,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                (l :: b0123456789)
                (l :: TyFun c0123456789 (TyFun d0123456789 (Foo a0123456789 b0123456789 c0123456789 d0123456789)
                                         -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (BSym2 l l) arg) ~ KindOf (BSym3 l l arg) =>
+      = forall arg. SameKind (Apply (BSym2 l l) arg) (BSym3 l l arg) =>
         BSym2KindInference
     type instance Apply (BSym2 l l) l = BSym3 l l l
     instance SuppressUnusedWarnings BSym1 where
@@ -126,7 +126,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                (l :: TyFun b0123456789 (TyFun c0123456789 (TyFun d0123456789 (Foo a0123456789 b0123456789 c0123456789 d0123456789)
                                                            -> GHC.Types.Type)
                                         -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (BSym1 l) arg) ~ KindOf (BSym2 l arg) =>
+      = forall arg. SameKind (Apply (BSym1 l) arg) (BSym2 l arg) =>
         BSym1KindInference
     type instance Apply (BSym1 l) l = BSym2 l l
     instance SuppressUnusedWarnings BSym0 where
@@ -136,7 +136,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                                                                               -> GHC.Types.Type)
                                                            -> GHC.Types.Type)
                                         -> GHC.Types.Type))
-      = forall arg. KindOf (Apply BSym0 arg) ~ KindOf (BSym1 arg) =>
+      = forall arg. SameKind (Apply BSym0 arg) (BSym1 arg) =>
         BSym0KindInference
     type instance Apply BSym0 l = BSym1 l
     type CSym4 (t :: a0123456789)
@@ -151,7 +151,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                (l :: b0123456789)
                (l :: c0123456789)
                (l :: TyFun d0123456789 (Foo a0123456789 b0123456789 c0123456789 d0123456789))
-      = forall arg. KindOf (Apply (CSym3 l l l) arg) ~ KindOf (CSym4 l l l arg) =>
+      = forall arg. SameKind (Apply (CSym3 l l l) arg) (CSym4 l l l arg) =>
         CSym3KindInference
     type instance Apply (CSym3 l l l) l = CSym4 l l l l
     instance SuppressUnusedWarnings CSym2 where
@@ -161,7 +161,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                (l :: b0123456789)
                (l :: TyFun c0123456789 (TyFun d0123456789 (Foo a0123456789 b0123456789 c0123456789 d0123456789)
                                         -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (CSym2 l l) arg) ~ KindOf (CSym3 l l arg) =>
+      = forall arg. SameKind (Apply (CSym2 l l) arg) (CSym3 l l arg) =>
         CSym2KindInference
     type instance Apply (CSym2 l l) l = CSym3 l l l
     instance SuppressUnusedWarnings CSym1 where
@@ -171,7 +171,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                (l :: TyFun b0123456789 (TyFun c0123456789 (TyFun d0123456789 (Foo a0123456789 b0123456789 c0123456789 d0123456789)
                                                            -> GHC.Types.Type)
                                         -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (CSym1 l) arg) ~ KindOf (CSym2 l arg) =>
+      = forall arg. SameKind (Apply (CSym1 l) arg) (CSym2 l arg) =>
         CSym1KindInference
     type instance Apply (CSym1 l) l = CSym2 l l
     instance SuppressUnusedWarnings CSym0 where
@@ -181,7 +181,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                                                                               -> GHC.Types.Type)
                                                            -> GHC.Types.Type)
                                         -> GHC.Types.Type))
-      = forall arg. KindOf (Apply CSym0 arg) ~ KindOf (CSym1 arg) =>
+      = forall arg. SameKind (Apply CSym0 arg) (CSym1 arg) =>
         CSym0KindInference
     type instance Apply CSym0 l = CSym1 l
     type DSym4 (t :: a0123456789)
@@ -196,7 +196,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                (l :: b0123456789)
                (l :: c0123456789)
                (l :: TyFun d0123456789 (Foo a0123456789 b0123456789 c0123456789 d0123456789))
-      = forall arg. KindOf (Apply (DSym3 l l l) arg) ~ KindOf (DSym4 l l l arg) =>
+      = forall arg. SameKind (Apply (DSym3 l l l) arg) (DSym4 l l l arg) =>
         DSym3KindInference
     type instance Apply (DSym3 l l l) l = DSym4 l l l l
     instance SuppressUnusedWarnings DSym2 where
@@ -206,7 +206,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                (l :: b0123456789)
                (l :: TyFun c0123456789 (TyFun d0123456789 (Foo a0123456789 b0123456789 c0123456789 d0123456789)
                                         -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (DSym2 l l) arg) ~ KindOf (DSym3 l l arg) =>
+      = forall arg. SameKind (Apply (DSym2 l l) arg) (DSym3 l l arg) =>
         DSym2KindInference
     type instance Apply (DSym2 l l) l = DSym3 l l l
     instance SuppressUnusedWarnings DSym1 where
@@ -216,7 +216,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                (l :: TyFun b0123456789 (TyFun c0123456789 (TyFun d0123456789 (Foo a0123456789 b0123456789 c0123456789 d0123456789)
                                                            -> GHC.Types.Type)
                                         -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (DSym1 l) arg) ~ KindOf (DSym2 l arg) =>
+      = forall arg. SameKind (Apply (DSym1 l) arg) (DSym2 l arg) =>
         DSym1KindInference
     type instance Apply (DSym1 l) l = DSym2 l l
     instance SuppressUnusedWarnings DSym0 where
@@ -226,7 +226,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                                                                               -> GHC.Types.Type)
                                                            -> GHC.Types.Type)
                                         -> GHC.Types.Type))
-      = forall arg. KindOf (Apply DSym0 arg) ~ KindOf (DSym1 arg) =>
+      = forall arg. SameKind (Apply DSym0 arg) (DSym1 arg) =>
         DSym0KindInference
     type instance Apply DSym0 l = DSym1 l
     type ESym4 (t :: a0123456789)
@@ -241,7 +241,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                (l :: b0123456789)
                (l :: c0123456789)
                (l :: TyFun d0123456789 (Foo a0123456789 b0123456789 c0123456789 d0123456789))
-      = forall arg. KindOf (Apply (ESym3 l l l) arg) ~ KindOf (ESym4 l l l arg) =>
+      = forall arg. SameKind (Apply (ESym3 l l l) arg) (ESym4 l l l arg) =>
         ESym3KindInference
     type instance Apply (ESym3 l l l) l = ESym4 l l l l
     instance SuppressUnusedWarnings ESym2 where
@@ -251,7 +251,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                (l :: b0123456789)
                (l :: TyFun c0123456789 (TyFun d0123456789 (Foo a0123456789 b0123456789 c0123456789 d0123456789)
                                         -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (ESym2 l l) arg) ~ KindOf (ESym3 l l arg) =>
+      = forall arg. SameKind (Apply (ESym2 l l) arg) (ESym3 l l arg) =>
         ESym2KindInference
     type instance Apply (ESym2 l l) l = ESym3 l l l
     instance SuppressUnusedWarnings ESym1 where
@@ -261,7 +261,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                (l :: TyFun b0123456789 (TyFun c0123456789 (TyFun d0123456789 (Foo a0123456789 b0123456789 c0123456789 d0123456789)
                                                            -> GHC.Types.Type)
                                         -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (ESym1 l) arg) ~ KindOf (ESym2 l arg) =>
+      = forall arg. SameKind (Apply (ESym1 l) arg) (ESym2 l arg) =>
         ESym1KindInference
     type instance Apply (ESym1 l) l = ESym2 l l
     instance SuppressUnusedWarnings ESym0 where
@@ -271,7 +271,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                                                                               -> GHC.Types.Type)
                                                            -> GHC.Types.Type)
                                         -> GHC.Types.Type))
-      = forall arg. KindOf (Apply ESym0 arg) ~ KindOf (ESym1 arg) =>
+      = forall arg. SameKind (Apply ESym0 arg) (ESym1 arg) =>
         ESym0KindInference
     type instance Apply ESym0 l = ESym1 l
     type FSym4 (t :: a0123456789)
@@ -286,7 +286,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                (l :: b0123456789)
                (l :: c0123456789)
                (l :: TyFun d0123456789 (Foo a0123456789 b0123456789 c0123456789 d0123456789))
-      = forall arg. KindOf (Apply (FSym3 l l l) arg) ~ KindOf (FSym4 l l l arg) =>
+      = forall arg. SameKind (Apply (FSym3 l l l) arg) (FSym4 l l l arg) =>
         FSym3KindInference
     type instance Apply (FSym3 l l l) l = FSym4 l l l l
     instance SuppressUnusedWarnings FSym2 where
@@ -296,7 +296,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                (l :: b0123456789)
                (l :: TyFun c0123456789 (TyFun d0123456789 (Foo a0123456789 b0123456789 c0123456789 d0123456789)
                                         -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (FSym2 l l) arg) ~ KindOf (FSym3 l l arg) =>
+      = forall arg. SameKind (Apply (FSym2 l l) arg) (FSym3 l l arg) =>
         FSym2KindInference
     type instance Apply (FSym2 l l) l = FSym3 l l l
     instance SuppressUnusedWarnings FSym1 where
@@ -306,7 +306,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                (l :: TyFun b0123456789 (TyFun c0123456789 (TyFun d0123456789 (Foo a0123456789 b0123456789 c0123456789 d0123456789)
                                                            -> GHC.Types.Type)
                                         -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (FSym1 l) arg) ~ KindOf (FSym2 l arg) =>
+      = forall arg. SameKind (Apply (FSym1 l) arg) (FSym2 l arg) =>
         FSym1KindInference
     type instance Apply (FSym1 l) l = FSym2 l l
     instance SuppressUnusedWarnings FSym0 where
@@ -316,7 +316,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                                                                               -> GHC.Types.Type)
                                                            -> GHC.Types.Type)
                                         -> GHC.Types.Type))
-      = forall arg. KindOf (Apply FSym0 arg) ~ KindOf (FSym1 arg) =>
+      = forall arg. SameKind (Apply FSym0 arg) (FSym1 arg) =>
         FSym0KindInference
     type instance Apply FSym0 l = FSym1 l
     type family Compare_0123456789 (a :: Nat)
@@ -332,7 +332,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Compare_0123456789Sym1KindInference GHC.Tuple.())
     data Compare_0123456789Sym1 (l :: Nat) (l :: TyFun Nat Ordering)
-      = forall arg. KindOf (Apply (Compare_0123456789Sym1 l) arg) ~ KindOf (Compare_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Compare_0123456789Sym1 l) arg) (Compare_0123456789Sym2 l arg) =>
         Compare_0123456789Sym1KindInference
     type instance Apply (Compare_0123456789Sym1 l) l = Compare_0123456789Sym2 l l
     instance SuppressUnusedWarnings Compare_0123456789Sym0 where
@@ -341,7 +341,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,) Compare_0123456789Sym0KindInference GHC.Tuple.())
     data Compare_0123456789Sym0 (l :: TyFun Nat (TyFun Nat Ordering
                                                  -> GHC.Types.Type))
-      = forall arg. KindOf (Apply Compare_0123456789Sym0 arg) ~ KindOf (Compare_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Compare_0123456789Sym0 arg) (Compare_0123456789Sym1 arg) =>
         Compare_0123456789Sym0KindInference
     type instance Apply Compare_0123456789Sym0 l = Compare_0123456789Sym1 l
     instance POrd (Proxy :: Proxy Nat) where
@@ -393,7 +393,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,) Compare_0123456789Sym1KindInference GHC.Tuple.())
     data Compare_0123456789Sym1 (l :: Foo a0123456789 b0123456789 c0123456789 d0123456789)
                                 (l :: TyFun (Foo a0123456789 b0123456789 c0123456789 d0123456789) Ordering)
-      = forall arg. KindOf (Apply (Compare_0123456789Sym1 l) arg) ~ KindOf (Compare_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Compare_0123456789Sym1 l) arg) (Compare_0123456789Sym2 l arg) =>
         Compare_0123456789Sym1KindInference
     type instance Apply (Compare_0123456789Sym1 l) l = Compare_0123456789Sym2 l l
     instance SuppressUnusedWarnings Compare_0123456789Sym0 where
@@ -402,7 +402,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,) Compare_0123456789Sym0KindInference GHC.Tuple.())
     data Compare_0123456789Sym0 (l :: TyFun (Foo a0123456789 b0123456789 c0123456789 d0123456789) (TyFun (Foo a0123456789 b0123456789 c0123456789 d0123456789) Ordering
                                                                                                    -> GHC.Types.Type))
-      = forall arg. KindOf (Apply Compare_0123456789Sym0 arg) ~ KindOf (Compare_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Compare_0123456789Sym0 arg) (Compare_0123456789Sym1 arg) =>
         Compare_0123456789Sym0KindInference
     type instance Apply Compare_0123456789Sym0 l = Compare_0123456789Sym1 l
     instance POrd (Proxy :: Proxy (Foo a b c d)) where

--- a/tests/compile-and-dump/Singletons/PatternMatching.ghc80.template
+++ b/tests/compile-and-dump/Singletons/PatternMatching.ghc80.template
@@ -22,7 +22,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) PairSym1KindInference GHC.Tuple.())
     data PairSym1 (l :: a0123456789)
                   (l :: TyFun b0123456789 (Pair a0123456789 b0123456789))
-      = forall arg. KindOf (Apply (PairSym1 l) arg) ~ KindOf (PairSym2 l arg) =>
+      = forall arg. SameKind (Apply (PairSym1 l) arg) (PairSym2 l arg) =>
         PairSym1KindInference
     type instance Apply (PairSym1 l) l = PairSym2 l l
     instance SuppressUnusedWarnings PairSym0 where
@@ -30,7 +30,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) PairSym0KindInference GHC.Tuple.())
     data PairSym0 (l :: TyFun a0123456789 (TyFun b0123456789 (Pair a0123456789 b0123456789)
                                            -> GHC.Types.Type))
-      = forall arg. KindOf (Apply PairSym0 arg) ~ KindOf (PairSym1 arg) =>
+      = forall arg. SameKind (Apply PairSym0 arg) (PairSym1 arg) =>
         PairSym0KindInference
     type instance Apply PairSym0 l = PairSym1 l
     type AListSym0 = AList
@@ -134,14 +134,14 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789TSym1KindInference GHC.Tuple.())
     data Let0123456789TSym1 l l
-      = forall arg. KindOf (Apply (Let0123456789TSym1 l) arg) ~ KindOf (Let0123456789TSym2 l arg) =>
+      = forall arg. SameKind (Apply (Let0123456789TSym1 l) arg) (Let0123456789TSym2 l arg) =>
         Let0123456789TSym1KindInference
     type instance Apply (Let0123456789TSym1 l) l = Let0123456789TSym2 l l
     instance SuppressUnusedWarnings Let0123456789TSym0 where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Let0123456789TSym0KindInference GHC.Tuple.())
     data Let0123456789TSym0 l
-      = forall arg. KindOf (Apply Let0123456789TSym0 arg) ~ KindOf (Let0123456789TSym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789TSym0 arg) (Let0123456789TSym1 arg) =>
         Let0123456789TSym0KindInference
     type instance Apply Let0123456789TSym0 l = Let0123456789TSym1 l
     type family Let0123456789T x y where
@@ -156,7 +156,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym4KindInference GHC.Tuple.())
     data Lambda_0123456789Sym4 l l l l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym4 l l l l) arg) ~ KindOf (Lambda_0123456789Sym5 l l l l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym4 l l l l) arg) (Lambda_0123456789Sym5 l l l l arg) =>
         Lambda_0123456789Sym4KindInference
     type instance Apply (Lambda_0123456789Sym4 l l l l) l = Lambda_0123456789Sym5 l l l l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym3 where
@@ -164,7 +164,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym3KindInference GHC.Tuple.())
     data Lambda_0123456789Sym3 l l l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym3 l l l) arg) ~ KindOf (Lambda_0123456789Sym4 l l l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym3 l l l) arg) (Lambda_0123456789Sym4 l l l arg) =>
         Lambda_0123456789Sym3KindInference
     type instance Apply (Lambda_0123456789Sym3 l l l) l = Lambda_0123456789Sym4 l l l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym2 where
@@ -172,7 +172,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym2KindInference GHC.Tuple.())
     data Lambda_0123456789Sym2 l l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym2 l l) arg) ~ KindOf (Lambda_0123456789Sym3 l l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym2 l l) arg) (Lambda_0123456789Sym3 l l arg) =>
         Lambda_0123456789Sym2KindInference
     type instance Apply (Lambda_0123456789Sym2 l l) l = Lambda_0123456789Sym3 l l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym1 where
@@ -180,7 +180,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym1KindInference GHC.Tuple.())
     data Lambda_0123456789Sym1 l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym1 l) arg) ~ KindOf (Lambda_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym1 l) arg) (Lambda_0123456789Sym2 l arg) =>
         Lambda_0123456789Sym1KindInference
     type instance Apply (Lambda_0123456789Sym1 l) l = Lambda_0123456789Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym0 where
@@ -188,7 +188,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym0KindInference GHC.Tuple.())
     data Lambda_0123456789Sym0 l
-      = forall arg. KindOf (Apply Lambda_0123456789Sym0 arg) ~ KindOf (Lambda_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Lambda_0123456789Sym0 arg) (Lambda_0123456789Sym1 arg) =>
         Lambda_0123456789Sym0KindInference
     type instance Apply Lambda_0123456789Sym0 l = Lambda_0123456789Sym1 l
     type family Case_0123456789 x y t where
@@ -204,7 +204,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym2KindInference GHC.Tuple.())
     data Lambda_0123456789Sym2 l l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym2 l l) arg) ~ KindOf (Lambda_0123456789Sym3 l l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym2 l l) arg) (Lambda_0123456789Sym3 l l arg) =>
         Lambda_0123456789Sym2KindInference
     type instance Apply (Lambda_0123456789Sym2 l l) l = Lambda_0123456789Sym3 l l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym1 where
@@ -212,7 +212,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym1KindInference GHC.Tuple.())
     data Lambda_0123456789Sym1 l l
-      = forall arg. KindOf (Apply (Lambda_0123456789Sym1 l) arg) ~ KindOf (Lambda_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Lambda_0123456789Sym1 l) arg) (Lambda_0123456789Sym2 l arg) =>
         Lambda_0123456789Sym1KindInference
     type instance Apply (Lambda_0123456789Sym1 l) l = Lambda_0123456789Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789Sym0 where
@@ -220,7 +220,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym0KindInference GHC.Tuple.())
     data Lambda_0123456789Sym0 l
-      = forall arg. KindOf (Apply Lambda_0123456789Sym0 arg) ~ KindOf (Lambda_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Lambda_0123456789Sym0 arg) (Lambda_0123456789Sym1 arg) =>
         Lambda_0123456789Sym0KindInference
     type instance Apply Lambda_0123456789Sym0 l = Lambda_0123456789Sym1 l
     type family Case_0123456789 t where
@@ -258,7 +258,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) SillySym0KindInference GHC.Tuple.())
     data SillySym0 (l :: TyFun a0123456789 ())
-      = forall arg. KindOf (Apply SillySym0 arg) ~ KindOf (SillySym1 arg) =>
+      = forall arg. SameKind (Apply SillySym0 arg) (SillySym1 arg) =>
         SillySym0KindInference
     type instance Apply SillySym0 l = SillySym1 l
     type Foo2Sym1 (t :: (a0123456789, b0123456789)) = Foo2 t
@@ -266,7 +266,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Foo2Sym0KindInference GHC.Tuple.())
     data Foo2Sym0 (l :: TyFun (a0123456789, b0123456789) a0123456789)
-      = forall arg. KindOf (Apply Foo2Sym0 arg) ~ KindOf (Foo2Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) =>
         Foo2Sym0KindInference
     type instance Apply Foo2Sym0 l = Foo2Sym1 l
     type Foo1Sym1 (t :: (a0123456789, b0123456789)) = Foo1 t
@@ -274,7 +274,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Foo1Sym0KindInference GHC.Tuple.())
     data Foo1Sym0 (l :: TyFun (a0123456789, b0123456789) a0123456789)
-      = forall arg. KindOf (Apply Foo1Sym0 arg) ~ KindOf (Foo1Sym1 arg) =>
+      = forall arg. SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
         Foo1Sym0KindInference
     type instance Apply Foo1Sym0 l = Foo1Sym1 l
     type LszSym0 = Lsz

--- a/tests/compile-and-dump/Singletons/Records.ghc80.template
+++ b/tests/compile-and-dump/Singletons/Records.ghc80.template
@@ -8,7 +8,7 @@ Singletons/Records.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Field1Sym0KindInference GHC.Tuple.())
     data Field1Sym0 (l :: TyFun (Record a0123456789) a0123456789)
-      = forall arg. KindOf (Apply Field1Sym0 arg) ~ KindOf (Field1Sym1 arg) =>
+      = forall arg. SameKind (Apply Field1Sym0 arg) (Field1Sym1 arg) =>
         Field1Sym0KindInference
     type instance Apply Field1Sym0 l = Field1Sym1 l
     type Field2Sym1 (t :: Record a0123456789) = Field2 t
@@ -16,7 +16,7 @@ Singletons/Records.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Field2Sym0KindInference GHC.Tuple.())
     data Field2Sym0 (l :: TyFun (Record a0123456789) Bool)
-      = forall arg. KindOf (Apply Field2Sym0 arg) ~ KindOf (Field2Sym1 arg) =>
+      = forall arg. SameKind (Apply Field2Sym0 arg) (Field2Sym1 arg) =>
         Field2Sym0KindInference
     type instance Apply Field2Sym0 l = Field2Sym1 l
     type family Field1 (a :: Record a) :: a where
@@ -29,7 +29,7 @@ Singletons/Records.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) MkRecordSym1KindInference GHC.Tuple.())
     data MkRecordSym1 (l :: a0123456789)
                       (l :: TyFun Bool (Record a0123456789))
-      = forall arg. KindOf (Apply (MkRecordSym1 l) arg) ~ KindOf (MkRecordSym2 l arg) =>
+      = forall arg. SameKind (Apply (MkRecordSym1 l) arg) (MkRecordSym2 l arg) =>
         MkRecordSym1KindInference
     type instance Apply (MkRecordSym1 l) l = MkRecordSym2 l l
     instance SuppressUnusedWarnings MkRecordSym0 where
@@ -37,7 +37,7 @@ Singletons/Records.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) MkRecordSym0KindInference GHC.Tuple.())
     data MkRecordSym0 (l :: TyFun a0123456789 (TyFun Bool (Record a0123456789)
                                                -> GHC.Types.Type))
-      = forall arg. KindOf (Apply MkRecordSym0 arg) ~ KindOf (MkRecordSym1 arg) =>
+      = forall arg. SameKind (Apply MkRecordSym0 arg) (MkRecordSym1 arg) =>
         MkRecordSym0KindInference
     type instance Apply MkRecordSym0 l = MkRecordSym1 l
     data instance Sing (z :: Record a)

--- a/tests/compile-and-dump/Singletons/ReturnFunc.ghc80.template
+++ b/tests/compile-and-dump/Singletons/ReturnFunc.ghc80.template
@@ -18,7 +18,7 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) IdSym0KindInference GHC.Tuple.())
     data IdSym0 (l :: TyFun a0123456789 a0123456789)
-      = forall arg. KindOf (Apply IdSym0 arg) ~ KindOf (IdSym1 arg) =>
+      = forall arg. SameKind (Apply IdSym0 arg) (IdSym1 arg) =>
         IdSym0KindInference
     type instance Apply IdSym0 l = IdSym1 l
     type IdFooSym2 (t :: c0123456789) (t :: a0123456789) = IdFoo t t
@@ -27,7 +27,7 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) IdFooSym1KindInference GHC.Tuple.())
     data IdFooSym1 (l :: c0123456789)
                    (l :: TyFun a0123456789 a0123456789)
-      = forall arg. KindOf (Apply (IdFooSym1 l) arg) ~ KindOf (IdFooSym2 l arg) =>
+      = forall arg. SameKind (Apply (IdFooSym1 l) arg) (IdFooSym2 l arg) =>
         IdFooSym1KindInference
     type instance Apply (IdFooSym1 l) l = IdFooSym2 l l
     instance SuppressUnusedWarnings IdFooSym0 where
@@ -35,7 +35,7 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) IdFooSym0KindInference GHC.Tuple.())
     data IdFooSym0 (l :: TyFun c0123456789 (TyFun a0123456789 a0123456789
                                             -> GHC.Types.Type))
-      = forall arg. KindOf (Apply IdFooSym0 arg) ~ KindOf (IdFooSym1 arg) =>
+      = forall arg. SameKind (Apply IdFooSym0 arg) (IdFooSym1 arg) =>
         IdFooSym0KindInference
     type instance Apply IdFooSym0 l = IdFooSym1 l
     type ReturnFuncSym2 (t :: Nat) (t :: Nat) = ReturnFunc t t
@@ -43,7 +43,7 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) ReturnFuncSym1KindInference GHC.Tuple.())
     data ReturnFuncSym1 (l :: Nat) (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply (ReturnFuncSym1 l) arg) ~ KindOf (ReturnFuncSym2 l arg) =>
+      = forall arg. SameKind (Apply (ReturnFuncSym1 l) arg) (ReturnFuncSym2 l arg) =>
         ReturnFuncSym1KindInference
     type instance Apply (ReturnFuncSym1 l) l = ReturnFuncSym2 l l
     instance SuppressUnusedWarnings ReturnFuncSym0 where
@@ -51,7 +51,7 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) ReturnFuncSym0KindInference GHC.Tuple.())
     data ReturnFuncSym0 (l :: TyFun Nat (TyFun Nat Nat
                                          -> GHC.Types.Type))
-      = forall arg. KindOf (Apply ReturnFuncSym0 arg) ~ KindOf (ReturnFuncSym1 arg) =>
+      = forall arg. SameKind (Apply ReturnFuncSym0 arg) (ReturnFuncSym1 arg) =>
         ReturnFuncSym0KindInference
     type instance Apply ReturnFuncSym0 l = ReturnFuncSym1 l
     type family Id (a :: a) :: a where

--- a/tests/compile-and-dump/Singletons/Sections.ghc80.template
+++ b/tests/compile-and-dump/Singletons/Sections.ghc80.template
@@ -27,7 +27,7 @@ Singletons/Sections.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) Lambda_0123456789Sym0KindInference GHC.Tuple.())
     data Lambda_0123456789Sym0 l
-      = forall arg. KindOf (Apply Lambda_0123456789Sym0 arg) ~ KindOf (Lambda_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Lambda_0123456789Sym0 arg) (Lambda_0123456789Sym1 arg) =>
         Lambda_0123456789Sym0KindInference
     type instance Apply Lambda_0123456789Sym0 l = Lambda_0123456789Sym1 l
     type (:+$$$) (t :: Nat) (t :: Nat) = (:+) t t
@@ -35,15 +35,14 @@ Singletons/Sections.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) (:+$$###) GHC.Tuple.())
     data (:+$$) (l :: Nat) (l :: TyFun Nat Nat)
-      = forall arg. KindOf (Apply ((:+$$) l) arg) ~ KindOf ((:+$$$) l arg) =>
+      = forall arg. SameKind (Apply ((:+$$) l) arg) ((:+$$$) l arg) =>
         (:+$$###)
     type instance Apply ((:+$$) l) l = (:+$$$) l l
     instance SuppressUnusedWarnings (:+$) where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) (:+$###) GHC.Tuple.())
     data (:+$) (l :: TyFun Nat (TyFun Nat Nat -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (:+$) arg) ~ KindOf ((:+$$) arg) =>
-        (:+$###)
+      = forall arg. SameKind (Apply (:+$) arg) ((:+$$) arg) => (:+$###)
     type instance Apply (:+$) l = (:+$$) l
     type Foo1Sym0 = Foo1
     type Foo2Sym0 = Foo2

--- a/tests/compile-and-dump/Singletons/Star.ghc80.template
+++ b/tests/compile-and-dump/Singletons/Star.ghc80.template
@@ -25,7 +25,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
       Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) MaybeSym0KindInference GHC.Tuple.())
     data MaybeSym0 (l :: TyFun Type Type)
-      = forall arg. KindOf (Apply MaybeSym0 arg) ~ KindOf (MaybeSym1 arg) =>
+      = forall arg. SameKind (Apply MaybeSym0 arg) (MaybeSym1 arg) =>
         MaybeSym0KindInference
     type instance Apply MaybeSym0 l = MaybeSym1 l
     type VecSym2 (t :: Type) (t :: Nat) = Vec t t
@@ -33,14 +33,14 @@ Singletons/Star.hs:0:0:: Splicing declarations
       Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) VecSym1KindInference GHC.Tuple.())
     data VecSym1 (l :: Type) (l :: TyFun Nat Type)
-      = forall arg. KindOf (Apply (VecSym1 l) arg) ~ KindOf (VecSym2 l arg) =>
+      = forall arg. SameKind (Apply (VecSym1 l) arg) (VecSym2 l arg) =>
         VecSym1KindInference
     type instance Apply (VecSym1 l) l = VecSym2 l l
     instance Data.Singletons.SuppressUnusedWarnings.SuppressUnusedWarnings VecSym0 where
       Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) VecSym0KindInference GHC.Tuple.())
     data VecSym0 (l :: TyFun Type (TyFun Nat Type -> Type))
-      = forall arg. KindOf (Apply VecSym0 arg) ~ KindOf (VecSym1 arg) =>
+      = forall arg. SameKind (Apply VecSym0 arg) (VecSym1 arg) =>
         VecSym0KindInference
     type instance Apply VecSym0 l = VecSym1 l
     type family Compare_0123456789 (a :: Type)
@@ -77,7 +77,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
         = snd
             (GHC.Tuple.(,) Compare_0123456789Sym1KindInference GHC.Tuple.())
     data Compare_0123456789Sym1 (l :: Type) (l :: TyFun Type Ordering)
-      = forall arg. KindOf (Apply (Compare_0123456789Sym1 l) arg) ~ KindOf (Compare_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (Compare_0123456789Sym1 l) arg) (Compare_0123456789Sym2 l arg) =>
         Compare_0123456789Sym1KindInference
     type instance Apply (Compare_0123456789Sym1 l) l = Compare_0123456789Sym2 l l
     instance Data.Singletons.SuppressUnusedWarnings.SuppressUnusedWarnings Compare_0123456789Sym0 where
@@ -86,7 +86,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
             (GHC.Tuple.(,) Compare_0123456789Sym0KindInference GHC.Tuple.())
     data Compare_0123456789Sym0 (l :: TyFun Type (TyFun Type Ordering
                                                   -> Type))
-      = forall arg. KindOf (Apply Compare_0123456789Sym0 arg) ~ KindOf (Compare_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Compare_0123456789Sym0 arg) (Compare_0123456789Sym1 arg) =>
         Compare_0123456789Sym0KindInference
     type instance Apply Compare_0123456789Sym0 l = Compare_0123456789Sym1 l
     instance POrd (Proxy :: Proxy Type) where

--- a/tests/compile-and-dump/Singletons/T124.ghc80.template
+++ b/tests/compile-and-dump/Singletons/T124.ghc80.template
@@ -12,7 +12,7 @@ Singletons/T124.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) FooSym0KindInference GHC.Tuple.())
     data FooSym0 (l :: TyFun Bool ())
-      = forall arg. KindOf (Apply FooSym0 arg) ~ KindOf (FooSym1 arg) =>
+      = forall arg. SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
         FooSym0KindInference
     type instance Apply FooSym0 l = FooSym1 l
     type family Foo (a :: Bool) :: () where

--- a/tests/compile-and-dump/Singletons/T136.ghc80.template
+++ b/tests/compile-and-dump/Singletons/T136.ghc80.template
@@ -38,7 +38,7 @@ Singletons/T136.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Succ_0123456789Sym0KindInference GHC.Tuple.())
     data Succ_0123456789Sym0 (l :: TyFun [Bool] [Bool])
-      = forall arg. KindOf (Apply Succ_0123456789Sym0 arg) ~ KindOf (Succ_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Succ_0123456789Sym0 arg) (Succ_0123456789Sym1 arg) =>
         Succ_0123456789Sym0KindInference
     type instance Apply Succ_0123456789Sym0 l = Succ_0123456789Sym1 l
     type family Pred_0123456789 (a :: [Bool]) :: [Bool] where
@@ -50,7 +50,7 @@ Singletons/T136.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Pred_0123456789Sym0KindInference GHC.Tuple.())
     data Pred_0123456789Sym0 (l :: TyFun [Bool] [Bool])
-      = forall arg. KindOf (Apply Pred_0123456789Sym0 arg) ~ KindOf (Pred_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Pred_0123456789Sym0 arg) (Pred_0123456789Sym1 arg) =>
         Pred_0123456789Sym0KindInference
     type instance Apply Pred_0123456789Sym0 l = Pred_0123456789Sym1 l
     type family Case_0123456789 i arg_0123456789 t where
@@ -70,7 +70,7 @@ Singletons/T136.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) ToEnum_0123456789Sym0KindInference GHC.Tuple.())
     data ToEnum_0123456789Sym0 (l :: TyFun GHC.Types.Nat [Bool])
-      = forall arg. KindOf (Apply ToEnum_0123456789Sym0 arg) ~ KindOf (ToEnum_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply ToEnum_0123456789Sym0 arg) (ToEnum_0123456789Sym1 arg) =>
         ToEnum_0123456789Sym0KindInference
     type instance Apply ToEnum_0123456789Sym0 l = ToEnum_0123456789Sym1 l
     type family FromEnum_0123456789 (a :: [Bool]) :: GHC.Types.Nat where
@@ -83,7 +83,7 @@ Singletons/T136.hs:(0,0)-(0,0): Splicing declarations
         = snd
             (GHC.Tuple.(,) FromEnum_0123456789Sym0KindInference GHC.Tuple.())
     data FromEnum_0123456789Sym0 (l :: TyFun [Bool] GHC.Types.Nat)
-      = forall arg. KindOf (Apply FromEnum_0123456789Sym0 arg) ~ KindOf (FromEnum_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply FromEnum_0123456789Sym0 arg) (FromEnum_0123456789Sym1 arg) =>
         FromEnum_0123456789Sym0KindInference
     type instance Apply FromEnum_0123456789Sym0 l = FromEnum_0123456789Sym1 l
     instance PEnum (Proxy :: Proxy [Bool]) where

--- a/tests/compile-and-dump/Singletons/T136b.ghc80.template
+++ b/tests/compile-and-dump/Singletons/T136b.ghc80.template
@@ -10,7 +10,7 @@ Singletons/T136b.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) MethSym0KindInference GHC.Tuple.())
     data MethSym0 (l :: TyFun a0123456789 a0123456789)
-      = forall arg. KindOf (Apply MethSym0 arg) ~ KindOf (MethSym1 arg) =>
+      = forall arg. SameKind (Apply MethSym0 arg) (MethSym1 arg) =>
         MethSym0KindInference
     type instance Apply MethSym0 l = MethSym1 l
     class kproxy ~ Proxy => PC (kproxy :: Proxy a) where
@@ -31,7 +31,7 @@ Singletons/T136b.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) Meth_0123456789Sym0KindInference GHC.Tuple.())
     data Meth_0123456789Sym0 (l :: TyFun Bool Bool)
-      = forall arg. KindOf (Apply Meth_0123456789Sym0 arg) ~ KindOf (Meth_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Meth_0123456789Sym0 arg) (Meth_0123456789Sym1 arg) =>
         Meth_0123456789Sym0KindInference
     type instance Apply Meth_0123456789Sym0 l = Meth_0123456789Sym1 l
     instance PC (Proxy :: Proxy Bool) where

--- a/tests/compile-and-dump/Singletons/T159.ghc80.template
+++ b/tests/compile-and-dump/Singletons/T159.ghc80.template
@@ -47,14 +47,14 @@ Singletons/T159.hs:0:0:: Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) C1Sym1KindInference GHC.Tuple.())
     data C1Sym1 (l :: T0) (l :: TyFun T1 T1)
-      = forall arg. KindOf (Apply (C1Sym1 l) arg) ~ KindOf (C1Sym2 l arg) =>
+      = forall arg. SameKind (Apply (C1Sym1 l) arg) (C1Sym2 l arg) =>
         C1Sym1KindInference
     type instance Apply (C1Sym1 l) l = C1Sym2 l l
     instance SuppressUnusedWarnings C1Sym0 where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) C1Sym0KindInference GHC.Tuple.())
     data C1Sym0 (l :: TyFun T0 (TyFun T1 T1 -> GHC.Types.Type))
-      = forall arg. KindOf (Apply C1Sym0 arg) ~ KindOf (C1Sym1 arg) =>
+      = forall arg. SameKind (Apply C1Sym0 arg) (C1Sym1 arg) =>
         C1Sym0KindInference
     type instance Apply C1Sym0 l = C1Sym1 l
     type (:&&$$$) (t :: T0) (t :: T1) = (:&&) t t
@@ -62,14 +62,14 @@ Singletons/T159.hs:0:0:: Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) (:&&$$###) GHC.Tuple.())
     data (:&&$$) (l :: T0) (l :: TyFun T1 T1)
-      = forall arg. KindOf (Apply ((:&&$$) l) arg) ~ KindOf ((:&&$$$) l arg) =>
+      = forall arg. SameKind (Apply ((:&&$$) l) arg) ((:&&$$$) l arg) =>
         (:&&$$###)
     type instance Apply ((:&&$$) l) l = (:&&$$$) l l
     instance SuppressUnusedWarnings (:&&$) where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) (:&&$###) GHC.Tuple.())
     data (:&&$) (l :: TyFun T0 (TyFun T1 T1 -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (:&&$) arg) ~ KindOf ((:&&$$) arg) =>
+      = forall arg. SameKind (Apply (:&&$) arg) ((:&&$$) arg) =>
         (:&&$###)
     type instance Apply (:&&$) l = (:&&$$) l
     data instance Sing (z :: T1)
@@ -120,14 +120,14 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) C2Sym1KindInference GHC.Tuple.())
     data C2Sym1 (l :: T0) (l :: TyFun T2 T2)
-      = forall arg. KindOf (Apply (C2Sym1 l) arg) ~ KindOf (C2Sym2 l arg) =>
+      = forall arg. SameKind (Apply (C2Sym1 l) arg) (C2Sym2 l arg) =>
         C2Sym1KindInference
     type instance Apply (C2Sym1 l) l = C2Sym2 l l
     instance SuppressUnusedWarnings C2Sym0 where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) C2Sym0KindInference GHC.Tuple.())
     data C2Sym0 (l :: TyFun T0 (TyFun T2 T2 -> GHC.Types.Type))
-      = forall arg. KindOf (Apply C2Sym0 arg) ~ KindOf (C2Sym1 arg) =>
+      = forall arg. SameKind (Apply C2Sym0 arg) (C2Sym1 arg) =>
         C2Sym0KindInference
     type instance Apply C2Sym0 l = C2Sym1 l
     type (:||$$$) (t :: T0) (t :: T2) = (:||) t t
@@ -135,14 +135,14 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) (:||$$###) GHC.Tuple.())
     data (:||$$) (l :: T0) (l :: TyFun T2 T2)
-      = forall arg. KindOf (Apply ((:||$$) l) arg) ~ KindOf ((:||$$$) l arg) =>
+      = forall arg. SameKind (Apply ((:||$$) l) arg) ((:||$$$) l arg) =>
         (:||$$###)
     type instance Apply ((:||$$) l) l = (:||$$$) l l
     instance SuppressUnusedWarnings (:||$) where
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) (:||$###) GHC.Tuple.())
     data (:||$) (l :: TyFun T0 (TyFun T2 T2 -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (:||$) arg) ~ KindOf ((:||$$) arg) =>
+      = forall arg. SameKind (Apply (:||$) arg) ((:||$$) arg) =>
         (:||$###)
     type instance Apply (:||$) l = (:||$$) l
     infixr 5 :%||

--- a/tests/compile-and-dump/Singletons/T167.ghc80.template
+++ b/tests/compile-and-dump/Singletons/T167.ghc80.template
@@ -4,7 +4,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
             foosPrec :: Nat -> a -> DiffList
             fooList :: a -> DiffList
             fooList = undefined
-
+          
           instance Foo a => Foo [a] where
             foosPrec _ = fooList |]
   ======>
@@ -16,7 +16,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
     data FoosPrecSym2 (l :: Nat)
                       (l :: a0123456789)
                       (l :: TyFun [Bool] [Bool])
-      = forall arg. KindOf (Apply (FoosPrecSym2 l l) arg) ~ KindOf (FoosPrecSym3 l l arg) =>
+      = forall arg. SameKind (Apply (FoosPrecSym2 l l) arg) (FoosPrecSym3 l l arg) =>
         FoosPrecSym2KindInference
     type instance Apply (FoosPrecSym2 l l) l = FoosPrecSym3 l l l
     instance SuppressUnusedWarnings FoosPrecSym1 where
@@ -24,7 +24,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) FoosPrecSym1KindInference GHC.Tuple.())
     data FoosPrecSym1 (l :: Nat)
                       (l :: TyFun a0123456789 (TyFun [Bool] [Bool] -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (FoosPrecSym1 l) arg) ~ KindOf (FoosPrecSym2 l arg) =>
+      = forall arg. SameKind (Apply (FoosPrecSym1 l) arg) (FoosPrecSym2 l arg) =>
         FoosPrecSym1KindInference
     type instance Apply (FoosPrecSym1 l) l = FoosPrecSym2 l l
     instance SuppressUnusedWarnings FoosPrecSym0 where
@@ -33,7 +33,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
     data FoosPrecSym0 (l :: TyFun Nat (TyFun a0123456789 (TyFun [Bool] [Bool]
                                                           -> GHC.Types.Type)
                                        -> GHC.Types.Type))
-      = forall arg. KindOf (Apply FoosPrecSym0 arg) ~ KindOf (FoosPrecSym1 arg) =>
+      = forall arg. SameKind (Apply FoosPrecSym0 arg) (FoosPrecSym1 arg) =>
         FoosPrecSym0KindInference
     type instance Apply FoosPrecSym0 l = FoosPrecSym1 l
     type FooListSym2 (t :: a0123456789) (t :: [Bool]) = FooList t t
@@ -41,7 +41,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) FooListSym1KindInference GHC.Tuple.())
     data FooListSym1 (l :: a0123456789) (l :: TyFun [Bool] [Bool])
-      = forall arg. KindOf (Apply (FooListSym1 l) arg) ~ KindOf (FooListSym2 l arg) =>
+      = forall arg. SameKind (Apply (FooListSym1 l) arg) (FooListSym2 l arg) =>
         FooListSym1KindInference
     type instance Apply (FooListSym1 l) l = FooListSym2 l l
     instance SuppressUnusedWarnings FooListSym0 where
@@ -49,7 +49,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
         = snd (GHC.Tuple.(,) FooListSym0KindInference GHC.Tuple.())
     data FooListSym0 (l :: TyFun a0123456789 (TyFun [Bool] [Bool]
                                               -> GHC.Types.Type))
-      = forall arg. KindOf (Apply FooListSym0 arg) ~ KindOf (FooListSym1 arg) =>
+      = forall arg. SameKind (Apply FooListSym0 arg) (FooListSym1 arg) =>
         FooListSym0KindInference
     type instance Apply FooListSym0 l = FooListSym1 l
     type family FooList_0123456789 (a :: a)
@@ -63,7 +63,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,) FooList_0123456789Sym1KindInference GHC.Tuple.())
     data FooList_0123456789Sym1 (l :: a0123456789)
                                 (l :: TyFun [Bool] [Bool])
-      = forall arg. KindOf (Apply (FooList_0123456789Sym1 l) arg) ~ KindOf (FooList_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (FooList_0123456789Sym1 l) arg) (FooList_0123456789Sym2 l arg) =>
         FooList_0123456789Sym1KindInference
     type instance Apply (FooList_0123456789Sym1 l) l = FooList_0123456789Sym2 l l
     instance SuppressUnusedWarnings FooList_0123456789Sym0 where
@@ -72,7 +72,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,) FooList_0123456789Sym0KindInference GHC.Tuple.())
     data FooList_0123456789Sym0 (l :: TyFun a0123456789 (TyFun [Bool] [Bool]
                                                          -> GHC.Types.Type))
-      = forall arg. KindOf (Apply FooList_0123456789Sym0 arg) ~ KindOf (FooList_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply FooList_0123456789Sym0 arg) (FooList_0123456789Sym1 arg) =>
         FooList_0123456789Sym0KindInference
     type instance Apply FooList_0123456789Sym0 l = FooList_0123456789Sym1 l
     class kproxy ~ Proxy => PFoo (kproxy :: Proxy a) where
@@ -94,7 +94,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
     data FoosPrec_0123456789Sym2 (l :: Nat)
                                  (l :: [a0123456789])
                                  (l :: TyFun [Bool] [Bool])
-      = forall arg. KindOf (Apply (FoosPrec_0123456789Sym2 l l) arg) ~ KindOf (FoosPrec_0123456789Sym3 l l arg) =>
+      = forall arg. SameKind (Apply (FoosPrec_0123456789Sym2 l l) arg) (FoosPrec_0123456789Sym3 l l arg) =>
         FoosPrec_0123456789Sym2KindInference
     type instance Apply (FoosPrec_0123456789Sym2 l l) l = FoosPrec_0123456789Sym3 l l l
     instance SuppressUnusedWarnings FoosPrec_0123456789Sym1 where
@@ -103,7 +103,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,) FoosPrec_0123456789Sym1KindInference GHC.Tuple.())
     data FoosPrec_0123456789Sym1 (l :: Nat)
                                  (l :: TyFun [a0123456789] (TyFun [Bool] [Bool] -> GHC.Types.Type))
-      = forall arg. KindOf (Apply (FoosPrec_0123456789Sym1 l) arg) ~ KindOf (FoosPrec_0123456789Sym2 l arg) =>
+      = forall arg. SameKind (Apply (FoosPrec_0123456789Sym1 l) arg) (FoosPrec_0123456789Sym2 l arg) =>
         FoosPrec_0123456789Sym1KindInference
     type instance Apply (FoosPrec_0123456789Sym1 l) l = FoosPrec_0123456789Sym2 l l
     instance SuppressUnusedWarnings FoosPrec_0123456789Sym0 where
@@ -113,7 +113,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
     data FoosPrec_0123456789Sym0 (l :: TyFun Nat (TyFun [a0123456789] (TyFun [Bool] [Bool]
                                                                        -> GHC.Types.Type)
                                                   -> GHC.Types.Type))
-      = forall arg. KindOf (Apply FoosPrec_0123456789Sym0 arg) ~ KindOf (FoosPrec_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply FoosPrec_0123456789Sym0 arg) (FoosPrec_0123456789Sym1 arg) =>
         FoosPrec_0123456789Sym0KindInference
     type instance Apply FoosPrec_0123456789Sym0 l = FoosPrec_0123456789Sym1 l
     instance PFoo (Proxy :: Proxy [a]) where

--- a/tests/compile-and-dump/Singletons/T29.ghc80.template
+++ b/tests/compile-and-dump/Singletons/T29.ghc80.template
@@ -22,7 +22,7 @@ Singletons/T29.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) BanSym0KindInference GHC.Tuple.())
     data BanSym0 (l :: TyFun Bool Bool)
-      = forall arg. KindOf (Apply BanSym0 arg) ~ KindOf (BanSym1 arg) =>
+      = forall arg. SameKind (Apply BanSym0 arg) (BanSym1 arg) =>
         BanSym0KindInference
     type instance Apply BanSym0 l = BanSym1 l
     type BazSym1 (t :: Bool) = Baz t
@@ -30,7 +30,7 @@ Singletons/T29.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) BazSym0KindInference GHC.Tuple.())
     data BazSym0 (l :: TyFun Bool Bool)
-      = forall arg. KindOf (Apply BazSym0 arg) ~ KindOf (BazSym1 arg) =>
+      = forall arg. SameKind (Apply BazSym0 arg) (BazSym1 arg) =>
         BazSym0KindInference
     type instance Apply BazSym0 l = BazSym1 l
     type BarSym1 (t :: Bool) = Bar t
@@ -38,7 +38,7 @@ Singletons/T29.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) BarSym0KindInference GHC.Tuple.())
     data BarSym0 (l :: TyFun Bool Bool)
-      = forall arg. KindOf (Apply BarSym0 arg) ~ KindOf (BarSym1 arg) =>
+      = forall arg. SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
         BarSym0KindInference
     type instance Apply BarSym0 l = BarSym1 l
     type FooSym1 (t :: Bool) = Foo t
@@ -46,7 +46,7 @@ Singletons/T29.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) FooSym0KindInference GHC.Tuple.())
     data FooSym0 (l :: TyFun Bool Bool)
-      = forall arg. KindOf (Apply FooSym0 arg) ~ KindOf (FooSym1 arg) =>
+      = forall arg. SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
         FooSym0KindInference
     type instance Apply FooSym0 l = FooSym1 l
     type family Ban (a :: Bool) :: Bool where

--- a/tests/compile-and-dump/Singletons/T33.ghc80.template
+++ b/tests/compile-and-dump/Singletons/T33.ghc80.template
@@ -10,7 +10,7 @@ Singletons/T33.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) FooSym0KindInference GHC.Tuple.())
     data FooSym0 (l :: TyFun (Bool, Bool) ())
-      = forall arg. KindOf (Apply FooSym0 arg) ~ KindOf (FooSym1 arg) =>
+      = forall arg. SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
         FooSym0KindInference
     type instance Apply FooSym0 l = FooSym1 l
     type family Foo (a :: (Bool, Bool)) :: () where

--- a/tests/compile-and-dump/Singletons/T54.ghc80.template
+++ b/tests/compile-and-dump/Singletons/T54.ghc80.template
@@ -13,7 +13,7 @@ Singletons/T54.hs:(0,0)-(0,0): Splicing declarations
             (GHC.Tuple.(,)
                Let0123456789Scrutinee_0123456789Sym0KindInference GHC.Tuple.())
     data Let0123456789Scrutinee_0123456789Sym0 l
-      = forall arg. KindOf (Apply Let0123456789Scrutinee_0123456789Sym0 arg) ~ KindOf (Let0123456789Scrutinee_0123456789Sym1 arg) =>
+      = forall arg. SameKind (Apply Let0123456789Scrutinee_0123456789Sym0 arg) (Let0123456789Scrutinee_0123456789Sym1 arg) =>
         Let0123456789Scrutinee_0123456789Sym0KindInference
     type instance Apply Let0123456789Scrutinee_0123456789Sym0 l = Let0123456789Scrutinee_0123456789Sym1 l
     type family Let0123456789Scrutinee_0123456789 e where
@@ -25,7 +25,7 @@ Singletons/T54.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) GSym0KindInference GHC.Tuple.())
     data GSym0 (l :: TyFun Bool Bool)
-      = forall arg. KindOf (Apply GSym0 arg) ~ KindOf (GSym1 arg) =>
+      = forall arg. SameKind (Apply GSym0 arg) (GSym1 arg) =>
         GSym0KindInference
     type instance Apply GSym0 l = GSym1 l
     type family G (a :: Bool) :: Bool where

--- a/tests/compile-and-dump/Singletons/T78.ghc80.template
+++ b/tests/compile-and-dump/Singletons/T78.ghc80.template
@@ -14,7 +14,7 @@ Singletons/T78.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) FooSym0KindInference GHC.Tuple.())
     data FooSym0 (l :: TyFun (Maybe Bool) Bool)
-      = forall arg. KindOf (Apply FooSym0 arg) ~ KindOf (FooSym1 arg) =>
+      = forall arg. SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
         FooSym0KindInference
     type instance Apply FooSym0 l = FooSym1 l
     type family Foo (a :: Maybe Bool) :: Bool where

--- a/tests/compile-and-dump/Singletons/TopLevelPatterns.ghc80.template
+++ b/tests/compile-and-dump/Singletons/TopLevelPatterns.ghc80.template
@@ -12,14 +12,14 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = Data.Tuple.snd (GHC.Tuple.(,) BarSym1KindInference GHC.Tuple.())
     data BarSym1 (l :: Bool) (l :: TyFun Bool Foo)
-      = forall arg. KindOf (Apply (BarSym1 l) arg) ~ KindOf (BarSym2 l arg) =>
+      = forall arg. SameKind (Apply (BarSym1 l) arg) (BarSym2 l arg) =>
         BarSym1KindInference
     type instance Apply (BarSym1 l) l = BarSym2 l l
     instance SuppressUnusedWarnings BarSym0 where
       suppressUnusedWarnings _
         = Data.Tuple.snd (GHC.Tuple.(,) BarSym0KindInference GHC.Tuple.())
     data BarSym0 (l :: TyFun Bool (TyFun Bool Foo -> GHC.Types.Type))
-      = forall arg. KindOf (Apply BarSym0 arg) ~ KindOf (BarSym1 arg) =>
+      = forall arg. SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
         BarSym0KindInference
     type instance Apply BarSym0 l = BarSym1 l
     data instance Sing (z :: Bool)
@@ -116,7 +116,7 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = Data.Tuple.snd (GHC.Tuple.(,) NotSym0KindInference GHC.Tuple.())
     data NotSym0 (l :: TyFun Bool Bool)
-      = forall arg. KindOf (Apply NotSym0 arg) ~ KindOf (NotSym1 arg) =>
+      = forall arg. SameKind (Apply NotSym0 arg) (NotSym1 arg) =>
         NotSym0KindInference
     type instance Apply NotSym0 l = NotSym1 l
     type IdSym1 (t :: a0123456789) = Id t
@@ -124,7 +124,7 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = Data.Tuple.snd (GHC.Tuple.(,) IdSym0KindInference GHC.Tuple.())
     data IdSym0 (l :: TyFun a0123456789 a0123456789)
-      = forall arg. KindOf (Apply IdSym0 arg) ~ KindOf (IdSym1 arg) =>
+      = forall arg. SameKind (Apply IdSym0 arg) (IdSym1 arg) =>
         IdSym0KindInference
     type instance Apply IdSym0 l = IdSym1 l
     type FSym1 (t :: Bool) = F t
@@ -132,7 +132,7 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = Data.Tuple.snd (GHC.Tuple.(,) FSym0KindInference GHC.Tuple.())
     data FSym0 (l :: TyFun Bool Bool)
-      = forall arg. KindOf (Apply FSym0 arg) ~ KindOf (FSym1 arg) =>
+      = forall arg. SameKind (Apply FSym0 arg) (FSym1 arg) =>
         FSym0KindInference
     type instance Apply FSym0 l = FSym1 l
     type GSym1 (t :: Bool) = G t
@@ -140,7 +140,7 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = Data.Tuple.snd (GHC.Tuple.(,) GSym0KindInference GHC.Tuple.())
     data GSym0 (l :: TyFun Bool Bool)
-      = forall arg. KindOf (Apply GSym0 arg) ~ KindOf (GSym1 arg) =>
+      = forall arg. SameKind (Apply GSym0 arg) (GSym1 arg) =>
         GSym0KindInference
     type instance Apply GSym0 l = GSym1 l
     type HSym1 (t :: Bool) = H t
@@ -148,7 +148,7 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = Data.Tuple.snd (GHC.Tuple.(,) HSym0KindInference GHC.Tuple.())
     data HSym0 (l :: TyFun Bool Bool)
-      = forall arg. KindOf (Apply HSym0 arg) ~ KindOf (HSym1 arg) =>
+      = forall arg. SameKind (Apply HSym0 arg) (HSym1 arg) =>
         HSym0KindInference
     type instance Apply HSym0 l = HSym1 l
     type ISym1 (t :: Bool) = I t
@@ -156,7 +156,7 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = Data.Tuple.snd (GHC.Tuple.(,) ISym0KindInference GHC.Tuple.())
     data ISym0 (l :: TyFun Bool Bool)
-      = forall arg. KindOf (Apply ISym0 arg) ~ KindOf (ISym1 arg) =>
+      = forall arg. SameKind (Apply ISym0 arg) (ISym1 arg) =>
         ISym0KindInference
     type instance Apply ISym0 l = ISym1 l
     type JSym0 = J

--- a/tests/compile-and-dump/Singletons/Undef.ghc80.template
+++ b/tests/compile-and-dump/Singletons/Undef.ghc80.template
@@ -14,7 +14,7 @@ Singletons/Undef.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) BarSym0KindInference GHC.Tuple.())
     data BarSym0 (l :: TyFun Bool Bool)
-      = forall arg. KindOf (Apply BarSym0 arg) ~ KindOf (BarSym1 arg) =>
+      = forall arg. SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
         BarSym0KindInference
     type instance Apply BarSym0 l = BarSym1 l
     type FooSym1 (t :: Bool) = Foo t
@@ -22,7 +22,7 @@ Singletons/Undef.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings _
         = snd (GHC.Tuple.(,) FooSym0KindInference GHC.Tuple.())
     data FooSym0 (l :: TyFun Bool Bool)
-      = forall arg. KindOf (Apply FooSym0 arg) ~ KindOf (FooSym1 arg) =>
+      = forall arg. SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
         FooSym0KindInference
     type instance Apply FooSym0 l = FooSym1 l
     type family Bar (a :: Bool) :: Bool where


### PR DESCRIPTION
`KindOf` was defined in terms of `Proxy` because it was (mis)used in `KindInference` constructors. Now there's a dedicated type for kind unification, `SameKind`.