### PR TITLE
Banish some more Proxies

### DIFF
--- a/src/Data/Singletons/Promote/Defun.hs
+++ b/src/Data/Singletons/Promote/Defun.hs
@@ -151,7 +151,7 @@ defunctionalize name m_arg_kinds' m_res_kind' = do
           suppress    = DInstanceD Nothing []
                           (DConT suppressClassName `DAppT` DConT data_name)
                           [DLetDec $ DFunD suppressMethodName
-                                           [DClause [DWildPa]
+                                           [DClause []
                                                     ((DVarE 'snd) `DAppE`
                                                      mkTupleDExp [DConE con_name,
                                                                   mkTupleDExp []])]]

--- a/src/Data/Singletons/SuppressUnusedWarnings.hs
+++ b/src/Data/Singletons/SuppressUnusedWarnings.hs
@@ -7,14 +7,12 @@
 -- from the user. Why would anyone ever want this? Because what is below
 -- is dirty, and no one wants to see it.
 
-{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE AllowAmbiguousTypes, PolyKinds #-}
 
 module Data.Singletons.SuppressUnusedWarnings where
-
-import Data.Proxy
 
 -- | This class (which users should never see) is to be instantiated in order
 -- to use an otherwise-unused data constructor, such as the "kind-inference"
 -- data constructor for defunctionalization symbols.
 class SuppressUnusedWarnings (t :: k) where
-  suppressUnusedWarnings :: Proxy t -> ()
+  suppressUnusedWarnings :: ()

--- a/tests/ByHand.hs
+++ b/tests/ByHand.hs
@@ -14,7 +14,8 @@ This file is a great way to understand the singleton encoding better.
              FlexibleInstances, FlexibleContexts, UndecidableInstances,
              RankNTypes, TypeOperators, MultiParamTypeClasses,
              FunctionalDependencies, ScopedTypeVariables,
-             LambdaCase, TemplateHaskell, EmptyCase, TypeInType
+             LambdaCase, TemplateHaskell, EmptyCase, TypeInType,
+             AllowAmbiguousTypes, TypeApplications
  #-}
 
 module ByHand where
@@ -785,11 +786,11 @@ sFindIndices sP sLs =
             -> Sing ((Let123LoopSym2 t1 t2) @@ u1 @@ u2)
       sLoop _ SNil = SNil
       sLoop sN (sX `SCons` sXs) = case sP `applySing` sX of
-        STrue -> (singFun2 (Proxy :: Proxy ConsSym0) SCons) `applySing` sN `applySing`
-                   ((singFun2 (Proxy :: Proxy (Let123LoopSym2 t1 t2)) sLoop) `applySing` ((singFun1 (Proxy :: Proxy SuccSym0) SSucc) `applySing` sN) `applySing` sXs)
-        SFalse -> (singFun2 (Proxy :: Proxy (Let123LoopSym2 t1 t2)) sLoop) `applySing` ((singFun1 (Proxy :: Proxy SuccSym0) SSucc) `applySing` sN) `applySing` sXs
+        STrue -> (singFun2 @ConsSym0 SCons) `applySing` sN `applySing`
+                   ((singFun2 @(Let123LoopSym2 t1 t2) sLoop) `applySing` ((singFun1 @SuccSym0 SSucc) `applySing` sN) `applySing` sXs)
+        SFalse -> (singFun2 @(Let123LoopSym2 t1 t2) sLoop) `applySing` ((singFun1 @SuccSym0 SSucc) `applySing` sN) `applySing` sXs
   in
-  (singFun2 (Proxy :: Proxy (Let123LoopSym2 t1 t2)) sLoop) `applySing` SZero `applySing` sLs
+  (singFun2 @(Let123LoopSym2 t1 t2) sLoop) `applySing` SZero `applySing` sLs
 
 
 fI :: forall a. (a -> Bool) -> [a] -> [Nat]
@@ -827,7 +828,7 @@ type Lambda22Sym2 a b = Lambda22 a b
 sFI :: forall (t1 :: TyFun a Bool -> *) (t2 :: List a). Sing t1
     -> Sing t2
     -> Sing (FISym0 @@ t1 @@ t2)
-sFI = unSingFun2 (singFun2 (Proxy :: Proxy FI) (\p ls ->
+sFI = unSingFun2 (singFun2 @FI (\p ls ->
     let lambda :: forall {-(t1 :: TyFun a Bool -> *)-} t1 t2. Sing t1 -> Sing t2 -> Sing (Lambda22Sym0 @@ t1 @@ t2)
         lambda sP sLs =
           let sLoop :: (Lambda22Sym0 @@ t1 @@ t2) ~ (Let123LoopSym2 t1 t2 @@ Zero @@ t2) => forall (u1 :: Nat). Sing u1
@@ -835,11 +836,11 @@ sFI = unSingFun2 (singFun2 (Proxy :: Proxy FI) (\p ls ->
                     -> Sing ((Let123LoopSym2 t1 t2) @@ u1 @@ u2)
               sLoop _ SNil = SNil
               sLoop sN (sX `SCons` sXs) =  case sP `applySing` sX of
-                STrue -> (singFun2 (Proxy :: Proxy ConsSym0) SCons) `applySing` sN `applySing`
-                     ((singFun2 (Proxy :: Proxy (Let123LoopSym2 t1 t2)) sLoop) `applySing` ((singFun1 (Proxy :: Proxy SuccSym0) SSucc) `applySing` sN) `applySing` sXs)
-                SFalse -> (singFun2 (Proxy :: Proxy (Let123LoopSym2 t1 t2)) sLoop) `applySing` ((singFun1 (Proxy :: Proxy SuccSym0) SSucc) `applySing` sN) `applySing` sXs
+                STrue -> (singFun2 @ConsSym0 SCons) `applySing` sN `applySing`
+                     ((singFun2 @(Let123LoopSym2 t1 t2) sLoop) `applySing` ((singFun1 @SuccSym0 SSucc) `applySing` sN) `applySing` sXs)
+                SFalse -> (singFun2 @(Let123LoopSym2 t1 t2) sLoop) `applySing` ((singFun1 @SuccSym0 SSucc) `applySing` sN) `applySing` sXs
           in
-          (singFun2 (Proxy :: Proxy (Let123LoopSym2 t1 t2)) sLoop) `applySing` SZero `applySing` sLs
+          (singFun2 @(Let123LoopSym2 t1 t2) sLoop) `applySing` SZero `applySing` sLs
     in
     lambda p ls
   ))

--- a/tests/compile-and-dump/GradingClient/Database.ghc82.template
+++ b/tests/compile-and-dump/GradingClient/Database.ghc82.template
@@ -16,7 +16,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     type ZeroSym0 = Zero
     type SuccSym1 (t :: Nat) = Succ t
     instance SuppressUnusedWarnings SuccSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SuccSym0KindInference) GHC.Tuple.())
     data SuccSym0 (l :: TyFun Nat Nat)
       = forall arg. SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
@@ -30,7 +30,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     type Compare_0123456789876543210Sym2 (t :: Nat) (t :: Nat) =
         Compare_0123456789876543210 t t
     instance SuppressUnusedWarnings Compare_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -39,7 +39,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
         Compare_0123456789876543210Sym1KindInference
     type instance Apply (Compare_0123456789876543210Sym1 l) l = Compare_0123456789876543210 l l
     instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -239,14 +239,14 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     type NATSym0 = NAT
     type VECSym2 (t :: U) (t :: Nat) = VEC t t
     instance SuppressUnusedWarnings VECSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) VECSym1KindInference) GHC.Tuple.())
     data VECSym1 (l :: U) (l :: TyFun Nat U)
       = forall arg. SameKind (Apply (VECSym1 l) arg) (VECSym2 l arg) =>
         VECSym1KindInference
     type instance Apply (VECSym1 l) l = VEC l l
     instance SuppressUnusedWarnings VECSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) VECSym0KindInference) GHC.Tuple.())
     data VECSym0 (l :: TyFun U (TyFun Nat U -> Type))
       = forall arg. SameKind (Apply VECSym0 arg) (VECSym1 arg) =>
@@ -310,14 +310,14 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     type CZSym0 = CZ
     type AttrSym2 (t :: [AChar]) (t :: U) = Attr t t
     instance SuppressUnusedWarnings AttrSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) AttrSym1KindInference) GHC.Tuple.())
     data AttrSym1 (l :: [AChar]) (l :: TyFun U Attribute)
       = forall arg. SameKind (Apply (AttrSym1 l) arg) (AttrSym2 l arg) =>
         AttrSym1KindInference
     type instance Apply (AttrSym1 l) l = Attr l l
     instance SuppressUnusedWarnings AttrSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) AttrSym0KindInference) GHC.Tuple.())
     data AttrSym0 (l :: TyFun [AChar] (TyFun U Attribute -> Type))
       = forall arg. SameKind (Apply AttrSym0 arg) (AttrSym1 arg) =>
@@ -325,7 +325,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply AttrSym0 l = AttrSym1 l
     type SchSym1 (t :: [Attribute]) = Sch t
     instance SuppressUnusedWarnings SchSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SchSym0KindInference) GHC.Tuple.())
     data SchSym0 (l :: TyFun [Attribute] Schema)
       = forall arg. SameKind (Apply SchSym0 arg) (SchSym1 arg) =>
@@ -334,7 +334,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     type Let0123456789876543210Scrutinee_0123456789876543210Sym4 t t t t =
         Let0123456789876543210Scrutinee_0123456789876543210 t t t t
     instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym3 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210Scrutinee_0123456789876543210Sym3KindInference)
@@ -344,7 +344,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
         Let0123456789876543210Scrutinee_0123456789876543210Sym3KindInference
     type instance Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym3 l l l) l = Let0123456789876543210Scrutinee_0123456789876543210 l l l l
     instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210Scrutinee_0123456789876543210Sym2KindInference)
@@ -354,7 +354,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
         Let0123456789876543210Scrutinee_0123456789876543210Sym2KindInference
     type instance Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym2 l l) l = Let0123456789876543210Scrutinee_0123456789876543210Sym3 l l l
     instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210Scrutinee_0123456789876543210Sym1KindInference)
@@ -364,7 +364,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
         Let0123456789876543210Scrutinee_0123456789876543210Sym1KindInference
     type instance Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym1 l) l = Let0123456789876543210Scrutinee_0123456789876543210Sym2 l l
     instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference)
@@ -380,14 +380,14 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       Case_0123456789876543210 name name' u attrs False = Apply (Apply LookupSym0 name) (Apply SchSym0 attrs)
     type LookupSym2 (t :: [AChar]) (t :: Schema) = Lookup t t
     instance SuppressUnusedWarnings LookupSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) LookupSym1KindInference) GHC.Tuple.())
     data LookupSym1 (l :: [AChar]) (l :: TyFun Schema U)
       = forall arg. SameKind (Apply (LookupSym1 l) arg) (LookupSym2 l arg) =>
         LookupSym1KindInference
     type instance Apply (LookupSym1 l) l = Lookup l l
     instance SuppressUnusedWarnings LookupSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) LookupSym0KindInference) GHC.Tuple.())
     data LookupSym0 (l :: TyFun [AChar] (TyFun Schema U -> Type))
       = forall arg. SameKind (Apply LookupSym0 arg) (LookupSym1 arg) =>
@@ -395,14 +395,14 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply LookupSym0 l = LookupSym1 l
     type OccursSym2 (t :: [AChar]) (t :: Schema) = Occurs t t
     instance SuppressUnusedWarnings OccursSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) OccursSym1KindInference) GHC.Tuple.())
     data OccursSym1 (l :: [AChar]) (l :: TyFun Schema Bool)
       = forall arg. SameKind (Apply (OccursSym1 l) arg) (OccursSym2 l arg) =>
         OccursSym1KindInference
     type instance Apply (OccursSym1 l) l = Occurs l l
     instance SuppressUnusedWarnings OccursSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) OccursSym0KindInference) GHC.Tuple.())
     data OccursSym0 (l :: TyFun [AChar] (TyFun Schema Bool -> Type))
       = forall arg. SameKind (Apply OccursSym0 arg) (OccursSym1 arg) =>
@@ -410,14 +410,14 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply OccursSym0 l = OccursSym1 l
     type AttrNotInSym2 (t :: Attribute) (t :: Schema) = AttrNotIn t t
     instance SuppressUnusedWarnings AttrNotInSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) AttrNotInSym1KindInference) GHC.Tuple.())
     data AttrNotInSym1 (l :: Attribute) (l :: TyFun Schema Bool)
       = forall arg. SameKind (Apply (AttrNotInSym1 l) arg) (AttrNotInSym2 l arg) =>
         AttrNotInSym1KindInference
     type instance Apply (AttrNotInSym1 l) l = AttrNotIn l l
     instance SuppressUnusedWarnings AttrNotInSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) AttrNotInSym0KindInference) GHC.Tuple.())
     data AttrNotInSym0 (l :: TyFun Attribute (TyFun Schema Bool
                                               -> Type))
@@ -426,14 +426,14 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply AttrNotInSym0 l = AttrNotInSym1 l
     type DisjointSym2 (t :: Schema) (t :: Schema) = Disjoint t t
     instance SuppressUnusedWarnings DisjointSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) DisjointSym1KindInference) GHC.Tuple.())
     data DisjointSym1 (l :: Schema) (l :: TyFun Schema Bool)
       = forall arg. SameKind (Apply (DisjointSym1 l) arg) (DisjointSym2 l arg) =>
         DisjointSym1KindInference
     type instance Apply (DisjointSym1 l) l = Disjoint l l
     instance SuppressUnusedWarnings DisjointSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) DisjointSym0KindInference) GHC.Tuple.())
     data DisjointSym0 (l :: TyFun Schema (TyFun Schema Bool -> Type))
       = forall arg. SameKind (Apply DisjointSym0 arg) (DisjointSym1 arg) =>
@@ -441,14 +441,14 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply DisjointSym0 l = DisjointSym1 l
     type AppendSym2 (t :: Schema) (t :: Schema) = Append t t
     instance SuppressUnusedWarnings AppendSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) AppendSym1KindInference) GHC.Tuple.())
     data AppendSym1 (l :: Schema) (l :: TyFun Schema Schema)
       = forall arg. SameKind (Apply (AppendSym1 l) arg) (AppendSym2 l arg) =>
         AppendSym1KindInference
     type instance Apply (AppendSym1 l) l = Append l l
     instance SuppressUnusedWarnings AppendSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) AppendSym0KindInference) GHC.Tuple.())
     data AppendSym0 (l :: TyFun Schema (TyFun Schema Schema -> Type))
       = forall arg. SameKind (Apply AppendSym0 arg) (AppendSym1 arg) =>

--- a/tests/compile-and-dump/InsertionSort/InsertionSortImp.ghc82.template
+++ b/tests/compile-and-dump/InsertionSort/InsertionSortImp.ghc82.template
@@ -5,7 +5,7 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
     type ZeroSym0 = Zero
     type SuccSym1 (t :: Nat) = Succ t
     instance SuppressUnusedWarnings SuccSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SuccSym0KindInference) GHC.Tuple.())
     data SuccSym0 (l :: TyFun Nat Nat)
       = forall arg. SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
@@ -58,7 +58,7 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
     type Let0123456789876543210Scrutinee_0123456789876543210Sym3 t t t =
         Let0123456789876543210Scrutinee_0123456789876543210 t t t
     instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210Scrutinee_0123456789876543210Sym2KindInference)
@@ -68,7 +68,7 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
         Let0123456789876543210Scrutinee_0123456789876543210Sym2KindInference
     type instance Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym2 l l) l = Let0123456789876543210Scrutinee_0123456789876543210 l l l
     instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210Scrutinee_0123456789876543210Sym1KindInference)
@@ -78,7 +78,7 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
         Let0123456789876543210Scrutinee_0123456789876543210Sym1KindInference
     type instance Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym1 l) l = Let0123456789876543210Scrutinee_0123456789876543210Sym2 l l
     instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference)
@@ -94,14 +94,14 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
       Case_0123456789876543210 n h t False = Apply (Apply (:$) h) (Apply (Apply InsertSym0 n) t)
     type LeqSym2 (t :: Nat) (t :: Nat) = Leq t t
     instance SuppressUnusedWarnings LeqSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) LeqSym1KindInference) GHC.Tuple.())
     data LeqSym1 (l :: Nat) (l :: TyFun Nat Bool)
       = forall arg. SameKind (Apply (LeqSym1 l) arg) (LeqSym2 l arg) =>
         LeqSym1KindInference
     type instance Apply (LeqSym1 l) l = Leq l l
     instance SuppressUnusedWarnings LeqSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) LeqSym0KindInference) GHC.Tuple.())
     data LeqSym0 (l :: TyFun Nat (TyFun Nat Bool -> GHC.Types.Type))
       = forall arg. SameKind (Apply LeqSym0 arg) (LeqSym1 arg) =>
@@ -109,14 +109,14 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply LeqSym0 l = LeqSym1 l
     type InsertSym2 (t :: Nat) (t :: [Nat]) = Insert t t
     instance SuppressUnusedWarnings InsertSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) InsertSym1KindInference) GHC.Tuple.())
     data InsertSym1 (l :: Nat) (l :: TyFun [Nat] [Nat])
       = forall arg. SameKind (Apply (InsertSym1 l) arg) (InsertSym2 l arg) =>
         InsertSym1KindInference
     type instance Apply (InsertSym1 l) l = Insert l l
     instance SuppressUnusedWarnings InsertSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) InsertSym0KindInference) GHC.Tuple.())
     data InsertSym0 (l :: TyFun Nat (TyFun [Nat] [Nat]
                                      -> GHC.Types.Type))
@@ -125,7 +125,7 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply InsertSym0 l = InsertSym1 l
     type InsertionSortSym1 (t :: [Nat]) = InsertionSort t
     instance SuppressUnusedWarnings InsertionSortSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) InsertionSortSym0KindInference) GHC.Tuple.())
     data InsertionSortSym0 (l :: TyFun [Nat] [Nat])
       = forall arg. SameKind (Apply InsertionSortSym0 arg) (InsertionSortSym1 arg) =>

--- a/tests/compile-and-dump/Promote/Constructors.ghc82.template
+++ b/tests/compile-and-dump/Promote/Constructors.ghc82.template
@@ -8,14 +8,14 @@ Promote/Constructors.hs:(0,0)-(0,0): Splicing declarations
     type FooSym0 = Foo
     type (:+$$$) (t :: Foo) (t :: Foo) = (:+) t t
     instance SuppressUnusedWarnings (:+$$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:+$$###)) GHC.Tuple.())
     data (:+$$) (l :: Foo) (l :: TyFun Foo Foo)
       = forall arg. SameKind (Apply ((:+$$) l) arg) ((:+$$$) l arg) =>
         (:+$$###)
     type instance Apply ((:+$$) l) l = (:+) l l
     instance SuppressUnusedWarnings (:+$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:+$###)) GHC.Tuple.())
     data (:+$) (l :: TyFun Foo (TyFun Foo Foo -> GHC.Types.Type))
       = forall arg. SameKind (Apply (:+$) arg) ((:+$$) arg) => (:+$###)
@@ -23,14 +23,14 @@ Promote/Constructors.hs:(0,0)-(0,0): Splicing declarations
     type BarSym5 (t :: Bar) (t :: Bar) (t :: Bar) (t :: Bar) (t :: Foo) =
         Bar t t t t t
     instance SuppressUnusedWarnings BarSym4 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BarSym4KindInference) GHC.Tuple.())
     data BarSym4 (l :: Bar) (l :: Bar) (l :: Bar) (l :: Bar) (l :: TyFun Foo Bar)
       = forall arg. SameKind (Apply (BarSym4 l l l l) arg) (BarSym5 l l l l arg) =>
         BarSym4KindInference
     type instance Apply (BarSym4 l l l l) l = Bar l l l l l
     instance SuppressUnusedWarnings BarSym3 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BarSym3KindInference) GHC.Tuple.())
     data BarSym3 (l :: Bar) (l :: Bar) (l :: Bar) (l :: TyFun Bar (TyFun Foo Bar
                                                                    -> GHC.Types.Type))
@@ -38,7 +38,7 @@ Promote/Constructors.hs:(0,0)-(0,0): Splicing declarations
         BarSym3KindInference
     type instance Apply (BarSym3 l l l) l = BarSym4 l l l l
     instance SuppressUnusedWarnings BarSym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BarSym2KindInference) GHC.Tuple.())
     data BarSym2 (l :: Bar) (l :: Bar) (l :: TyFun Bar (TyFun Bar (TyFun Foo Bar
                                                                    -> GHC.Types.Type)
@@ -47,7 +47,7 @@ Promote/Constructors.hs:(0,0)-(0,0): Splicing declarations
         BarSym2KindInference
     type instance Apply (BarSym2 l l) l = BarSym3 l l l
     instance SuppressUnusedWarnings BarSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BarSym1KindInference) GHC.Tuple.())
     data BarSym1 (l :: Bar) (l :: TyFun Bar (TyFun Bar (TyFun Bar (TyFun Foo Bar
                                                                    -> GHC.Types.Type)
@@ -57,7 +57,7 @@ Promote/Constructors.hs:(0,0)-(0,0): Splicing declarations
         BarSym1KindInference
     type instance Apply (BarSym1 l) l = BarSym2 l l
     instance SuppressUnusedWarnings BarSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BarSym0KindInference) GHC.Tuple.())
     data BarSym0 (l :: TyFun Bar (TyFun Bar (TyFun Bar (TyFun Bar (TyFun Foo Bar
                                                                    -> GHC.Types.Type)

--- a/tests/compile-and-dump/Promote/GenDefunSymbols.ghc82.template
+++ b/tests/compile-and-dump/Promote/GenDefunSymbols.ghc82.template
@@ -5,7 +5,7 @@ Promote/GenDefunSymbols.hs:0:0:: Splicing declarations
                              -> Type) (t :: Maybe a0123456789876543210) =
         LiftMaybe t t
     instance SuppressUnusedWarnings LiftMaybeSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) LiftMaybeSym1KindInference) GHC.Tuple.())
     data LiftMaybeSym1 (l :: TyFun a0123456789876543210 b0123456789876543210
                              -> Type) (l :: TyFun (Maybe a0123456789876543210) (Maybe b0123456789876543210))
@@ -13,7 +13,7 @@ Promote/GenDefunSymbols.hs:0:0:: Splicing declarations
         LiftMaybeSym1KindInference
     type instance Apply (LiftMaybeSym1 l) l = LiftMaybe l l
     instance SuppressUnusedWarnings LiftMaybeSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) LiftMaybeSym0KindInference) GHC.Tuple.())
     data LiftMaybeSym0 (l :: TyFun (TyFun a0123456789876543210 b0123456789876543210
                                     -> Type) (TyFun (Maybe a0123456789876543210) (Maybe b0123456789876543210)
@@ -24,7 +24,7 @@ Promote/GenDefunSymbols.hs:0:0:: Splicing declarations
     type ZeroSym0 = Zero
     type SuccSym1 (t :: NatT) = Succ t
     instance SuppressUnusedWarnings SuccSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SuccSym0KindInference) GHC.Tuple.())
     data SuccSym0 (l :: TyFun NatT NatT)
       = forall arg. Data.Singletons.SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
@@ -32,14 +32,14 @@ Promote/GenDefunSymbols.hs:0:0:: Splicing declarations
     type instance Apply SuccSym0 l = Succ l
     type (:+$$$) (t :: Nat) (t :: Nat) = (:+) t t
     instance SuppressUnusedWarnings (:+$$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:+$$###)) GHC.Tuple.())
     data (:+$$) (l :: Nat) l
       = forall arg. Data.Singletons.SameKind (Apply ((:+$$) l) arg) ((:+$$$) l arg) =>
         (:+$$###)
     type instance Apply ((:+$$) l) l = (:+) l l
     instance SuppressUnusedWarnings (:+$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:+$###)) GHC.Tuple.())
     data (:+$) l
       = forall arg. Data.Singletons.SameKind (Apply (:+$) arg) ((:+$$) arg) =>

--- a/tests/compile-and-dump/Promote/Newtypes.ghc82.template
+++ b/tests/compile-and-dump/Promote/Newtypes.ghc82.template
@@ -11,7 +11,7 @@ Promote/Newtypes.hs:(0,0)-(0,0): Splicing declarations
     newtype Bar = Bar {unBar :: Nat}
     type UnBarSym1 (t :: Bar) = UnBar t
     instance SuppressUnusedWarnings UnBarSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) UnBarSym0KindInference) GHC.Tuple.())
     data UnBarSym0 (l :: TyFun Bar Nat)
       = forall arg. SameKind (Apply UnBarSym0 arg) (UnBarSym1 arg) =>
@@ -26,7 +26,7 @@ Promote/Newtypes.hs:(0,0)-(0,0): Splicing declarations
       type (:==) (a :: Foo) (b :: Foo) = Equals_0123456789876543210 a b
     type FooSym1 (t :: Nat) = Foo t
     instance SuppressUnusedWarnings FooSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym0KindInference) GHC.Tuple.())
     data FooSym0 (l :: TyFun Nat Foo)
       = forall arg. SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
@@ -34,7 +34,7 @@ Promote/Newtypes.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply FooSym0 l = Foo l
     type BarSym1 (t :: Nat) = Bar t
     instance SuppressUnusedWarnings BarSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BarSym0KindInference) GHC.Tuple.())
     data BarSym0 (l :: TyFun Nat Bar)
       = forall arg. SameKind (Apply BarSym0 arg) (BarSym1 arg) =>

--- a/tests/compile-and-dump/Promote/Prelude.ghc82.template
+++ b/tests/compile-and-dump/Promote/Prelude.ghc82.template
@@ -6,7 +6,7 @@ Promote/Prelude.hs:(0,0)-(0,0): Splicing declarations
   ======>
     type OddSym1 (t :: Nat) = Odd t
     instance SuppressUnusedWarnings OddSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) OddSym0KindInference) GHC.Tuple.())
     data OddSym0 (l :: TyFun Nat Bool)
       = forall arg. Data.Singletons.SameKind (Apply OddSym0 arg) (OddSym1 arg) =>

--- a/tests/compile-and-dump/Promote/Prelude.hs
+++ b/tests/compile-and-dump/Promote/Prelude.hs
@@ -3,7 +3,6 @@ module Promote.Prelude where
 import Data.Promotion.TH
 import Data.Promotion.Prelude
 import Data.Promotion.Prelude.List
-import Data.Proxy
 import GHC.TypeLits
 
 lengthTest1a :: Proxy (Length '[True, True, True, True])

--- a/tests/compile-and-dump/Promote/T180.ghc82.template
+++ b/tests/compile-and-dump/Promote/T180.ghc82.template
@@ -10,7 +10,7 @@ Promote/T180.hs:(0,0)-(0,0): Splicing declarations
     z (X2 x) = x
     type ZSym1 t = Z t
     instance SuppressUnusedWarnings ZSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ZSym0KindInference) GHC.Tuple.())
     data ZSym0 l
       = forall arg. SameKind (Apply ZSym0 arg) (ZSym1 arg) =>
@@ -21,7 +21,7 @@ Promote/T180.hs:(0,0)-(0,0): Splicing declarations
       Z (X2 x) = x
     type YSym1 (t :: X) = Y t
     instance SuppressUnusedWarnings YSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) YSym0KindInference) GHC.Tuple.())
     data YSym0 (l :: TyFun X Symbol)
       = forall arg. SameKind (Apply YSym0 arg) (YSym1 arg) =>
@@ -32,7 +32,7 @@ Promote/T180.hs:(0,0)-(0,0): Splicing declarations
       Y (X2 field) = field
     type X1Sym1 (t :: Symbol) = X1 t
     instance SuppressUnusedWarnings X1Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) X1Sym0KindInference) GHC.Tuple.())
     data X1Sym0 (l :: TyFun Symbol X)
       = forall arg. SameKind (Apply X1Sym0 arg) (X1Sym1 arg) =>
@@ -40,7 +40,7 @@ Promote/T180.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply X1Sym0 l = X1 l
     type X2Sym1 (t :: Symbol) = X2 t
     instance SuppressUnusedWarnings X2Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) X2Sym0KindInference) GHC.Tuple.())
     data X2Sym0 (l :: TyFun Symbol X)
       = forall arg. SameKind (Apply X2Sym0 arg) (X2Sym1 arg) =>

--- a/tests/compile-and-dump/Singletons/AsPattern.ghc82.template
+++ b/tests/compile-and-dump/Singletons/AsPattern.ghc82.template
@@ -36,14 +36,14 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
     foo p@(_ GHC.Types.: (_ GHC.Types.: _)) = p
     type BazSym3 (t :: Nat) (t :: Nat) (t :: Nat) = Baz t t t
     instance SuppressUnusedWarnings BazSym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BazSym2KindInference) GHC.Tuple.())
     data BazSym2 (l :: Nat) (l :: Nat) (l :: TyFun Nat Baz)
       = forall arg. SameKind (Apply (BazSym2 l l) arg) (BazSym3 l l arg) =>
         BazSym2KindInference
     type instance Apply (BazSym2 l l) l = Baz l l l
     instance SuppressUnusedWarnings BazSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BazSym1KindInference) GHC.Tuple.())
     data BazSym1 (l :: Nat) (l :: TyFun Nat (TyFun Nat Baz
                                              -> GHC.Types.Type))
@@ -51,7 +51,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
         BazSym1KindInference
     type instance Apply (BazSym1 l) l = BazSym2 l l
     instance SuppressUnusedWarnings BazSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BazSym0KindInference) GHC.Tuple.())
     data BazSym0 (l :: TyFun Nat (TyFun Nat (TyFun Nat Baz
                                              -> GHC.Types.Type)
@@ -64,7 +64,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
       = '[]
     type Let0123456789876543210PSym1 t = Let0123456789876543210P t
     instance SuppressUnusedWarnings Let0123456789876543210PSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210PSym0KindInference)
                GHC.Tuple.())
@@ -77,7 +77,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
     type Let0123456789876543210PSym3 t t t =
         Let0123456789876543210P t t t
     instance SuppressUnusedWarnings Let0123456789876543210PSym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210PSym2KindInference)
                GHC.Tuple.())
@@ -86,7 +86,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
         Let0123456789876543210PSym2KindInference
     type instance Apply (Let0123456789876543210PSym2 l l) l = Let0123456789876543210P l l l
     instance SuppressUnusedWarnings Let0123456789876543210PSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210PSym1KindInference)
                GHC.Tuple.())
@@ -95,7 +95,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
         Let0123456789876543210PSym1KindInference
     type instance Apply (Let0123456789876543210PSym1 l) l = Let0123456789876543210PSym2 l l
     instance SuppressUnusedWarnings Let0123456789876543210PSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210PSym0KindInference)
                GHC.Tuple.())
@@ -107,7 +107,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
       Let0123456789876543210P wild_0123456789876543210 wild_0123456789876543210 wild_0123456789876543210 = Apply (Apply (:$) wild_0123456789876543210) (Apply (Apply (:$) wild_0123456789876543210) wild_0123456789876543210)
     type Let0123456789876543210PSym2 t t = Let0123456789876543210P t t
     instance SuppressUnusedWarnings Let0123456789876543210PSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210PSym1KindInference)
                GHC.Tuple.())
@@ -116,7 +116,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
         Let0123456789876543210PSym1KindInference
     type instance Apply (Let0123456789876543210PSym1 l) l = Let0123456789876543210P l l
     instance SuppressUnusedWarnings Let0123456789876543210PSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210PSym0KindInference)
                GHC.Tuple.())
@@ -132,7 +132,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
     type Let0123456789876543210PSym3 t t t =
         Let0123456789876543210P t t t
     instance SuppressUnusedWarnings Let0123456789876543210PSym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210PSym2KindInference)
                GHC.Tuple.())
@@ -141,7 +141,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
         Let0123456789876543210PSym2KindInference
     type instance Apply (Let0123456789876543210PSym2 l l) l = Let0123456789876543210P l l l
     instance SuppressUnusedWarnings Let0123456789876543210PSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210PSym1KindInference)
                GHC.Tuple.())
@@ -150,7 +150,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
         Let0123456789876543210PSym1KindInference
     type instance Apply (Let0123456789876543210PSym1 l) l = Let0123456789876543210PSym2 l l
     instance SuppressUnusedWarnings Let0123456789876543210PSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210PSym0KindInference)
                GHC.Tuple.())
@@ -162,7 +162,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
       Let0123456789876543210P wild_0123456789876543210 wild_0123456789876543210 wild_0123456789876543210 = Apply JustSym0 (Apply (Apply (Apply BazSym0 wild_0123456789876543210) wild_0123456789876543210) wild_0123456789876543210)
     type Let0123456789876543210XSym1 t = Let0123456789876543210X t
     instance SuppressUnusedWarnings Let0123456789876543210XSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210XSym0KindInference)
                GHC.Tuple.())
@@ -177,7 +177,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
       = NothingSym0
     type FooSym1 (t :: [Nat]) = Foo t
     instance SuppressUnusedWarnings FooSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym0KindInference) GHC.Tuple.())
     data FooSym0 (l :: TyFun [Nat] [Nat])
       = forall arg. SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
@@ -185,7 +185,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply FooSym0 l = Foo l
     type TupSym1 (t :: (Nat, Nat)) = Tup t
     instance SuppressUnusedWarnings TupSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) TupSym0KindInference) GHC.Tuple.())
     data TupSym0 (l :: TyFun (Nat, Nat) (Nat, Nat))
       = forall arg. SameKind (Apply TupSym0 arg) (TupSym1 arg) =>
@@ -193,7 +193,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply TupSym0 l = Tup l
     type Baz_Sym1 (t :: Maybe Baz) = Baz_ t
     instance SuppressUnusedWarnings Baz_Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Baz_Sym0KindInference) GHC.Tuple.())
     data Baz_Sym0 (l :: TyFun (Maybe Baz) (Maybe Baz))
       = forall arg. SameKind (Apply Baz_Sym0 arg) (Baz_Sym1 arg) =>
@@ -201,7 +201,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply Baz_Sym0 l = Baz_ l
     type BarSym1 (t :: Maybe Nat) = Bar t
     instance SuppressUnusedWarnings BarSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BarSym0KindInference) GHC.Tuple.())
     data BarSym0 (l :: TyFun (Maybe Nat) (Maybe Nat))
       = forall arg. SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
@@ -209,7 +209,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply BarSym0 l = Bar l
     type MaybePlusSym1 (t :: Maybe Nat) = MaybePlus t
     instance SuppressUnusedWarnings MaybePlusSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MaybePlusSym0KindInference) GHC.Tuple.())
     data MaybePlusSym0 (l :: TyFun (Maybe Nat) (Maybe Nat))
       = forall arg. SameKind (Apply MaybePlusSym0 arg) (MaybePlusSym1 arg) =>

--- a/tests/compile-and-dump/Singletons/AsPattern.hs
+++ b/tests/compile-and-dump/Singletons/AsPattern.hs
@@ -1,6 +1,5 @@
 module Singletons.AsPattern where
 
-import Data.Proxy
 import Data.Singletons
 import Data.Singletons.TH
 import Data.Singletons.Prelude.Maybe

--- a/tests/compile-and-dump/Singletons/BoundedDeriving.ghc82.template
+++ b/tests/compile-and-dump/Singletons/BoundedDeriving.ghc82.template
@@ -39,7 +39,7 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
     type ESym0 = E
     type Foo3Sym1 (t :: a0123456789876543210) = Foo3 t
     instance SuppressUnusedWarnings Foo3Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo3Sym0KindInference) GHC.Tuple.())
     data Foo3Sym0 (l :: TyFun a0123456789876543210 (Foo3 a0123456789876543210))
       = forall arg. SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
@@ -49,14 +49,14 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
     type Foo42Sym0 = Foo42
     type PairSym2 (t :: Bool) (t :: Bool) = Pair t t
     instance SuppressUnusedWarnings PairSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) PairSym1KindInference) GHC.Tuple.())
     data PairSym1 (l :: Bool) (l :: TyFun Bool Pair)
       = forall arg. SameKind (Apply (PairSym1 l) arg) (PairSym2 l arg) =>
         PairSym1KindInference
     type instance Apply (PairSym1 l) l = Pair l l
     instance SuppressUnusedWarnings PairSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) PairSym0KindInference) GHC.Tuple.())
     data PairSym0 (l :: TyFun Bool (TyFun Bool Pair -> Type))
       = forall arg. SameKind (Apply PairSym0 arg) (PairSym1 arg) =>

--- a/tests/compile-and-dump/Singletons/BoxUnBox.ghc82.template
+++ b/tests/compile-and-dump/Singletons/BoxUnBox.ghc82.template
@@ -10,7 +10,7 @@ Singletons/BoxUnBox.hs:(0,0)-(0,0): Splicing declarations
     unBox (FBox a) = a
     type FBoxSym1 (t :: a0123456789876543210) = FBox t
     instance SuppressUnusedWarnings FBoxSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FBoxSym0KindInference) GHC.Tuple.())
     data FBoxSym0 (l :: TyFun a0123456789876543210 (Box a0123456789876543210))
       = forall arg. SameKind (Apply FBoxSym0 arg) (FBoxSym1 arg) =>
@@ -18,7 +18,7 @@ Singletons/BoxUnBox.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply FBoxSym0 l = FBox l
     type UnBoxSym1 (t :: Box a0123456789876543210) = UnBox t
     instance SuppressUnusedWarnings UnBoxSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) UnBoxSym0KindInference) GHC.Tuple.())
     data UnBoxSym0 (l :: TyFun (Box a0123456789876543210) a0123456789876543210)
       = forall arg. SameKind (Apply UnBoxSym0 arg) (UnBoxSym1 arg) =>

--- a/tests/compile-and-dump/Singletons/CaseExpressions.ghc82.template
+++ b/tests/compile-and-dump/Singletons/CaseExpressions.ghc82.template
@@ -44,7 +44,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
     type Lambda_0123456789876543210Sym3 t t t =
         Lambda_0123456789876543210 t t t
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
@@ -53,7 +53,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym2KindInference
     type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -62,7 +62,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym1KindInference
     type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -74,7 +74,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
       Case_0123456789876543210 x y = Apply (Apply (Apply Lambda_0123456789876543210Sym0 x) y) y
     type Let0123456789876543210ZSym2 t t = Let0123456789876543210Z t t
     instance SuppressUnusedWarnings Let0123456789876543210ZSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210ZSym1KindInference)
                GHC.Tuple.())
@@ -83,7 +83,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
         Let0123456789876543210ZSym1KindInference
     type instance Apply (Let0123456789876543210ZSym1 l) l = Let0123456789876543210Z l l
     instance SuppressUnusedWarnings Let0123456789876543210ZSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210ZSym0KindInference)
                GHC.Tuple.())
@@ -98,7 +98,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
     type Let0123456789876543210Scrutinee_0123456789876543210Sym2 t t =
         Let0123456789876543210Scrutinee_0123456789876543210 t t
     instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210Scrutinee_0123456789876543210Sym1KindInference)
@@ -108,7 +108,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
         Let0123456789876543210Scrutinee_0123456789876543210Sym1KindInference
     type instance Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym1 l) l = Let0123456789876543210Scrutinee_0123456789876543210 l l
     instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference)
@@ -124,7 +124,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
     type Let0123456789876543210Scrutinee_0123456789876543210Sym1 t =
         Let0123456789876543210Scrutinee_0123456789876543210 t
     instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference)
@@ -142,7 +142,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
       Case_0123456789876543210 d x Nothing = d
     type Foo5Sym1 (t :: a0123456789876543210) = Foo5 t
     instance SuppressUnusedWarnings Foo5Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo5Sym0KindInference) GHC.Tuple.())
     data Foo5Sym0 (l :: TyFun a0123456789876543210 a0123456789876543210)
       = forall arg. SameKind (Apply Foo5Sym0 arg) (Foo5Sym1 arg) =>
@@ -150,7 +150,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply Foo5Sym0 l = Foo5 l
     type Foo4Sym1 (t :: a0123456789876543210) = Foo4 t
     instance SuppressUnusedWarnings Foo4Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo4Sym0KindInference) GHC.Tuple.())
     data Foo4Sym0 (l :: TyFun a0123456789876543210 a0123456789876543210)
       = forall arg. SameKind (Apply Foo4Sym0 arg) (Foo4Sym1 arg) =>
@@ -159,14 +159,14 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
     type Foo3Sym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
         Foo3 t t
     instance SuppressUnusedWarnings Foo3Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo3Sym1KindInference) GHC.Tuple.())
     data Foo3Sym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 a0123456789876543210)
       = forall arg. SameKind (Apply (Foo3Sym1 l) arg) (Foo3Sym2 l arg) =>
         Foo3Sym1KindInference
     type instance Apply (Foo3Sym1 l) l = Foo3 l l
     instance SuppressUnusedWarnings Foo3Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo3Sym0KindInference) GHC.Tuple.())
     data Foo3Sym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 a0123456789876543210
                                                     -> GHC.Types.Type))
@@ -176,14 +176,14 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
     type Foo2Sym2 (t :: a0123456789876543210) (t :: Maybe a0123456789876543210) =
         Foo2 t t
     instance SuppressUnusedWarnings Foo2Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo2Sym1KindInference) GHC.Tuple.())
     data Foo2Sym1 (l :: a0123456789876543210) (l :: TyFun (Maybe a0123456789876543210) a0123456789876543210)
       = forall arg. SameKind (Apply (Foo2Sym1 l) arg) (Foo2Sym2 l arg) =>
         Foo2Sym1KindInference
     type instance Apply (Foo2Sym1 l) l = Foo2 l l
     instance SuppressUnusedWarnings Foo2Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo2Sym0KindInference) GHC.Tuple.())
     data Foo2Sym0 (l :: TyFun a0123456789876543210 (TyFun (Maybe a0123456789876543210) a0123456789876543210
                                                     -> GHC.Types.Type))
@@ -193,14 +193,14 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
     type Foo1Sym2 (t :: a0123456789876543210) (t :: Maybe a0123456789876543210) =
         Foo1 t t
     instance SuppressUnusedWarnings Foo1Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo1Sym1KindInference) GHC.Tuple.())
     data Foo1Sym1 (l :: a0123456789876543210) (l :: TyFun (Maybe a0123456789876543210) a0123456789876543210)
       = forall arg. SameKind (Apply (Foo1Sym1 l) arg) (Foo1Sym2 l arg) =>
         Foo1Sym1KindInference
     type instance Apply (Foo1Sym1 l) l = Foo1 l l
     instance SuppressUnusedWarnings Foo1Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo1Sym0KindInference) GHC.Tuple.())
     data Foo1Sym0 (l :: TyFun a0123456789876543210 (TyFun (Maybe a0123456789876543210) a0123456789876543210
                                                     -> GHC.Types.Type))

--- a/tests/compile-and-dump/Singletons/Classes.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Classes.ghc82.template
@@ -67,14 +67,14 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     type GSym0 = G
     type FooCompareSym2 (t :: Foo) (t :: Foo) = FooCompare t t
     instance SuppressUnusedWarnings FooCompareSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooCompareSym1KindInference) GHC.Tuple.())
     data FooCompareSym1 (l :: Foo) (l :: TyFun Foo Ordering)
       = forall arg. SameKind (Apply (FooCompareSym1 l) arg) (FooCompareSym2 l arg) =>
         FooCompareSym1KindInference
     type instance Apply (FooCompareSym1 l) l = FooCompare l l
     instance SuppressUnusedWarnings FooCompareSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooCompareSym0KindInference) GHC.Tuple.())
     data FooCompareSym0 (l :: TyFun Foo (TyFun Foo Ordering
                                          -> GHC.Types.Type))
@@ -84,14 +84,14 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     type ConstSym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
         Const t t
     instance SuppressUnusedWarnings ConstSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ConstSym1KindInference) GHC.Tuple.())
     data ConstSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 a0123456789876543210)
       = forall arg. SameKind (Apply (ConstSym1 l) arg) (ConstSym2 l arg) =>
         ConstSym1KindInference
     type instance Apply (ConstSym1 l) l = Const l l
     instance SuppressUnusedWarnings ConstSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ConstSym0KindInference) GHC.Tuple.())
     data ConstSym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 a0123456789876543210
                                                      -> GHC.Types.Type))
@@ -109,14 +109,14 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     type MycompareSym2 (t :: a0123456789876543210) (t :: a0123456789876543210) =
         Mycompare t t
     instance SuppressUnusedWarnings MycompareSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MycompareSym1KindInference) GHC.Tuple.())
     data MycompareSym1 (l :: a0123456789876543210) (l :: TyFun a0123456789876543210 Ordering)
       = forall arg. SameKind (Apply (MycompareSym1 l) arg) (MycompareSym2 l arg) =>
         MycompareSym1KindInference
     type instance Apply (MycompareSym1 l) l = Mycompare l l
     instance SuppressUnusedWarnings MycompareSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MycompareSym0KindInference) GHC.Tuple.())
     data MycompareSym0 (l :: TyFun a0123456789876543210 (TyFun a0123456789876543210 Ordering
                                                          -> GHC.Types.Type))
@@ -126,14 +126,14 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     type (:<=>$$$) (t :: a0123456789876543210) (t :: a0123456789876543210) =
         (:<=>) t t
     instance SuppressUnusedWarnings (:<=>$$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:<=>$$###)) GHC.Tuple.())
     data (:<=>$$) (l :: a0123456789876543210) (l :: TyFun a0123456789876543210 Ordering)
       = forall arg. SameKind (Apply ((:<=>$$) l) arg) ((:<=>$$$) l arg) =>
         (:<=>$$###)
     type instance Apply ((:<=>$$) l) l = (:<=>) l l
     instance SuppressUnusedWarnings (:<=>$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:<=>$###)) GHC.Tuple.())
     data (:<=>$) (l :: TyFun a0123456789876543210 (TyFun a0123456789876543210 Ordering
                                                    -> GHC.Types.Type))
@@ -145,7 +145,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     type TFHelper_0123456789876543210Sym2 (t :: a0123456789876543210) (t :: a0123456789876543210) =
         TFHelper_0123456789876543210 t t
     instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) TFHelper_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -154,7 +154,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         TFHelper_0123456789876543210Sym1KindInference
     type instance Apply (TFHelper_0123456789876543210Sym1 l) l = TFHelper_0123456789876543210 l l
     instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) TFHelper_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -175,7 +175,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     type Mycompare_0123456789876543210Sym2 (t :: Nat) (t :: Nat) =
         Mycompare_0123456789876543210 t t
     instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -184,7 +184,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         Mycompare_0123456789876543210Sym1KindInference
     type instance Apply (Mycompare_0123456789876543210Sym1 l) l = Mycompare_0123456789876543210 l l
     instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -200,7 +200,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     type Mycompare_0123456789876543210Sym2 (t :: ()) (t :: ()) =
         Mycompare_0123456789876543210 t t
     instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -209,7 +209,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         Mycompare_0123456789876543210Sym1KindInference
     type instance Apply (Mycompare_0123456789876543210Sym1 l) l = Mycompare_0123456789876543210 l l
     instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -225,7 +225,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     type Mycompare_0123456789876543210Sym2 (t :: Foo) (t :: Foo) =
         Mycompare_0123456789876543210 t t
     instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -234,7 +234,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         Mycompare_0123456789876543210Sym1KindInference
     type instance Apply (Mycompare_0123456789876543210Sym1 l) l = Mycompare_0123456789876543210 l l
     instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -253,7 +253,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     type TFHelper_0123456789876543210Sym2 (t :: Foo2) (t :: Foo2) =
         TFHelper_0123456789876543210 t t
     instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) TFHelper_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -262,7 +262,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         TFHelper_0123456789876543210Sym1KindInference
     type instance Apply (TFHelper_0123456789876543210Sym1 l) l = TFHelper_0123456789876543210 l l
     instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) TFHelper_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -395,7 +395,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     type Mycompare_0123456789876543210Sym2 (t :: Foo2) (t :: Foo2) =
         Mycompare_0123456789876543210 t t
     instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -404,7 +404,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         Mycompare_0123456789876543210Sym1KindInference
     type instance Apply (Mycompare_0123456789876543210Sym1 l) l = Mycompare_0123456789876543210 l l
     instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -422,7 +422,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     type Compare_0123456789876543210Sym2 (t :: Foo2) (t :: Foo2) =
         Compare_0123456789876543210 t t
     instance SuppressUnusedWarnings Compare_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -431,7 +431,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         Compare_0123456789876543210Sym1KindInference
     type instance Apply (Compare_0123456789876543210Sym1 l) l = Compare_0123456789876543210 l l
     instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -461,7 +461,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     type Zero'Sym0 = Zero'
     type Succ'Sym1 (t :: Nat') = Succ' t
     instance SuppressUnusedWarnings Succ'Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Succ'Sym0KindInference) GHC.Tuple.())
     data Succ'Sym0 (l :: TyFun Nat' Nat')
       = forall arg. SameKind (Apply Succ'Sym0 arg) (Succ'Sym1 arg) =>
@@ -475,7 +475,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     type Mycompare_0123456789876543210Sym2 (t :: Nat') (t :: Nat') =
         Mycompare_0123456789876543210 t t
     instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -484,7 +484,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         Mycompare_0123456789876543210Sym1KindInference
     type instance Apply (Mycompare_0123456789876543210Sym1 l) l = Mycompare_0123456789876543210 l l
     instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())

--- a/tests/compile-and-dump/Singletons/Classes2.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Classes2.ghc82.template
@@ -17,7 +17,7 @@ Singletons/Classes2.hs:(0,0)-(0,0): Splicing declarations
     type ZeroFooSym0 = ZeroFoo
     type SuccFooSym1 (t :: NatFoo) = SuccFoo t
     instance SuppressUnusedWarnings SuccFooSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SuccFooSym0KindInference) GHC.Tuple.())
     data SuccFooSym0 (l :: TyFun NatFoo NatFoo)
       = forall arg. SameKind (Apply SuccFooSym0 arg) (SuccFooSym1 arg) =>
@@ -31,7 +31,7 @@ Singletons/Classes2.hs:(0,0)-(0,0): Splicing declarations
     type Mycompare_0123456789876543210Sym2 (t :: NatFoo) (t :: NatFoo) =
         Mycompare_0123456789876543210 t t
     instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -40,7 +40,7 @@ Singletons/Classes2.hs:(0,0)-(0,0): Splicing declarations
         Mycompare_0123456789876543210Sym1KindInference
     type instance Apply (Mycompare_0123456789876543210Sym1 l) l = Mycompare_0123456789876543210 l l
     instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())

--- a/tests/compile-and-dump/Singletons/Contains.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Contains.ghc82.template
@@ -10,14 +10,14 @@ Singletons/Contains.hs:(0,0)-(0,0): Splicing declarations
     type ContainsSym2 (t :: a0123456789876543210) (t :: [a0123456789876543210]) =
         Contains t t
     instance SuppressUnusedWarnings ContainsSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ContainsSym1KindInference) GHC.Tuple.())
     data ContainsSym1 (l :: a0123456789876543210) (l :: TyFun [a0123456789876543210] Bool)
       = forall arg. SameKind (Apply (ContainsSym1 l) arg) (ContainsSym2 l arg) =>
         ContainsSym1KindInference
     type instance Apply (ContainsSym1 l) l = Contains l l
     instance SuppressUnusedWarnings ContainsSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ContainsSym0KindInference) GHC.Tuple.())
     data ContainsSym0 (l :: TyFun a0123456789876543210 (TyFun [a0123456789876543210] Bool
                                                         -> GHC.Types.Type))

--- a/tests/compile-and-dump/Singletons/DataValues.ghc82.template
+++ b/tests/compile-and-dump/Singletons/DataValues.ghc82.template
@@ -19,14 +19,14 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
     type PairSym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
         Pair t t
     instance SuppressUnusedWarnings PairSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) PairSym1KindInference) GHC.Tuple.())
     data PairSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 (Pair a0123456789876543210 b0123456789876543210))
       = forall arg. SameKind (Apply (PairSym1 l) arg) (PairSym2 l arg) =>
         PairSym1KindInference
     type instance Apply (PairSym1 l) l = Pair l l
     instance SuppressUnusedWarnings PairSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) PairSym0KindInference) GHC.Tuple.())
     data PairSym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 (Pair a0123456789876543210 b0123456789876543210)
                                                     -> GHC.Types.Type))

--- a/tests/compile-and-dump/Singletons/EnumDeriving.ghc82.template
+++ b/tests/compile-and-dump/Singletons/EnumDeriving.ghc82.template
@@ -28,7 +28,7 @@ Singletons/EnumDeriving.hs:(0,0)-(0,0): Splicing declarations
     type ToEnum_0123456789876543210Sym1 (t :: GHC.Types.Nat) =
         ToEnum_0123456789876543210 t
     instance SuppressUnusedWarnings ToEnum_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ToEnum_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -43,7 +43,7 @@ Singletons/EnumDeriving.hs:(0,0)-(0,0): Splicing declarations
     type FromEnum_0123456789876543210Sym1 (t :: Foo) =
         FromEnum_0123456789876543210 t
     instance SuppressUnusedWarnings FromEnum_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) FromEnum_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -133,7 +133,7 @@ Singletons/EnumDeriving.hs:0:0:: Splicing declarations
     type ToEnum_0123456789876543210Sym1 (t :: GHC.Types.Nat) =
         ToEnum_0123456789876543210 t
     instance SuppressUnusedWarnings ToEnum_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ToEnum_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -147,7 +147,7 @@ Singletons/EnumDeriving.hs:0:0:: Splicing declarations
     type FromEnum_0123456789876543210Sym1 (t :: Quux) =
         FromEnum_0123456789876543210 t
     instance SuppressUnusedWarnings FromEnum_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) FromEnum_0123456789876543210Sym0KindInference)
                GHC.Tuple.())

--- a/tests/compile-and-dump/Singletons/Error.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Error.ghc82.template
@@ -9,7 +9,7 @@ Singletons/Error.hs:(0,0)-(0,0): Splicing declarations
     head GHC.Types.[] = error "Data.Singletons.List.head: empty list"
     type HeadSym1 (t :: [a0123456789876543210]) = Head t
     instance SuppressUnusedWarnings HeadSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) HeadSym0KindInference) GHC.Tuple.())
     data HeadSym0 (l :: TyFun [a0123456789876543210] a0123456789876543210)
       = forall arg. SameKind (Apply HeadSym0 arg) (HeadSym1 arg) =>

--- a/tests/compile-and-dump/Singletons/Fixity.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Fixity.ghc82.template
@@ -19,14 +19,14 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
     type (:====$$$) (t :: a0123456789876543210) (t :: a0123456789876543210) =
         (:====) t t
     instance SuppressUnusedWarnings (:====$$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:====$$###)) GHC.Tuple.())
     data (:====$$) (l :: a0123456789876543210) (l :: TyFun a0123456789876543210 a0123456789876543210)
       = forall arg. SameKind (Apply ((:====$$) l) arg) ((:====$$$) l arg) =>
         (:====$$###)
     type instance Apply ((:====$$) l) l = (:====) l l
     instance SuppressUnusedWarnings (:====$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:====$###)) GHC.Tuple.())
     data (:====$) (l :: TyFun a0123456789876543210 (TyFun a0123456789876543210 a0123456789876543210
                                                     -> GHC.Types.Type))
@@ -40,14 +40,14 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
     type (:<=>$$$) (t :: a0123456789876543210) (t :: a0123456789876543210) =
         (:<=>) t t
     instance SuppressUnusedWarnings (:<=>$$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:<=>$$###)) GHC.Tuple.())
     data (:<=>$$) (l :: a0123456789876543210) (l :: TyFun a0123456789876543210 Ordering)
       = forall arg. SameKind (Apply ((:<=>$$) l) arg) ((:<=>$$$) l arg) =>
         (:<=>$$###)
     type instance Apply ((:<=>$$) l) l = (:<=>) l l
     instance SuppressUnusedWarnings (:<=>$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:<=>$###)) GHC.Tuple.())
     data (:<=>$) (l :: TyFun a0123456789876543210 (TyFun a0123456789876543210 Ordering
                                                    -> GHC.Types.Type))

--- a/tests/compile-and-dump/Singletons/FunDeps.ghc82.template
+++ b/tests/compile-and-dump/Singletons/FunDeps.ghc82.template
@@ -24,7 +24,7 @@ Singletons/FunDeps.hs:(0,0)-(0,0): Splicing declarations
       = Apply MethSym0 TrueSym0
     type MethSym1 (t :: a0123456789876543210) = Meth t
     instance SuppressUnusedWarnings MethSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MethSym0KindInference) GHC.Tuple.())
     data MethSym0 (l :: TyFun a0123456789876543210 a0123456789876543210)
       = forall arg. SameKind (Apply MethSym0 arg) (MethSym1 arg) =>
@@ -32,7 +32,7 @@ Singletons/FunDeps.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply MethSym0 l = Meth l
     type L2rSym1 (t :: a0123456789876543210) = L2r t
     instance SuppressUnusedWarnings L2rSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) L2rSym0KindInference) GHC.Tuple.())
     data L2rSym0 (l :: TyFun a0123456789876543210 b0123456789876543210)
       = forall arg. SameKind (Apply L2rSym0 arg) (L2rSym1 arg) =>
@@ -46,7 +46,7 @@ Singletons/FunDeps.hs:(0,0)-(0,0): Splicing declarations
     type Meth_0123456789876543210Sym1 (t :: Bool) =
         Meth_0123456789876543210 t
     instance SuppressUnusedWarnings Meth_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Meth_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -60,7 +60,7 @@ Singletons/FunDeps.hs:(0,0)-(0,0): Splicing declarations
     type L2r_0123456789876543210Sym1 (t :: Bool) =
         L2r_0123456789876543210 t
     instance SuppressUnusedWarnings L2r_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) L2r_0123456789876543210Sym0KindInference)
                GHC.Tuple.())

--- a/tests/compile-and-dump/Singletons/HigherOrder.ghc82.template
+++ b/tests/compile-and-dump/Singletons/HigherOrder.ghc82.template
@@ -43,7 +43,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     etad = zipWith (\ n b -> if b then Succ (Succ n) else n)
     type LeftSym1 (t :: a0123456789876543210) = Left t
     instance SuppressUnusedWarnings LeftSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) LeftSym0KindInference) GHC.Tuple.())
     data LeftSym0 (l :: TyFun a0123456789876543210 (Either a0123456789876543210 b0123456789876543210))
       = forall arg. SameKind (Apply LeftSym0 arg) (LeftSym1 arg) =>
@@ -51,7 +51,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply LeftSym0 l = Left l
     type RightSym1 (t :: b0123456789876543210) = Right t
     instance SuppressUnusedWarnings RightSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) RightSym0KindInference) GHC.Tuple.())
     data RightSym0 (l :: TyFun b0123456789876543210 (Either a0123456789876543210 b0123456789876543210))
       = forall arg. SameKind (Apply RightSym0 arg) (RightSym1 arg) =>
@@ -65,7 +65,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     type Lambda_0123456789876543210Sym4 t t t t =
         Lambda_0123456789876543210 t t t t
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym3 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym3KindInference)
                GHC.Tuple.())
@@ -74,7 +74,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym3KindInference
     type instance Apply (Lambda_0123456789876543210Sym3 l l l) l = Lambda_0123456789876543210 l l l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
@@ -83,7 +83,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym2KindInference
     type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210Sym3 l l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -92,7 +92,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym1KindInference
     type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -108,7 +108,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     type Lambda_0123456789876543210Sym4 t t t t =
         Lambda_0123456789876543210 t t t t
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym3 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym3KindInference)
                GHC.Tuple.())
@@ -117,7 +117,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym3KindInference
     type instance Apply (Lambda_0123456789876543210Sym3 l l l) l = Lambda_0123456789876543210 l l l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
@@ -126,7 +126,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym2KindInference
     type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210Sym3 l l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -135,7 +135,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym1KindInference
     type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -150,7 +150,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
                                                 -> GHC.Types.Type) (t :: a0123456789876543210) =
         Foo t t t
     instance SuppressUnusedWarnings FooSym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym2KindInference) GHC.Tuple.())
     data FooSym2 (l :: TyFun (TyFun a0123456789876543210 b0123456789876543210
                               -> GHC.Types.Type) (TyFun a0123456789876543210 b0123456789876543210
@@ -161,7 +161,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
         FooSym2KindInference
     type instance Apply (FooSym2 l l) l = Foo l l l
     instance SuppressUnusedWarnings FooSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym1KindInference) GHC.Tuple.())
     data FooSym1 (l :: TyFun (TyFun a0123456789876543210 b0123456789876543210
                               -> GHC.Types.Type) (TyFun a0123456789876543210 b0123456789876543210
@@ -173,7 +173,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
         FooSym1KindInference
     type instance Apply (FooSym1 l) l = FooSym2 l l
     instance SuppressUnusedWarnings FooSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym0KindInference) GHC.Tuple.())
     data FooSym0 (l :: TyFun (TyFun (TyFun a0123456789876543210 b0123456789876543210
                                      -> GHC.Types.Type) (TyFun a0123456789876543210 b0123456789876543210
@@ -190,7 +190,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
                            -> GHC.Types.Type) (t :: [a0123456789876543210]) (t :: [b0123456789876543210]) =
         ZipWith t t t
     instance SuppressUnusedWarnings ZipWithSym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ZipWithSym2KindInference) GHC.Tuple.())
     data ZipWithSym2 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 c0123456789876543210
                                                        -> GHC.Types.Type)
@@ -199,7 +199,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
         ZipWithSym2KindInference
     type instance Apply (ZipWithSym2 l l) l = ZipWith l l l
     instance SuppressUnusedWarnings ZipWithSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ZipWithSym1KindInference) GHC.Tuple.())
     data ZipWithSym1 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 c0123456789876543210
                                                        -> GHC.Types.Type)
@@ -209,7 +209,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
         ZipWithSym1KindInference
     type instance Apply (ZipWithSym1 l) l = ZipWithSym2 l l
     instance SuppressUnusedWarnings ZipWithSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ZipWithSym0KindInference) GHC.Tuple.())
     data ZipWithSym0 (l :: TyFun (TyFun a0123456789876543210 (TyFun b0123456789876543210 c0123456789876543210
                                                               -> GHC.Types.Type)
@@ -221,14 +221,14 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply ZipWithSym0 l = ZipWithSym1 l
     type SplungeSym2 (t :: [Nat]) (t :: [Bool]) = Splunge t t
     instance SuppressUnusedWarnings SplungeSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SplungeSym1KindInference) GHC.Tuple.())
     data SplungeSym1 (l :: [Nat]) (l :: TyFun [Bool] [Nat])
       = forall arg. SameKind (Apply (SplungeSym1 l) arg) (SplungeSym2 l arg) =>
         SplungeSym1KindInference
     type instance Apply (SplungeSym1 l) l = Splunge l l
     instance SuppressUnusedWarnings SplungeSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SplungeSym0KindInference) GHC.Tuple.())
     data SplungeSym0 (l :: TyFun [Nat] (TyFun [Bool] [Nat]
                                         -> GHC.Types.Type))
@@ -237,14 +237,14 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply SplungeSym0 l = SplungeSym1 l
     type EtadSym2 (t :: [Nat]) (t :: [Bool]) = Etad t t
     instance SuppressUnusedWarnings EtadSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) EtadSym1KindInference) GHC.Tuple.())
     data EtadSym1 (l :: [Nat]) (l :: TyFun [Bool] [Nat])
       = forall arg. SameKind (Apply (EtadSym1 l) arg) (EtadSym2 l arg) =>
         EtadSym1KindInference
     type instance Apply (EtadSym1 l) l = Etad l l
     instance SuppressUnusedWarnings EtadSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) EtadSym0KindInference) GHC.Tuple.())
     data EtadSym0 (l :: TyFun [Nat] (TyFun [Bool] [Nat]
                                      -> GHC.Types.Type))
@@ -255,7 +255,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
                              -> GHC.Types.Type) (t :: Maybe a0123456789876543210) =
         LiftMaybe t t
     instance SuppressUnusedWarnings LiftMaybeSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) LiftMaybeSym1KindInference) GHC.Tuple.())
     data LiftMaybeSym1 (l :: TyFun a0123456789876543210 b0123456789876543210
                              -> GHC.Types.Type) (l :: TyFun (Maybe a0123456789876543210) (Maybe b0123456789876543210))
@@ -263,7 +263,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
         LiftMaybeSym1KindInference
     type instance Apply (LiftMaybeSym1 l) l = LiftMaybe l l
     instance SuppressUnusedWarnings LiftMaybeSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) LiftMaybeSym0KindInference) GHC.Tuple.())
     data LiftMaybeSym0 (l :: TyFun (TyFun a0123456789876543210 b0123456789876543210
                                     -> GHC.Types.Type) (TyFun (Maybe a0123456789876543210) (Maybe b0123456789876543210)
@@ -275,7 +275,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
                        -> GHC.Types.Type) (t :: [a0123456789876543210]) =
         Map t t
     instance SuppressUnusedWarnings MapSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MapSym1KindInference) GHC.Tuple.())
     data MapSym1 (l :: TyFun a0123456789876543210 b0123456789876543210
                        -> GHC.Types.Type) (l :: TyFun [a0123456789876543210] [b0123456789876543210])
@@ -283,7 +283,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
         MapSym1KindInference
     type instance Apply (MapSym1 l) l = Map l l
     instance SuppressUnusedWarnings MapSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MapSym0KindInference) GHC.Tuple.())
     data MapSym0 (l :: TyFun (TyFun a0123456789876543210 b0123456789876543210
                               -> GHC.Types.Type) (TyFun [a0123456789876543210] [b0123456789876543210]

--- a/tests/compile-and-dump/Singletons/LambdaCase.ghc82.template
+++ b/tests/compile-and-dump/Singletons/LambdaCase.ghc82.template
@@ -37,7 +37,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
     type Lambda_0123456789876543210Sym3 t t t =
         Lambda_0123456789876543210 t t t
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
@@ -46,7 +46,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym2KindInference
     type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -55,7 +55,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym1KindInference
     type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -71,7 +71,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
     type Lambda_0123456789876543210Sym2 t t =
         Lambda_0123456789876543210 t t
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -80,7 +80,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym1KindInference
     type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210 l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -96,7 +96,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
     type Lambda_0123456789876543210Sym3 t t t =
         Lambda_0123456789876543210 t t t
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
@@ -105,7 +105,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym2KindInference
     type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -114,7 +114,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym1KindInference
     type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -125,14 +125,14 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
     type Foo3Sym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
         Foo3 t t
     instance SuppressUnusedWarnings Foo3Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo3Sym1KindInference) GHC.Tuple.())
     data Foo3Sym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 a0123456789876543210)
       = forall arg. SameKind (Apply (Foo3Sym1 l) arg) (Foo3Sym2 l arg) =>
         Foo3Sym1KindInference
     type instance Apply (Foo3Sym1 l) l = Foo3 l l
     instance SuppressUnusedWarnings Foo3Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo3Sym0KindInference) GHC.Tuple.())
     data Foo3Sym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 a0123456789876543210
                                                     -> GHC.Types.Type))
@@ -142,14 +142,14 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
     type Foo2Sym2 (t :: a0123456789876543210) (t :: Maybe a0123456789876543210) =
         Foo2 t t
     instance SuppressUnusedWarnings Foo2Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo2Sym1KindInference) GHC.Tuple.())
     data Foo2Sym1 (l :: a0123456789876543210) (l :: TyFun (Maybe a0123456789876543210) a0123456789876543210)
       = forall arg. SameKind (Apply (Foo2Sym1 l) arg) (Foo2Sym2 l arg) =>
         Foo2Sym1KindInference
     type instance Apply (Foo2Sym1 l) l = Foo2 l l
     instance SuppressUnusedWarnings Foo2Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo2Sym0KindInference) GHC.Tuple.())
     data Foo2Sym0 (l :: TyFun a0123456789876543210 (TyFun (Maybe a0123456789876543210) a0123456789876543210
                                                     -> GHC.Types.Type))
@@ -159,14 +159,14 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
     type Foo1Sym2 (t :: a0123456789876543210) (t :: Maybe a0123456789876543210) =
         Foo1 t t
     instance SuppressUnusedWarnings Foo1Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo1Sym1KindInference) GHC.Tuple.())
     data Foo1Sym1 (l :: a0123456789876543210) (l :: TyFun (Maybe a0123456789876543210) a0123456789876543210)
       = forall arg. SameKind (Apply (Foo1Sym1 l) arg) (Foo1Sym2 l arg) =>
         Foo1Sym1KindInference
     type instance Apply (Foo1Sym1 l) l = Foo1 l l
     instance SuppressUnusedWarnings Foo1Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo1Sym0KindInference) GHC.Tuple.())
     data Foo1Sym0 (l :: TyFun a0123456789876543210 (TyFun (Maybe a0123456789876543210) a0123456789876543210
                                                     -> GHC.Types.Type))

--- a/tests/compile-and-dump/Singletons/Lambdas.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Lambdas.ghc82.template
@@ -43,14 +43,14 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     type FooSym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
         Foo t t
     instance SuppressUnusedWarnings FooSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym1KindInference) GHC.Tuple.())
     data FooSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 (Foo a0123456789876543210 b0123456789876543210))
       = forall arg. SameKind (Apply (FooSym1 l) arg) (FooSym2 l arg) =>
         FooSym1KindInference
     type instance Apply (FooSym1 l) l = Foo l l
     instance SuppressUnusedWarnings FooSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym0KindInference) GHC.Tuple.())
     data FooSym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 (Foo a0123456789876543210 b0123456789876543210)
                                                    -> GHC.Types.Type))
@@ -64,7 +64,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     type Lambda_0123456789876543210Sym2 t t =
         Lambda_0123456789876543210 t t
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -73,7 +73,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym1KindInference
     type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210 l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -89,7 +89,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     type Lambda_0123456789876543210Sym3 t t t =
         Lambda_0123456789876543210 t t t
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
@@ -98,7 +98,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym2KindInference
     type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -107,7 +107,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym1KindInference
     type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -122,7 +122,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     type Lambda_0123456789876543210Sym4 t t t t =
         Lambda_0123456789876543210 t t t t
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym3 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym3KindInference)
                GHC.Tuple.())
@@ -131,7 +131,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym3KindInference
     type instance Apply (Lambda_0123456789876543210Sym3 l l l) l = Lambda_0123456789876543210 l l l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
@@ -140,7 +140,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym2KindInference
     type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210Sym3 l l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -149,7 +149,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym1KindInference
     type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -162,7 +162,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     type Lambda_0123456789876543210Sym3 t t t =
         Lambda_0123456789876543210 t t t
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
@@ -171,7 +171,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym2KindInference
     type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -180,7 +180,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym1KindInference
     type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -193,7 +193,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     type Lambda_0123456789876543210Sym3 t t t =
         Lambda_0123456789876543210 t t t
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
@@ -202,7 +202,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym2KindInference
     type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -211,7 +211,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym1KindInference
     type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -227,7 +227,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     type Lambda_0123456789876543210Sym5 t t t t t =
         Lambda_0123456789876543210 t t t t t
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym4 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym4KindInference)
                GHC.Tuple.())
@@ -236,7 +236,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym4KindInference
     type instance Apply (Lambda_0123456789876543210Sym4 l l l l) l = Lambda_0123456789876543210 l l l l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym3 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym3KindInference)
                GHC.Tuple.())
@@ -245,7 +245,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym3KindInference
     type instance Apply (Lambda_0123456789876543210Sym3 l l l) l = Lambda_0123456789876543210Sym4 l l l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
@@ -254,7 +254,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym2KindInference
     type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210Sym3 l l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -263,7 +263,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym1KindInference
     type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -276,7 +276,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     type Lambda_0123456789876543210Sym2 t t =
         Lambda_0123456789876543210 t t
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -285,7 +285,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym1KindInference
     type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210 l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -300,7 +300,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     type Lambda_0123456789876543210Sym3 t t t =
         Lambda_0123456789876543210 t t t
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
@@ -309,7 +309,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym2KindInference
     type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -318,7 +318,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym1KindInference
     type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -333,7 +333,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     type Lambda_0123456789876543210Sym3 t t t =
         Lambda_0123456789876543210 t t t
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
@@ -342,7 +342,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym2KindInference
     type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -351,7 +351,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym1KindInference
     type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -364,7 +364,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     type Lambda_0123456789876543210Sym4 t t t t =
         Lambda_0123456789876543210 t t t t
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym3 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym3KindInference)
                GHC.Tuple.())
@@ -373,7 +373,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym3KindInference
     type instance Apply (Lambda_0123456789876543210Sym3 l l l) l = Lambda_0123456789876543210 l l l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
@@ -382,7 +382,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym2KindInference
     type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210Sym3 l l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -391,7 +391,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym1KindInference
     type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -402,7 +402,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     type Foo8Sym1 (t :: Foo a0123456789876543210 b0123456789876543210) =
         Foo8 t
     instance SuppressUnusedWarnings Foo8Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo8Sym0KindInference) GHC.Tuple.())
     data Foo8Sym0 (l :: TyFun (Foo a0123456789876543210 b0123456789876543210) a0123456789876543210)
       = forall arg. SameKind (Apply Foo8Sym0 arg) (Foo8Sym1 arg) =>
@@ -411,14 +411,14 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     type Foo7Sym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
         Foo7 t t
     instance SuppressUnusedWarnings Foo7Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo7Sym1KindInference) GHC.Tuple.())
     data Foo7Sym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 b0123456789876543210)
       = forall arg. SameKind (Apply (Foo7Sym1 l) arg) (Foo7Sym2 l arg) =>
         Foo7Sym1KindInference
     type instance Apply (Foo7Sym1 l) l = Foo7 l l
     instance SuppressUnusedWarnings Foo7Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo7Sym0KindInference) GHC.Tuple.())
     data Foo7Sym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 b0123456789876543210
                                                     -> GHC.Types.Type))
@@ -428,14 +428,14 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     type Foo6Sym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
         Foo6 t t
     instance SuppressUnusedWarnings Foo6Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo6Sym1KindInference) GHC.Tuple.())
     data Foo6Sym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 a0123456789876543210)
       = forall arg. SameKind (Apply (Foo6Sym1 l) arg) (Foo6Sym2 l arg) =>
         Foo6Sym1KindInference
     type instance Apply (Foo6Sym1 l) l = Foo6 l l
     instance SuppressUnusedWarnings Foo6Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo6Sym0KindInference) GHC.Tuple.())
     data Foo6Sym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 a0123456789876543210
                                                     -> GHC.Types.Type))
@@ -445,14 +445,14 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     type Foo5Sym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
         Foo5 t t
     instance SuppressUnusedWarnings Foo5Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo5Sym1KindInference) GHC.Tuple.())
     data Foo5Sym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 b0123456789876543210)
       = forall arg. SameKind (Apply (Foo5Sym1 l) arg) (Foo5Sym2 l arg) =>
         Foo5Sym1KindInference
     type instance Apply (Foo5Sym1 l) l = Foo5 l l
     instance SuppressUnusedWarnings Foo5Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo5Sym0KindInference) GHC.Tuple.())
     data Foo5Sym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 b0123456789876543210
                                                     -> GHC.Types.Type))
@@ -462,14 +462,14 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     type Foo4Sym3 (t :: a0123456789876543210) (t :: b0123456789876543210) (t :: c0123456789876543210) =
         Foo4 t t t
     instance SuppressUnusedWarnings Foo4Sym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo4Sym2KindInference) GHC.Tuple.())
     data Foo4Sym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun c0123456789876543210 a0123456789876543210)
       = forall arg. SameKind (Apply (Foo4Sym2 l l) arg) (Foo4Sym3 l l arg) =>
         Foo4Sym2KindInference
     type instance Apply (Foo4Sym2 l l) l = Foo4 l l l
     instance SuppressUnusedWarnings Foo4Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo4Sym1KindInference) GHC.Tuple.())
     data Foo4Sym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 (TyFun c0123456789876543210 a0123456789876543210
                                                                                 -> GHC.Types.Type))
@@ -477,7 +477,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
         Foo4Sym1KindInference
     type instance Apply (Foo4Sym1 l) l = Foo4Sym2 l l
     instance SuppressUnusedWarnings Foo4Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo4Sym0KindInference) GHC.Tuple.())
     data Foo4Sym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 (TyFun c0123456789876543210 a0123456789876543210
                                                                                 -> GHC.Types.Type)
@@ -487,7 +487,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply Foo4Sym0 l = Foo4Sym1 l
     type Foo3Sym1 (t :: a0123456789876543210) = Foo3 t
     instance SuppressUnusedWarnings Foo3Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo3Sym0KindInference) GHC.Tuple.())
     data Foo3Sym0 (l :: TyFun a0123456789876543210 a0123456789876543210)
       = forall arg. SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
@@ -496,14 +496,14 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     type Foo2Sym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
         Foo2 t t
     instance SuppressUnusedWarnings Foo2Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo2Sym1KindInference) GHC.Tuple.())
     data Foo2Sym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 a0123456789876543210)
       = forall arg. SameKind (Apply (Foo2Sym1 l) arg) (Foo2Sym2 l arg) =>
         Foo2Sym1KindInference
     type instance Apply (Foo2Sym1 l) l = Foo2 l l
     instance SuppressUnusedWarnings Foo2Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo2Sym0KindInference) GHC.Tuple.())
     data Foo2Sym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 a0123456789876543210
                                                     -> GHC.Types.Type))
@@ -513,14 +513,14 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     type Foo1Sym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
         Foo1 t t
     instance SuppressUnusedWarnings Foo1Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo1Sym1KindInference) GHC.Tuple.())
     data Foo1Sym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 a0123456789876543210)
       = forall arg. SameKind (Apply (Foo1Sym1 l) arg) (Foo1Sym2 l arg) =>
         Foo1Sym1KindInference
     type instance Apply (Foo1Sym1 l) l = Foo1 l l
     instance SuppressUnusedWarnings Foo1Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo1Sym0KindInference) GHC.Tuple.())
     data Foo1Sym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 a0123456789876543210
                                                     -> GHC.Types.Type))
@@ -530,14 +530,14 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     type Foo0Sym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
         Foo0 t t
     instance SuppressUnusedWarnings Foo0Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo0Sym1KindInference) GHC.Tuple.())
     data Foo0Sym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 a0123456789876543210)
       = forall arg. SameKind (Apply (Foo0Sym1 l) arg) (Foo0Sym2 l arg) =>
         Foo0Sym1KindInference
     type instance Apply (Foo0Sym1 l) l = Foo0 l l
     instance SuppressUnusedWarnings Foo0Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo0Sym0KindInference) GHC.Tuple.())
     data Foo0Sym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 a0123456789876543210
                                                     -> GHC.Types.Type))

--- a/tests/compile-and-dump/Singletons/LambdasComprehensive.ghc82.template
+++ b/tests/compile-and-dump/Singletons/LambdasComprehensive.ghc82.template
@@ -17,7 +17,7 @@ Singletons/LambdasComprehensive.hs:(0,0)-(0,0): Splicing declarations
     type Lambda_0123456789876543210Sym1 t =
         Lambda_0123456789876543210 t
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())

--- a/tests/compile-and-dump/Singletons/LetStatements.ghc82.template
+++ b/tests/compile-and-dump/Singletons/LetStatements.ghc82.template
@@ -197,7 +197,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
                                    y_0123456789876543210) = y_0123456789876543210
     type Let0123456789876543210YSym1 t = Let0123456789876543210Y t
     instance SuppressUnusedWarnings Let0123456789876543210YSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210YSym0KindInference)
                GHC.Tuple.())
@@ -207,7 +207,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply Let0123456789876543210YSym0 l = Let0123456789876543210Y l
     type Let0123456789876543210ZSym1 t = Let0123456789876543210Z t
     instance SuppressUnusedWarnings Let0123456789876543210ZSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210ZSym0KindInference)
                GHC.Tuple.())
@@ -218,7 +218,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type Let0123456789876543210X_0123456789876543210Sym1 t =
         Let0123456789876543210X_0123456789876543210 t
     instance SuppressUnusedWarnings Let0123456789876543210X_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210X_0123456789876543210Sym0KindInference)
@@ -235,7 +235,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       Let0123456789876543210X_0123456789876543210 x = Apply (Apply Tuple2Sym0 (Apply SuccSym0 x)) x
     type Let0123456789876543210BarSym1 t = Let0123456789876543210Bar t
     instance SuppressUnusedWarnings Let0123456789876543210BarSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210BarSym0KindInference)
                GHC.Tuple.())
@@ -248,7 +248,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type (:<<<%%%%%%%%%%%%%%%%%%%:+$$$$) t (t :: Nat) (t :: Nat) =
         (:<<<%%%%%%%%%%%%%%%%%%%:+) t t t
     instance SuppressUnusedWarnings (:<<<%%%%%%%%%%%%%%%%%%%:+$$$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) (:<<<%%%%%%%%%%%%%%%%%%%:+$$$###)) GHC.Tuple.())
     data (:<<<%%%%%%%%%%%%%%%%%%%:+$$$) l (l :: Nat) (l :: TyFun Nat Nat)
@@ -256,7 +256,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         (:<<<%%%%%%%%%%%%%%%%%%%:+$$$###)
     type instance Apply ((:<<<%%%%%%%%%%%%%%%%%%%:+$$$) l l) l = (:<<<%%%%%%%%%%%%%%%%%%%:+) l l l
     instance SuppressUnusedWarnings (:<<<%%%%%%%%%%%%%%%%%%%:+$$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) (:<<<%%%%%%%%%%%%%%%%%%%:+$$###)) GHC.Tuple.())
     data (:<<<%%%%%%%%%%%%%%%%%%%:+$$) l (l :: TyFun Nat (TyFun Nat Nat
@@ -265,7 +265,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         (:<<<%%%%%%%%%%%%%%%%%%%:+$$###)
     type instance Apply ((:<<<%%%%%%%%%%%%%%%%%%%:+$$) l) l = (:<<<%%%%%%%%%%%%%%%%%%%:+$$$) l l
     instance SuppressUnusedWarnings (:<<<%%%%%%%%%%%%%%%%%%%:+$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) (:<<<%%%%%%%%%%%%%%%%%%%:+$###)) GHC.Tuple.())
     data (:<<<%%%%%%%%%%%%%%%%%%%:+$) l
@@ -277,7 +277,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       (:<<<%%%%%%%%%%%%%%%%%%%:+) x (Succ n) m = Apply SuccSym0 (Apply (Apply ((:<<<%%%%%%%%%%%%%%%%%%%:+$$) x) n) x)
     type Let0123456789876543210ZSym1 t = Let0123456789876543210Z t
     instance SuppressUnusedWarnings Let0123456789876543210ZSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210ZSym0KindInference)
                GHC.Tuple.())
@@ -288,7 +288,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type (:<<<%%%%%%%%%%%%%%%%%%%:+$$$$) t (t :: Nat) (t :: Nat) =
         (:<<<%%%%%%%%%%%%%%%%%%%:+) t t t
     instance SuppressUnusedWarnings (:<<<%%%%%%%%%%%%%%%%%%%:+$$$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) (:<<<%%%%%%%%%%%%%%%%%%%:+$$$###)) GHC.Tuple.())
     data (:<<<%%%%%%%%%%%%%%%%%%%:+$$$) l (l :: Nat) (l :: TyFun Nat Nat)
@@ -296,7 +296,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         (:<<<%%%%%%%%%%%%%%%%%%%:+$$$###)
     type instance Apply ((:<<<%%%%%%%%%%%%%%%%%%%:+$$$) l l) l = (:<<<%%%%%%%%%%%%%%%%%%%:+) l l l
     instance SuppressUnusedWarnings (:<<<%%%%%%%%%%%%%%%%%%%:+$$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) (:<<<%%%%%%%%%%%%%%%%%%%:+$$###)) GHC.Tuple.())
     data (:<<<%%%%%%%%%%%%%%%%%%%:+$$) l (l :: TyFun Nat (TyFun Nat Nat
@@ -305,7 +305,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         (:<<<%%%%%%%%%%%%%%%%%%%:+$$###)
     type instance Apply ((:<<<%%%%%%%%%%%%%%%%%%%:+$$) l) l = (:<<<%%%%%%%%%%%%%%%%%%%:+$$$) l l
     instance SuppressUnusedWarnings (:<<<%%%%%%%%%%%%%%%%%%%:+$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) (:<<<%%%%%%%%%%%%%%%%%%%:+$###)) GHC.Tuple.())
     data (:<<<%%%%%%%%%%%%%%%%%%%:+$) l
@@ -320,7 +320,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type (:<<<%%%%%%%%%%%%%%%%%%%:+$$$$) t (t :: Nat) (t :: Nat) =
         (:<<<%%%%%%%%%%%%%%%%%%%:+) t t t
     instance SuppressUnusedWarnings (:<<<%%%%%%%%%%%%%%%%%%%:+$$$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) (:<<<%%%%%%%%%%%%%%%%%%%:+$$$###)) GHC.Tuple.())
     data (:<<<%%%%%%%%%%%%%%%%%%%:+$$$) l (l :: Nat) (l :: TyFun Nat Nat)
@@ -328,7 +328,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         (:<<<%%%%%%%%%%%%%%%%%%%:+$$$###)
     type instance Apply ((:<<<%%%%%%%%%%%%%%%%%%%:+$$$) l l) l = (:<<<%%%%%%%%%%%%%%%%%%%:+) l l l
     instance SuppressUnusedWarnings (:<<<%%%%%%%%%%%%%%%%%%%:+$$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) (:<<<%%%%%%%%%%%%%%%%%%%:+$$###)) GHC.Tuple.())
     data (:<<<%%%%%%%%%%%%%%%%%%%:+$$) l (l :: TyFun Nat (TyFun Nat Nat
@@ -337,7 +337,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         (:<<<%%%%%%%%%%%%%%%%%%%:+$$###)
     type instance Apply ((:<<<%%%%%%%%%%%%%%%%%%%:+$$) l) l = (:<<<%%%%%%%%%%%%%%%%%%%:+$$$) l l
     instance SuppressUnusedWarnings (:<<<%%%%%%%%%%%%%%%%%%%:+$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) (:<<<%%%%%%%%%%%%%%%%%%%:+$###)) GHC.Tuple.())
     data (:<<<%%%%%%%%%%%%%%%%%%%:+$) l
@@ -352,7 +352,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type Lambda_0123456789876543210Sym3 t t t =
         Lambda_0123456789876543210 t t t
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
@@ -361,7 +361,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym2KindInference
     type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -370,7 +370,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym1KindInference
     type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -381,7 +381,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type Let0123456789876543210ZSym2 t (t :: Nat) =
         Let0123456789876543210Z t t
     instance SuppressUnusedWarnings Let0123456789876543210ZSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210ZSym1KindInference)
                GHC.Tuple.())
@@ -390,7 +390,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         Let0123456789876543210ZSym1KindInference
     type instance Apply (Let0123456789876543210ZSym1 l) l = Let0123456789876543210Z l l
     instance SuppressUnusedWarnings Let0123456789876543210ZSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210ZSym0KindInference)
                GHC.Tuple.())
@@ -405,7 +405,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type Lambda_0123456789876543210Sym2 t t =
         Lambda_0123456789876543210 t t
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -414,7 +414,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym1KindInference
     type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210 l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -424,7 +424,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
     type Let0123456789876543210ZSym1 t = Let0123456789876543210Z t
     instance SuppressUnusedWarnings Let0123456789876543210ZSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210ZSym0KindInference)
                GHC.Tuple.())
@@ -436,7 +436,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       Let0123456789876543210Z x = Apply (Apply Lambda_0123456789876543210Sym0 x) ZeroSym0
     type Let0123456789876543210XSym1 t = Let0123456789876543210X t
     instance SuppressUnusedWarnings Let0123456789876543210XSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210XSym0KindInference)
                GHC.Tuple.())
@@ -449,7 +449,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type Let0123456789876543210FSym2 t (t :: Nat) =
         Let0123456789876543210F t t
     instance SuppressUnusedWarnings Let0123456789876543210FSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210FSym1KindInference)
                GHC.Tuple.())
@@ -458,7 +458,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         Let0123456789876543210FSym1KindInference
     type instance Apply (Let0123456789876543210FSym1 l) l = Let0123456789876543210F l l
     instance SuppressUnusedWarnings Let0123456789876543210FSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210FSym0KindInference)
                GHC.Tuple.())
@@ -470,7 +470,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       Let0123456789876543210F x y = Apply SuccSym0 y
     type Let0123456789876543210ZSym1 t = Let0123456789876543210Z t
     instance SuppressUnusedWarnings Let0123456789876543210ZSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210ZSym0KindInference)
                GHC.Tuple.())
@@ -482,7 +482,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       Let0123456789876543210Z x = Apply (Let0123456789876543210FSym1 x) x
     type Let0123456789876543210ZSym2 t t = Let0123456789876543210Z t t
     instance SuppressUnusedWarnings Let0123456789876543210ZSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210ZSym1KindInference)
                GHC.Tuple.())
@@ -491,7 +491,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         Let0123456789876543210ZSym1KindInference
     type instance Apply (Let0123456789876543210ZSym1 l) l = Let0123456789876543210Z l l
     instance SuppressUnusedWarnings Let0123456789876543210ZSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210ZSym0KindInference)
                GHC.Tuple.())
@@ -504,7 +504,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type Let0123456789876543210FSym2 t (t :: Nat) =
         Let0123456789876543210F t t
     instance SuppressUnusedWarnings Let0123456789876543210FSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210FSym1KindInference)
                GHC.Tuple.())
@@ -513,7 +513,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         Let0123456789876543210FSym1KindInference
     type instance Apply (Let0123456789876543210FSym1 l) l = Let0123456789876543210F l l
     instance SuppressUnusedWarnings Let0123456789876543210FSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210FSym0KindInference)
                GHC.Tuple.())
@@ -526,7 +526,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type Let0123456789876543210FSym2 t (t :: Nat) =
         Let0123456789876543210F t t
     instance SuppressUnusedWarnings Let0123456789876543210FSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210FSym1KindInference)
                GHC.Tuple.())
@@ -535,7 +535,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         Let0123456789876543210FSym1KindInference
     type instance Apply (Let0123456789876543210FSym1 l) l = Let0123456789876543210F l l
     instance SuppressUnusedWarnings Let0123456789876543210FSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210FSym0KindInference)
                GHC.Tuple.())
@@ -547,7 +547,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       Let0123456789876543210F x y = Apply SuccSym0 y
     type Let0123456789876543210YSym1 t = Let0123456789876543210Y t
     instance SuppressUnusedWarnings Let0123456789876543210YSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210YSym0KindInference)
                GHC.Tuple.())
@@ -565,7 +565,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       = Apply SuccSym0 Let0123456789876543210YSym0
     type Let0123456789876543210YSym1 t = Let0123456789876543210Y t
     instance SuppressUnusedWarnings Let0123456789876543210YSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210YSym0KindInference)
                GHC.Tuple.())
@@ -577,7 +577,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       Let0123456789876543210Y x = Apply SuccSym0 ZeroSym0
     type Foo14Sym1 (t :: Nat) = Foo14 t
     instance SuppressUnusedWarnings Foo14Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo14Sym0KindInference) GHC.Tuple.())
     data Foo14Sym0 (l :: TyFun Nat (Nat, Nat))
       = forall arg. SameKind (Apply Foo14Sym0 arg) (Foo14Sym1 arg) =>
@@ -585,7 +585,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply Foo14Sym0 l = Foo14 l
     type Foo13_Sym1 (t :: a0123456789876543210) = Foo13_ t
     instance SuppressUnusedWarnings Foo13_Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo13_Sym0KindInference) GHC.Tuple.())
     data Foo13_Sym0 (l :: TyFun a0123456789876543210 a0123456789876543210)
       = forall arg. SameKind (Apply Foo13_Sym0 arg) (Foo13_Sym1 arg) =>
@@ -593,7 +593,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply Foo13_Sym0 l = Foo13_ l
     type Foo13Sym1 (t :: a0123456789876543210) = Foo13 t
     instance SuppressUnusedWarnings Foo13Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo13Sym0KindInference) GHC.Tuple.())
     data Foo13Sym0 (l :: TyFun a0123456789876543210 a0123456789876543210)
       = forall arg. SameKind (Apply Foo13Sym0 arg) (Foo13Sym1 arg) =>
@@ -601,7 +601,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply Foo13Sym0 l = Foo13 l
     type Foo12Sym1 (t :: Nat) = Foo12 t
     instance SuppressUnusedWarnings Foo12Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo12Sym0KindInference) GHC.Tuple.())
     data Foo12Sym0 (l :: TyFun Nat Nat)
       = forall arg. SameKind (Apply Foo12Sym0 arg) (Foo12Sym1 arg) =>
@@ -609,7 +609,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply Foo12Sym0 l = Foo12 l
     type Foo11Sym1 (t :: Nat) = Foo11 t
     instance SuppressUnusedWarnings Foo11Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo11Sym0KindInference) GHC.Tuple.())
     data Foo11Sym0 (l :: TyFun Nat Nat)
       = forall arg. SameKind (Apply Foo11Sym0 arg) (Foo11Sym1 arg) =>
@@ -617,7 +617,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply Foo11Sym0 l = Foo11 l
     type Foo10Sym1 (t :: Nat) = Foo10 t
     instance SuppressUnusedWarnings Foo10Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo10Sym0KindInference) GHC.Tuple.())
     data Foo10Sym0 (l :: TyFun Nat Nat)
       = forall arg. SameKind (Apply Foo10Sym0 arg) (Foo10Sym1 arg) =>
@@ -625,7 +625,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply Foo10Sym0 l = Foo10 l
     type Foo9Sym1 (t :: Nat) = Foo9 t
     instance SuppressUnusedWarnings Foo9Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo9Sym0KindInference) GHC.Tuple.())
     data Foo9Sym0 (l :: TyFun Nat Nat)
       = forall arg. SameKind (Apply Foo9Sym0 arg) (Foo9Sym1 arg) =>
@@ -633,7 +633,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply Foo9Sym0 l = Foo9 l
     type Foo8Sym1 (t :: Nat) = Foo8 t
     instance SuppressUnusedWarnings Foo8Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo8Sym0KindInference) GHC.Tuple.())
     data Foo8Sym0 (l :: TyFun Nat Nat)
       = forall arg. SameKind (Apply Foo8Sym0 arg) (Foo8Sym1 arg) =>
@@ -641,7 +641,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply Foo8Sym0 l = Foo8 l
     type Foo7Sym1 (t :: Nat) = Foo7 t
     instance SuppressUnusedWarnings Foo7Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo7Sym0KindInference) GHC.Tuple.())
     data Foo7Sym0 (l :: TyFun Nat Nat)
       = forall arg. SameKind (Apply Foo7Sym0 arg) (Foo7Sym1 arg) =>
@@ -649,7 +649,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply Foo7Sym0 l = Foo7 l
     type Foo6Sym1 (t :: Nat) = Foo6 t
     instance SuppressUnusedWarnings Foo6Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo6Sym0KindInference) GHC.Tuple.())
     data Foo6Sym0 (l :: TyFun Nat Nat)
       = forall arg. SameKind (Apply Foo6Sym0 arg) (Foo6Sym1 arg) =>
@@ -657,7 +657,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply Foo6Sym0 l = Foo6 l
     type Foo5Sym1 (t :: Nat) = Foo5 t
     instance SuppressUnusedWarnings Foo5Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo5Sym0KindInference) GHC.Tuple.())
     data Foo5Sym0 (l :: TyFun Nat Nat)
       = forall arg. SameKind (Apply Foo5Sym0 arg) (Foo5Sym1 arg) =>
@@ -665,7 +665,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply Foo5Sym0 l = Foo5 l
     type Foo4Sym1 (t :: Nat) = Foo4 t
     instance SuppressUnusedWarnings Foo4Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo4Sym0KindInference) GHC.Tuple.())
     data Foo4Sym0 (l :: TyFun Nat Nat)
       = forall arg. SameKind (Apply Foo4Sym0 arg) (Foo4Sym1 arg) =>
@@ -673,7 +673,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply Foo4Sym0 l = Foo4 l
     type Foo3Sym1 (t :: Nat) = Foo3 t
     instance SuppressUnusedWarnings Foo3Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo3Sym0KindInference) GHC.Tuple.())
     data Foo3Sym0 (l :: TyFun Nat Nat)
       = forall arg. SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
@@ -682,7 +682,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type Foo2Sym0 = Foo2
     type Foo1Sym1 (t :: Nat) = Foo1 t
     instance SuppressUnusedWarnings Foo1Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo1Sym0KindInference) GHC.Tuple.())
     data Foo1Sym0 (l :: TyFun Nat Nat)
       = forall arg. SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>

--- a/tests/compile-and-dump/Singletons/Maybe.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Maybe.ghc82.template
@@ -16,7 +16,7 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
     type NothingSym0 = Nothing
     type JustSym1 (t :: a0123456789876543210) = Just t
     instance SuppressUnusedWarnings JustSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) JustSym0KindInference) GHC.Tuple.())
     data JustSym0 (l :: TyFun a0123456789876543210 (Maybe a0123456789876543210))
       = forall arg. SameKind (Apply JustSym0 arg) (JustSym1 arg) =>

--- a/tests/compile-and-dump/Singletons/Nat.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Nat.ghc82.template
@@ -33,7 +33,7 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
     type ZeroSym0 = Zero
     type SuccSym1 (t :: Nat) = Succ t
     instance SuppressUnusedWarnings SuccSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SuccSym0KindInference) GHC.Tuple.())
     data SuccSym0 (l :: TyFun Nat Nat)
       = forall arg. SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
@@ -41,7 +41,7 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply SuccSym0 l = Succ l
     type PredSym1 (t :: Nat) = Pred t
     instance SuppressUnusedWarnings PredSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) PredSym0KindInference) GHC.Tuple.())
     data PredSym0 (l :: TyFun Nat Nat)
       = forall arg. SameKind (Apply PredSym0 arg) (PredSym1 arg) =>
@@ -49,14 +49,14 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply PredSym0 l = Pred l
     type PlusSym2 (t :: Nat) (t :: Nat) = Plus t t
     instance SuppressUnusedWarnings PlusSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) PlusSym1KindInference) GHC.Tuple.())
     data PlusSym1 (l :: Nat) (l :: TyFun Nat Nat)
       = forall arg. SameKind (Apply (PlusSym1 l) arg) (PlusSym2 l arg) =>
         PlusSym1KindInference
     type instance Apply (PlusSym1 l) l = Plus l l
     instance SuppressUnusedWarnings PlusSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) PlusSym0KindInference) GHC.Tuple.())
     data PlusSym0 (l :: TyFun Nat (TyFun Nat Nat -> GHC.Types.Type))
       = forall arg. SameKind (Apply PlusSym0 arg) (PlusSym1 arg) =>

--- a/tests/compile-and-dump/Singletons/Nat.hs
+++ b/tests/compile-and-dump/Singletons/Nat.hs
@@ -4,7 +4,6 @@ module Singletons.Nat where
 
 import Data.Singletons.TH
 import Data.Singletons
-import Data.Proxy
 import Data.Singletons.SuppressUnusedWarnings
 
 $(singletons [d|

--- a/tests/compile-and-dump/Singletons/Operators.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Operators.ghc82.template
@@ -25,14 +25,14 @@ Singletons/Operators.hs:(0,0)-(0,0): Splicing declarations
     type FLeafSym0 = FLeaf
     type (:+:$$$) (t :: Foo) (t :: Foo) = (:+:) t t
     instance SuppressUnusedWarnings (:+:$$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:+:$$###)) GHC.Tuple.())
     data (:+:$$) (l :: Foo) (l :: TyFun Foo Foo)
       = forall arg. SameKind (Apply ((:+:$$) l) arg) ((:+:$$$) l arg) =>
         (:+:$$###)
     type instance Apply ((:+:$$) l) l = (:+:) l l
     instance SuppressUnusedWarnings (:+:$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:+:$###)) GHC.Tuple.())
     data (:+:$) (l :: TyFun Foo (TyFun Foo Foo -> GHC.Types.Type))
       = forall arg. SameKind (Apply (:+:$) arg) ((:+:$$) arg) =>
@@ -40,21 +40,21 @@ Singletons/Operators.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply (:+:$) l = (:+:$$) l
     type (:+$$$) (t :: Nat) (t :: Nat) = (:+) t t
     instance SuppressUnusedWarnings (:+$$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:+$$###)) GHC.Tuple.())
     data (:+$$) (l :: Nat) (l :: TyFun Nat Nat)
       = forall arg. SameKind (Apply ((:+$$) l) arg) ((:+$$$) l arg) =>
         (:+$$###)
     type instance Apply ((:+$$) l) l = (:+) l l
     instance SuppressUnusedWarnings (:+$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:+$###)) GHC.Tuple.())
     data (:+$) (l :: TyFun Nat (TyFun Nat Nat -> GHC.Types.Type))
       = forall arg. SameKind (Apply (:+$) arg) ((:+$$) arg) => (:+$###)
     type instance Apply (:+$) l = (:+$$) l
     type ChildSym1 (t :: Foo) = Child t
     instance SuppressUnusedWarnings ChildSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ChildSym0KindInference) GHC.Tuple.())
     data ChildSym0 (l :: TyFun Foo Foo)
       = forall arg. SameKind (Apply ChildSym0 arg) (ChildSym1 arg) =>

--- a/tests/compile-and-dump/Singletons/Operators.hs
+++ b/tests/compile-and-dump/Singletons/Operators.hs
@@ -2,7 +2,6 @@
 
 module Singletons.Operators where
 
-import Data.Proxy
 import Data.Singletons
 import Data.Singletons.TH
 import Singletons.Nat

--- a/tests/compile-and-dump/Singletons/OrdDeriving.ghc82.template
+++ b/tests/compile-and-dump/Singletons/OrdDeriving.ghc82.template
@@ -32,7 +32,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     type ZeroSym0 = Zero
     type SuccSym1 (t :: Nat) = Succ t
     instance SuppressUnusedWarnings SuccSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SuccSym0KindInference) GHC.Tuple.())
     data SuccSym0 (l :: TyFun Nat Nat)
       = forall arg. SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
@@ -51,14 +51,14 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     type ASym4 (t :: a0123456789876543210) (t :: b0123456789876543210) (t :: c0123456789876543210) (t :: d0123456789876543210) =
         A t t t t
     instance SuppressUnusedWarnings ASym3 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ASym3KindInference) GHC.Tuple.())
     data ASym3 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: c0123456789876543210) (l :: TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))
       = forall arg. SameKind (Apply (ASym3 l l l) arg) (ASym4 l l l arg) =>
         ASym3KindInference
     type instance Apply (ASym3 l l l) l = A l l l l
     instance SuppressUnusedWarnings ASym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ASym2KindInference) GHC.Tuple.())
     data ASym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
                                                                                                          -> GHC.Types.Type))
@@ -66,7 +66,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         ASym2KindInference
     type instance Apply (ASym2 l l) l = ASym3 l l l
     instance SuppressUnusedWarnings ASym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ASym1KindInference) GHC.Tuple.())
     data ASym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 (TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
                                                                                                          -> GHC.Types.Type)
@@ -75,7 +75,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         ASym1KindInference
     type instance Apply (ASym1 l) l = ASym2 l l
     instance SuppressUnusedWarnings ASym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ASym0KindInference) GHC.Tuple.())
     data ASym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 (TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
                                                                                                          -> GHC.Types.Type)
@@ -87,14 +87,14 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     type BSym4 (t :: a0123456789876543210) (t :: b0123456789876543210) (t :: c0123456789876543210) (t :: d0123456789876543210) =
         B t t t t
     instance SuppressUnusedWarnings BSym3 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BSym3KindInference) GHC.Tuple.())
     data BSym3 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: c0123456789876543210) (l :: TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))
       = forall arg. SameKind (Apply (BSym3 l l l) arg) (BSym4 l l l arg) =>
         BSym3KindInference
     type instance Apply (BSym3 l l l) l = B l l l l
     instance SuppressUnusedWarnings BSym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BSym2KindInference) GHC.Tuple.())
     data BSym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
                                                                                                          -> GHC.Types.Type))
@@ -102,7 +102,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         BSym2KindInference
     type instance Apply (BSym2 l l) l = BSym3 l l l
     instance SuppressUnusedWarnings BSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BSym1KindInference) GHC.Tuple.())
     data BSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 (TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
                                                                                                          -> GHC.Types.Type)
@@ -111,7 +111,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         BSym1KindInference
     type instance Apply (BSym1 l) l = BSym2 l l
     instance SuppressUnusedWarnings BSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BSym0KindInference) GHC.Tuple.())
     data BSym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 (TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
                                                                                                          -> GHC.Types.Type)
@@ -123,14 +123,14 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     type CSym4 (t :: a0123456789876543210) (t :: b0123456789876543210) (t :: c0123456789876543210) (t :: d0123456789876543210) =
         C t t t t
     instance SuppressUnusedWarnings CSym3 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) CSym3KindInference) GHC.Tuple.())
     data CSym3 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: c0123456789876543210) (l :: TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))
       = forall arg. SameKind (Apply (CSym3 l l l) arg) (CSym4 l l l arg) =>
         CSym3KindInference
     type instance Apply (CSym3 l l l) l = C l l l l
     instance SuppressUnusedWarnings CSym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) CSym2KindInference) GHC.Tuple.())
     data CSym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
                                                                                                          -> GHC.Types.Type))
@@ -138,7 +138,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         CSym2KindInference
     type instance Apply (CSym2 l l) l = CSym3 l l l
     instance SuppressUnusedWarnings CSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) CSym1KindInference) GHC.Tuple.())
     data CSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 (TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
                                                                                                          -> GHC.Types.Type)
@@ -147,7 +147,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         CSym1KindInference
     type instance Apply (CSym1 l) l = CSym2 l l
     instance SuppressUnusedWarnings CSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) CSym0KindInference) GHC.Tuple.())
     data CSym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 (TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
                                                                                                          -> GHC.Types.Type)
@@ -159,14 +159,14 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     type DSym4 (t :: a0123456789876543210) (t :: b0123456789876543210) (t :: c0123456789876543210) (t :: d0123456789876543210) =
         D t t t t
     instance SuppressUnusedWarnings DSym3 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) DSym3KindInference) GHC.Tuple.())
     data DSym3 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: c0123456789876543210) (l :: TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))
       = forall arg. SameKind (Apply (DSym3 l l l) arg) (DSym4 l l l arg) =>
         DSym3KindInference
     type instance Apply (DSym3 l l l) l = D l l l l
     instance SuppressUnusedWarnings DSym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) DSym2KindInference) GHC.Tuple.())
     data DSym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
                                                                                                          -> GHC.Types.Type))
@@ -174,7 +174,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         DSym2KindInference
     type instance Apply (DSym2 l l) l = DSym3 l l l
     instance SuppressUnusedWarnings DSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) DSym1KindInference) GHC.Tuple.())
     data DSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 (TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
                                                                                                          -> GHC.Types.Type)
@@ -183,7 +183,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         DSym1KindInference
     type instance Apply (DSym1 l) l = DSym2 l l
     instance SuppressUnusedWarnings DSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) DSym0KindInference) GHC.Tuple.())
     data DSym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 (TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
                                                                                                          -> GHC.Types.Type)
@@ -195,14 +195,14 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     type ESym4 (t :: a0123456789876543210) (t :: b0123456789876543210) (t :: c0123456789876543210) (t :: d0123456789876543210) =
         E t t t t
     instance SuppressUnusedWarnings ESym3 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ESym3KindInference) GHC.Tuple.())
     data ESym3 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: c0123456789876543210) (l :: TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))
       = forall arg. SameKind (Apply (ESym3 l l l) arg) (ESym4 l l l arg) =>
         ESym3KindInference
     type instance Apply (ESym3 l l l) l = E l l l l
     instance SuppressUnusedWarnings ESym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ESym2KindInference) GHC.Tuple.())
     data ESym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
                                                                                                          -> GHC.Types.Type))
@@ -210,7 +210,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         ESym2KindInference
     type instance Apply (ESym2 l l) l = ESym3 l l l
     instance SuppressUnusedWarnings ESym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ESym1KindInference) GHC.Tuple.())
     data ESym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 (TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
                                                                                                          -> GHC.Types.Type)
@@ -219,7 +219,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         ESym1KindInference
     type instance Apply (ESym1 l) l = ESym2 l l
     instance SuppressUnusedWarnings ESym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ESym0KindInference) GHC.Tuple.())
     data ESym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 (TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
                                                                                                          -> GHC.Types.Type)
@@ -231,14 +231,14 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     type FSym4 (t :: a0123456789876543210) (t :: b0123456789876543210) (t :: c0123456789876543210) (t :: d0123456789876543210) =
         F t t t t
     instance SuppressUnusedWarnings FSym3 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FSym3KindInference) GHC.Tuple.())
     data FSym3 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: c0123456789876543210) (l :: TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))
       = forall arg. SameKind (Apply (FSym3 l l l) arg) (FSym4 l l l arg) =>
         FSym3KindInference
     type instance Apply (FSym3 l l l) l = F l l l l
     instance SuppressUnusedWarnings FSym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FSym2KindInference) GHC.Tuple.())
     data FSym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
                                                                                                          -> GHC.Types.Type))
@@ -246,7 +246,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         FSym2KindInference
     type instance Apply (FSym2 l l) l = FSym3 l l l
     instance SuppressUnusedWarnings FSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FSym1KindInference) GHC.Tuple.())
     data FSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 (TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
                                                                                                          -> GHC.Types.Type)
@@ -255,7 +255,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         FSym1KindInference
     type instance Apply (FSym1 l) l = FSym2 l l
     instance SuppressUnusedWarnings FSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FSym0KindInference) GHC.Tuple.())
     data FSym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 (TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
                                                                                                          -> GHC.Types.Type)
@@ -272,7 +272,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     type Compare_0123456789876543210Sym2 (t :: Nat) (t :: Nat) =
         Compare_0123456789876543210 t t
     instance SuppressUnusedWarnings Compare_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -281,7 +281,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         Compare_0123456789876543210Sym1KindInference
     type instance Apply (Compare_0123456789876543210Sym1 l) l = Compare_0123456789876543210 l l
     instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -332,7 +332,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     type Compare_0123456789876543210Sym2 (t :: Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210) (t :: Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210) =
         Compare_0123456789876543210 t t
     instance SuppressUnusedWarnings Compare_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -341,7 +341,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         Compare_0123456789876543210Sym1KindInference
     type instance Apply (Compare_0123456789876543210Sym1 l) l = Compare_0123456789876543210 l l
     instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())

--- a/tests/compile-and-dump/Singletons/PatternMatching.ghc82.template
+++ b/tests/compile-and-dump/Singletons/PatternMatching.ghc82.template
@@ -19,14 +19,14 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     type PairSym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
         Pair t t
     instance SuppressUnusedWarnings PairSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) PairSym1KindInference) GHC.Tuple.())
     data PairSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 (Pair a0123456789876543210 b0123456789876543210))
       = forall arg. SameKind (Apply (PairSym1 l) arg) (PairSym2 l arg) =>
         PairSym1KindInference
     type instance Apply (PairSym1 l) l = Pair l l
     instance SuppressUnusedWarnings PairSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) PairSym0KindInference) GHC.Tuple.())
     data PairSym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 (Pair a0123456789876543210 b0123456789876543210)
                                                     -> GHC.Types.Type))
@@ -122,7 +122,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
       Case_0123456789876543210 x _z_0123456789876543210 = Tuple0Sym0
     type Let0123456789876543210TSym2 t t = Let0123456789876543210T t t
     instance SuppressUnusedWarnings Let0123456789876543210TSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210TSym1KindInference)
                GHC.Tuple.())
@@ -131,7 +131,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
         Let0123456789876543210TSym1KindInference
     type instance Apply (Let0123456789876543210TSym1 l) l = Let0123456789876543210T l l
     instance SuppressUnusedWarnings Let0123456789876543210TSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210TSym0KindInference)
                GHC.Tuple.())
@@ -148,7 +148,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     type Lambda_0123456789876543210Sym5 t t t t t =
         Lambda_0123456789876543210 t t t t t
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym4 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym4KindInference)
                GHC.Tuple.())
@@ -157,7 +157,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym4KindInference
     type instance Apply (Lambda_0123456789876543210Sym4 l l l l) l = Lambda_0123456789876543210 l l l l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym3 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym3KindInference)
                GHC.Tuple.())
@@ -166,7 +166,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym3KindInference
     type instance Apply (Lambda_0123456789876543210Sym3 l l l) l = Lambda_0123456789876543210Sym4 l l l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
@@ -175,7 +175,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym2KindInference
     type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210Sym3 l l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -184,7 +184,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym1KindInference
     type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -202,7 +202,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     type Lambda_0123456789876543210Sym3 t t t =
         Lambda_0123456789876543210 t t t
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
@@ -211,7 +211,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym2KindInference
     type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -220,7 +220,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym1KindInference
     type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -260,7 +260,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
       Case_0123456789876543210 (Pair _z_0123456789876543210 y_0123456789876543210) = y_0123456789876543210
     type SillySym1 (t :: a0123456789876543210) = Silly t
     instance SuppressUnusedWarnings SillySym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SillySym0KindInference) GHC.Tuple.())
     data SillySym0 (l :: TyFun a0123456789876543210 ())
       = forall arg. SameKind (Apply SillySym0 arg) (SillySym1 arg) =>
@@ -269,7 +269,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     type Foo2Sym1 (t :: (a0123456789876543210, b0123456789876543210)) =
         Foo2 t
     instance SuppressUnusedWarnings Foo2Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo2Sym0KindInference) GHC.Tuple.())
     data Foo2Sym0 (l :: TyFun (a0123456789876543210,
                                b0123456789876543210) a0123456789876543210)
@@ -279,7 +279,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     type Foo1Sym1 (t :: (a0123456789876543210, b0123456789876543210)) =
         Foo1 t
     instance SuppressUnusedWarnings Foo1Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo1Sym0KindInference) GHC.Tuple.())
     data Foo1Sym0 (l :: TyFun (a0123456789876543210,
                                b0123456789876543210) a0123456789876543210)

--- a/tests/compile-and-dump/Singletons/PolyKinds.ghc82.template
+++ b/tests/compile-and-dump/Singletons/PolyKinds.ghc82.template
@@ -8,7 +8,7 @@ Singletons/PolyKinds.hs:(0,0)-(0,0): Splicing declarations
     type FffSym1 (t :: Proxy (a0123456789876543210 :: k0123456789876543210)) =
         Fff t
     instance SuppressUnusedWarnings FffSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FffSym0KindInference) GHC.Tuple.())
     data FffSym0 (l :: TyFun (Proxy (a0123456789876543210 :: k0123456789876543210)) ())
       = forall arg. SameKind (Apply FffSym0 arg) (FffSym1 arg) =>

--- a/tests/compile-and-dump/Singletons/Records.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Records.ghc82.template
@@ -5,7 +5,7 @@ Singletons/Records.hs:(0,0)-(0,0): Splicing declarations
     data Record a = MkRecord {field1 :: a, field2 :: Bool}
     type Field1Sym1 (t :: Record a0123456789876543210) = Field1 t
     instance SuppressUnusedWarnings Field1Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Field1Sym0KindInference) GHC.Tuple.())
     data Field1Sym0 (l :: TyFun (Record a0123456789876543210) a0123456789876543210)
       = forall arg. SameKind (Apply Field1Sym0 arg) (Field1Sym1 arg) =>
@@ -13,7 +13,7 @@ Singletons/Records.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply Field1Sym0 l = Field1 l
     type Field2Sym1 (t :: Record a0123456789876543210) = Field2 t
     instance SuppressUnusedWarnings Field2Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Field2Sym0KindInference) GHC.Tuple.())
     data Field2Sym0 (l :: TyFun (Record a0123456789876543210) Bool)
       = forall arg. SameKind (Apply Field2Sym0 arg) (Field2Sym1 arg) =>
@@ -26,14 +26,14 @@ Singletons/Records.hs:(0,0)-(0,0): Splicing declarations
     type MkRecordSym2 (t :: a0123456789876543210) (t :: Bool) =
         MkRecord t t
     instance SuppressUnusedWarnings MkRecordSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MkRecordSym1KindInference) GHC.Tuple.())
     data MkRecordSym1 (l :: a0123456789876543210) (l :: TyFun Bool (Record a0123456789876543210))
       = forall arg. SameKind (Apply (MkRecordSym1 l) arg) (MkRecordSym2 l arg) =>
         MkRecordSym1KindInference
     type instance Apply (MkRecordSym1 l) l = MkRecord l l
     instance SuppressUnusedWarnings MkRecordSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MkRecordSym0KindInference) GHC.Tuple.())
     data MkRecordSym0 (l :: TyFun a0123456789876543210 (TyFun Bool (Record a0123456789876543210)
                                                         -> GHC.Types.Type))

--- a/tests/compile-and-dump/Singletons/ReturnFunc.ghc82.template
+++ b/tests/compile-and-dump/Singletons/ReturnFunc.ghc82.template
@@ -15,7 +15,7 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
     idFoo _ = id
     type IdSym1 (t :: a0123456789876543210) = Id t
     instance SuppressUnusedWarnings IdSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) IdSym0KindInference) GHC.Tuple.())
     data IdSym0 (l :: TyFun a0123456789876543210 a0123456789876543210)
       = forall arg. SameKind (Apply IdSym0 arg) (IdSym1 arg) =>
@@ -24,14 +24,14 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
     type IdFooSym2 (t :: c0123456789876543210) (t :: a0123456789876543210) =
         IdFoo t t
     instance SuppressUnusedWarnings IdFooSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) IdFooSym1KindInference) GHC.Tuple.())
     data IdFooSym1 (l :: c0123456789876543210) (l :: TyFun a0123456789876543210 a0123456789876543210)
       = forall arg. SameKind (Apply (IdFooSym1 l) arg) (IdFooSym2 l arg) =>
         IdFooSym1KindInference
     type instance Apply (IdFooSym1 l) l = IdFoo l l
     instance SuppressUnusedWarnings IdFooSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) IdFooSym0KindInference) GHC.Tuple.())
     data IdFooSym0 (l :: TyFun c0123456789876543210 (TyFun a0123456789876543210 a0123456789876543210
                                                      -> GHC.Types.Type))
@@ -40,14 +40,14 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply IdFooSym0 l = IdFooSym1 l
     type ReturnFuncSym2 (t :: Nat) (t :: Nat) = ReturnFunc t t
     instance SuppressUnusedWarnings ReturnFuncSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ReturnFuncSym1KindInference) GHC.Tuple.())
     data ReturnFuncSym1 (l :: Nat) (l :: TyFun Nat Nat)
       = forall arg. SameKind (Apply (ReturnFuncSym1 l) arg) (ReturnFuncSym2 l arg) =>
         ReturnFuncSym1KindInference
     type instance Apply (ReturnFuncSym1 l) l = ReturnFunc l l
     instance SuppressUnusedWarnings ReturnFuncSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ReturnFuncSym0KindInference) GHC.Tuple.())
     data ReturnFuncSym0 (l :: TyFun Nat (TyFun Nat Nat
                                          -> GHC.Types.Type))

--- a/tests/compile-and-dump/Singletons/Sections.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Sections.ghc82.template
@@ -24,7 +24,7 @@ Singletons/Sections.hs:(0,0)-(0,0): Splicing declarations
     type Lambda_0123456789876543210Sym1 t =
         Lambda_0123456789876543210 t
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -34,14 +34,14 @@ Singletons/Sections.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210 l
     type (:+$$$) (t :: Nat) (t :: Nat) = (:+) t t
     instance SuppressUnusedWarnings (:+$$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:+$$###)) GHC.Tuple.())
     data (:+$$) (l :: Nat) (l :: TyFun Nat Nat)
       = forall arg. SameKind (Apply ((:+$$) l) arg) ((:+$$$) l arg) =>
         (:+$$###)
     type instance Apply ((:+$$) l) l = (:+) l l
     instance SuppressUnusedWarnings (:+$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:+$###)) GHC.Tuple.())
     data (:+$) (l :: TyFun Nat (TyFun Nat Nat -> GHC.Types.Type))
       = forall arg. SameKind (Apply (:+$) arg) ((:+$$) arg) => (:+$###)

--- a/tests/compile-and-dump/Singletons/Star.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Star.ghc82.template
@@ -22,7 +22,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
     type StringSym0 = String
     type MaybeSym1 (t :: Type) = Maybe t
     instance Data.Singletons.SuppressUnusedWarnings.SuppressUnusedWarnings MaybeSym0 where
-      Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings _
+      Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MaybeSym0KindInference) GHC.Tuple.())
     data MaybeSym0 (l :: TyFun Type Type)
       = forall arg. SameKind (Apply MaybeSym0 arg) (MaybeSym1 arg) =>
@@ -30,14 +30,14 @@ Singletons/Star.hs:0:0:: Splicing declarations
     type instance Apply MaybeSym0 l = Maybe l
     type VecSym2 (t :: Type) (t :: Nat) = Vec t t
     instance Data.Singletons.SuppressUnusedWarnings.SuppressUnusedWarnings VecSym1 where
-      Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings _
+      Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) VecSym1KindInference) GHC.Tuple.())
     data VecSym1 (l :: Type) (l :: TyFun Nat Type)
       = forall arg. SameKind (Apply (VecSym1 l) arg) (VecSym2 l arg) =>
         VecSym1KindInference
     type instance Apply (VecSym1 l) l = Vec l l
     instance Data.Singletons.SuppressUnusedWarnings.SuppressUnusedWarnings VecSym0 where
-      Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings _
+      Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) VecSym0KindInference) GHC.Tuple.())
     data VecSym0 (l :: TyFun Type (TyFun Nat Type -> Type))
       = forall arg. SameKind (Apply VecSym0 arg) (VecSym1 arg) =>
@@ -72,7 +72,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
     type Compare_0123456789876543210Sym2 (t :: Type) (t :: Type) =
         Compare_0123456789876543210 t t
     instance Data.Singletons.SuppressUnusedWarnings.SuppressUnusedWarnings Compare_0123456789876543210Sym1 where
-      Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings _
+      Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -81,7 +81,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
         Compare_0123456789876543210Sym1KindInference
     type instance Apply (Compare_0123456789876543210Sym1 l) l = Compare_0123456789876543210 l l
     instance Data.Singletons.SuppressUnusedWarnings.SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
-      Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings _
+      Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())

--- a/tests/compile-and-dump/Singletons/T124.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T124.ghc82.template
@@ -9,7 +9,7 @@ Singletons/T124.hs:(0,0)-(0,0): Splicing declarations
     foo False = GHC.Tuple.()
     type FooSym1 (t :: Bool) = Foo t
     instance SuppressUnusedWarnings FooSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym0KindInference) GHC.Tuple.())
     data FooSym0 (l :: TyFun Bool ())
       = forall arg. SameKind (Apply FooSym0 arg) (FooSym1 arg) =>

--- a/tests/compile-and-dump/Singletons/T136.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T136.ghc82.template
@@ -36,7 +36,7 @@ Singletons/T136.hs:(0,0)-(0,0): Splicing declarations
     type Succ_0123456789876543210Sym1 (t :: [Bool]) =
         Succ_0123456789876543210 t
     instance SuppressUnusedWarnings Succ_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Succ_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -51,7 +51,7 @@ Singletons/T136.hs:(0,0)-(0,0): Splicing declarations
     type Pred_0123456789876543210Sym1 (t :: [Bool]) =
         Pred_0123456789876543210 t
     instance SuppressUnusedWarnings Pred_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Pred_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -72,7 +72,7 @@ Singletons/T136.hs:(0,0)-(0,0): Splicing declarations
     type ToEnum_0123456789876543210Sym1 (t :: GHC.Types.Nat) =
         ToEnum_0123456789876543210 t
     instance SuppressUnusedWarnings ToEnum_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ToEnum_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -87,7 +87,7 @@ Singletons/T136.hs:(0,0)-(0,0): Splicing declarations
     type FromEnum_0123456789876543210Sym1 (t :: [Bool]) =
         FromEnum_0123456789876543210 t
     instance SuppressUnusedWarnings FromEnum_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) FromEnum_0123456789876543210Sym0KindInference)
                GHC.Tuple.())

--- a/tests/compile-and-dump/Singletons/T136b.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T136b.ghc82.template
@@ -7,7 +7,7 @@ Singletons/T136b.hs:(0,0)-(0,0): Splicing declarations
       meth :: a -> a
     type MethSym1 (t :: a0123456789876543210) = Meth t
     instance SuppressUnusedWarnings MethSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MethSym0KindInference) GHC.Tuple.())
     data MethSym0 (l :: TyFun a0123456789876543210 a0123456789876543210)
       = forall arg. SameKind (Apply MethSym0 arg) (MethSym1 arg) =>
@@ -29,7 +29,7 @@ Singletons/T136b.hs:(0,0)-(0,0): Splicing declarations
     type Meth_0123456789876543210Sym1 (t :: Bool) =
         Meth_0123456789876543210 t
     instance SuppressUnusedWarnings Meth_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Meth_0123456789876543210Sym0KindInference)
                GHC.Tuple.())

--- a/tests/compile-and-dump/Singletons/T145.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T145.ghc82.template
@@ -8,14 +8,14 @@ Singletons/T145.hs:(0,0)-(0,0): Splicing declarations
     type ColSym2 (t :: f0123456789876543210 a0123456789876543210) (t :: a0123456789876543210) =
         Col t t
     instance SuppressUnusedWarnings ColSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ColSym1KindInference) GHC.Tuple.())
     data ColSym1 (l :: f0123456789876543210 a0123456789876543210) (l :: TyFun a0123456789876543210 Bool)
       = forall arg. SameKind (Apply (ColSym1 l) arg) (ColSym2 l arg) =>
         ColSym1KindInference
     type instance Apply (ColSym1 l) l = Col l l
     instance SuppressUnusedWarnings ColSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ColSym0KindInference) GHC.Tuple.())
     data ColSym0 (l :: TyFun (f0123456789876543210 a0123456789876543210) (TyFun a0123456789876543210 Bool
                                                                           -> Type))

--- a/tests/compile-and-dump/Singletons/T159.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T159.ghc82.template
@@ -44,14 +44,14 @@ Singletons/T159.hs:0:0:: Splicing declarations
     type N1Sym0 = N1
     type C1Sym2 (t :: T0) (t :: T1) = C1 t t
     instance SuppressUnusedWarnings C1Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) C1Sym1KindInference) GHC.Tuple.())
     data C1Sym1 (l :: T0) (l :: TyFun T1 T1)
       = forall arg. SameKind (Apply (C1Sym1 l) arg) (C1Sym2 l arg) =>
         C1Sym1KindInference
     type instance Apply (C1Sym1 l) l = C1 l l
     instance SuppressUnusedWarnings C1Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) C1Sym0KindInference) GHC.Tuple.())
     data C1Sym0 (l :: TyFun T0 (TyFun T1 T1 -> GHC.Types.Type))
       = forall arg. SameKind (Apply C1Sym0 arg) (C1Sym1 arg) =>
@@ -59,14 +59,14 @@ Singletons/T159.hs:0:0:: Splicing declarations
     type instance Apply C1Sym0 l = C1Sym1 l
     type (:&&$$$) (t :: T0) (t :: T1) = (:&&) t t
     instance SuppressUnusedWarnings (:&&$$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:&&$$###)) GHC.Tuple.())
     data (:&&$$) (l :: T0) (l :: TyFun T1 T1)
       = forall arg. SameKind (Apply ((:&&$$) l) arg) ((:&&$$$) l arg) =>
         (:&&$$###)
     type instance Apply ((:&&$$) l) l = (:&&) l l
     instance SuppressUnusedWarnings (:&&$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:&&$###)) GHC.Tuple.())
     data (:&&$) (l :: TyFun T0 (TyFun T1 T1 -> GHC.Types.Type))
       = forall arg. SameKind (Apply (:&&$) arg) ((:&&$$) arg) =>
@@ -118,14 +118,14 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
     type N2Sym0 = N2
     type C2Sym2 (t :: T0) (t :: T2) = C2 t t
     instance SuppressUnusedWarnings C2Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) C2Sym1KindInference) GHC.Tuple.())
     data C2Sym1 (l :: T0) (l :: TyFun T2 T2)
       = forall arg. SameKind (Apply (C2Sym1 l) arg) (C2Sym2 l arg) =>
         C2Sym1KindInference
     type instance Apply (C2Sym1 l) l = C2 l l
     instance SuppressUnusedWarnings C2Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) C2Sym0KindInference) GHC.Tuple.())
     data C2Sym0 (l :: TyFun T0 (TyFun T2 T2 -> GHC.Types.Type))
       = forall arg. SameKind (Apply C2Sym0 arg) (C2Sym1 arg) =>
@@ -133,14 +133,14 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply C2Sym0 l = C2Sym1 l
     type (:||$$$) (t :: T0) (t :: T2) = (:||) t t
     instance SuppressUnusedWarnings (:||$$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:||$$###)) GHC.Tuple.())
     data (:||$$) (l :: T0) (l :: TyFun T2 T2)
       = forall arg. SameKind (Apply ((:||$$) l) arg) ((:||$$$) l arg) =>
         (:||$$###)
     type instance Apply ((:||$$) l) l = (:||) l l
     instance SuppressUnusedWarnings (:||$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:||$###)) GHC.Tuple.())
     data (:||$) (l :: TyFun T0 (TyFun T2 T2 -> GHC.Types.Type))
       = forall arg. SameKind (Apply (:||$) arg) ((:||$$) arg) =>

--- a/tests/compile-and-dump/Singletons/T167.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T167.ghc82.template
@@ -11,14 +11,14 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
     type FoosPrecSym3 (t :: Nat) (t :: a0123456789876543210) (t :: [Bool]) =
         FoosPrec t t t
     instance SuppressUnusedWarnings FoosPrecSym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FoosPrecSym2KindInference) GHC.Tuple.())
     data FoosPrecSym2 (l :: Nat) (l :: a0123456789876543210) (l :: TyFun [Bool] [Bool])
       = forall arg. SameKind (Apply (FoosPrecSym2 l l) arg) (FoosPrecSym3 l l arg) =>
         FoosPrecSym2KindInference
     type instance Apply (FoosPrecSym2 l l) l = FoosPrec l l l
     instance SuppressUnusedWarnings FoosPrecSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FoosPrecSym1KindInference) GHC.Tuple.())
     data FoosPrecSym1 (l :: Nat) (l :: TyFun a0123456789876543210 (TyFun [Bool] [Bool]
                                                                    -> GHC.Types.Type))
@@ -26,7 +26,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
         FoosPrecSym1KindInference
     type instance Apply (FoosPrecSym1 l) l = FoosPrecSym2 l l
     instance SuppressUnusedWarnings FoosPrecSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FoosPrecSym0KindInference) GHC.Tuple.())
     data FoosPrecSym0 (l :: TyFun Nat (TyFun a0123456789876543210 (TyFun [Bool] [Bool]
                                                                    -> GHC.Types.Type)
@@ -37,14 +37,14 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
     type FooListSym2 (t :: a0123456789876543210) (t :: [Bool]) =
         FooList t t
     instance SuppressUnusedWarnings FooListSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooListSym1KindInference) GHC.Tuple.())
     data FooListSym1 (l :: a0123456789876543210) (l :: TyFun [Bool] [Bool])
       = forall arg. SameKind (Apply (FooListSym1 l) arg) (FooListSym2 l arg) =>
         FooListSym1KindInference
     type instance Apply (FooListSym1 l) l = FooList l l
     instance SuppressUnusedWarnings FooListSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooListSym0KindInference) GHC.Tuple.())
     data FooListSym0 (l :: TyFun a0123456789876543210 (TyFun [Bool] [Bool]
                                                        -> GHC.Types.Type))
@@ -56,7 +56,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
     type FooList_0123456789876543210Sym2 (t :: a0123456789876543210) (t :: [Bool]) =
         FooList_0123456789876543210 t t
     instance SuppressUnusedWarnings FooList_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) FooList_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -65,7 +65,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
         FooList_0123456789876543210Sym1KindInference
     type instance Apply (FooList_0123456789876543210Sym1 l) l = FooList_0123456789876543210 l l
     instance SuppressUnusedWarnings FooList_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) FooList_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -83,7 +83,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
     type FoosPrec_0123456789876543210Sym3 (t :: Nat) (t :: [a0123456789876543210]) (t :: [Bool]) =
         FoosPrec_0123456789876543210 t t t
     instance SuppressUnusedWarnings FoosPrec_0123456789876543210Sym2 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) FoosPrec_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
@@ -92,7 +92,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
         FoosPrec_0123456789876543210Sym2KindInference
     type instance Apply (FoosPrec_0123456789876543210Sym2 l l) l = FoosPrec_0123456789876543210 l l l
     instance SuppressUnusedWarnings FoosPrec_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) FoosPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -102,7 +102,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
         FoosPrec_0123456789876543210Sym1KindInference
     type instance Apply (FoosPrec_0123456789876543210Sym1 l) l = FoosPrec_0123456789876543210Sym2 l l
     instance SuppressUnusedWarnings FoosPrec_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) FoosPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())

--- a/tests/compile-and-dump/Singletons/T172.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T172.ghc82.template
@@ -5,14 +5,14 @@ Singletons/T172.hs:(0,0)-(0,0): Splicing declarations
   ======>
     type ($>$$$) (t :: Nat) (t :: Nat) = ($>) t t
     instance SuppressUnusedWarnings ($>$$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:$>$$###)) GHC.Tuple.())
     data ($>$$) (l :: Nat) (l :: TyFun Nat Nat)
       = forall arg. SameKind (Apply (($>$$) l) arg) (($>$$$) l arg) =>
         (:$>$$###)
     type instance Apply (($>$$) l) l = ($>) l l
     instance SuppressUnusedWarnings ($>$) where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:$>$###)) GHC.Tuple.())
     data ($>$) (l :: TyFun Nat (TyFun Nat Nat -> GHC.Types.Type))
       = forall arg. SameKind (Apply ($>$) arg) (($>$$) arg) => (:$>$###)

--- a/tests/compile-and-dump/Singletons/T176.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T176.ghc82.template
@@ -29,7 +29,7 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
     type Lambda_0123456789876543210Sym2 t t =
         Lambda_0123456789876543210 t t
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -38,7 +38,7 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
         Lambda_0123456789876543210Sym1KindInference
     type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210 l l
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -48,7 +48,7 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
     type Quux2Sym1 (t :: a0123456789876543210) = Quux2 t
     instance SuppressUnusedWarnings Quux2Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Quux2Sym0KindInference) GHC.Tuple.())
     data Quux2Sym0 (l :: TyFun a0123456789876543210 a0123456789876543210)
       = forall arg. SameKind (Apply Quux2Sym0 arg) (Quux2Sym1 arg) =>
@@ -56,7 +56,7 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply Quux2Sym0 l = Quux2 l
     type Quux1Sym1 (t :: a0123456789876543210) = Quux1 t
     instance SuppressUnusedWarnings Quux1Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Quux1Sym0KindInference) GHC.Tuple.())
     data Quux1Sym0 (l :: TyFun a0123456789876543210 a0123456789876543210)
       = forall arg. SameKind (Apply Quux1Sym0 arg) (Quux1Sym1 arg) =>
@@ -70,7 +70,7 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
                                                     -> Type) =
         Bar1 t t
     instance SuppressUnusedWarnings Bar1Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Bar1Sym1KindInference) GHC.Tuple.())
     data Bar1Sym1 (l :: a0123456789876543210) (l :: TyFun (TyFun a0123456789876543210 b0123456789876543210
                                                            -> Type) b0123456789876543210)
@@ -78,7 +78,7 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
         Bar1Sym1KindInference
     type instance Apply (Bar1Sym1 l) l = Bar1 l l
     instance SuppressUnusedWarnings Bar1Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Bar1Sym0KindInference) GHC.Tuple.())
     data Bar1Sym0 (l :: TyFun a0123456789876543210 (TyFun (TyFun a0123456789876543210 b0123456789876543210
                                                            -> Type) b0123456789876543210
@@ -93,14 +93,14 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
     type Bar2Sym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
         Bar2 t t
     instance SuppressUnusedWarnings Bar2Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Bar2Sym1KindInference) GHC.Tuple.())
     data Bar2Sym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 b0123456789876543210)
       = forall arg. SameKind (Apply (Bar2Sym1 l) arg) (Bar2Sym2 l arg) =>
         Bar2Sym1KindInference
     type instance Apply (Bar2Sym1 l) l = Bar2 l l
     instance SuppressUnusedWarnings Bar2Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Bar2Sym0KindInference) GHC.Tuple.())
     data Bar2Sym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 b0123456789876543210
                                                     -> Type))

--- a/tests/compile-and-dump/Singletons/T178.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T178.ghc82.template
@@ -40,7 +40,7 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
     type Compare_0123456789876543210Sym2 (t :: Occ) (t :: Occ) =
         Compare_0123456789876543210 t t
     instance SuppressUnusedWarnings Compare_0123456789876543210Sym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -49,7 +49,7 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
         Compare_0123456789876543210Sym1KindInference
     type instance Apply (Compare_0123456789876543210Sym1 l) l = Compare_0123456789876543210 l l
     instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())

--- a/tests/compile-and-dump/Singletons/T29.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T29.ghc82.template
@@ -19,7 +19,7 @@ Singletons/T29.hs:(0,0)-(0,0): Splicing declarations
     ban x = ((not . (not . not)) $! x)
     type BanSym1 (t :: Bool) = Ban t
     instance SuppressUnusedWarnings BanSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BanSym0KindInference) GHC.Tuple.())
     data BanSym0 (l :: TyFun Bool Bool)
       = forall arg. SameKind (Apply BanSym0 arg) (BanSym1 arg) =>
@@ -27,7 +27,7 @@ Singletons/T29.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply BanSym0 l = Ban l
     type BazSym1 (t :: Bool) = Baz t
     instance SuppressUnusedWarnings BazSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BazSym0KindInference) GHC.Tuple.())
     data BazSym0 (l :: TyFun Bool Bool)
       = forall arg. SameKind (Apply BazSym0 arg) (BazSym1 arg) =>
@@ -35,7 +35,7 @@ Singletons/T29.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply BazSym0 l = Baz l
     type BarSym1 (t :: Bool) = Bar t
     instance SuppressUnusedWarnings BarSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BarSym0KindInference) GHC.Tuple.())
     data BarSym0 (l :: TyFun Bool Bool)
       = forall arg. SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
@@ -43,7 +43,7 @@ Singletons/T29.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply BarSym0 l = Bar l
     type FooSym1 (t :: Bool) = Foo t
     instance SuppressUnusedWarnings FooSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym0KindInference) GHC.Tuple.())
     data FooSym0 (l :: TyFun Bool Bool)
       = forall arg. SameKind (Apply FooSym0 arg) (FooSym1 arg) =>

--- a/tests/compile-and-dump/Singletons/T33.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T33.ghc82.template
@@ -7,7 +7,7 @@ Singletons/T33.hs:(0,0)-(0,0): Splicing declarations
     foo ~(_, _) = GHC.Tuple.()
     type FooSym1 (t :: (Bool, Bool)) = Foo t
     instance SuppressUnusedWarnings FooSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym0KindInference) GHC.Tuple.())
     data FooSym0 (l :: TyFun (Bool, Bool) ())
       = forall arg. SameKind (Apply FooSym0 arg) (FooSym1 arg) =>

--- a/tests/compile-and-dump/Singletons/T54.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T54.ghc82.template
@@ -8,7 +8,7 @@ Singletons/T54.hs:(0,0)-(0,0): Splicing declarations
     type Let0123456789876543210Scrutinee_0123456789876543210Sym1 t =
         Let0123456789876543210Scrutinee_0123456789876543210 t
     instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference)
@@ -23,7 +23,7 @@ Singletons/T54.hs:(0,0)-(0,0): Splicing declarations
       Case_0123456789876543210 e '[_z_0123456789876543210] = NotSym0
     type GSym1 (t :: Bool) = G t
     instance SuppressUnusedWarnings GSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) GSym0KindInference) GHC.Tuple.())
     data GSym0 (l :: TyFun Bool Bool)
       = forall arg. SameKind (Apply GSym0 arg) (GSym1 arg) =>

--- a/tests/compile-and-dump/Singletons/T78.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T78.ghc82.template
@@ -11,7 +11,7 @@ Singletons/T78.hs:(0,0)-(0,0): Splicing declarations
     foo Nothing = False
     type FooSym1 (t :: Maybe Bool) = Foo t
     instance SuppressUnusedWarnings FooSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym0KindInference) GHC.Tuple.())
     data FooSym0 (l :: TyFun (Maybe Bool) Bool)
       = forall arg. SameKind (Apply FooSym0 arg) (FooSym1 arg) =>

--- a/tests/compile-and-dump/Singletons/TopLevelPatterns.ghc82.template
+++ b/tests/compile-and-dump/Singletons/TopLevelPatterns.ghc82.template
@@ -9,7 +9,7 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
     type TrueSym0 = True
     type BarSym2 (t :: Bool) (t :: Bool) = Bar t t
     instance SuppressUnusedWarnings BarSym1 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = Data.Tuple.snd
             ((GHC.Tuple.(,) BarSym1KindInference) GHC.Tuple.())
     data BarSym1 (l :: Bool) (l :: TyFun Bool Foo)
@@ -17,7 +17,7 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
         BarSym1KindInference
     type instance Apply (BarSym1 l) l = Bar l l
     instance SuppressUnusedWarnings BarSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = Data.Tuple.snd
             ((GHC.Tuple.(,) BarSym0KindInference) GHC.Tuple.())
     data BarSym0 (l :: TyFun Bool (TyFun Bool Foo -> GHC.Types.Type))
@@ -117,7 +117,7 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
     type False_Sym0 = False_
     type NotSym1 (t :: Bool) = Not t
     instance SuppressUnusedWarnings NotSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = Data.Tuple.snd
             ((GHC.Tuple.(,) NotSym0KindInference) GHC.Tuple.())
     data NotSym0 (l :: TyFun Bool Bool)
@@ -126,7 +126,7 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply NotSym0 l = Not l
     type IdSym1 (t :: a0123456789876543210) = Id t
     instance SuppressUnusedWarnings IdSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = Data.Tuple.snd ((GHC.Tuple.(,) IdSym0KindInference) GHC.Tuple.())
     data IdSym0 (l :: TyFun a0123456789876543210 a0123456789876543210)
       = forall arg. SameKind (Apply IdSym0 arg) (IdSym1 arg) =>
@@ -134,7 +134,7 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply IdSym0 l = Id l
     type FSym1 (t :: Bool) = F t
     instance SuppressUnusedWarnings FSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = Data.Tuple.snd ((GHC.Tuple.(,) FSym0KindInference) GHC.Tuple.())
     data FSym0 (l :: TyFun Bool Bool)
       = forall arg. SameKind (Apply FSym0 arg) (FSym1 arg) =>
@@ -142,7 +142,7 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply FSym0 l = F l
     type GSym1 (t :: Bool) = G t
     instance SuppressUnusedWarnings GSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = Data.Tuple.snd ((GHC.Tuple.(,) GSym0KindInference) GHC.Tuple.())
     data GSym0 (l :: TyFun Bool Bool)
       = forall arg. SameKind (Apply GSym0 arg) (GSym1 arg) =>
@@ -150,7 +150,7 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply GSym0 l = G l
     type HSym1 (t :: Bool) = H t
     instance SuppressUnusedWarnings HSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = Data.Tuple.snd ((GHC.Tuple.(,) HSym0KindInference) GHC.Tuple.())
     data HSym0 (l :: TyFun Bool Bool)
       = forall arg. SameKind (Apply HSym0 arg) (HSym1 arg) =>
@@ -158,7 +158,7 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply HSym0 l = H l
     type ISym1 (t :: Bool) = I t
     instance SuppressUnusedWarnings ISym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = Data.Tuple.snd ((GHC.Tuple.(,) ISym0KindInference) GHC.Tuple.())
     data ISym0 (l :: TyFun Bool Bool)
       = forall arg. SameKind (Apply ISym0 arg) (ISym1 arg) =>

--- a/tests/compile-and-dump/Singletons/Undef.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Undef.ghc82.template
@@ -11,7 +11,7 @@ Singletons/Undef.hs:(0,0)-(0,0): Splicing declarations
     bar = error "urk"
     type BarSym1 (t :: Bool) = Bar t
     instance SuppressUnusedWarnings BarSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BarSym0KindInference) GHC.Tuple.())
     data BarSym0 (l :: TyFun Bool Bool)
       = forall arg. SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
@@ -19,7 +19,7 @@ Singletons/Undef.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply BarSym0 l = Bar l
     type FooSym1 (t :: Bool) = Foo t
     instance SuppressUnusedWarnings FooSym0 where
-      suppressUnusedWarnings _
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym0KindInference) GHC.Tuple.())
     data FooSym0 (l :: TyFun Bool Bool)
       = forall arg. SameKind (Apply FooSym0 arg) (FooSym1 arg) =>


### PR DESCRIPTION
* The `ByHand` tests no longer compile after commit 444db17856018555ed1e9c89cc16f6d6ed0795a9, so let's update them to avoid `Proxy` when appropriate.
* The `SuppressUnusedWarnings` class doesn't really _need_ to use `Proxy`, does it? Let's remove it from there as well.