### PR TITLE
Promoted classes without Proxy

### DIFF
--- a/src/Data/Promotion/Prelude.hs
+++ b/src/Data/Promotion/Prelude.hs
@@ -70,9 +70,6 @@ module Data.Promotion.Prelude (
   -- ** Zipping and unzipping lists
   Zip, Zip3, ZipWith, ZipWith3, Unzip, Unzip3,
 
-  -- * Other datatypes
-  Proxy(..),
-
   -- * Defunctionalization symbols
   FalseSym0, TrueSym0,
   NotSym0, NotSym1, (:&&$), (:&&$$), (:&&$$$), (:||$), (:||$$), (:||$$$),
@@ -153,7 +150,6 @@ module Data.Promotion.Prelude (
   (:!!$), (:!!$$), (:!!$$$),
   ) where
 
-import Data.Proxy ( Proxy(..) )
 import Data.Promotion.Prelude.Base
 import Data.Promotion.Prelude.Bool
 import Data.Promotion.Prelude.Either

--- a/src/Data/Singletons/Prelude/Eq.hs
+++ b/src/Data/Singletons/Prelude/Eq.hs
@@ -21,7 +21,6 @@ module Data.Singletons.Prelude.Eq (
   ) where
 
 import Data.Singletons.Prelude.Bool
-import Data.Singletons
 import Data.Singletons.Single
 import Data.Singletons.Prelude.Instances
 import Data.Singletons.Util
@@ -33,7 +32,7 @@ import Data.Type.Equality
 
 -- | The promoted analogue of 'Eq'. If you supply no definition for '(:==)',
 -- then it defaults to a use of '(==)', from @Data.Type.Equality@.
-class kproxy ~ 'Proxy => PEq (kproxy :: Proxy a) where
+class PEq a where
   type (:==) (x :: a) (y :: a) :: Bool
   type (:/=) (x :: a) (y :: a) :: Bool
 

--- a/src/Data/Singletons/Prelude/Num.hs
+++ b/src/Data/Singletons/Prelude/Num.hs
@@ -72,7 +72,7 @@ type family SignumNat (a :: Nat) :: Nat where
   SignumNat 0 = 0
   SignumNat x = 1
 
-instance PNum ('Proxy :: Proxy Nat) where
+instance PNum Nat where
   type a :+ b = a + b
   type a :- b = a - b
   type a :* b = a * b

--- a/src/Data/Singletons/Promote.hs
+++ b/src/Data/Singletons/Promote.hs
@@ -236,16 +236,20 @@ promoteClassDec :: UClassDecl
                 -> PrM AClassDecl
 promoteClassDec decl@(ClassDecl { cd_cxt  = cxt
                                 , cd_name = cls_name
-                                , cd_tvbs = tvbs
+                                , cd_tvbs = tvbs'
                                 , cd_fds  = fundeps
                                 , cd_lde  = lde@LetDecEnv
                                     { lde_defns = defaults
                                     , lde_types = meth_sigs
                                     , lde_infix = infix_decls } }) = do
+  let
+    -- a workaround for GHC Trac #12928
+    cuskify :: DTyVarBndr -> DTyVarBndr
+    cuskify (DPlainTV tvname) = DKindedTV tvname DStarT
+    cuskify tv                = tv
+    tvbs = map cuskify tvbs'
   let pClsName = promoteClassName cls_name
-  (ptvbs, proxyCxt) <- mkKProxies (map extractTvbName tvbs)
   pCxt <- mapM promote_superclass_pred cxt
-  let cxt'  = pCxt ++ proxyCxt
   sig_decs <- mapM (uncurry promote_sig) (Map.toList meth_sigs)
   let defaults_list  = Map.toList defaults
       defaults_names = map fst defaults_list
@@ -255,7 +259,7 @@ promoteClassDec decl@(ClassDecl { cd_cxt  = cxt
   let infix_decls' = catMaybes $ map (uncurry promoteInfixDecl) infix_decls
 
   -- no need to do anything to the fundeps. They work as is!
-  emitDecs [DClassD cxt' pClsName ptvbs fundeps
+  emitDecs [DClassD pCxt pClsName tvbs fundeps
                     (sig_decs ++ default_decs ++ infix_decls')]
   let defaults_list' = zip defaults_names ann_rhss
       proms          = zip defaults_names prom_rhss
@@ -277,7 +281,7 @@ promoteClassDec decl@(ClassDecl { cd_cxt  = cxt
     promote_superclass_pred :: DPred -> PrM DPred
     promote_superclass_pred = go
       where
-      go (DAppPr pr ty) = DAppPr <$> go pr <*> fmap kindParam (promoteType ty)
+      go (DAppPr pr ty) = DAppPr <$> go pr <*> promoteType ty
       go (DSigPr pr _k) = go pr    -- just ignore the kind; it can't matter
       go (DVarPr name)  = fail $ "Cannot promote ConstraintKinds variables like "
                               ++ show name
@@ -295,7 +299,7 @@ promoteInstanceDec meth_sigs
   let subst = Map.fromList $ zip cls_tvb_names inst_kis
   (meths', ann_rhss, _) <- mapAndUnzip3M (promoteMethod (Just subst) meth_sigs) meths
   emitDecs [DInstanceD Nothing [] (foldType (DConT pClsName)
-                                    (map kindParam inst_kis)) meths']
+                                    inst_kis) meths']
   return (decl { id_meths = zip (map fst meths) ann_rhss })
   where
     pClsName = promoteClassName cls_name
@@ -304,16 +308,12 @@ promoteInstanceDec meth_sigs
     lookup_cls_tvb_names = do
       mb_info <- dsReify pClsName
       case mb_info of
-        Just (DTyConI (DClassD _ _ tvbs _ _) _) -> return (map extract_kv_name tvbs)
+        Just (DTyConI (DClassD _ _ tvbs _ _) _) -> return (map extractTvbName tvbs)
         _ -> do
           mb_info' <- dsReify cls_name
           case mb_info' of
             Just (DTyConI (DClassD _ _ tvbs _ _) _) -> return (map extractTvbName tvbs)
             _ -> fail $ "Cannot find class declaration annotation for " ++ show cls_name
-
-    extract_kv_name :: DTyVarBndr -> Name
-    extract_kv_name (DKindedTV _ (DConT _kproxy `DAppT` DVarT kv_name)) = kv_name
-    extract_kv_name tvb = error $ "Internal error: extract_kv_name\n" ++ show tvb
 
 -- promoteMethod needs to substitute in a method's kind because GHC does not do
 -- enough kind checking of associated types. See GHC#9063. When that bug is fixed,

--- a/src/Data/Singletons/Promote/Eq.hs
+++ b/src/Data/Singletons/Promote/Eq.hs
@@ -35,7 +35,7 @@ mkEqTypeInstance kind cons = do
                                              (foldType (DConT helperName)
                                                        [DVarT aName, DVarT bName]))
       inst = DInstanceD Nothing [] ((DConT $ promoteClassName eqName) `DAppT`
-                                    kindParam kind) [eqInst]
+                                    kind) [eqInst]
 
   return [closedFam, inst]
 

--- a/src/Data/Singletons/Promote/Type.hs
+++ b/src/Data/Singletons/Promote/Type.hs
@@ -29,10 +29,8 @@ promoteType = go []
     go args     (DAppT t1 t2) = do
       k2 <- go [] t2
       go (k2 : args) t1
-    go args     (DSigT ty _) = go args ty  -- just ignore signatures
-    go []       (DVarT name) = return $ DVarT name
-    go _        (DVarT name) = fail $ "Cannot promote an applied type variable " ++
-                                      show name ++ "."
+    go args     (DSigT ty ki) = DSigT <$> go args ty <*> go [] ki
+    go args     (DVarT name) = return $ foldType (DVarT name) args
     go []       (DConT name)
       | name == typeRepName               = return DStarT
       | name == stringName                = return $ DConT symbolName

--- a/src/Data/Singletons/Promote/Type.hs
+++ b/src/Data/Singletons/Promote/Type.hs
@@ -29,7 +29,10 @@ promoteType = go []
     go args     (DAppT t1 t2) = do
       k2 <- go [] t2
       go (k2 : args) t1
-    go args     (DSigT ty ki) = DSigT <$> go args ty <*> go [] ki
+    go args     (DSigT ty ki) = do
+      ty' <- go [] ty
+      -- No need to promote 'ki' - it is already a kind.
+      return $ foldType (DSigT ty' ki) args
     go args     (DVarT name) = return $ foldType (DVarT name) args
     go []       (DConT name)
       | name == typeRepName               = return DStarT

--- a/src/Data/Singletons/Single/Monad.hs
+++ b/src/Data/Singletons/Single/Monad.hs
@@ -229,5 +229,7 @@ singDecsM locals thing = do
   (decs1, decs2) <- singM locals thing
   return $ decs1 ++ decs2
 
+-- Temporary function until support for -XTypeApplications is
+-- implemented in TH-desugar.
 proxyFor :: DType -> DExp
 proxyFor ty = DSigE (DConE 'Proxy) (DAppT (DConT ''Proxy) ty)

--- a/src/Data/Singletons/Single/Monad.hs
+++ b/src/Data/Singletons/Single/Monad.hs
@@ -228,3 +228,6 @@ singDecsM :: DsMonad q => [Dec] -> SgM [DDec] -> q [DDec]
 singDecsM locals thing = do
   (decs1, decs2) <- singM locals thing
   return $ decs1 ++ decs2
+
+proxyFor :: DType -> DExp
+proxyFor ty = DSigE (DConE 'Proxy) (DAppT (DConT ''Proxy) ty)

--- a/src/Data/Singletons/TH.hs
+++ b/src/Data/Singletons/TH.hs
@@ -54,7 +54,7 @@ module Data.Singletons.TH (
   POrd(..), SOrd(..), ThenCmp, sThenCmp, Foldl, sFoldl,
   Any,
   SDecide(..), (:~:)(..), Void, Refuted, Decision(..),
-  Proxy(..), SomeSing(..),
+  SomeSing(..),
 
   Error, ErrorSym0,
   TrueSym0, FalseSym0,
@@ -88,7 +88,6 @@ import Language.Haskell.TH.Desugar
 import GHC.Exts
 import Language.Haskell.TH
 import Data.Singletons.Util
-import Data.Proxy ( Proxy(..) )
 import Control.Arrow ( first )
 
 -- | The function 'cases' generates a case expression where each right-hand side

--- a/src/Data/Singletons/TypeLits/Internal.hs
+++ b/src/Data/Singletons/TypeLits/Internal.hs
@@ -89,9 +89,9 @@ instance SDecide Symbol where
     where errStr = "Broken Symbol singletons"
 
 -- PEq instances
-instance PEq ('Proxy :: Proxy Nat) where
+instance PEq Nat where
   type (a :: Nat) :== (b :: Nat) = a == b
-instance PEq ('Proxy :: Proxy Symbol) where
+instance PEq Symbol where
   type (a :: Symbol) :== (b :: Symbol) = a == b
 
 -- need SEq instances for TypeLits kinds
@@ -106,10 +106,10 @@ instance SEq Symbol where
     | otherwise                   = unsafeCoerce SFalse
 
 -- POrd instances
-instance POrd ('Proxy :: Proxy Nat) where
+instance POrd Nat where
   type (a :: Nat) `Compare` (b :: Nat) = a `TL.CmpNat` b
 
-instance POrd ('Proxy :: Proxy Symbol) where
+instance POrd Symbol where
   type (a :: Symbol) `Compare` (b :: Symbol) = a `TL.CmpSymbol` b
 
 -- | Kind-restricted synonym for 'Sing' for @Nat@s

--- a/src/Data/Singletons/TypeRepStar.hs
+++ b/src/Data/Singletons/TypeRepStar.hs
@@ -51,7 +51,7 @@ instance SingKind Type where
   fromSing (STypeRep :: Sing a) = typeOf (undefined :: a)
   toSing = dirty_mk_STypeRep
 
-instance PEq ('Proxy :: Proxy Type) where
+instance PEq Type where
   type (a :: *) :== (b :: *) = a == b
 
 instance SEq Type where

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -60,6 +60,9 @@ tests =
     , compileAndDumpStdTest "T157"
     , compileAndDumpStdTest "T159"
     , compileAndDumpStdTest "T167"
+    , compileAndDumpStdTest "T145"
+    , compileAndDumpStdTest "PolyKinds"
+    , compileAndDumpStdTest "PolyKindsApp"
     ],
     testCompileAndDumpGroup "Promote"
     [ compileAndDumpStdTest "Constructors"

--- a/tests/compile-and-dump/GradingClient/Database.ghc80.template
+++ b/tests/compile-and-dump/GradingClient/Database.ghc80.template
@@ -11,7 +11,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       Equals_0123456789 Zero Zero = TrueSym0
       Equals_0123456789 (Succ a) (Succ b) = (:==) a b
       Equals_0123456789 (a :: Nat) (b :: Nat) = FalseSym0
-    instance PEq (Proxy :: Proxy Nat) where
+    instance PEq Nat where
       type (:==) (a :: Nat) (b :: Nat) = Equals_0123456789 a b
     type ZeroSym0 = Zero
     type SuccSym1 (t :: Nat) = Succ t
@@ -47,7 +47,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       = forall arg. SameKind (Apply Compare_0123456789Sym0 arg) (Compare_0123456789Sym1 arg) =>
         Compare_0123456789Sym0KindInference
     type instance Apply Compare_0123456789Sym0 l = Compare_0123456789Sym1 l
-    instance POrd (Proxy :: Proxy Nat) where
+    instance POrd Nat where
       type Compare (a :: Nat) (a :: Nat) = Apply (Apply Compare_0123456789Sym0 a) a
     data instance Sing (z :: Nat)
       = z ~ Zero => SZero |
@@ -264,7 +264,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       Equals_0123456789 NAT NAT = TrueSym0
       Equals_0123456789 (VEC a a) (VEC b b) = (:&&) ((:==) a b) ((:==) a b)
       Equals_0123456789 (a :: U) (b :: U) = FalseSym0
-    instance PEq (Proxy :: Proxy U) where
+    instance PEq U where
       type (:==) (a :: U) (b :: U) = Equals_0123456789 a b
     type BOOLSym0 = BOOL
     type STRINGSym0 = STRING
@@ -313,7 +313,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       Equals_0123456789 CY CY = TrueSym0
       Equals_0123456789 CZ CZ = TrueSym0
       Equals_0123456789 (a :: AChar) (b :: AChar) = FalseSym0
-    instance PEq (Proxy :: Proxy AChar) where
+    instance PEq AChar where
       type (:==) (a :: AChar) (b :: AChar) = Equals_0123456789 a b
     type CASym0 = CA
     type CBSym0 = CB

--- a/tests/compile-and-dump/Promote/Newtypes.ghc80.template
+++ b/tests/compile-and-dump/Promote/Newtypes.ghc80.template
@@ -22,7 +22,7 @@ Promote/Newtypes.hs:(0,0)-(0,0): Splicing declarations
     type family Equals_0123456789 (a :: Foo) (b :: Foo) :: Bool where
       Equals_0123456789 (Foo a) (Foo b) = (:==) a b
       Equals_0123456789 (a :: Foo) (b :: Foo) = FalseSym0
-    instance PEq (Proxy :: Proxy Foo) where
+    instance PEq Foo where
       type (:==) (a :: Foo) (b :: Foo) = Equals_0123456789 a b
     type FooSym1 (t :: Nat) = Foo t
     instance SuppressUnusedWarnings FooSym0 where

--- a/tests/compile-and-dump/Singletons/BoundedDeriving.ghc80.template
+++ b/tests/compile-and-dump/Singletons/BoundedDeriving.ghc80.template
@@ -68,7 +68,7 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
     type family MaxBound_0123456789 :: Foo1 where
       MaxBound_0123456789 = Foo1Sym0
     type MaxBound_0123456789Sym0 = MaxBound_0123456789
-    instance PBounded (Proxy :: Proxy Foo1) where
+    instance PBounded Foo1 where
       type MinBound = MinBound_0123456789Sym0
       type MaxBound = MaxBound_0123456789Sym0
     type family MinBound_0123456789 :: Foo2 where
@@ -77,7 +77,7 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
     type family MaxBound_0123456789 :: Foo2 where
       MaxBound_0123456789 = ESym0
     type MaxBound_0123456789Sym0 = MaxBound_0123456789
-    instance PBounded (Proxy :: Proxy Foo2) where
+    instance PBounded Foo2 where
       type MinBound = MinBound_0123456789Sym0
       type MaxBound = MaxBound_0123456789Sym0
     type family MinBound_0123456789 :: Foo3 a where
@@ -86,7 +86,7 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
     type family MaxBound_0123456789 :: Foo3 a where
       MaxBound_0123456789 = Apply Foo3Sym0 MaxBoundSym0
     type MaxBound_0123456789Sym0 = MaxBound_0123456789
-    instance PBounded (Proxy :: Proxy (Foo3 a)) where
+    instance PBounded (Foo3 a) where
       type MinBound = MinBound_0123456789Sym0
       type MaxBound = MaxBound_0123456789Sym0
     type family MinBound_0123456789 :: Foo4 a b where
@@ -95,7 +95,7 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
     type family MaxBound_0123456789 :: Foo4 a b where
       MaxBound_0123456789 = Foo42Sym0
     type MaxBound_0123456789Sym0 = MaxBound_0123456789
-    instance PBounded (Proxy :: Proxy (Foo4 a b)) where
+    instance PBounded (Foo4 a b) where
       type MinBound = MinBound_0123456789Sym0
       type MaxBound = MaxBound_0123456789Sym0
     type family MinBound_0123456789 :: Pair where
@@ -104,7 +104,7 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
     type family MaxBound_0123456789 :: Pair where
       MaxBound_0123456789 = Apply (Apply PairSym0 MaxBoundSym0) MaxBoundSym0
     type MaxBound_0123456789Sym0 = MaxBound_0123456789
-    instance PBounded (Proxy :: Proxy Pair) where
+    instance PBounded Pair where
       type MinBound = MinBound_0123456789Sym0
       type MaxBound = MaxBound_0123456789Sym0
     data instance Sing (z :: Foo1) = z ~ Foo1 => SFoo1

--- a/tests/compile-and-dump/Singletons/Classes.ghc80.template
+++ b/tests/compile-and-dump/Singletons/Classes.ghc80.template
@@ -163,7 +163,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       = forall arg. SameKind (Apply TFHelper_0123456789Sym0 arg) (TFHelper_0123456789Sym1 arg) =>
         TFHelper_0123456789Sym0KindInference
     type instance Apply TFHelper_0123456789Sym0 l = TFHelper_0123456789Sym1 l
-    class kproxy ~ Proxy => PMyOrd (kproxy :: Proxy a) where
+    class PMyOrd (a :: GHC.Types.Type) where
       type Mycompare (arg :: a) (arg :: a) :: Ordering
       type (:<=>) (arg :: a) (arg :: a) :: Ordering
       type (:<=>) a a = Apply (Apply TFHelper_0123456789Sym0 a) a
@@ -192,7 +192,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       = forall arg. SameKind (Apply Mycompare_0123456789Sym0 arg) (Mycompare_0123456789Sym1 arg) =>
         Mycompare_0123456789Sym0KindInference
     type instance Apply Mycompare_0123456789Sym0 l = Mycompare_0123456789Sym1 l
-    instance PMyOrd (Proxy :: Proxy Nat) where
+    instance PMyOrd Nat where
       type Mycompare (a :: Nat) (a :: Nat) = Apply (Apply Mycompare_0123456789Sym0 a) a
     type family Mycompare_0123456789 (a :: ())
                                      (a :: ()) :: Ordering where
@@ -216,7 +216,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       = forall arg. SameKind (Apply Mycompare_0123456789Sym0 arg) (Mycompare_0123456789Sym1 arg) =>
         Mycompare_0123456789Sym0KindInference
     type instance Apply Mycompare_0123456789Sym0 l = Mycompare_0123456789Sym1 l
-    instance PMyOrd (Proxy :: Proxy ()) where
+    instance PMyOrd () where
       type Mycompare (a :: ()) (a :: ()) = Apply (Apply Mycompare_0123456789Sym0 a) a
     type family Mycompare_0123456789 (a :: Foo)
                                      (a :: Foo) :: Ordering where
@@ -240,7 +240,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       = forall arg. SameKind (Apply Mycompare_0123456789Sym0 arg) (Mycompare_0123456789Sym1 arg) =>
         Mycompare_0123456789Sym0KindInference
     type instance Apply Mycompare_0123456789Sym0 l = Mycompare_0123456789Sym1 l
-    instance PMyOrd (Proxy :: Proxy Foo) where
+    instance PMyOrd Foo where
       type Mycompare (a :: Foo) (a :: Foo) = Apply (Apply Mycompare_0123456789Sym0 a) a
     type family TFHelper_0123456789 (a :: Foo2)
                                     (a :: Foo2) :: Bool where
@@ -267,7 +267,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       = forall arg. SameKind (Apply TFHelper_0123456789Sym0 arg) (TFHelper_0123456789Sym1 arg) =>
         TFHelper_0123456789Sym0KindInference
     type instance Apply TFHelper_0123456789Sym0 l = TFHelper_0123456789Sym1 l
-    instance PEq (Proxy :: Proxy Foo2) where
+    instance PEq Foo2 where
       type (:==) (a :: Foo2) (a :: Foo2) = Apply (Apply TFHelper_0123456789Sym0 a) a
     infix 4 %:<=>
     sFooCompare ::
@@ -512,7 +512,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       = forall arg. SameKind (Apply Mycompare_0123456789Sym0 arg) (Mycompare_0123456789Sym1 arg) =>
         Mycompare_0123456789Sym0KindInference
     type instance Apply Mycompare_0123456789Sym0 l = Mycompare_0123456789Sym1 l
-    instance PMyOrd (Proxy :: Proxy Foo2) where
+    instance PMyOrd Foo2 where
       type Mycompare (a :: Foo2) (a :: Foo2) = Apply (Apply Mycompare_0123456789Sym0 a) a
     type family Compare_0123456789 (a :: Foo2)
                                    (a :: Foo2) :: Ordering where
@@ -538,7 +538,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       = forall arg. SameKind (Apply Compare_0123456789Sym0 arg) (Compare_0123456789Sym1 arg) =>
         Compare_0123456789Sym0KindInference
     type instance Apply Compare_0123456789Sym0 l = Compare_0123456789Sym1 l
-    instance POrd (Proxy :: Proxy Foo2) where
+    instance POrd Foo2 where
       type Compare (a :: Foo2) (a :: Foo2) = Apply (Apply Compare_0123456789Sym0 a) a
 Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     singletons
@@ -591,7 +591,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       = forall arg. SameKind (Apply Mycompare_0123456789Sym0 arg) (Mycompare_0123456789Sym1 arg) =>
         Mycompare_0123456789Sym0KindInference
     type instance Apply Mycompare_0123456789Sym0 l = Mycompare_0123456789Sym1 l
-    instance PMyOrd (Proxy :: Proxy Nat') where
+    instance PMyOrd Nat' where
       type Mycompare (a :: Nat') (a :: Nat') = Apply (Apply Mycompare_0123456789Sym0 a) a
     data instance Sing (z :: Nat')
       = z ~ Zero' => SZero' |

--- a/tests/compile-and-dump/Singletons/Classes2.ghc80.template
+++ b/tests/compile-and-dump/Singletons/Classes2.ghc80.template
@@ -49,7 +49,7 @@ Singletons/Classes2.hs:(0,0)-(0,0): Splicing declarations
       = forall arg. SameKind (Apply Mycompare_0123456789Sym0 arg) (Mycompare_0123456789Sym1 arg) =>
         Mycompare_0123456789Sym0KindInference
     type instance Apply Mycompare_0123456789Sym0 l = Mycompare_0123456789Sym1 l
-    instance PMyOrd (Proxy :: Proxy NatFoo) where
+    instance PMyOrd NatFoo where
       type Mycompare (a :: NatFoo) (a :: NatFoo) = Apply (Apply Mycompare_0123456789Sym0 a) a
     data instance Sing (z :: NatFoo)
       = z ~ ZeroFoo => SZeroFoo |

--- a/tests/compile-and-dump/Singletons/EnumDeriving.ghc80.template
+++ b/tests/compile-and-dump/Singletons/EnumDeriving.ghc80.template
@@ -48,7 +48,7 @@ Singletons/EnumDeriving.hs:(0,0)-(0,0): Splicing declarations
       = forall arg. SameKind (Apply FromEnum_0123456789Sym0 arg) (FromEnum_0123456789Sym1 arg) =>
         FromEnum_0123456789Sym0KindInference
     type instance Apply FromEnum_0123456789Sym0 l = FromEnum_0123456789Sym1 l
-    instance PEnum (Proxy :: Proxy Foo) where
+    instance PEnum Foo where
       type ToEnum (a :: GHC.Types.Nat) = Apply ToEnum_0123456789Sym0 a
       type FromEnum (a :: Foo) = Apply FromEnum_0123456789Sym0 a
     data instance Sing (z :: Foo)
@@ -210,7 +210,7 @@ Singletons/EnumDeriving.hs:0:0:: Splicing declarations
       = forall arg. SameKind (Apply FromEnum_0123456789Sym0 arg) (FromEnum_0123456789Sym1 arg) =>
         FromEnum_0123456789Sym0KindInference
     type instance Apply FromEnum_0123456789Sym0 l = FromEnum_0123456789Sym1 l
-    instance PEnum (Proxy :: Proxy Quux) where
+    instance PEnum Quux where
       type ToEnum (a :: GHC.Types.Nat) = Apply ToEnum_0123456789Sym0 a
       type FromEnum (a :: Quux) = Apply FromEnum_0123456789Sym0 a
     instance SEnum Quux where

--- a/tests/compile-and-dump/Singletons/EqInstances.ghc80.template
+++ b/tests/compile-and-dump/Singletons/EqInstances.ghc80.template
@@ -10,7 +10,7 @@ Singletons/EqInstances.hs:0:0:: Splicing declarations
       Equals_0123456789 FLeaf FLeaf = TrueSym0
       Equals_0123456789 ((:+:) a a) ((:+:) b b) = (:&&) ((:==) a b) ((:==) a b)
       Equals_0123456789 (a :: Foo) (b :: Foo) = FalseSym0
-    instance PEq (Proxy :: Proxy Foo) where
+    instance PEq Foo where
       type (:==) (a :: Foo) (b :: Foo) = Equals_0123456789 a b
     instance SEq Empty where
       (%:==) a _
@@ -19,5 +19,5 @@ Singletons/EqInstances.hs:0:0:: Splicing declarations
     type family Equals_0123456789 (a :: Empty)
                                   (b :: Empty) :: Bool where
       Equals_0123456789 (a :: Empty) (b :: Empty) = FalseSym0
-    instance PEq (Proxy :: Proxy Empty) where
+    instance PEq Empty where
       type (:==) (a :: Empty) (b :: Empty) = Equals_0123456789 a b

--- a/tests/compile-and-dump/Singletons/Fixity.ghc80.template
+++ b/tests/compile-and-dump/Singletons/Fixity.ghc80.template
@@ -53,7 +53,7 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
       = forall arg. SameKind (Apply (:<=>$) arg) ((:<=>$$) arg) =>
         (:<=>$###)
     type instance Apply (:<=>$) l = (:<=>$$) l
-    class kproxy ~ Proxy => PMyOrd (kproxy :: Proxy a) where
+    class PMyOrd (a :: GHC.Types.Type) where
       type (:<=>) (arg :: a) (arg :: a) :: Ordering
     infix 4 %:====
     infix 4 %:<=>

--- a/tests/compile-and-dump/Singletons/FunDeps.ghc80.template
+++ b/tests/compile-and-dump/Singletons/FunDeps.ghc80.template
@@ -38,8 +38,8 @@ Singletons/FunDeps.hs:(0,0)-(0,0): Splicing declarations
       = forall arg. SameKind (Apply L2rSym0 arg) (L2rSym1 arg) =>
         L2rSym0KindInference
     type instance Apply L2rSym0 l = L2rSym1 l
-    class (kproxy ~ Proxy, kproxy ~ Proxy) => PFD (kproxy :: Proxy a)
-                                                  (kproxy :: Proxy b) | a -> b where
+    class PFD (a :: GHC.Types.Type)
+              (b :: GHC.Types.Type) | a -> b where
       type Meth (arg :: a) :: a
       type L2r (arg :: a) :: b
     type family Meth_0123456789 (a :: Bool) :: Bool where
@@ -63,7 +63,7 @@ Singletons/FunDeps.hs:(0,0)-(0,0): Splicing declarations
       = forall arg. SameKind (Apply L2r_0123456789Sym0 arg) (L2r_0123456789Sym1 arg) =>
         L2r_0123456789Sym0KindInference
     type instance Apply L2r_0123456789Sym0 l = L2r_0123456789Sym1 l
-    instance PFD (Proxy :: Proxy Bool) (Proxy :: Proxy Nat) where
+    instance PFD Bool Nat where
       type Meth (a :: Bool) = Apply Meth_0123456789Sym0 a
       type L2r (a :: Bool) = Apply L2r_0123456789Sym0 a
     sT1 :: Sing T1Sym0

--- a/tests/compile-and-dump/Singletons/Maybe.ghc80.template
+++ b/tests/compile-and-dump/Singletons/Maybe.ghc80.template
@@ -12,7 +12,7 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
       Equals_0123456789 Nothing Nothing = TrueSym0
       Equals_0123456789 (Just a) (Just b) = (:==) a b
       Equals_0123456789 (a :: Maybe k) (b :: Maybe k) = FalseSym0
-    instance PEq (Proxy :: Proxy (Maybe k)) where
+    instance PEq (Maybe k) where
       type (:==) (a :: Maybe k) (b :: Maybe k) = Equals_0123456789 a b
     type NothingSym0 = Nothing
     type JustSym1 (t :: a0123456789) = Just t

--- a/tests/compile-and-dump/Singletons/Nat.ghc80.template
+++ b/tests/compile-and-dump/Singletons/Nat.ghc80.template
@@ -28,7 +28,7 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
       Equals_0123456789 Zero Zero = TrueSym0
       Equals_0123456789 (Succ a) (Succ b) = (:==) a b
       Equals_0123456789 (a :: Nat) (b :: Nat) = FalseSym0
-    instance PEq (Proxy :: Proxy Nat) where
+    instance PEq Nat where
       type (:==) (a :: Nat) (b :: Nat) = Equals_0123456789 a b
     type ZeroSym0 = Zero
     type SuccSym1 (t :: Nat) = Succ t

--- a/tests/compile-and-dump/Singletons/OrdDeriving.ghc80.template
+++ b/tests/compile-and-dump/Singletons/OrdDeriving.ghc80.template
@@ -27,7 +27,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       Equals_0123456789 Zero Zero = TrueSym0
       Equals_0123456789 (Succ a) (Succ b) = (:==) a b
       Equals_0123456789 (a :: Nat) (b :: Nat) = FalseSym0
-    instance PEq (Proxy :: Proxy Nat) where
+    instance PEq Nat where
       type (:==) (a :: Nat) (b :: Nat) = Equals_0123456789 a b
     type ZeroSym0 = Zero
     type SuccSym1 (t :: Nat) = Succ t
@@ -47,7 +47,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       Equals_0123456789 (E a a a a) (E b b b b) = (:&&) ((:==) a b) ((:&&) ((:==) a b) ((:&&) ((:==) a b) ((:==) a b)))
       Equals_0123456789 (F a a a a) (F b b b b) = (:&&) ((:==) a b) ((:&&) ((:==) a b) ((:&&) ((:==) a b) ((:==) a b)))
       Equals_0123456789 (a :: Foo k k k k) (b :: Foo k k k k) = FalseSym0
-    instance PEq (Proxy :: Proxy (Foo k k k k)) where
+    instance PEq (Foo k k k k) where
       type (:==) (a :: Foo k k k k) (b :: Foo k k k k) = Equals_0123456789 a b
     type ASym4 (t :: a0123456789)
                (t :: b0123456789)
@@ -344,7 +344,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       = forall arg. SameKind (Apply Compare_0123456789Sym0 arg) (Compare_0123456789Sym1 arg) =>
         Compare_0123456789Sym0KindInference
     type instance Apply Compare_0123456789Sym0 l = Compare_0123456789Sym1 l
-    instance POrd (Proxy :: Proxy Nat) where
+    instance POrd Nat where
       type Compare (a :: Nat) (a :: Nat) = Apply (Apply Compare_0123456789Sym0 a) a
     type family Compare_0123456789 (a :: Foo a b c d)
                                    (a :: Foo a b c d) :: Ordering where
@@ -405,7 +405,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       = forall arg. SameKind (Apply Compare_0123456789Sym0 arg) (Compare_0123456789Sym1 arg) =>
         Compare_0123456789Sym0KindInference
     type instance Apply Compare_0123456789Sym0 l = Compare_0123456789Sym1 l
-    instance POrd (Proxy :: Proxy (Foo a b c d)) where
+    instance POrd (Foo a b c d) where
       type Compare (a :: Foo a b c d) (a :: Foo a b c d) = Apply (Apply Compare_0123456789Sym0 a) a
     data instance Sing (z :: Nat)
       = z ~ Zero => SZero |

--- a/tests/compile-and-dump/Singletons/PolyKinds.ghc80.template
+++ b/tests/compile-and-dump/Singletons/PolyKinds.ghc80.template
@@ -1,0 +1,21 @@
+Singletons/PolyKinds.hs:(0,0)-(0,0): Splicing declarations
+    singletons
+      [d| class Cls (a :: k) where
+            fff :: Proxy (a :: k) -> () |]
+  ======>
+    class Cls (a :: k) where
+      fff :: Proxy (a :: k) -> ()
+    type FffSym1 (t :: Proxy (a0123456789 :: k0123456789)) = Fff t
+    instance SuppressUnusedWarnings FffSym0 where
+      suppressUnusedWarnings _
+        = snd (GHC.Tuple.(,) FffSym0KindInference GHC.Tuple.())
+    data FffSym0 (l :: TyFun (Proxy (a0123456789 :: k0123456789)) ())
+      = forall arg. SameKind (Apply FffSym0 arg) (FffSym1 arg) =>
+        FffSym0KindInference
+    type instance Apply FffSym0 l = FffSym1 l
+    class PCls (a :: k) where
+      type Fff (arg :: Proxy (a :: k)) :: ()
+    class SCls (a :: k) where
+      sFff ::
+        forall (t :: Proxy (a :: k)).
+        Sing t -> Sing (Apply FffSym0 t :: ())

--- a/tests/compile-and-dump/Singletons/PolyKinds.hs
+++ b/tests/compile-and-dump/Singletons/PolyKinds.hs
@@ -1,0 +1,8 @@
+module Singletons.PolyKinds where
+
+import Data.Singletons.TH
+
+$(singletons [d|
+  class Cls (a :: k) where
+    fff :: Proxy (a :: k) -> ()
+  |])

--- a/tests/compile-and-dump/Singletons/PolyKindsApp.ghc80.template
+++ b/tests/compile-and-dump/Singletons/PolyKindsApp.ghc80.template
@@ -1,0 +1,12 @@
+Singletons/PolyKindsApp.hs:(0,0)-(0,0): Splicing declarations
+    singletons
+      [d| class Cls (a :: k -> Type) where
+            fff :: (a :: k -> Type) (b :: k) |]
+  ======>
+    class Cls (a :: k -> Type) where
+      fff :: forall b. (a :: k -> Type) (b :: k)
+    type FffSym0 = Fff
+    class PCls (a :: k -> Type) where
+      type Fff :: (a :: k -> Type) (b :: k)
+    class SCls (a :: k -> Type) where
+      sFff :: Sing (FffSym0 :: (a :: k -> Type) (b :: k))

--- a/tests/compile-and-dump/Singletons/PolyKindsApp.hs
+++ b/tests/compile-and-dump/Singletons/PolyKindsApp.hs
@@ -1,0 +1,12 @@
+module Singletons.PolyKindsApp where
+
+import Data.Kind
+import Data.Singletons.TH
+
+$(singletons [d|
+  class Cls (a :: k -> Type) where
+    fff :: (a :: k -> Type) (b :: k)
+
+  -- instance Cls Proxy where
+  --  fff = Proxy
+  |])

--- a/tests/compile-and-dump/Singletons/Star.ghc80.template
+++ b/tests/compile-and-dump/Singletons/Star.ghc80.template
@@ -15,7 +15,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
       Equals_0123456789 (Maybe a) (Maybe b) = (:==) a b
       Equals_0123456789 (Vec a a) (Vec b b) = (:&&) ((:==) a b) ((:==) a b)
       Equals_0123456789 (a :: Type) (b :: Type) = FalseSym0
-    instance PEq (Proxy :: Proxy Type) where
+    instance PEq Type where
       type (:==) (a :: Type) (b :: Type) = Equals_0123456789 a b
     type NatSym0 = Nat
     type IntSym0 = Int
@@ -89,7 +89,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
       = forall arg. SameKind (Apply Compare_0123456789Sym0 arg) (Compare_0123456789Sym1 arg) =>
         Compare_0123456789Sym0KindInference
     type instance Apply Compare_0123456789Sym0 l = Compare_0123456789Sym1 l
-    instance POrd (Proxy :: Proxy Type) where
+    instance POrd Type where
       type Compare (a :: Type) (a :: Type) = Apply (Apply Compare_0123456789Sym0 a) a
     instance (SOrd Type, SOrd Nat) => SOrd Type where
       sCompare ::

--- a/tests/compile-and-dump/Singletons/T136.ghc80.template
+++ b/tests/compile-and-dump/Singletons/T136.ghc80.template
@@ -86,7 +86,7 @@ Singletons/T136.hs:(0,0)-(0,0): Splicing declarations
       = forall arg. SameKind (Apply FromEnum_0123456789Sym0 arg) (FromEnum_0123456789Sym1 arg) =>
         FromEnum_0123456789Sym0KindInference
     type instance Apply FromEnum_0123456789Sym0 l = FromEnum_0123456789Sym1 l
-    instance PEnum (Proxy :: Proxy [Bool]) where
+    instance PEnum [Bool] where
       type Succ (a :: [Bool]) = Apply Succ_0123456789Sym0 a
       type Pred (a :: [Bool]) = Apply Pred_0123456789Sym0 a
       type ToEnum (a :: GHC.Types.Nat) = Apply ToEnum_0123456789Sym0 a

--- a/tests/compile-and-dump/Singletons/T136b.ghc80.template
+++ b/tests/compile-and-dump/Singletons/T136b.ghc80.template
@@ -13,7 +13,7 @@ Singletons/T136b.hs:(0,0)-(0,0): Splicing declarations
       = forall arg. SameKind (Apply MethSym0 arg) (MethSym1 arg) =>
         MethSym0KindInference
     type instance Apply MethSym0 l = MethSym1 l
-    class kproxy ~ Proxy => PC (kproxy :: Proxy a) where
+    class PC (a :: GHC.Types.Type) where
       type Meth (arg :: a) :: a
     class SC a where
       sMeth :: forall (t :: a). Sing t -> Sing (Apply MethSym0 t :: a)
@@ -34,7 +34,7 @@ Singletons/T136b.hs:(0,0)-(0,0): Splicing declarations
       = forall arg. SameKind (Apply Meth_0123456789Sym0 arg) (Meth_0123456789Sym1 arg) =>
         Meth_0123456789Sym0KindInference
     type instance Apply Meth_0123456789Sym0 l = Meth_0123456789Sym1 l
-    instance PC (Proxy :: Proxy Bool) where
+    instance PC Bool where
       type Meth (a :: Bool) = Apply Meth_0123456789Sym0 a
     instance SC Bool where
       sMeth ::

--- a/tests/compile-and-dump/Singletons/T145.ghc80.template
+++ b/tests/compile-and-dump/Singletons/T145.ghc80.template
@@ -1,0 +1,31 @@
+Singletons/T145.hs:(0,0)-(0,0): Splicing declarations
+    singletons
+      [d| class Column (f :: Type -> Type) where
+            col :: f a -> a -> Bool |]
+  ======>
+    class Column (f :: Type -> Type) where
+      col :: forall a. f a -> a -> Bool
+    type ColSym2 (t :: f0123456789 a0123456789) (t :: a0123456789) =
+        Col t t
+    instance SuppressUnusedWarnings ColSym1 where
+      suppressUnusedWarnings _
+        = snd (GHC.Tuple.(,) ColSym1KindInference GHC.Tuple.())
+    data ColSym1 (l :: f0123456789 a0123456789)
+                 (l :: TyFun a0123456789 Bool)
+      = forall arg. SameKind (Apply (ColSym1 l) arg) (ColSym2 l arg) =>
+        ColSym1KindInference
+    type instance Apply (ColSym1 l) l = ColSym2 l l
+    instance SuppressUnusedWarnings ColSym0 where
+      suppressUnusedWarnings _
+        = snd (GHC.Tuple.(,) ColSym0KindInference GHC.Tuple.())
+    data ColSym0 (l :: TyFun (f0123456789 a0123456789) (TyFun a0123456789 Bool
+                                                        -> Type))
+      = forall arg. SameKind (Apply ColSym0 arg) (ColSym1 arg) =>
+        ColSym0KindInference
+    type instance Apply ColSym0 l = ColSym1 l
+    class PColumn (f :: Type -> Type) where
+      type Col (arg :: f a) (arg :: a) :: Bool
+    class SColumn (f :: Type -> Type) where
+      sCol ::
+        forall (t :: f a) (t :: a).
+        Sing t -> Sing t -> Sing (Apply (Apply ColSym0 t) t :: Bool)

--- a/tests/compile-and-dump/Singletons/T145.hs
+++ b/tests/compile-and-dump/Singletons/T145.hs
@@ -1,0 +1,9 @@
+module Singletons.T145 where
+
+import Data.Singletons.TH
+import Data.Kind
+
+$(singletons [d|
+  class Column (f :: Type -> Type) where
+    col :: f a -> a -> Bool
+  |])

--- a/tests/compile-and-dump/Singletons/T167.ghc80.template
+++ b/tests/compile-and-dump/Singletons/T167.ghc80.template
@@ -75,7 +75,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
       = forall arg. SameKind (Apply FooList_0123456789Sym0 arg) (FooList_0123456789Sym1 arg) =>
         FooList_0123456789Sym0KindInference
     type instance Apply FooList_0123456789Sym0 l = FooList_0123456789Sym1 l
-    class kproxy ~ Proxy => PFoo (kproxy :: Proxy a) where
+    class PFoo (a :: GHC.Types.Type) where
       type FoosPrec (arg :: Nat) (arg :: a) (arg :: [Bool]) :: [Bool]
       type FooList (arg :: a) (arg :: [Bool]) :: [Bool]
       type FooList a a = Apply (Apply FooList_0123456789Sym0 a) a
@@ -116,7 +116,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
       = forall arg. SameKind (Apply FoosPrec_0123456789Sym0 arg) (FoosPrec_0123456789Sym1 arg) =>
         FoosPrec_0123456789Sym0KindInference
     type instance Apply FoosPrec_0123456789Sym0 l = FoosPrec_0123456789Sym1 l
-    instance PFoo (Proxy :: Proxy [a]) where
+    instance PFoo [a] where
       type FoosPrec (a :: Nat) (a :: [a]) (a :: [Bool]) = Apply (Apply (Apply FoosPrec_0123456789Sym0 a) a) a
     class SFoo a where
       sFoosPrec ::


### PR DESCRIPTION
closes https://github.com/goldfirere/singletons/issues/149

In the light of https://ghc.haskell.org/trac/ghc/ticket/12928, I decided to proceed as follows:

* if a class type variable has no explicit kind, we make no effort to guess it and default to `*`. This is OK because before `TypeInType` we were limited by `KProxy` anyway.
* if a class type variable has an explicit kind, it is preserved.

This way, we always get CUSKs where we need them.

I also modified `promoteType` slightly, so this PR closes https://github.com/goldfirere/singletons/issues/145, because now this code compiles:

```
{-# LANGUAGE TypeInType, ScopedTypeVariables, TypeFamilies, GADTs, TemplateHaskell #-}

import Data.Kind
import Data.Singletons.Promote

$(promote [d|
  class Column (f :: Type -> Type) where
    col :: f a -> a -> Bool
  |])
```