### PR TITLE
Fix #187

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Changelog for singletons project
 ================================
 
+next
+----
+* Permit derived `Ord` instances for empty datatypes.
+
 2.3
 ---
 * Documentation clarifiation in `Data.Singletons.TypeLits`, thanks to @ivan-m.
@@ -16,7 +20,7 @@ removed. `DemoteRep` has been renamed `Demote`.
 
 * Generating singletons also now generates fixity declarations for the singletonized
   definitions, thanks to @int-index.
-  
+
 * Though more an implementation detail: singletons no longer uses kind-level proxies anywhere,
   thanks again to @int-index.
 

--- a/src/Data/Singletons/Deriving/Ord.hs
+++ b/src/Data/Singletons/Deriving/Ord.hs
@@ -24,7 +24,11 @@ import Data.Singletons.Syntax
 mkOrdInstance :: Quasi q => DType -> [DCon] -> q UInstDecl
 mkOrdInstance ty cons = do
   let constraints = inferConstraints (DConPr ordName) cons
-  compare_eq_clauses <- mapM mk_equal_clause cons
+  -- This case also handles empty datatypes, since we can just create
+  -- one clause with wildcard matches and zero fields to fold over
+  compare_eq_clauses <- mapM mk_equal_clause $ if null cons
+                                                  then [Nothing]
+                                                  else map Just cons
   let compare_noneq_clauses = map (uncurry mk_nonequal_clause)
                                   [ (con1, con2)
                                   | con1 <- zip cons [1..]
@@ -38,13 +42,18 @@ mkOrdInstance ty cons = do
                                  , UFunction (compare_eq_clauses ++
                                               compare_noneq_clauses) )] })
 
-mk_equal_clause :: Quasi q => DCon -> q DClause
-mk_equal_clause (DCon _tvbs _cxt name fields _rty) = do
-  let tys = tysOfConFields fields
+mk_equal_clause :: Quasi q => Maybe DCon -- Nothing if it's an empty datatype,
+                                         -- Just a constructor name otherwise
+                           -> q DClause
+mk_equal_clause mb_con = do
+  let tys = maybe [] (snd . extractNameTypes) mb_con
   a_names <- mapM (const $ newUniqueName "a") tys
   b_names <- mapM (const $ newUniqueName "b") tys
-  let pat1 = DConPa name (map DVarPa a_names)
-      pat2 = DConPa name (map DVarPa b_names)
+  let mk_pat names = maybe DWildPa
+                           (\con -> DConPa (extractName con) (map DVarPa names))
+                           mb_con
+      pat1 = mk_pat a_names
+      pat2 = mk_pat b_names
   return $ DClause [pat1, pat2] (DVarE foldlName `DAppE`
                                  DVarE thenCmpName `DAppE`
                                  DConE cmpEQName `DAppE`

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -68,6 +68,7 @@ tests =
     , compileAndDumpStdTest "T175"
     , compileAndDumpStdTest "T176"
     , compileAndDumpStdTest "T178"
+    , compileAndDumpStdTest "T187"
     ],
     testCompileAndDumpGroup "Promote"
     [ compileAndDumpStdTest "Constructors"

--- a/tests/compile-and-dump/Singletons/T187.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T187.ghc82.template
@@ -14,7 +14,7 @@ Singletons/T187.hs:(0,0)-(0,0): Splicing declarations
     instance PEq Empty where
       type (:==) (a :: Empty) (b :: Empty) = Equals_0123456789876543210 a b
     type family Compare_0123456789876543210 (a :: Empty) (a :: Empty) :: Ordering where
-      Compare_0123456789876543210 _z_0123456789876543210 _z_0123456789876543210 = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) '[]
+      Compare_0123456789876543210 _z_0123456789876543210 _z_0123456789876543210 = EQSym0
     type Compare_0123456789876543210Sym2 (t :: Empty) (t :: Empty) =
         Compare_0123456789876543210 t t
     instance SuppressUnusedWarnings Compare_0123456789876543210Sym1 where
@@ -65,10 +65,4 @@ Singletons/T187.hs:(0,0)-(0,0): Splicing declarations
                                                               -> GHC.Types.Type)
                                                  -> GHC.Types.Type) t1 :: TyFun Empty Ordering
                                                                           -> GHC.Types.Type) t2 :: Ordering)
-      sCompare _ _
-        = (applySing
-             ((applySing
-                 ((applySing ((singFun3 @FoldlSym0) sFoldl))
-                    ((singFun2 @ThenCmpSym0) sThenCmp)))
-                SEQ))
-            SNil
+      sCompare _ _ = SEQ

--- a/tests/compile-and-dump/Singletons/T187.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T187.ghc82.template
@@ -1,0 +1,74 @@
+Singletons/T187.hs:(0,0)-(0,0): Splicing declarations
+    singletonsOnly
+      (return
+         [DataD
+            []
+            ''Empty
+            []
+            Nothing
+            []
+            [DerivClause Nothing [ConT ''Eq, ConT ''Ord]]])
+  ======>
+    type family Equals_0123456789876543210 (a :: Empty) (b :: Empty) :: Bool where
+      Equals_0123456789876543210 (a :: Empty) (b :: Empty) = FalseSym0
+    instance PEq Empty where
+      type (:==) (a :: Empty) (b :: Empty) = Equals_0123456789876543210 a b
+    type family Compare_0123456789876543210 (a :: Empty) (a :: Empty) :: Ordering where
+      Compare_0123456789876543210 _z_0123456789876543210 _z_0123456789876543210 = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) '[]
+    type Compare_0123456789876543210Sym2 (t :: Empty) (t :: Empty) =
+        Compare_0123456789876543210 t t
+    instance SuppressUnusedWarnings Compare_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Compare_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data Compare_0123456789876543210Sym1 (l :: Empty) (l :: TyFun Empty Ordering)
+      = forall arg. SameKind (Apply (Compare_0123456789876543210Sym1 l) arg) (Compare_0123456789876543210Sym2 l arg) =>
+        Compare_0123456789876543210Sym1KindInference
+    type instance Apply (Compare_0123456789876543210Sym1 l) l = Compare_0123456789876543210 l l
+    instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data Compare_0123456789876543210Sym0 (l :: TyFun Empty (TyFun Empty Ordering
+                                                            -> GHC.Types.Type))
+      = forall arg. SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
+        Compare_0123456789876543210Sym0KindInference
+    type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
+    instance POrd Empty where
+      type Compare (a :: Empty) (a :: Empty) = Apply (Apply Compare_0123456789876543210Sym0 a) a
+    data instance Sing (z :: Empty)
+    type SEmpty = (Sing :: Empty -> GHC.Types.Type)
+    instance SingKind Empty where
+      type Demote Empty = Empty
+      fromSing z
+        = case z of {
+            _ -> error "Empty case reached -- this should be impossible" }
+      toSing z
+        = case z of {
+            _ -> error "Empty case reached -- this should be impossible" }
+    instance SEq Empty where
+      (%:==) a _
+        = case a of {
+            _ -> error "Empty case reached -- this should be impossible" }
+    instance SDecide Empty where
+      (%~) a _
+        = case a of {
+            _ -> error "Empty case reached -- this should be impossible" }
+    instance SOrd Empty where
+      sCompare ::
+        forall (t1 :: Empty) (t2 :: Empty).
+        Sing t1
+        -> Sing t2
+           -> Sing (Apply (Apply (CompareSym0 :: TyFun Empty (TyFun Empty Ordering
+                                                              -> GHC.Types.Type)
+                                                 -> GHC.Types.Type) t1 :: TyFun Empty Ordering
+                                                                          -> GHC.Types.Type) t2 :: Ordering)
+      sCompare _ _
+        = (applySing
+             ((applySing
+                 ((applySing ((singFun3 @FoldlSym0) sFoldl))
+                    ((singFun2 @ThenCmpSym0) sThenCmp)))
+                SEQ))
+            SNil

--- a/tests/compile-and-dump/Singletons/T187.hs
+++ b/tests/compile-and-dump/Singletons/T187.hs
@@ -1,0 +1,12 @@
+module T187 where
+
+import Language.Haskell.TH
+import Data.Singletons.Prelude
+import Data.Singletons.TH
+
+data Empty
+
+-- We need to construct the TH AST for Empty directly for now, as singletons
+-- doesn't support standalone deriving declarations
+$(singletonsOnly (return [DataD [] ''Empty [] Nothing []
+                            [DerivClause Nothing [ConT ''Eq, ConT ''Ord]]]))


### PR DESCRIPTION
Allowing derived `Ord` instances for empty datatypes proves to be not so challenging, as we can effectively generate this implementation of `compare` (promoted and singled, of course):

```haskell
compare _ _ = foldl thenCmp EQ []
```

Fixes #187.