### PR TITLE
Promoted classes without Proxy

### DIFF
--- a/src/Data/Promotion/Prelude.hs
+++ b/src/Data/Promotion/Prelude.hs
@@ -70,9 +70,6 @@ module Data.Promotion.Prelude (
   -- ** Zipping and unzipping lists
   Zip, Zip3, ZipWith, ZipWith3, Unzip, Unzip3,
 
-  -- * Other datatypes
-  Proxy(..),
-
   -- * Defunctionalization symbols
   FalseSym0, TrueSym0,
   NotSym0, NotSym1, (:&&$), (:&&$$), (:&&$$$), (:||$), (:||$$), (:||$$$),
@@ -153,7 +150,6 @@ module Data.Promotion.Prelude (
   (:!!$), (:!!$$), (:!!$$$),
   ) where
 
-import Data.Proxy ( Proxy(..) )
 import Data.Promotion.Prelude.Base
 import Data.Promotion.Prelude.Bool
 import Data.Promotion.Prelude.Either

--- a/src/Data/Singletons/Prelude/Eq.hs
+++ b/src/Data/Singletons/Prelude/Eq.hs
@@ -21,7 +21,6 @@ module Data.Singletons.Prelude.Eq (
   ) where
 
 import Data.Singletons.Prelude.Bool
-import Data.Singletons
 import Data.Singletons.Single
 import Data.Singletons.Prelude.Instances
 import Data.Singletons.Util
@@ -33,7 +32,7 @@ import Data.Type.Equality
 
 -- | The promoted analogue of 'Eq'. If you supply no definition for '(:==)',
 -- then it defaults to a use of '(==)', from @Data.Type.Equality@.
-class kproxy ~ 'Proxy => PEq (kproxy :: Proxy a) where
+class PEq a where
   type (:==) (x :: a) (y :: a) :: Bool
   type (:/=) (x :: a) (y :: a) :: Bool
 

--- a/src/Data/Singletons/Prelude/Num.hs
+++ b/src/Data/Singletons/Prelude/Num.hs
@@ -72,7 +72,7 @@ type family SignumNat (a :: Nat) :: Nat where
   SignumNat 0 = 0
   SignumNat x = 1
 
-instance PNum ('Proxy :: Proxy Nat) where
+instance PNum Nat where
   type a :+ b = a + b
   type a :- b = a - b
   type a :* b = a * b

--- a/src/Data/Singletons/Promote.hs
+++ b/src/Data/Singletons/Promote.hs
@@ -243,9 +243,7 @@ promoteClassDec decl@(ClassDecl { cd_cxt  = cxt
                                     , lde_types = meth_sigs
                                     , lde_infix = infix_decls } }) = do
   let pClsName = promoteClassName cls_name
-  (ptvbs, proxyCxt) <- mkKProxies (map extractTvbName tvbs)
   pCxt <- mapM promote_superclass_pred cxt
-  let cxt'  = pCxt ++ proxyCxt
   sig_decs <- mapM (uncurry promote_sig) (Map.toList meth_sigs)
   let defaults_list  = Map.toList defaults
       defaults_names = map fst defaults_list
@@ -255,7 +253,7 @@ promoteClassDec decl@(ClassDecl { cd_cxt  = cxt
   let infix_decls' = catMaybes $ map (uncurry promoteInfixDecl) infix_decls
 
   -- no need to do anything to the fundeps. They work as is!
-  emitDecs [DClassD cxt' pClsName ptvbs fundeps
+  emitDecs [DClassD pCxt pClsName tvbs fundeps
                     (sig_decs ++ default_decs ++ infix_decls')]
   let defaults_list' = zip defaults_names ann_rhss
       proms          = zip defaults_names prom_rhss
@@ -277,7 +275,7 @@ promoteClassDec decl@(ClassDecl { cd_cxt  = cxt
     promote_superclass_pred :: DPred -> PrM DPred
     promote_superclass_pred = go
       where
-      go (DAppPr pr ty) = DAppPr <$> go pr <*> fmap kindParam (promoteType ty)
+      go (DAppPr pr ty) = DAppPr <$> go pr <*> promoteType ty
       go (DSigPr pr _k) = go pr    -- just ignore the kind; it can't matter
       go (DVarPr name)  = fail $ "Cannot promote ConstraintKinds variables like "
                               ++ show name
@@ -295,7 +293,7 @@ promoteInstanceDec meth_sigs
   let subst = Map.fromList $ zip cls_tvb_names inst_kis
   (meths', ann_rhss, _) <- mapAndUnzip3M (promoteMethod (Just subst) meth_sigs) meths
   emitDecs [DInstanceD Nothing [] (foldType (DConT pClsName)
-                                    (map kindParam inst_kis)) meths']
+                                    inst_kis) meths']
   return (decl { id_meths = zip (map fst meths) ann_rhss })
   where
     pClsName = promoteClassName cls_name
@@ -304,16 +302,12 @@ promoteInstanceDec meth_sigs
     lookup_cls_tvb_names = do
       mb_info <- dsReify pClsName
       case mb_info of
-        Just (DTyConI (DClassD _ _ tvbs _ _) _) -> return (map extract_kv_name tvbs)
+        Just (DTyConI (DClassD _ _ tvbs _ _) _) -> return (map extractTvbName tvbs)
         _ -> do
           mb_info' <- dsReify cls_name
           case mb_info' of
             Just (DTyConI (DClassD _ _ tvbs _ _) _) -> return (map extractTvbName tvbs)
             _ -> fail $ "Cannot find class declaration annotation for " ++ show cls_name
-
-    extract_kv_name :: DTyVarBndr -> Name
-    extract_kv_name (DKindedTV _ (DConT _kproxy `DAppT` DVarT kv_name)) = kv_name
-    extract_kv_name tvb = error $ "Internal error: extract_kv_name\n" ++ show tvb
 
 -- promoteMethod needs to substitute in a method's kind because GHC does not do
 -- enough kind checking of associated types. See GHC#9063. When that bug is fixed,
@@ -352,7 +346,10 @@ promoteMethod m_subst sigs_map (meth_name, meth_rhs) = do
                                   (DKindSig meth_res_ki')
                                   Nothing)
                                eqns]
-  emitDecsM (defunctionalize helperName (map Just meth_arg_kis') (Just meth_res_ki'))
+  emitDecsM $
+    -- Generating KindInference constructors here causes compile-time errors
+    -- instead of helping kind inference. I don't understand why.
+    defunctionalizeWithoutKindInference helperName (map Just meth_arg_kis') (Just meth_res_ki')
   return ( DTySynInstD
              proName
              (DTySynEqn family_args

--- a/src/Data/Singletons/Promote/Eq.hs
+++ b/src/Data/Singletons/Promote/Eq.hs
@@ -35,7 +35,7 @@ mkEqTypeInstance kind cons = do
                                              (foldType (DConT helperName)
                                                        [DVarT aName, DVarT bName]))
       inst = DInstanceD Nothing [] ((DConT $ promoteClassName eqName) `DAppT`
-                                    kindParam kind) [eqInst]
+                                    kind) [eqInst]
 
   return [closedFam, inst]
 

--- a/src/Data/Singletons/Single/Monad.hs
+++ b/src/Data/Singletons/Single/Monad.hs
@@ -228,3 +228,6 @@ singDecsM :: DsMonad q => [Dec] -> SgM [DDec] -> q [DDec]
 singDecsM locals thing = do
   (decs1, decs2) <- singM locals thing
   return $ decs1 ++ decs2
+
+proxyFor :: DType -> DExp
+proxyFor ty = DSigE (DConE 'Proxy) (DAppT (DConT ''Proxy) ty)

--- a/src/Data/Singletons/TH.hs
+++ b/src/Data/Singletons/TH.hs
@@ -54,7 +54,7 @@ module Data.Singletons.TH (
   POrd(..), SOrd(..), ThenCmp, sThenCmp, Foldl, sFoldl,
   Any,
   SDecide(..), (:~:)(..), Void, Refuted, Decision(..),
-  Proxy(..), SomeSing(..),
+  SomeSing(..),
 
   Error, ErrorSym0,
   TrueSym0, FalseSym0,
@@ -88,7 +88,6 @@ import Language.Haskell.TH.Desugar
 import GHC.Exts
 import Language.Haskell.TH
 import Data.Singletons.Util
-import Data.Proxy ( Proxy(..) )
 import Control.Arrow ( first )
 
 -- | The function 'cases' generates a case expression where each right-hand side

--- a/src/Data/Singletons/TypeLits/Internal.hs
+++ b/src/Data/Singletons/TypeLits/Internal.hs
@@ -89,9 +89,9 @@ instance SDecide Symbol where
     where errStr = "Broken Symbol singletons"
 
 -- PEq instances
-instance PEq ('Proxy :: Proxy Nat) where
+instance PEq Nat where
   type (a :: Nat) :== (b :: Nat) = a == b
-instance PEq ('Proxy :: Proxy Symbol) where
+instance PEq Symbol where
   type (a :: Symbol) :== (b :: Symbol) = a == b
 
 -- need SEq instances for TypeLits kinds
@@ -106,10 +106,10 @@ instance SEq Symbol where
     | otherwise                   = unsafeCoerce SFalse
 
 -- POrd instances
-instance POrd ('Proxy :: Proxy Nat) where
+instance POrd Nat where
   type (a :: Nat) `Compare` (b :: Nat) = a `TL.CmpNat` b
 
-instance POrd ('Proxy :: Proxy Symbol) where
+instance POrd Symbol where
   type (a :: Symbol) `Compare` (b :: Symbol) = a `TL.CmpSymbol` b
 
 -- | Kind-restricted synonym for 'Sing' for @Nat@s

--- a/src/Data/Singletons/TypeRepStar.hs
+++ b/src/Data/Singletons/TypeRepStar.hs
@@ -51,7 +51,7 @@ instance SingKind Type where
   fromSing (STypeRep :: Sing a) = typeOf (undefined :: a)
   toSing = dirty_mk_STypeRep
 
-instance PEq ('Proxy :: Proxy Type) where
+instance PEq Type where
   type (a :: *) :== (b :: *) = a == b
 
 instance SEq Type where


### PR DESCRIPTION
This request removes Proxy from parameters of promoted classes. However, I don't know whether the method I used to achieve this is sound: I removed the generation of `KindInference` constructors in a particular place.

If I replace `defunctionalizeWithoutKindInference` with `defunctionalize` there, compilation fails:

```
src/Data/Singletons/Prelude/Ord.hs:45:3: error:
    • Expected kind ‘a0’, but ‘t0’ has kind ‘a1627686870’
    • In the first argument of ‘(:<=)’, namely ‘t_a1fEr’
      In the type ‘(:<=) t_a1fEr t_a1fEt’
      In the type declaration for ‘:<=$$$’
```

`-ddump-splices` for this module is huge, but I managed to produce quite a small example that leads to a similar error:

```
$(promoteOnly [d|
  class Cls a  where
    fff :: a -> ()
    ggg :: a -> Bool -> ()

    fff a = ggg a True
  |])
```

```
src/Data/Singletons/Prelude/Ord.hs:35:9: error:
    • Expected kind ‘a_ahNl’, but ‘t_ahNt’ has kind ‘a1627458359’
    • In the first argument of ‘Ggg’, namely ‘t_ahNt’
      In the type ‘Ggg t_ahNt t_ahNu’
      In the type declaration for ‘GggSym2’
```

Here's the generated code (with `SuppressUnusedWarnings` manually removed):

```
type FffSym1 (t_ahNo :: a1627458359) = Fff t_ahNo
data FffSym0 (l_ahNp :: TyFun a1627458359 ())
  = forall arg_ahNq. SameKind (Apply FffSym0 arg_ahNq) (FffSym1 arg_ahNq) =>
    FffSym0KindInference
type instance Apply FffSym0 l_ahNp = FffSym1 l_ahNp
type GggSym2 (t_ahNt :: a1627458359) (t_ahNu :: Bool) =
    Ggg t_ahNt t_ahNu
data GggSym1 (l_ahNy :: a1627458359) (l_ahNx :: TyFun Bool ())
  = forall arg_ahNz. SameKind (Apply (GggSym1 l_ahNy) arg_ahNz) (GggSym2 l_ahNy arg_ahNz) =>
    GggSym1KindInference
type instance Apply (GggSym1 l_ahNy) l_ahNx = GggSym2 l_ahNy l_ahNx
data GggSym0 (l_ahNv :: TyFun a1627458359 (TyFun Bool () -> Type))
  = forall arg_ahNw. SameKind (Apply GggSym0 arg_ahNw) (GggSym1 arg_ahNw) =>
    GggSym0KindInference
type instance Apply GggSym0 l_ahNv = GggSym1 l_ahNv
type family Fff_1627458380_ahNH (a_ahNF :: a_ahNl) :: () where
  Fff_1627458380_ahNH a_ahNE = Apply (Apply GggSym0 a_ahNE) TrueSym0
type Fff_1627458380Sym1 (t_ahNI :: a1627458359) =
    Fff_1627458380_ahNH t_ahNI
data Fff_1627458380Sym0 (l_ahNJ :: TyFun a1627458359 ())
  = forall arg_ahNK. SameKind (Apply Fff_1627458380Sym0 arg_ahNK) (Fff_1627458380Sym1 arg_ahNK) =>
    Fff_1627458380Sym0KindInference
type instance Apply Fff_1627458380Sym0 l_ahNJ = Fff_1627458380Sym1 l_ahNJ
class PCls a_ahNl where
  type Fff (arg_ahNn :: a_ahNl) :: ()
  type Ggg (arg_ahNr :: a_ahNl) (arg_ahNs :: Bool) :: ()
  type Fff a_ahNF = Apply Fff_1627458380Sym0 a_ahNF
```

I noticed that removing at least one (not necessarily all) of the generated `KindInference`-constructors convinced GHC to accept this, but I don't understand why. So in the hack that I implemented, they are not generated at all.

It's really bugging me. Richard, perhaps you have better insight than me as to why removing a `KindInference` constructor fixes the problem? In https://github.com/goldfirere/singletons/issues/149 you mention that it might be an upstream issue with GHC. Now that there's a smaller test case, can you confirm it so I can open a Trac ticket?

cc @goldfirere 