### PR TITLE
Add promotion, singling, and deriving for Show

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ Changelog for singletons project
 
 next
 ----
+* Add promoted and singled versions of `Show`, including `deriving` support.
+
 * Permit derived `Ord` instances for empty datatypes.
 
 2.3

--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ The following constructs are fully supported:
 * sections
 * undefined
 * error
-* deriving `Eq`, `Ord`, `Bounded`, and `Enum`
+* deriving `Eq`, `Ord`, `Show`, `Bounded`, and `Enum`
 * class constraints (though these sometimes fail with `let`, `lambda`, and `case`)
 * literals (for `Nat` and `Symbol`), including overloaded number literals
 * unboxed tuples (which are treated as normal tuples)
@@ -556,6 +556,13 @@ Symbolic types used in kinds were not supported in GHC, but now are. However,
 telling datacon names apart from tycon names. [This
 issue](https://github.com/goldfirere/singletons/issues/163) tracks adding
 this feature.
+
+A promoted and singled `Show` instance is provided for `Symbol`, but it is only
+a crude approximation of the value-level `Show` instance for `String`. On the
+value level, showing `String`s escapes special characters (such as double
+quotes), but implementing this requires pattern-matching on character literals,
+something which is currently impossible at the level. As a consequence, the
+type-level `Show` instance for `Symbol`s does not do any character escaping.
 
 Support for `*`
 ---------------

--- a/singletons.cabal
+++ b/singletons.cabal
@@ -44,9 +44,10 @@ library
   hs-source-dirs:     src
   build-depends:      base >= 4.10 && < 5,
                       mtl >= 2.1.2,
+                      ghc-boot-th,
                       template-haskell,
                       containers >= 0.5,
-                      th-desugar >= 1.7 && < 1.8,
+                      th-desugar >= 1.7.1 && < 1.8,
                       syb >= 0.4,
                       text >= 1.2
   default-language:   Haskell2010
@@ -70,6 +71,7 @@ library
                       Data.Singletons.Prelude.List.NonEmpty,
                       Data.Singletons.Prelude.Maybe,
                       Data.Singletons.Prelude.Num
+                      Data.Singletons.Prelude.Show,
                       Data.Singletons.Prelude.Tuple,
                       Data.Promotion.Prelude,
                       Data.Promotion.TH,
@@ -84,6 +86,7 @@ library
                       Data.Promotion.Prelude.List.NonEmpty,
                       Data.Promotion.Prelude.Maybe,
                       Data.Promotion.Prelude.Num,
+                      Data.Promotion.Prelude.Show,
                       Data.Promotion.Prelude.Tuple,
                       Data.Singletons.TypeLits,
                       Data.Singletons.Decide,
@@ -93,6 +96,7 @@ library
                       Data.Singletons.Deriving.Bounded,
                       Data.Singletons.Deriving.Enum,
                       Data.Singletons.Deriving.Ord,
+                      Data.Singletons.Deriving.Show,
                       Data.Singletons.Prelude.List.NonEmpty.Internal,
                       Data.Singletons.Promote,
                       Data.Singletons.Promote.Monad,

--- a/singletons.cabal
+++ b/singletons.cabal
@@ -47,7 +47,7 @@ library
                       ghc-boot-th,
                       template-haskell,
                       containers >= 0.5,
-                      th-desugar >= 1.7.1 && < 1.8,
+                      th-desugar >= 1.8 && < 1.9,
                       syb >= 0.4,
                       text >= 1.2
   default-language:   Haskell2010

--- a/src/Data/Promotion/Prelude.hs
+++ b/src/Data/Promotion/Prelude.hs
@@ -42,6 +42,9 @@ module Data.Promotion.Prelude (
   -- * Promoted numbers
   module Data.Promotion.Prelude.Num,
 
+  -- * Promoted 'Show'
+  module Data.Promotion.Prelude.Show,
+
   -- ** Miscellaneous functions
   Id, Const, (:.), type ($), type ($!), Flip, AsTypeOf, Until, Seq,
 
@@ -161,4 +164,5 @@ import Data.Promotion.Prelude.Ord
 import Data.Promotion.Prelude.Enum
   hiding (Succ, Pred, SuccSym0, SuccSym1, PredSym0, PredSym1)
 import Data.Promotion.Prelude.Num
+import Data.Promotion.Prelude.Show
 import Data.Singletons.TypeLits

--- a/src/Data/Promotion/Prelude.hs
+++ b/src/Data/Promotion/Prelude.hs
@@ -43,7 +43,7 @@ module Data.Promotion.Prelude (
   module Data.Promotion.Prelude.Num,
 
   -- * Promoted 'Show'
-  PShow(..), ShowS, SChar, (:<>), Shows, ShowChar, ShowString, ShowParen,
+  PShow(..), ShowS, SChar, show_, (:<>), Shows, ShowChar, ShowString, ShowParen,
 
   -- ** Miscellaneous functions
   Id, Const, (:.), type ($), type ($!), Flip, AsTypeOf, Until, Seq,
@@ -98,7 +98,7 @@ module Data.Promotion.Prelude (
   (:^$), (:^$$),
 
   ShowsPrecSym0, ShowsPrecSym1, ShowsPrecSym2, ShowsPrecSym3,
-  Show'Sym0, Show'Sym1,
+  Show_Sym0, Show_Sym1,
   ShowListSym0, ShowListSym1, ShowListSym2,
   (:<>$), (:<>$$), (:<>$$$),
   ShowsSym0, ShowsSym1, ShowsSym2,

--- a/src/Data/Promotion/Prelude.hs
+++ b/src/Data/Promotion/Prelude.hs
@@ -43,7 +43,7 @@ module Data.Promotion.Prelude (
   module Data.Promotion.Prelude.Num,
 
   -- * Promoted 'Show'
-  module Data.Promotion.Prelude.Show,
+  PShow(..), ShowS, SChar, (:<>), Shows, ShowChar, ShowString, ShowParen,
 
   -- ** Miscellaneous functions
   Id, Const, (:.), type ($), type ($!), Flip, AsTypeOf, Until, Seq,
@@ -96,6 +96,15 @@ module Data.Promotion.Prelude (
   UncurrySym0, UncurrySym1, UncurrySym2,
 
   (:^$), (:^$$),
+
+  ShowsPrecSym0, ShowsPrecSym1, ShowsPrecSym2, ShowsPrecSym3,
+  Show'Sym0, Show'Sym1,
+  ShowListSym0, ShowListSym1, ShowListSym2,
+  (:<>$), (:<>$$), (:<>$$$),
+  ShowsSym0, ShowsSym1, ShowsSym2,
+  ShowCharSym0, ShowCharSym1, ShowCharSym2,
+  ShowStringSym0, ShowStringSym1, ShowStringSym2,
+  ShowParenSym0, ShowParenSym1, ShowParenSym2,
 
   IdSym0, IdSym1, ConstSym0, ConstSym1, ConstSym2,
   (:.$), (:.$$), (:.$$$),

--- a/src/Data/Promotion/Prelude/Show.hs
+++ b/src/Data/Promotion/Prelude/Show.hs
@@ -12,38 +12,23 @@
 -----------------------------------------------------------------------------
 
 module Data.Promotion.Prelude.Show (
-  PShow(..), SymbolS, SChar,
+  PShow(..), SymbolS, SChar, show_, (:<>),
+  Shows, ShowListWith, ShowChar, ShowString, ShowParen,
+  ShowSpace, ShowCommaSpace, AppPrec, AppPrec1,
 
+  -- * Defunctionalization symbols
   ShowsPrecSym0, ShowsPrecSym1, ShowsPrecSym2, ShowsPrecSym3,
-  Show'Sym0, Show'Sym1,
+  Show_Sym0, Show_Sym1,
   ShowListSym0, ShowListSym1, ShowListSym2,
-
-  (:<>),
   (:<>$), (:<>$$), (:<>$$$),
-
-  Shows,
   ShowsSym0, ShowsSym1, ShowsSym2,
-
-  ShowListWith,
   ShowListWithSym0, ShowListWithSym1, ShowListWithSym2, ShowListWithSym3,
-
-  ShowChar,
   ShowCharSym0, ShowCharSym1, ShowCharSym2,
-
-  ShowString,
   ShowStringSym0, ShowStringSym1, ShowStringSym2,
-
-  ShowParen,
   ShowParenSym0, ShowParenSym1, ShowParenSym2,
-
-  ShowSpace,
   ShowSpaceSym0, ShowSpaceSym1,
-
-  ShowCommaSpace,
   ShowCommaSpaceSym0, ShowCommaSpaceSym1,
-
-  AppPrec, AppPrecSym0,
-  AppPrec1, AppPrec1Sym0
+  AppPrecSym0, AppPrec1Sym0
   ) where
 
 import Data.Singletons.Prelude.Show

--- a/src/Data/Promotion/Prelude/Show.hs
+++ b/src/Data/Promotion/Prelude/Show.hs
@@ -1,0 +1,49 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Promotion.Prelude.Show
+-- Copyright   :  (C) 2014 Jan Stolarek, Richard Eisenberg
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Jan Stolarek (jan.stolarek@p.lodz.pl)
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Exports a promoted version of 'Show'
+--
+-----------------------------------------------------------------------------
+
+module Data.Promotion.Prelude.Show (
+  PShow(..), SymbolS, SChar,
+
+  ShowsPrecSym0, ShowsPrecSym1, ShowsPrecSym2, ShowsPrecSym3,
+  Show'Sym0, Show'Sym1,
+  ShowListSym0, ShowListSym1, ShowListSym2,
+
+  (:<>),
+  (:<>$), (:<>$$), (:<>$$$),
+
+  Shows,
+  ShowsSym0, ShowsSym1, ShowsSym2,
+
+  ShowListWith,
+  ShowListWithSym0, ShowListWithSym1, ShowListWithSym2, ShowListWithSym3,
+
+  ShowChar,
+  ShowCharSym0, ShowCharSym1, ShowCharSym2,
+
+  ShowString,
+  ShowStringSym0, ShowStringSym1, ShowStringSym2,
+
+  ShowParen,
+  ShowParenSym0, ShowParenSym1, ShowParenSym2,
+
+  ShowSpace,
+  ShowSpaceSym0, ShowSpaceSym1,
+
+  ShowCommaSpace,
+  ShowCommaSpaceSym0, ShowCommaSpaceSym1,
+
+  AppPrec, AppPrecSym0,
+  AppPrec1, AppPrec1Sym0
+  ) where
+
+import Data.Singletons.Prelude.Show

--- a/src/Data/Promotion/TH.hs
+++ b/src/Data/Promotion/TH.hs
@@ -30,6 +30,9 @@ module Data.Promotion.TH (
   -- ** Functions to generate @Enum@ instances
   promoteEnumInstances, promoteEnumInstance,
 
+  -- ** Functions to generate @Show@ instances
+  promoteShowInstances, promoteShowInstance,
+
   -- ** defunctionalization
   TyFun, Apply, type (@@),
 

--- a/src/Data/Singletons/CustomStar.hs
+++ b/src/Data/Singletons/CustomStar.hs
@@ -108,7 +108,7 @@ singletonStar names = do
           (types, vars) <- evalForPair $ mapM (kindToType []) args
           dataName <- if real then mkDataName (nameBase name) else return name
           return $ DCon (map DPlainTV vars) [] dataName
-                        (DNormalC (map (\ty -> (noBang, ty)) types))
+                        (DNormalC False (map (\ty -> (noBang, ty)) types))
                         Nothing
             where
               noBang = Bang NoSourceUnpackedness NoSourceStrictness

--- a/src/Data/Singletons/Deriving/Show.hs
+++ b/src/Data/Singletons/Deriving/Show.hs
@@ -1,7 +1,7 @@
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Singletons.Deriving.Show
--- Copyright   :  (C) 2015 Richard Eisenberg
+-- Copyright   :  (C) 2017 Ryan Scott
 -- License     :  BSD-style (see LICENSE)
 -- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
 -- Stability   :  experimental
@@ -89,8 +89,8 @@ mk_showsPrec_clause p (DCon _ _ con_name con_fields _) = go con_fields
           `DAppE` (DVarE gtName `DAppE` DVarE p `DAppE` dIntegerE appPrec)
           `DAppE` named_args
 
-    -- A record constructor with no fields? This probably won't ever happen,
-    -- but just to be safe, we'll act as if it were a DNormalC.
+    -- We show a record constructor with no fields the same way we'd show a
+    -- normal constructor with no fields.
     go (DRecC []) = go (DNormalC False [])
 
     go (DRecC tys) = do

--- a/src/Data/Singletons/Deriving/Show.hs
+++ b/src/Data/Singletons/Deriving/Show.hs
@@ -1,0 +1,140 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Singletons.Deriving.Show
+-- Copyright   :  (C) 2015 Richard Eisenberg
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Implements deriving of Show instances
+--
+----------------------------------------------------------------------------
+{-# LANGUAGE ScopedTypeVariables #-}
+module Data.Singletons.Deriving.Show (mkShowInstance) where
+
+import Language.Haskell.TH.Syntax hiding (showName)
+import Language.Haskell.TH.Ppr (pprint)
+import Language.Haskell.TH.Desugar
+import Data.Singletons.Names
+import Data.Singletons.Util
+import Data.Singletons.Syntax
+import Data.Singletons.Deriving.Infer
+import Control.Monad (when)
+import Data.Maybe (fromMaybe)
+import GHC.Lexeme (startsConSym, startsVarSym)
+import GHC.Show (appPrec, appPrec1)
+
+mkShowInstance :: DsMonad q => DType -> [DCon] -> q UInstDecl
+mkShowInstance ty cons = do
+  when (null cons) $
+    fail ("Can't derive Show instance for " ++ pprint (typeToTH ty) ++ ".")
+  clauses <- mk_showsPrec cons
+  return $ InstDecl { id_cxt = inferConstraints (DConPr showName) cons
+                    , id_name = showName
+                    , id_arg_tys = [ty]
+                    , id_meths = [ (showsPrecName, UFunction clauses) ] }
+
+mk_showsPrec :: DsMonad q => [DCon] -> q [DClause]
+mk_showsPrec cons = do
+    p <- newUniqueName "p" -- The precedence argument (not always used)
+    mapM (mk_showsPrec_clause p) cons
+
+mk_showsPrec_clause :: forall q. DsMonad q => Name -> DCon -> q DClause
+mk_showsPrec_clause p (DCon _ _ con_name con_fields _) = go con_fields
+  where
+    go :: DConFields -> q DClause
+
+    -- No fields: print just the constructor name, with no parentheses
+    go (DNormalC _ []) = return $
+      DClause [DWildPa, DConPa con_name []] $
+        DVarE showStringName `DAppE` dStringE (parenInfixConName con_name "")
+
+    -- Infix constructors have special Show treatment.
+    go (DNormalC True [_, _]) = do
+      argL <- newUniqueName "argL"
+      argR <- newUniqueName "argR"
+      fi <- fromMaybe defaultFixity <$> reifyFixityWithLocals con_name
+      let con_prec = case fi of Fixity prec _ -> prec
+          op_name  = nameBase con_name
+          infixOpE = DAppE (DVarE showStringName) . dStringE $
+                       if isInfixDataCon op_name
+                          then " "  ++ op_name ++ " "
+                          -- Make sure to handle infix data constructors
+                          -- like (Int `Foo` Int)
+                          else " `" ++ op_name ++ "` "
+      return $ DClause [DVarPa p, DConPa con_name [DVarPa argL, DVarPa argR]] $
+        (DVarE showParenName `DAppE` (DVarE gtName `DAppE` DVarE p
+                                                   `DAppE` dIntegerE con_prec))
+          `DAppE` (DVarE composeName
+                     `DAppE` showsPrecE (con_prec + 1) argL
+                     `DAppE` (DVarE composeName
+                                `DAppE` infixOpE
+                                `DAppE` showsPrecE (con_prec + 1) argR))
+
+    go (DNormalC _ tys) = do
+      args <- mapM (const $ newUniqueName "arg") tys
+      let show_args     = map (showsPrecE appPrec1) args
+          composed_args = foldr1 (\v q -> DVarE composeName
+                                           `DAppE` v
+                                           `DAppE` (DVarE composeName
+                                                     `DAppE` DVarE showSpaceName
+                                                     `DAppE` q)) show_args
+          named_args = DVarE composeName
+                         `DAppE` (DVarE showStringName
+                                   `DAppE` dStringE (parenInfixConName con_name " "))
+                         `DAppE` composed_args
+      return $ DClause [DVarPa p, DConPa con_name $ map DVarPa args] $
+        DVarE showParenName
+          `DAppE` (DVarE gtName `DAppE` DVarE p `DAppE` dIntegerE appPrec)
+          `DAppE` named_args
+
+    -- A record constructor with no fields? This probably won't ever happen,
+    -- but just to be safe, we'll act as if it were a DNormalC.
+    go (DRecC []) = go (DNormalC False [])
+
+    go (DRecC tys) = do
+      args <- mapM (const $ newUniqueName "arg") tys
+      let show_args =
+            concatMap (\((arg_name, _, _), arg) ->
+                        let arg_nameBase = nameBase arg_name
+                            infix_rec    = showParen (isSym arg_nameBase)
+                                                     (showString arg_nameBase) ""
+                        in [ DVarE showStringName `DAppE` dStringE (infix_rec ++ " = ")
+                           , showsPrecE 0 arg
+                           , DVarE showCommaSpaceName
+                           ])
+                      (zip tys args)
+          brace_comma_args =   (DVarE showCharName `DAppE` dStringE "{")
+                             : take (length show_args - 1) show_args
+          composed_args = foldr (\x y -> DVarE composeName `DAppE` x `DAppE` y)
+                                (DVarE showCharName `DAppE` dStringE "}")
+                                brace_comma_args
+          named_args = DVarE composeName
+                         `DAppE` (DVarE showStringName
+                                   `DAppE` dStringE (parenInfixConName con_name " "))
+                         `DAppE` composed_args
+      return $ DClause [DVarPa p, DConPa con_name $ map DVarPa args] $
+        DVarE showParenName
+          `DAppE` (DVarE gtName `DAppE` DVarE p `DAppE` dIntegerE appPrec)
+          `DAppE` named_args
+
+-- | Parenthesize an infix constructor name if it is being applied as a prefix
+-- function (e.g., data Amp a = (:&) a a)
+parenInfixConName :: Name -> ShowS
+parenInfixConName conName =
+    let conNameBase = nameBase conName
+    in showParen (isInfixDataCon conNameBase) $ showString conNameBase
+
+showsPrecE :: Int -> Name -> DExp
+showsPrecE prec n = DVarE showsPrecName `DAppE` dIntegerE prec `DAppE` DVarE n
+
+dStringE :: String -> DExp
+dStringE = DLitE . StringL
+
+dIntegerE :: Int -> DExp
+dIntegerE = DLitE . IntegerL . fromIntegral
+
+isSym :: String -> Bool
+isSym ""      = False
+isSym (c : _) = startsVarSym c || startsConSym c

--- a/src/Data/Singletons/Names.hs
+++ b/src/Data/Singletons/Names.hs
@@ -17,6 +17,7 @@ import Language.Haskell.TH.Syntax
 import Language.Haskell.TH.Desugar
 import GHC.TypeLits ( Nat, Symbol )
 import GHC.Exts ( Any, Constraint )
+import GHC.Show ( showCommaSpace, showSpace )
 import Data.Typeable ( TypeRep )
 import Data.Singletons.Util
 import Control.Monad
@@ -37,7 +38,9 @@ anyTypeName, boolName, andName, tyEqName, compareName, minBoundName,
   sameKindName, tyFromIntegerName, tyNegateName, sFromIntegerName,
   sNegateName, errorName, foldlName, cmpEQName, cmpLTName, cmpGTName,
   singletonsToEnumName, singletonsFromEnumName, enumName, singletonsEnumName,
-  equalsName, constraintName :: Name
+  equalsName, constraintName,
+  showName, showCharName, showCommaSpaceName, showParenName, showsPrecName,
+  showSpaceName, showStringName, composeName, gtName :: Name
 anyTypeName = ''Any
 boolName = ''Bool
 andName = '(&&)
@@ -101,6 +104,15 @@ enumName = ''Enum
 singletonsEnumName = mk_name_tc "Data.Singletons.Prelude.Enum" "Enum"
 equalsName = '(==)
 constraintName = ''Constraint
+showName = ''Show
+showCharName = 'showChar
+showParenName = 'showParen
+showSpaceName = 'showSpace
+showsPrecName = 'showsPrec
+showStringName = 'showString
+composeName = '(.)
+gtName = '(>)
+showCommaSpaceName = 'showCommaSpace
 
 singPkg :: String
 singPkg = $( (LitE . StringL . loc_package) `liftM` location )

--- a/src/Data/Singletons/Prelude.hs
+++ b/src/Data/Singletons/Prelude.hs
@@ -55,7 +55,8 @@ module Data.Singletons.Prelude (
   module Data.Singletons.Prelude.Num,
 
   -- * Singleton 'Show'
-  module Data.Singletons.Prelude.Show,
+  PShow(..), SShow(..), ShowS, SChar, (:<>), (%:<>),
+  Shows, sShows, ShowChar, sShowChar, ShowString, sShowString, ShowParen, sShowParen,
 
   -- ** Miscellaneous functions
   Id, sId, Const, sConst, (:.), (%:.), type ($), (%$), type ($!), (%$!),
@@ -111,6 +112,15 @@ module Data.Singletons.Prelude (
   FstSym0, FstSym1, SndSym0, SndSym1,
   CurrySym0, CurrySym1, CurrySym2, CurrySym3,
   UncurrySym0, UncurrySym1, UncurrySym2,
+
+  ShowsPrecSym0, ShowsPrecSym1, ShowsPrecSym2, ShowsPrecSym3,
+  Show'Sym0, Show'Sym1,
+  ShowListSym0, ShowListSym1, ShowListSym2,
+  (:<>$), (:<>$$), (:<>$$$),
+  ShowsSym0, ShowsSym1, ShowsSym2,
+  ShowCharSym0, ShowCharSym1, ShowCharSym2,
+  ShowStringSym0, ShowStringSym1, ShowStringSym2,
+  ShowParenSym0, ShowParenSym1, ShowParenSym2,
 
   IdSym0, IdSym1, ConstSym0, ConstSym1, ConstSym2,
   (:.$), (:.$$), (:.$$$),

--- a/src/Data/Singletons/Prelude.hs
+++ b/src/Data/Singletons/Prelude.hs
@@ -54,6 +54,9 @@ module Data.Singletons.Prelude (
   -- * Singletons numbers
   module Data.Singletons.Prelude.Num,
 
+  -- * Singleton 'Show'
+  module Data.Singletons.Prelude.Show,
+
   -- ** Miscellaneous functions
   Id, sId, Const, sConst, (:.), (%:.), type ($), (%$), type ($!), (%$!),
   Flip, sFlip, AsTypeOf, sAsTypeOf,
@@ -160,4 +163,5 @@ import Data.Singletons.Prelude.Instances
 import Data.Singletons.Prelude.Enum
   hiding (Succ, Pred, SuccSym0, SuccSym1, PredSym0, PredSym1, sSucc, sPred)
 import Data.Singletons.Prelude.Num
+import Data.Singletons.Prelude.Show
 import Data.Singletons.TypeLits

--- a/src/Data/Singletons/Prelude.hs
+++ b/src/Data/Singletons/Prelude.hs
@@ -90,6 +90,7 @@ module Data.Singletons.Prelude (
   maybe_,
   bool_,
   any_,
+  show_,
 
   -- * Defunctionalization symbols
   FalseSym0, TrueSym0,
@@ -114,7 +115,7 @@ module Data.Singletons.Prelude (
   UncurrySym0, UncurrySym1, UncurrySym2,
 
   ShowsPrecSym0, ShowsPrecSym1, ShowsPrecSym2, ShowsPrecSym3,
-  Show'Sym0, Show'Sym1,
+  Show_Sym0, Show_Sym1,
   ShowListSym0, ShowListSym1, ShowListSym2,
   (:<>$), (:<>$$), (:<>$$$),
   ShowsSym0, ShowsSym1, ShowsSym2,

--- a/src/Data/Singletons/Prelude/Show.hs
+++ b/src/Data/Singletons/Prelude/Show.hs
@@ -24,7 +24,7 @@
 -----------------------------------------------------------------------------
 
 module Data.Singletons.Prelude.Show (
-  PShow(..), SShow(..), SymbolS, SChar,
+  PShow(..), SShow(..), SymbolS, SChar, show_,
   (:<>), (%:<>),
   Shows, sShows,
   ShowListWith, sShowListWith,
@@ -38,7 +38,7 @@ module Data.Singletons.Prelude.Show (
 
   -- * Defunctionalization symbols
   ShowsPrecSym0, ShowsPrecSym1, ShowsPrecSym2, ShowsPrecSym3,
-  Show'Sym0, Show'Sym1,
+  Show_Sym0, Show_Sym1,
   ShowListSym0, ShowListSym1, ShowListSym2,
   (:<>$), (:<>$$), (:<>$$$),
   ShowsSym0, ShowsSym1, ShowsSym2,
@@ -110,12 +110,11 @@ type SChar = Symbol
 $(singletonsOnly [d|
   class Show a where
     showsPrec :: Nat -> a -> SymbolS
-    -- Intentionally renamed to avoid clashing with the Show class
-    show'     :: a -> Symbol
+    show_     :: a -> Symbol
     showList  :: [a] -> SymbolS
 
-    showsPrec _ x s = show' x <> s
-    show' x         = shows x ""
+    showsPrec _ x s = show_ x <> s
+    show_ x         = shows x ""
     showList ls   s = showListWith shows ls s
 
   shows :: Show a => a -> SymbolS
@@ -196,12 +195,12 @@ instance SShow Nat where
     case ex of
       SomeSymbol (_ :: Proxy s) -> unsafeCoerce (SSym :: Sing s)
 
-  -- Annoyingly enough, the default definitions for sShow' and sShowList won't
-  -- typecheck because they rely on the type-level Show' and ShowList reducing,
+  -- Annoyingly enough, the default definitions for sShow_ and sShowList won't
+  -- typecheck because they rely on the type-level Show_ and ShowList reducing,
   -- but since we don't have a PShow Nat instance, that doesn't happen. To work
-  -- around this, we define sShow' and sShowList by hand.
+  -- around this, we define sShow_ and sShowList by hand.
 
-  sShow' sn =
+  sShow_ sn =
     let n = fromSing sn
         ex = someSymbolVal (P.show n)
     in
@@ -215,5 +214,10 @@ instance SShow Nat where
     in
     case ex of
       SomeSymbol (_ :: Proxy s) -> unsafeCoerce (SSym :: Sing s)
+
+-- | 'P.show', but with an extra underscore so that its promoted counterpart
+-- ('Show_') will not clash with the 'Show' class.
+show_ :: P.Show a => a -> String
+show_ = P.show
 
 $(singShowInstances [ ''(), ''Maybe, ''Either, ''NonEmpty, ''Bool, ''Ordering ])

--- a/src/Data/Singletons/Prelude/Show.hs
+++ b/src/Data/Singletons/Prelude/Show.hs
@@ -10,12 +10,10 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-{-# LANGUAGE TypeApplications #-}
-
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Singletons.Prelude.Show
--- Copyright   :  (C) 2013 Richard Eisenberg
+-- Copyright   :  (C) 2017 Ryan Scott
 -- License     :  BSD-style (see LICENSE)
 -- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
 -- Stability   :  experimental
@@ -27,38 +25,30 @@
 
 module Data.Singletons.Prelude.Show (
   PShow(..), SShow(..), SymbolS, SChar,
+  (:<>), (%:<>),
+  Shows, sShows,
+  ShowListWith, sShowListWith,
+  ShowChar, sShowChar,
+  ShowString, sShowString,
+  ShowParen, sShowParen,
+  ShowSpace, sShowSpace,
+  ShowCommaSpace, sShowCommaSpace,
+  AppPrec, sAppPrec,
+  AppPrec1, sAppPrec1,
 
+  -- * Defunctionalization symbols
   ShowsPrecSym0, ShowsPrecSym1, ShowsPrecSym2, ShowsPrecSym3,
   Show'Sym0, Show'Sym1,
   ShowListSym0, ShowListSym1, ShowListSym2,
-
-  (:<>), (%:<>),
   (:<>$), (:<>$$), (:<>$$$),
-
-  Shows, sShows,
   ShowsSym0, ShowsSym1, ShowsSym2,
-
-  ShowListWith, sShowListWith,
   ShowListWithSym0, ShowListWithSym1, ShowListWithSym2, ShowListWithSym3,
-
-  ShowChar, sShowChar,
   ShowCharSym0, ShowCharSym1, ShowCharSym2,
-
-  ShowString, sShowString,
   ShowStringSym0, ShowStringSym1, ShowStringSym2,
-
-  ShowParen, sShowParen,
   ShowParenSym0, ShowParenSym1, ShowParenSym2,
-
-  ShowSpace, sShowSpace,
   ShowSpaceSym0, ShowSpaceSym1,
-
-  ShowCommaSpace, sShowCommaSpace,
   ShowCommaSpaceSym0, ShowCommaSpaceSym1,
-
-  AppPrec, sAppPrec, AppPrecSym0,
-
-  AppPrec1, sAppPrec1, AppPrec1Sym0
+  AppPrecSym0, AppPrec1Sym0
   ) where
 
 import           Data.Kind (Type)

--- a/src/Data/Singletons/Prelude/Show.hs
+++ b/src/Data/Singletons/Prelude/Show.hs
@@ -1,0 +1,229 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeInType #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# LANGUAGE TypeApplications #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Singletons.Prelude.Show
+-- Copyright   :  (C) 2013 Richard Eisenberg
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Defines the SShow singleton version of the Show type class.
+--
+-----------------------------------------------------------------------------
+
+module Data.Singletons.Prelude.Show (
+  PShow(..), SShow(..), SymbolS, SChar,
+
+  ShowsPrecSym0, ShowsPrecSym1, ShowsPrecSym2, ShowsPrecSym3,
+  Show'Sym0, Show'Sym1,
+  ShowListSym0, ShowListSym1, ShowListSym2,
+
+  (:<>), (%:<>),
+  (:<>$), (:<>$$), (:<>$$$),
+
+  Shows, sShows,
+  ShowsSym0, ShowsSym1, ShowsSym2,
+
+  ShowListWith, sShowListWith,
+  ShowListWithSym0, ShowListWithSym1, ShowListWithSym2, ShowListWithSym3,
+
+  ShowChar, sShowChar,
+  ShowCharSym0, ShowCharSym1, ShowCharSym2,
+
+  ShowString, sShowString,
+  ShowStringSym0, ShowStringSym1, ShowStringSym2,
+
+  ShowParen, sShowParen,
+  ShowParenSym0, ShowParenSym1, ShowParenSym2,
+
+  ShowSpace, sShowSpace,
+  ShowSpaceSym0, ShowSpaceSym1,
+
+  ShowCommaSpace, sShowCommaSpace,
+  ShowCommaSpaceSym0, ShowCommaSpaceSym1,
+
+  AppPrec, sAppPrec, AppPrecSym0,
+
+  AppPrec1, sAppPrec1, AppPrec1Sym0
+  ) where
+
+import           Data.Kind (Type)
+import           Data.List.NonEmpty (NonEmpty)
+import           Data.Monoid ((<>))
+import           Data.Singletons.Prelude.Base
+import           Data.Singletons.Prelude.Instances
+import           Data.Singletons.Prelude.List
+import           Data.Singletons.Prelude.Ord
+import           Data.Singletons.Single
+import           Data.Singletons.TH
+import           Data.Singletons.TypeLits
+import qualified Data.Text as T
+
+import           GHC.TypeLits
+
+import qualified Prelude as P
+import           Prelude hiding (Show(..))
+
+import           Unsafe.Coerce (unsafeCoerce)
+
+-- | The promoted analogue of '(<>)' for 'Symbol's. This uses the special
+-- 'AppendSymbol' type family from "GHC.TypeLits".
+type a :<> b = AppendSymbol a b
+infixr 6 :<>
+
+-- | The singleton analogue of '(<>)' for 'Symbol's.
+(%:<>) :: Sing a -> Sing b -> Sing (a :<> b)
+sa %:<> sb =
+    let a  = fromSing sa
+        b  = fromSing sb
+        ex = someSymbolVal $ T.unpack $ a <> b
+    in case ex of
+         SomeSymbol (_ :: Proxy ab) -> unsafeCoerce (SSym :: Sing ab)
+infixr 6 %:<>
+
+type (:<>$$$) (x :: Symbol) (y :: Symbol) =
+    (:<>) x y
+instance SuppressUnusedWarnings (:<>$$) where
+  suppressUnusedWarnings = snd ((:<>$$###), ())
+data (:<>$$) (x :: Symbol) (y :: TyFun Symbol Symbol)
+  = forall arg. KindOf (Apply ((:<>$$) x) arg) ~ KindOf ((:<>$$$) x arg) => (:<>$$###)
+type instance Apply ((:<>$$) x) y = (:<>$$$) x y
+instance SuppressUnusedWarnings (:<>$) where
+  suppressUnusedWarnings = snd ((:<>$###), ())
+data (:<>$) (x :: TyFun Symbol (TyFun Symbol Symbol -> Type))
+  = forall arg. KindOf (Apply (:<>$) arg) ~ KindOf ((:<>$$) arg) => (:<>$###)
+type instance Apply (:<>$) x = (:<>$$) x
+
+-- | The @shows@ functions return a function that prepends the
+-- output 'Symbol' to an existing 'Symbol'.  This allows constant-time
+-- concatenation of results using function composition.
+type SymbolS = Symbol -> Symbol
+
+-- | GHC currently has no notion of type-level 'Char's, so we fake them with
+-- single-character 'Symbol's.
+type SChar = Symbol
+
+$(singletonsOnly [d|
+  class Show a where
+    showsPrec :: Nat -> a -> SymbolS
+    -- Intentionally renamed to avoid clashing with the Show class
+    show'     :: a -> Symbol
+    showList  :: [a] -> SymbolS
+
+    showsPrec _ x s = show' x <> s
+    show' x         = shows x ""
+    showList ls   s = showListWith shows ls s
+
+  shows :: Show a => a -> SymbolS
+  shows s = showsPrec 0 s
+
+  showListWith :: (a -> SymbolS) -> [a] -> SymbolS
+  showListWith _     []     s = "[]" <> s
+  showListWith showx (x:xs) s = "["  <> showx x (showl xs)
+    where
+      showl []     = "]" <> s
+      showl (y:ys) = "," <> showx y (showl ys)
+
+  showChar :: SChar -> SymbolS
+  showChar = (<>)
+
+  showString :: Symbol -> SymbolS
+  showString = (<>)
+
+  showParen :: Bool -> SymbolS -> SymbolS
+  showParen b p = if b then showChar "(" . p . showChar ")" else p
+
+  showSpace :: SymbolS
+  showSpace = \xs -> " " <> xs
+
+  showCommaSpace :: SymbolS
+  showCommaSpace = showString ", "
+
+  appPrec, appPrec1 :: Nat
+  appPrec  = 10
+  appPrec1 = 11
+
+  instance Show a => Show [a] where
+    showsPrec _ = showList
+
+  -- -| This is not an ideal Show instance for Symbol, since the Show instance
+  -- for String escapes special characters. Unfortunately, GHC lacks the ability
+  -- to case on individual characters in a Symbol (at least, not without GHC
+  -- plugins), so this is the best we can do for the time being.
+  instance Show Symbol where
+    showsPrec _ = showString
+
+  show_tuple :: [SymbolS] -> SymbolS
+  show_tuple ss = showChar "("
+                . foldr1 (\s r -> s . showChar "," . r) ss
+                . showChar ")"
+
+  instance (Show a, Show b) => Show (a,b)  where
+    showsPrec _ (a,b) s = show_tuple [shows a, shows b] s
+
+  instance (Show a, Show b, Show c) => Show (a, b, c) where
+    showsPrec _ (a,b,c) s = show_tuple [shows a, shows b, shows c] s
+
+  instance (Show a, Show b, Show c, Show d) => Show (a, b, c, d) where
+    showsPrec _ (a,b,c,d) s = show_tuple [shows a, shows b, shows c, shows d] s
+
+  instance (Show a, Show b, Show c, Show d, Show e) => Show (a, b, c, d, e) where
+    showsPrec _ (a,b,c,d,e) s = show_tuple [shows a, shows b, shows c, shows d, shows e] s
+
+  instance (Show a, Show b, Show c, Show d, Show e, Show f) => Show (a,b,c,d,e,f) where
+    showsPrec _ (a,b,c,d,e,f) s = show_tuple [shows a, shows b, shows c, shows d, shows e, shows f] s
+
+  instance (Show a, Show b, Show c, Show d, Show e, Show f, Show g)
+          => Show (a,b,c,d,e,f,g) where
+    showsPrec _ (a,b,c,d,e,f,g) s
+          = show_tuple [shows a, shows b, shows c, shows d, shows e, shows f, shows g] s
+  |])
+
+-- At the moment, I can't think of a way to implement a PShow Nat instance,
+-- since that would require a way to convert Nats to Symbols at the type level.
+-- Oh well.
+
+instance SShow Nat where
+  sShowsPrec _ sn sx =
+    let n = fromSing sn
+        x = fromSing sx
+        ex = someSymbolVal (P.show n ++ T.unpack x)
+    in
+    case ex of
+      SomeSymbol (_ :: Proxy s) -> unsafeCoerce (SSym :: Sing s)
+
+  -- Annoyingly enough, the default definitions for sShow' and sShowList won't
+  -- typecheck because they rely on the type-level Show' and ShowList reducing,
+  -- but since we don't have a PShow Nat instance, that doesn't happen. To work
+  -- around this, we define sShow' and sShowList by hand.
+
+  sShow' sn =
+    let n = fromSing sn
+        ex = someSymbolVal (P.show n)
+    in
+    case ex of
+      SomeSymbol (_ :: Proxy s) -> unsafeCoerce (SSym :: Sing s)
+
+  sShowList sl sx =
+    let l = fromSing sl
+        x = fromSing sx
+        ex = someSymbolVal (P.show l ++ T.unpack x)
+    in
+    case ex of
+      SomeSymbol (_ :: Proxy s) -> unsafeCoerce (SSym :: Sing s)
+
+$(singShowInstances [ ''(), ''Maybe, ''Either, ''NonEmpty, ''Bool, ''Ordering ])

--- a/src/Data/Singletons/Promote.hs
+++ b/src/Data/Singletons/Promote.hs
@@ -22,6 +22,7 @@ import Data.Singletons.Promote.Type
 import Data.Singletons.Deriving.Ord
 import Data.Singletons.Deriving.Bounded
 import Data.Singletons.Deriving.Enum
+import Data.Singletons.Deriving.Show
 import Data.Singletons.Partition
 import Data.Singletons.Util
 import Data.Singletons.Syntax
@@ -94,6 +95,14 @@ promoteEnumInstances = concatMapM promoteEnumInstance
 -- | Produce an instance for 'PEnum' from the given type
 promoteEnumInstance :: DsMonad q => Name -> q [Dec]
 promoteEnumInstance = promoteInstance mkEnumInstance "Enum"
+
+-- | Produce instances for 'PShow' from the given types
+promoteShowInstances :: DsMonad q => [Name] -> q [Dec]
+promoteShowInstances = concatMapM promoteShowInstance
+
+-- | Produce an instance for 'PShow' from the given type
+promoteShowInstance :: DsMonad q => Name -> q [Dec]
+promoteShowInstance = promoteInstance mkShowInstance "Show"
 
 -- | Produce an instance for '(:==)' (type-level equality) from the given type
 promoteEqInstance :: DsMonad q => Name -> q [Dec]

--- a/src/Data/Singletons/Promote/Defun.hs
+++ b/src/Data/Singletons/Promote/Defun.hs
@@ -140,7 +140,7 @@ defunctionalize name m_arg_kinds' m_res_kind' = do
           con_decl    = DCon [DPlainTV extra_name]
                              [con_eq_ct]
                              con_name
-                             (DNormalC [])
+                             (DNormalC False [])
                              Nothing
           data_decl   = DDataD Data [] data_name params [con_decl] []
           app_eqn     = DTySynEqn [ foldType (DConT data_name)

--- a/src/Data/Singletons/Single.hs
+++ b/src/Data/Singletons/Single.hs
@@ -16,6 +16,7 @@ import Language.Haskell.TH.Syntax (Quasi(..))
 import Data.Singletons.Deriving.Ord
 import Data.Singletons.Deriving.Bounded
 import Data.Singletons.Deriving.Enum
+import Data.Singletons.Deriving.Show
 import Data.Singletons.Util
 import Data.Singletons.Promote
 import Data.Singletons.Promote.Monad ( promoteM )
@@ -165,6 +166,14 @@ singEnumInstances = concatMapM singEnumInstance
 -- | Create instance of 'SEnum' for the given type
 singEnumInstance :: DsMonad q => Name -> q [Dec]
 singEnumInstance = singInstance mkEnumInstance "Enum"
+
+-- | Create instance of 'SShow' for the given type
+singShowInstance :: DsMonad q => Name -> q [Dec]
+singShowInstance = singInstance mkShowInstance "Show"
+
+-- | Create instances of 'SShow' for the given types
+singShowInstances :: DsMonad q => [Name] -> q [Dec]
+singShowInstances = concatMapM singShowInstance
 
 singInstance :: DsMonad q
              => (DType -> [DCon] -> q UInstDecl)

--- a/src/Data/Singletons/Single/Data.hs
+++ b/src/Data/Singletons/Single/Data.hs
@@ -147,7 +147,7 @@ singCtor a (DCon _tvbs cxt name fields _rty)
 
   let noBang    = Bang NoSourceUnpackedness NoSourceStrictness
       conFields = case fields of
-                    DNormalC _ -> DNormalC $ map (noBang,) args
+                    DNormalC dInfix _ -> DNormalC dInfix $ map (noBang,) args
                     DRecC rec_fields ->
                       DRecC [ (singValName field_name, noBang, arg)
                             | (field_name, _, _) <- rec_fields

--- a/src/Data/Singletons/TH.hs
+++ b/src/Data/Singletons/TH.hs
@@ -39,6 +39,10 @@ module Data.Singletons.TH (
   promoteEnumInstances, promoteEnumInstance,
   singEnumInstances, singEnumInstance,
 
+  -- ** Functions to generate 'Show' instances
+  promoteShowInstances, promoteShowInstance,
+  singShowInstances, singShowInstance,
+
   -- ** Utility functions
   cases, sCases,
 

--- a/src/Data/Singletons/Util.hs
+++ b/src/Data/Singletons/Util.hs
@@ -79,7 +79,7 @@ checkForRepInDecls decls =
   checkForRep (allNamesIn decls)
 
 tysOfConFields :: DConFields -> [DType]
-tysOfConFields (DNormalC stys) = map snd stys
+tysOfConFields (DNormalC _ stys) = map snd stys
 tysOfConFields (DRecC vstys)   = map (\(_,_,ty) -> ty) vstys
 
 -- extract the name and number of arguments to a constructor
@@ -92,6 +92,11 @@ extractNameTypes (DCon _ _ n fields _) = (n, tysOfConFields fields)
 
 extractName :: DCon -> Name
 extractName (DCon _ _ n _ _) = n
+
+-- | is a valid Haskell infix data constructor (i.e., does it begin with a colon?)
+isInfixDataCon :: String -> Bool
+isInfixDataCon (':':_) = True
+isInfixDataCon _       = False
 
 -- is an identifier uppercase?
 isUpcase :: Name -> Bool

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -69,6 +69,8 @@ tests =
     , compileAndDumpStdTest "T176"
     , compileAndDumpStdTest "T178"
     , compileAndDumpStdTest "T187"
+    , compileAndDumpStdTest "ShowDeriving"
+    , compileAndDumpStdTest "BadShowDeriving"
     ],
     testCompileAndDumpGroup "Promote"
     [ compileAndDumpStdTest "Constructors"

--- a/tests/compile-and-dump/GradingClient/Database.ghc82.template
+++ b/tests/compile-and-dump/GradingClient/Database.ghc82.template
@@ -468,6 +468,106 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       Disjoint (Sch ((:) h t)) s = Apply (Apply (:&&$) (Apply (Apply AttrNotInSym0 h) s)) (Apply (Apply DisjointSym0 (Apply SchSym0 t)) s)
     type family Append (a :: Schema) (a :: Schema) :: Schema where
       Append (Sch s1) (Sch s2) = Apply SchSym0 (Apply (Apply (:++$) s1) s2)
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: U) (a :: Symbol) :: Symbol where
+      ShowsPrec_0123456789876543210 _ BOOL a_0123456789876543210 = Apply (Apply ShowStringSym0 "BOOL") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ STRING a_0123456789876543210 = Apply (Apply ShowStringSym0 "STRING") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ NAT a_0123456789876543210 = Apply (Apply ShowStringSym0 "NAT") a_0123456789876543210
+      ShowsPrec_0123456789876543210 p_0123456789876543210 (VEC arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (:>$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (:.$) (Apply ShowStringSym0 "VEC ")) (Apply (Apply (:.$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (:.$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
+    type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: U) (t :: Symbol) =
+        ShowsPrec_0123456789876543210 t t t
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym2 (l :: GHC.Types.Nat) (l :: U) (l :: TyFun Symbol Symbol)
+      = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
+        ShowsPrec_0123456789876543210Sym2KindInference
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun U (TyFun Symbol Symbol
+                                                                               -> Type))
+      = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
+        ShowsPrec_0123456789876543210Sym1KindInference
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat (TyFun U (TyFun Symbol Symbol
+                                                                               -> Type)
+                                                                      -> Type))
+      = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
+        ShowsPrec_0123456789876543210Sym0KindInference
+    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+    instance PShow U where
+      type ShowsPrec (a :: GHC.Types.Nat) (a :: U) (a :: Symbol) = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: AChar) (a :: Symbol) :: Symbol where
+      ShowsPrec_0123456789876543210 _ CA a_0123456789876543210 = Apply (Apply ShowStringSym0 "CA") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ CB a_0123456789876543210 = Apply (Apply ShowStringSym0 "CB") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ CC a_0123456789876543210 = Apply (Apply ShowStringSym0 "CC") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ CD a_0123456789876543210 = Apply (Apply ShowStringSym0 "CD") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ CE a_0123456789876543210 = Apply (Apply ShowStringSym0 "CE") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ CF a_0123456789876543210 = Apply (Apply ShowStringSym0 "CF") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ CG a_0123456789876543210 = Apply (Apply ShowStringSym0 "CG") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ CH a_0123456789876543210 = Apply (Apply ShowStringSym0 "CH") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ CI a_0123456789876543210 = Apply (Apply ShowStringSym0 "CI") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ CJ a_0123456789876543210 = Apply (Apply ShowStringSym0 "CJ") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ CK a_0123456789876543210 = Apply (Apply ShowStringSym0 "CK") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ CL a_0123456789876543210 = Apply (Apply ShowStringSym0 "CL") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ CM a_0123456789876543210 = Apply (Apply ShowStringSym0 "CM") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ CN a_0123456789876543210 = Apply (Apply ShowStringSym0 "CN") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ CO a_0123456789876543210 = Apply (Apply ShowStringSym0 "CO") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ CP a_0123456789876543210 = Apply (Apply ShowStringSym0 "CP") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ CQ a_0123456789876543210 = Apply (Apply ShowStringSym0 "CQ") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ CR a_0123456789876543210 = Apply (Apply ShowStringSym0 "CR") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ CS a_0123456789876543210 = Apply (Apply ShowStringSym0 "CS") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ CT a_0123456789876543210 = Apply (Apply ShowStringSym0 "CT") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ CU a_0123456789876543210 = Apply (Apply ShowStringSym0 "CU") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ CV a_0123456789876543210 = Apply (Apply ShowStringSym0 "CV") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ CW a_0123456789876543210 = Apply (Apply ShowStringSym0 "CW") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ CX a_0123456789876543210 = Apply (Apply ShowStringSym0 "CX") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ CY a_0123456789876543210 = Apply (Apply ShowStringSym0 "CY") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ CZ a_0123456789876543210 = Apply (Apply ShowStringSym0 "CZ") a_0123456789876543210
+    type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: AChar) (t :: Symbol) =
+        ShowsPrec_0123456789876543210 t t t
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym2 (l :: GHC.Types.Nat) (l :: AChar) (l :: TyFun Symbol Symbol)
+      = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
+        ShowsPrec_0123456789876543210Sym2KindInference
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun AChar (TyFun Symbol Symbol
+                                                                                   -> Type))
+      = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
+        ShowsPrec_0123456789876543210Sym1KindInference
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat (TyFun AChar (TyFun Symbol Symbol
+                                                                                   -> Type)
+                                                                      -> Type))
+      = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
+        ShowsPrec_0123456789876543210Sym0KindInference
+    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+    instance PShow AChar where
+      type ShowsPrec (a :: GHC.Types.Nat) (a :: AChar) (a :: Symbol) = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     sLookup ::
       forall (t :: [AChar]) (t :: Schema).
       Sing t -> Sing t -> Sing (Apply (Apply LookupSym0 t) t :: U)
@@ -4708,6 +4808,293 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       toSing (Sch b)
         = case toSing b :: SomeSing [Attribute] of {
             SomeSing c -> SomeSing (SSch c) }
+    instance (SShow U, SShow Nat) => SShow U where
+      sShowsPrec ::
+        forall (t1 :: GHC.Types.Nat) (t2 :: U) (t3 :: Symbol).
+        Sing t1
+        -> Sing t2
+           -> Sing t3
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat (TyFun U (TyFun Symbol Symbol
+                                                                                           -> Type)
+                                                                                  -> Type)
+                                                             -> Type) t1 :: TyFun U (TyFun Symbol Symbol
+                                                                                     -> Type)
+                                                                            -> Type) t2 :: TyFun Symbol Symbol
+                                                                                           -> Type) t3 :: Symbol)
+      sShowsPrec
+        _
+        SBOOL
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "BOOL")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SSTRING
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "STRING")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SNAT
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "NAT")))
+            sA_0123456789876543210
+      sShowsPrec
+        (sP_0123456789876543210 :: Sing p_0123456789876543210)
+        (SVEC (sArg_0123456789876543210 :: Sing arg_0123456789876543210)
+              (sArg_0123456789876543210 :: Sing arg_0123456789876543210))
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing
+                 ((applySing ((singFun3 @ShowParenSym0) sShowParen))
+                    ((applySing
+                        ((applySing ((singFun2 @(:>$)) (%:>))) sP_0123456789876543210))
+                       (sFromInteger (sing :: Sing 10)))))
+                ((applySing
+                    ((applySing ((singFun3 @(:.$)) (%:.)))
+                       ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                          (sing :: Sing "VEC "))))
+                   ((applySing
+                       ((applySing ((singFun3 @(:.$)) (%:.)))
+                          ((applySing
+                              ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
+                                 (sFromInteger (sing :: Sing 11))))
+                             sArg_0123456789876543210)))
+                      ((applySing
+                          ((applySing ((singFun3 @(:.$)) (%:.)))
+                             ((singFun1 @ShowSpaceSym0) sShowSpace)))
+                         ((applySing
+                             ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
+                                (sFromInteger (sing :: Sing 11))))
+                            sArg_0123456789876543210))))))
+            sA_0123456789876543210
+    instance SShow AChar where
+      sShowsPrec ::
+        forall (t1 :: GHC.Types.Nat) (t2 :: AChar) (t3 :: Symbol).
+        Sing t1
+        -> Sing t2
+           -> Sing t3
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat (TyFun AChar (TyFun Symbol Symbol
+                                                                                               -> Type)
+                                                                                  -> Type)
+                                                             -> Type) t1 :: TyFun AChar (TyFun Symbol Symbol
+                                                                                         -> Type)
+                                                                            -> Type) t2 :: TyFun Symbol Symbol
+                                                                                           -> Type) t3 :: Symbol)
+      sShowsPrec
+        _
+        SCA
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "CA")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SCB
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "CB")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SCC
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "CC")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SCD
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "CD")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SCE
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "CE")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SCF
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "CF")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SCG
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "CG")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SCH
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "CH")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SCI
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "CI")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SCJ
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "CJ")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SCK
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "CK")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SCL
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "CL")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SCM
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "CM")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SCN
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "CN")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SCO
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "CO")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SCP
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "CP")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SCQ
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "CQ")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SCR
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "CR")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SCS
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "CS")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SCT
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "CT")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SCU
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "CU")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SCV
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "CV")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SCW
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "CW")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SCX
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "CX")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SCY
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "CY")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SCZ
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "CZ")))
+            sA_0123456789876543210
     instance SingI BOOL where
       sing = SBOOL
     instance SingI STRING where

--- a/tests/compile-and-dump/GradingClient/Database.hs
+++ b/tests/compile-and-dump/GradingClient/Database.hs
@@ -24,6 +24,7 @@ module GradingClient.Database where
 
 import Prelude hiding ( tail, id )
 import Data.Singletons.Prelude hiding ( Lookup, sLookup )
+import Data.Singletons.Prelude.Show
 import Data.Singletons.SuppressUnusedWarnings
 import Data.Singletons.TH
 import Control.Monad

--- a/tests/compile-and-dump/Singletons/BadShowDeriving.ghc82.template
+++ b/tests/compile-and-dump/Singletons/BadShowDeriving.ghc82.template
@@ -1,0 +1,6 @@
+
+Singletons/BadShowDeriving.hs:0:0: error:
+    Can't derive Show instance for Foo_0.
+  |
+6 | $(singletons [d| data Foo deriving Show |])
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/compile-and-dump/Singletons/BadShowDeriving.hs
+++ b/tests/compile-and-dump/Singletons/BadShowDeriving.hs
@@ -1,0 +1,6 @@
+module Singletons.BadShowDeriving where
+
+import Data.Singletons.Prelude
+import Data.Singletons.TH
+
+$(singletons [d| data Foo deriving Show |])

--- a/tests/compile-and-dump/Singletons/DataValues.ghc82.template
+++ b/tests/compile-and-dump/Singletons/DataValues.ghc82.template
@@ -45,6 +45,42 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
       = Apply (Apply PairSym0 (Apply (Apply PairSym0 (Apply JustSym0 ZeroSym0)) ZeroSym0)) FalseSym0
     type family Pr where
       = Apply (Apply PairSym0 (Apply SuccSym0 ZeroSym0)) (Apply (Apply (:$) ZeroSym0) '[])
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Pair a b) (a :: Symbol) :: Symbol where
+      ShowsPrec_0123456789876543210 p_0123456789876543210 (Pair arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (:>$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (:.$) (Apply ShowStringSym0 "Pair ")) (Apply (Apply (:.$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (:.$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
+    type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: Pair a0123456789876543210 b0123456789876543210) (t :: Symbol) =
+        ShowsPrec_0123456789876543210 t t t
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym2 (l :: GHC.Types.Nat) (l :: Pair a0123456789876543210 b0123456789876543210) (l :: TyFun Symbol Symbol)
+      = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
+        ShowsPrec_0123456789876543210Sym2KindInference
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun (Pair a0123456789876543210 b0123456789876543210) (TyFun Symbol Symbol
+                                                                                                                              -> GHC.Types.Type))
+      = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
+        ShowsPrec_0123456789876543210Sym1KindInference
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat (TyFun (Pair a0123456789876543210 b0123456789876543210) (TyFun Symbol Symbol
+                                                                                                                              -> GHC.Types.Type)
+                                                                      -> GHC.Types.Type))
+      = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
+        ShowsPrec_0123456789876543210Sym0KindInference
+    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+    instance PShow (Pair a b) where
+      type ShowsPrec (a :: GHC.Types.Nat) (a :: Pair a b) (a :: Symbol) = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     sAList :: Sing AListSym0
     sTuple :: Sing TupleSym0
     sComplex :: Sing ComplexSym0
@@ -89,5 +125,47 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
               (GHC.Tuple.(,) (toSing b :: SomeSing a)) (toSing b :: SomeSing b)
           of {
             GHC.Tuple.(,) (SomeSing c) (SomeSing c) -> SomeSing ((SPair c) c) }
+    instance (SShow a, SShow b) => SShow (Pair a b) where
+      sShowsPrec ::
+        forall (t1 :: GHC.Types.Nat) (t2 :: Pair a b) (t3 :: Symbol).
+        Sing t1
+        -> Sing t2
+           -> Sing t3
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat (TyFun (Pair a b) (TyFun Symbol Symbol
+                                                                                                    -> GHC.Types.Type)
+                                                                                  -> GHC.Types.Type)
+                                                             -> GHC.Types.Type) t1 :: TyFun (Pair a b) (TyFun Symbol Symbol
+                                                                                                        -> GHC.Types.Type)
+                                                                                      -> GHC.Types.Type) t2 :: TyFun Symbol Symbol
+                                                                                                               -> GHC.Types.Type) t3 :: Symbol)
+      sShowsPrec
+        (sP_0123456789876543210 :: Sing p_0123456789876543210)
+        (SPair (sArg_0123456789876543210 :: Sing arg_0123456789876543210)
+               (sArg_0123456789876543210 :: Sing arg_0123456789876543210))
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing
+                 ((applySing ((singFun3 @ShowParenSym0) sShowParen))
+                    ((applySing
+                        ((applySing ((singFun2 @(:>$)) (%:>))) sP_0123456789876543210))
+                       (sFromInteger (sing :: Sing 10)))))
+                ((applySing
+                    ((applySing ((singFun3 @(:.$)) (%:.)))
+                       ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                          (sing :: Sing "Pair "))))
+                   ((applySing
+                       ((applySing ((singFun3 @(:.$)) (%:.)))
+                          ((applySing
+                              ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
+                                 (sFromInteger (sing :: Sing 11))))
+                             sArg_0123456789876543210)))
+                      ((applySing
+                          ((applySing ((singFun3 @(:.$)) (%:.)))
+                             ((singFun1 @ShowSpaceSym0) sShowSpace)))
+                         ((applySing
+                             ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
+                                (sFromInteger (sing :: Sing 11))))
+                            sArg_0123456789876543210))))))
+            sA_0123456789876543210
     instance (SingI n, SingI n) => SingI (Pair (n :: a) (n :: b)) where
       sing = (SPair sing) sing

--- a/tests/compile-and-dump/Singletons/DataValues.hs
+++ b/tests/compile-and-dump/Singletons/DataValues.hs
@@ -2,6 +2,7 @@ module Singletons.DataValues where
 
 import Data.Singletons.TH
 import Data.Singletons.Prelude
+import Data.Singletons.Prelude.Show
 import Singletons.Nat
 import Data.Singletons.SuppressUnusedWarnings
 

--- a/tests/compile-and-dump/Singletons/Maybe.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Maybe.ghc82.template
@@ -22,6 +22,43 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
       = forall arg. SameKind (Apply JustSym0 arg) (JustSym1 arg) =>
         JustSym0KindInference
     type instance Apply JustSym0 l = Just l
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Maybe a) (a :: GHC.Types.Symbol) :: GHC.Types.Symbol where
+      ShowsPrec_0123456789876543210 _ Nothing a_0123456789876543210 = Apply (Apply ShowStringSym0 "Nothing") a_0123456789876543210
+      ShowsPrec_0123456789876543210 p_0123456789876543210 (Just arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (:>$) p_0123456789876543210) (Data.Singletons.Prelude.Num.FromInteger 10))) (Apply (Apply (:.$) (Apply ShowStringSym0 "Just ")) (Apply (Apply ShowsPrecSym0 (Data.Singletons.Prelude.Num.FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
+    type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: Maybe a0123456789876543210) (t :: GHC.Types.Symbol) =
+        ShowsPrec_0123456789876543210 t t t
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym2 (l :: GHC.Types.Nat) (l :: Maybe a0123456789876543210) (l :: TyFun GHC.Types.Symbol GHC.Types.Symbol)
+      = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
+        ShowsPrec_0123456789876543210Sym2KindInference
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun (Maybe a0123456789876543210) (TyFun GHC.Types.Symbol GHC.Types.Symbol
+                                                                                                          -> GHC.Types.Type))
+      = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
+        ShowsPrec_0123456789876543210Sym1KindInference
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat (TyFun (Maybe a0123456789876543210) (TyFun GHC.Types.Symbol GHC.Types.Symbol
+                                                                                                          -> GHC.Types.Type)
+                                                                      -> GHC.Types.Type))
+      = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
+        ShowsPrec_0123456789876543210Sym0KindInference
+    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+    instance PShow (Maybe a) where
+      type ShowsPrec (a :: GHC.Types.Nat) (a :: Maybe a) (a :: GHC.Types.Symbol) = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     data instance Sing (z :: Maybe a)
       = z ~ Nothing => SNothing |
         forall (n :: a). z ~ Just n => SJust (Sing (n :: a))
@@ -56,6 +93,48 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
             Proved Refl -> Proved Refl
             Disproved contra
               -> Disproved (\ refl -> case refl of { Refl -> contra Refl })
+    instance SShow a => SShow (Maybe a) where
+      sShowsPrec ::
+        forall (t1 :: GHC.Types.Nat)
+               (t2 :: Maybe a)
+               (t3 :: GHC.Types.Symbol).
+        Sing t1
+        -> Sing t2
+           -> Sing t3
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat (TyFun (Maybe a) (TyFun GHC.Types.Symbol GHC.Types.Symbol
+                                                                                                   -> GHC.Types.Type)
+                                                                                  -> GHC.Types.Type)
+                                                             -> GHC.Types.Type) t1 :: TyFun (Maybe a) (TyFun GHC.Types.Symbol GHC.Types.Symbol
+                                                                                                       -> GHC.Types.Type)
+                                                                                      -> GHC.Types.Type) t2 :: TyFun GHC.Types.Symbol GHC.Types.Symbol
+                                                                                                               -> GHC.Types.Type) t3 :: GHC.Types.Symbol)
+      sShowsPrec
+        _
+        SNothing
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "Nothing")))
+            sA_0123456789876543210
+      sShowsPrec
+        (sP_0123456789876543210 :: Sing p_0123456789876543210)
+        (SJust (sArg_0123456789876543210 :: Sing arg_0123456789876543210))
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing
+                 ((applySing ((singFun3 @ShowParenSym0) sShowParen))
+                    ((applySing
+                        ((applySing ((singFun2 @(:>$)) (%:>))) sP_0123456789876543210))
+                       (Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 10)))))
+                ((applySing
+                    ((applySing ((singFun3 @(:.$)) (%:.)))
+                       ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                          (sing :: Sing "Just "))))
+                   ((applySing
+                       ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
+                          (Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 11))))
+                      sArg_0123456789876543210))))
+            sA_0123456789876543210
     instance SingI Nothing where
       sing = SNothing
     instance SingI n => SingI (Just (n :: a)) where

--- a/tests/compile-and-dump/Singletons/Maybe.hs
+++ b/tests/compile-and-dump/Singletons/Maybe.hs
@@ -6,6 +6,11 @@ import Data.Singletons.TH
 import Data.Singletons.SuppressUnusedWarnings
 import Prelude hiding (Maybe, Nothing, Just)
 
+-- Work around #190
+import Data.Singletons.Prelude.Base
+import Data.Singletons.Prelude.Ord
+import Data.Singletons.Prelude.Show
+
 $(singletons [d|
   data Maybe a = Nothing | Just a deriving (Eq, Show)
  |])

--- a/tests/compile-and-dump/Singletons/Nat.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Nat.ghc82.template
@@ -68,6 +68,43 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
     type family Plus (a :: Nat) (a :: Nat) :: Nat where
       Plus Zero m = m
       Plus (Succ n) m = Apply SuccSym0 (Apply (Apply PlusSym0 n) m)
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Nat) (a :: GHC.Types.Symbol) :: GHC.Types.Symbol where
+      ShowsPrec_0123456789876543210 _ Zero a_0123456789876543210 = Apply (Apply ShowStringSym0 "Zero") a_0123456789876543210
+      ShowsPrec_0123456789876543210 p_0123456789876543210 (Succ arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (:>$) p_0123456789876543210) (Data.Singletons.Prelude.Num.FromInteger 10))) (Apply (Apply (:.$) (Apply ShowStringSym0 "Succ ")) (Apply (Apply ShowsPrecSym0 (Data.Singletons.Prelude.Num.FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
+    type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: Nat) (t :: GHC.Types.Symbol) =
+        ShowsPrec_0123456789876543210 t t t
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym2 (l :: GHC.Types.Nat) (l :: Nat) (l :: TyFun GHC.Types.Symbol GHC.Types.Symbol)
+      = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
+        ShowsPrec_0123456789876543210Sym2KindInference
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun Nat (TyFun GHC.Types.Symbol GHC.Types.Symbol
+                                                                                 -> GHC.Types.Type))
+      = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
+        ShowsPrec_0123456789876543210Sym1KindInference
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat (TyFun Nat (TyFun GHC.Types.Symbol GHC.Types.Symbol
+                                                                                 -> GHC.Types.Type)
+                                                                      -> GHC.Types.Type))
+      = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
+        ShowsPrec_0123456789876543210Sym0KindInference
+    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+    instance PShow Nat where
+      type ShowsPrec (a :: GHC.Types.Nat) (a :: Nat) (a :: GHC.Types.Symbol) = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     sPred ::
       forall (t :: Nat). Sing t -> Sing (Apply PredSym0 t :: Nat)
     sPlus ::
@@ -113,6 +150,46 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
             Proved Refl -> Proved Refl
             Disproved contra
               -> Disproved (\ refl -> case refl of { Refl -> contra Refl })
+    instance SShow Nat => SShow Nat where
+      sShowsPrec ::
+        forall (t1 :: GHC.Types.Nat) (t2 :: Nat) (t3 :: GHC.Types.Symbol).
+        Sing t1
+        -> Sing t2
+           -> Sing t3
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat (TyFun Nat (TyFun GHC.Types.Symbol GHC.Types.Symbol
+                                                                                             -> GHC.Types.Type)
+                                                                                  -> GHC.Types.Type)
+                                                             -> GHC.Types.Type) t1 :: TyFun Nat (TyFun GHC.Types.Symbol GHC.Types.Symbol
+                                                                                                 -> GHC.Types.Type)
+                                                                                      -> GHC.Types.Type) t2 :: TyFun GHC.Types.Symbol GHC.Types.Symbol
+                                                                                                               -> GHC.Types.Type) t3 :: GHC.Types.Symbol)
+      sShowsPrec
+        _
+        SZero
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "Zero")))
+            sA_0123456789876543210
+      sShowsPrec
+        (sP_0123456789876543210 :: Sing p_0123456789876543210)
+        (SSucc (sArg_0123456789876543210 :: Sing arg_0123456789876543210))
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing
+                 ((applySing ((singFun3 @ShowParenSym0) sShowParen))
+                    ((applySing
+                        ((applySing ((singFun2 @(:>$)) (%:>))) sP_0123456789876543210))
+                       (Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 10)))))
+                ((applySing
+                    ((applySing ((singFun3 @(:.$)) (%:.)))
+                       ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                          (sing :: Sing "Succ "))))
+                   ((applySing
+                       ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
+                          (Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 11))))
+                      sArg_0123456789876543210))))
+            sA_0123456789876543210
     instance SingI Zero where
       sing = SZero
     instance SingI n => SingI (Succ (n :: Nat)) where

--- a/tests/compile-and-dump/Singletons/Nat.hs
+++ b/tests/compile-and-dump/Singletons/Nat.hs
@@ -6,6 +6,11 @@ import Data.Singletons.TH
 import Data.Singletons
 import Data.Singletons.SuppressUnusedWarnings
 
+-- Work around #190
+import Data.Singletons.Prelude.Base
+import Data.Singletons.Prelude.Ord
+import Data.Singletons.Prelude.Show
+
 $(singletons [d|
   data Nat where
     Zero :: Nat

--- a/tests/compile-and-dump/Singletons/Operators.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Operators.ghc82.template
@@ -80,7 +80,7 @@ Singletons/Operators.hs:(0,0)-(0,0): Splicing declarations
     data instance Sing (z :: Foo)
       = z ~ FLeaf => SFLeaf |
         forall (n :: Foo) (n :: Foo). z ~ (:+:) n n =>
-        (:%+:) (Sing (n :: Foo)) (Sing (n :: Foo))
+        (Sing (n :: Foo)) :%+: (Sing (n :: Foo))
     type SFoo = (Sing :: Foo -> GHC.Types.Type)
     instance SingKind Foo where
       type Demote Foo = Foo

--- a/tests/compile-and-dump/Singletons/PatternMatching.ghc82.template
+++ b/tests/compile-and-dump/Singletons/PatternMatching.ghc82.template
@@ -45,6 +45,42 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
       = Apply (Apply PairSym0 (Apply (Apply PairSym0 (Apply JustSym0 ZeroSym0)) ZeroSym0)) FalseSym0
     type family Pr where
       = Apply (Apply PairSym0 (Apply SuccSym0 ZeroSym0)) (Apply (Apply (:$) ZeroSym0) '[])
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Pair a b) (a :: Symbol) :: Symbol where
+      ShowsPrec_0123456789876543210 p_0123456789876543210 (Pair arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (:>$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (:.$) (Apply ShowStringSym0 "Pair ")) (Apply (Apply (:.$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (:.$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
+    type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: Pair a0123456789876543210 b0123456789876543210) (t :: Symbol) =
+        ShowsPrec_0123456789876543210 t t t
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym2 (l :: GHC.Types.Nat) (l :: Pair a0123456789876543210 b0123456789876543210) (l :: TyFun Symbol Symbol)
+      = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
+        ShowsPrec_0123456789876543210Sym2KindInference
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun (Pair a0123456789876543210 b0123456789876543210) (TyFun Symbol Symbol
+                                                                                                                              -> GHC.Types.Type))
+      = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
+        ShowsPrec_0123456789876543210Sym1KindInference
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat (TyFun (Pair a0123456789876543210 b0123456789876543210) (TyFun Symbol Symbol
+                                                                                                                              -> GHC.Types.Type)
+                                                                      -> GHC.Types.Type))
+      = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
+        ShowsPrec_0123456789876543210Sym0KindInference
+    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+    instance PShow (Pair a b) where
+      type ShowsPrec (a :: GHC.Types.Nat) (a :: Pair a b) (a :: Symbol) = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     sAList :: Sing AListSym0
     sTuple :: Sing TupleSym0
     sComplex :: Sing ComplexSym0
@@ -89,6 +125,48 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
               (GHC.Tuple.(,) (toSing b :: SomeSing a)) (toSing b :: SomeSing b)
           of {
             GHC.Tuple.(,) (SomeSing c) (SomeSing c) -> SomeSing ((SPair c) c) }
+    instance (SShow a, SShow b) => SShow (Pair a b) where
+      sShowsPrec ::
+        forall (t1 :: GHC.Types.Nat) (t2 :: Pair a b) (t3 :: Symbol).
+        Sing t1
+        -> Sing t2
+           -> Sing t3
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat (TyFun (Pair a b) (TyFun Symbol Symbol
+                                                                                                    -> GHC.Types.Type)
+                                                                                  -> GHC.Types.Type)
+                                                             -> GHC.Types.Type) t1 :: TyFun (Pair a b) (TyFun Symbol Symbol
+                                                                                                        -> GHC.Types.Type)
+                                                                                      -> GHC.Types.Type) t2 :: TyFun Symbol Symbol
+                                                                                                               -> GHC.Types.Type) t3 :: Symbol)
+      sShowsPrec
+        (sP_0123456789876543210 :: Sing p_0123456789876543210)
+        (SPair (sArg_0123456789876543210 :: Sing arg_0123456789876543210)
+               (sArg_0123456789876543210 :: Sing arg_0123456789876543210))
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing
+                 ((applySing ((singFun3 @ShowParenSym0) sShowParen))
+                    ((applySing
+                        ((applySing ((singFun2 @(:>$)) (%:>))) sP_0123456789876543210))
+                       (sFromInteger (sing :: Sing 10)))))
+                ((applySing
+                    ((applySing ((singFun3 @(:.$)) (%:.)))
+                       ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                          (sing :: Sing "Pair "))))
+                   ((applySing
+                       ((applySing ((singFun3 @(:.$)) (%:.)))
+                          ((applySing
+                              ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
+                                 (sFromInteger (sing :: Sing 11))))
+                             sArg_0123456789876543210)))
+                      ((applySing
+                          ((applySing ((singFun3 @(:.$)) (%:.)))
+                             ((singFun1 @ShowSpaceSym0) sShowSpace)))
+                         ((applySing
+                             ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
+                                (sFromInteger (sing :: Sing 11))))
+                            sArg_0123456789876543210))))))
+            sA_0123456789876543210
     instance (SingI n, SingI n) => SingI (Pair (n :: a) (n :: b)) where
       sing = (SPair sing) sing
 Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations

--- a/tests/compile-and-dump/Singletons/PatternMatching.hs
+++ b/tests/compile-and-dump/Singletons/PatternMatching.hs
@@ -4,6 +4,7 @@
 module Singletons.PatternMatching where
 
 import Data.Singletons.Prelude
+import Data.Singletons.Prelude.Show
 import Data.Singletons.TH
 import Singletons.Nat
 

--- a/tests/compile-and-dump/Singletons/ShowDeriving.ghc82.template
+++ b/tests/compile-and-dump/Singletons/ShowDeriving.ghc82.template
@@ -1,0 +1,517 @@
+Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
+    singletons
+      [d| data Foo1
+            = MkFoo1
+            deriving Show
+          data Foo2 a
+            = MkFoo2a a a | a `MkFoo2b` a | (:*:) a a | a :&: a
+            deriving Show
+          data Foo3
+            = MkFoo3 {getFoo3a :: Bool, *** :: Bool}
+            deriving Show |]
+  ======>
+    data Foo1
+      = MkFoo1
+      deriving Show
+    data Foo2 a
+      = MkFoo2a a a | a `MkFoo2b` a | (:*:) a a | a :&: a
+      deriving Show
+    data Foo3
+      = MkFoo3 {getFoo3a :: Bool, *** :: Bool}
+      deriving Show
+    type GetFoo3aSym1 (t :: Foo3) = GetFoo3a t
+    instance SuppressUnusedWarnings GetFoo3aSym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) GetFoo3aSym0KindInference) GHC.Tuple.())
+    data GetFoo3aSym0 (l :: TyFun Foo3 Bool)
+      = forall arg. SameKind (Apply GetFoo3aSym0 arg) (GetFoo3aSym1 arg) =>
+        GetFoo3aSym0KindInference
+    type instance Apply GetFoo3aSym0 l = GetFoo3a l
+    type (:***$$) (t :: Foo3) = (:***) t
+    instance SuppressUnusedWarnings (:***$) where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) (:***$###)) GHC.Tuple.())
+    data (:***$) (l :: TyFun Foo3 Bool)
+      = forall arg. SameKind (Apply (:***$) arg) ((:***$$) arg) =>
+        (:***$###)
+    type instance Apply (:***$) l = (:***) l
+    type family GetFoo3a (a :: Foo3) :: Bool where
+      GetFoo3a (MkFoo3 field _) = field
+    type family (:***) (a :: Foo3) :: Bool where
+      (:***) (MkFoo3 _ field) = field
+    type MkFoo1Sym0 = MkFoo1
+    type MkFoo2aSym2 (t :: a0123456789876543210) (t :: a0123456789876543210) =
+        MkFoo2a t t
+    instance SuppressUnusedWarnings MkFoo2aSym1 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) MkFoo2aSym1KindInference) GHC.Tuple.())
+    data MkFoo2aSym1 (l :: a0123456789876543210) (l :: TyFun a0123456789876543210 (Foo2 a0123456789876543210))
+      = forall arg. SameKind (Apply (MkFoo2aSym1 l) arg) (MkFoo2aSym2 l arg) =>
+        MkFoo2aSym1KindInference
+    type instance Apply (MkFoo2aSym1 l) l = MkFoo2a l l
+    instance SuppressUnusedWarnings MkFoo2aSym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) MkFoo2aSym0KindInference) GHC.Tuple.())
+    data MkFoo2aSym0 (l :: TyFun a0123456789876543210 (TyFun a0123456789876543210 (Foo2 a0123456789876543210)
+                                                       -> GHC.Types.Type))
+      = forall arg. SameKind (Apply MkFoo2aSym0 arg) (MkFoo2aSym1 arg) =>
+        MkFoo2aSym0KindInference
+    type instance Apply MkFoo2aSym0 l = MkFoo2aSym1 l
+    type MkFoo2bSym2 (t :: a0123456789876543210) (t :: a0123456789876543210) =
+        MkFoo2b t t
+    instance SuppressUnusedWarnings MkFoo2bSym1 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) MkFoo2bSym1KindInference) GHC.Tuple.())
+    data MkFoo2bSym1 (l :: a0123456789876543210) (l :: TyFun a0123456789876543210 (Foo2 a0123456789876543210))
+      = forall arg. SameKind (Apply (MkFoo2bSym1 l) arg) (MkFoo2bSym2 l arg) =>
+        MkFoo2bSym1KindInference
+    type instance Apply (MkFoo2bSym1 l) l = MkFoo2b l l
+    instance SuppressUnusedWarnings MkFoo2bSym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) MkFoo2bSym0KindInference) GHC.Tuple.())
+    data MkFoo2bSym0 (l :: TyFun a0123456789876543210 (TyFun a0123456789876543210 (Foo2 a0123456789876543210)
+                                                       -> GHC.Types.Type))
+      = forall arg. SameKind (Apply MkFoo2bSym0 arg) (MkFoo2bSym1 arg) =>
+        MkFoo2bSym0KindInference
+    type instance Apply MkFoo2bSym0 l = MkFoo2bSym1 l
+    type (:*:$$$) (t :: a0123456789876543210) (t :: a0123456789876543210) =
+        (:*:) t t
+    instance SuppressUnusedWarnings (:*:$$) where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) (:*:$$###)) GHC.Tuple.())
+    data (:*:$$) (l :: a0123456789876543210) (l :: TyFun a0123456789876543210 (Foo2 a0123456789876543210))
+      = forall arg. SameKind (Apply ((:*:$$) l) arg) ((:*:$$$) l arg) =>
+        (:*:$$###)
+    type instance Apply ((:*:$$) l) l = (:*:) l l
+    instance SuppressUnusedWarnings (:*:$) where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) (:*:$###)) GHC.Tuple.())
+    data (:*:$) (l :: TyFun a0123456789876543210 (TyFun a0123456789876543210 (Foo2 a0123456789876543210)
+                                                  -> GHC.Types.Type))
+      = forall arg. SameKind (Apply (:*:$) arg) ((:*:$$) arg) =>
+        (:*:$###)
+    type instance Apply (:*:$) l = (:*:$$) l
+    type (:&:$$$) (t :: a0123456789876543210) (t :: a0123456789876543210) =
+        (:&:) t t
+    instance SuppressUnusedWarnings (:&:$$) where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) (:&:$$###)) GHC.Tuple.())
+    data (:&:$$) (l :: a0123456789876543210) (l :: TyFun a0123456789876543210 (Foo2 a0123456789876543210))
+      = forall arg. SameKind (Apply ((:&:$$) l) arg) ((:&:$$$) l arg) =>
+        (:&:$$###)
+    type instance Apply ((:&:$$) l) l = (:&:) l l
+    instance SuppressUnusedWarnings (:&:$) where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) (:&:$###)) GHC.Tuple.())
+    data (:&:$) (l :: TyFun a0123456789876543210 (TyFun a0123456789876543210 (Foo2 a0123456789876543210)
+                                                  -> GHC.Types.Type))
+      = forall arg. SameKind (Apply (:&:$) arg) ((:&:$$) arg) =>
+        (:&:$###)
+    type instance Apply (:&:$) l = (:&:$$) l
+    type MkFoo3Sym2 (t :: Bool) (t :: Bool) = MkFoo3 t t
+    instance SuppressUnusedWarnings MkFoo3Sym1 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) MkFoo3Sym1KindInference) GHC.Tuple.())
+    data MkFoo3Sym1 (l :: Bool) (l :: TyFun Bool Foo3)
+      = forall arg. SameKind (Apply (MkFoo3Sym1 l) arg) (MkFoo3Sym2 l arg) =>
+        MkFoo3Sym1KindInference
+    type instance Apply (MkFoo3Sym1 l) l = MkFoo3 l l
+    instance SuppressUnusedWarnings MkFoo3Sym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) MkFoo3Sym0KindInference) GHC.Tuple.())
+    data MkFoo3Sym0 (l :: TyFun Bool (TyFun Bool Foo3
+                                      -> GHC.Types.Type))
+      = forall arg. SameKind (Apply MkFoo3Sym0 arg) (MkFoo3Sym1 arg) =>
+        MkFoo3Sym0KindInference
+    type instance Apply MkFoo3Sym0 l = MkFoo3Sym1 l
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Foo1) (a :: Symbol) :: Symbol where
+      ShowsPrec_0123456789876543210 _ MkFoo1 a_0123456789876543210 = Apply (Apply ShowStringSym0 "MkFoo1") a_0123456789876543210
+    type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: Foo1) (t :: Symbol) =
+        ShowsPrec_0123456789876543210 t t t
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym2 (l :: GHC.Types.Nat) (l :: Foo1) (l :: TyFun Symbol Symbol)
+      = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
+        ShowsPrec_0123456789876543210Sym2KindInference
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun Foo1 (TyFun Symbol Symbol
+                                                                                  -> GHC.Types.Type))
+      = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
+        ShowsPrec_0123456789876543210Sym1KindInference
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat (TyFun Foo1 (TyFun Symbol Symbol
+                                                                                  -> GHC.Types.Type)
+                                                                      -> GHC.Types.Type))
+      = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
+        ShowsPrec_0123456789876543210Sym0KindInference
+    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+    instance PShow Foo1 where
+      type ShowsPrec (a :: GHC.Types.Nat) (a :: Foo1) (a :: Symbol) = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Foo2 a) (a :: Symbol) :: Symbol where
+      ShowsPrec_0123456789876543210 p_0123456789876543210 (MkFoo2a arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (:>$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (:.$) (Apply ShowStringSym0 "MkFoo2a ")) (Apply (Apply (:.$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (:.$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
+      ShowsPrec_0123456789876543210 p_0123456789876543210 (MkFoo2b argL_0123456789876543210 argR_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (:>$) p_0123456789876543210) (FromInteger 9))) (Apply (Apply (:.$) (Apply (Apply ShowsPrecSym0 (FromInteger 10)) argL_0123456789876543210)) (Apply (Apply (:.$) (Apply ShowStringSym0 " `MkFoo2b` ")) (Apply (Apply ShowsPrecSym0 (FromInteger 10)) argR_0123456789876543210)))) a_0123456789876543210
+      ShowsPrec_0123456789876543210 p_0123456789876543210 ((:*:) arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (:>$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (:.$) (Apply ShowStringSym0 "(:*:) ")) (Apply (Apply (:.$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (:.$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
+      ShowsPrec_0123456789876543210 p_0123456789876543210 ((:&:) argL_0123456789876543210 argR_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (:>$) p_0123456789876543210) (FromInteger 9))) (Apply (Apply (:.$) (Apply (Apply ShowsPrecSym0 (FromInteger 10)) argL_0123456789876543210)) (Apply (Apply (:.$) (Apply ShowStringSym0 " :&: ")) (Apply (Apply ShowsPrecSym0 (FromInteger 10)) argR_0123456789876543210)))) a_0123456789876543210
+    type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: Foo2 a0123456789876543210) (t :: Symbol) =
+        ShowsPrec_0123456789876543210 t t t
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym2 (l :: GHC.Types.Nat) (l :: Foo2 a0123456789876543210) (l :: TyFun Symbol Symbol)
+      = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
+        ShowsPrec_0123456789876543210Sym2KindInference
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun (Foo2 a0123456789876543210) (TyFun Symbol Symbol
+                                                                                                         -> GHC.Types.Type))
+      = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
+        ShowsPrec_0123456789876543210Sym1KindInference
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat (TyFun (Foo2 a0123456789876543210) (TyFun Symbol Symbol
+                                                                                                         -> GHC.Types.Type)
+                                                                      -> GHC.Types.Type))
+      = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
+        ShowsPrec_0123456789876543210Sym0KindInference
+    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+    instance PShow (Foo2 a) where
+      type ShowsPrec (a :: GHC.Types.Nat) (a :: Foo2 a) (a :: Symbol) = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Foo3) (a :: Symbol) :: Symbol where
+      ShowsPrec_0123456789876543210 p_0123456789876543210 (MkFoo3 arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (:>$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (:.$) (Apply ShowStringSym0 "MkFoo3 ")) (Apply (Apply (:.$) (Apply ShowCharSym0 "{")) (Apply (Apply (:.$) (Apply ShowStringSym0 "getFoo3a = ")) (Apply (Apply (:.$) (Apply (Apply ShowsPrecSym0 (FromInteger 0)) arg_0123456789876543210)) (Apply (Apply (:.$) ShowCommaSpaceSym0) (Apply (Apply (:.$) (Apply ShowStringSym0 "(***) = ")) (Apply (Apply (:.$) (Apply (Apply ShowsPrecSym0 (FromInteger 0)) arg_0123456789876543210)) (Apply ShowCharSym0 "}"))))))))) a_0123456789876543210
+    type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: Foo3) (t :: Symbol) =
+        ShowsPrec_0123456789876543210 t t t
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym2 (l :: GHC.Types.Nat) (l :: Foo3) (l :: TyFun Symbol Symbol)
+      = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
+        ShowsPrec_0123456789876543210Sym2KindInference
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun Foo3 (TyFun Symbol Symbol
+                                                                                  -> GHC.Types.Type))
+      = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
+        ShowsPrec_0123456789876543210Sym1KindInference
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat (TyFun Foo3 (TyFun Symbol Symbol
+                                                                                  -> GHC.Types.Type)
+                                                                      -> GHC.Types.Type))
+      = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
+        ShowsPrec_0123456789876543210Sym0KindInference
+    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+    instance PShow Foo3 where
+      type ShowsPrec (a :: GHC.Types.Nat) (a :: Foo3) (a :: Symbol) = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+    data instance Sing (z :: Foo1) = z ~ MkFoo1 => SMkFoo1
+    type SFoo1 = (Sing :: Foo1 -> GHC.Types.Type)
+    instance SingKind Foo1 where
+      type Demote Foo1 = Foo1
+      fromSing SMkFoo1 = MkFoo1
+      toSing MkFoo1 = SomeSing SMkFoo1
+    data instance Sing (z :: Foo2 a)
+      = forall (n :: a) (n :: a). z ~ MkFoo2a n n =>
+        SMkFoo2a (Sing (n :: a)) (Sing (n :: a)) |
+        forall (n :: a) (n :: a). z ~ MkFoo2b n n =>
+        (Sing (n :: a)) `SMkFoo2b` (Sing (n :: a)) |
+        forall (n :: a) (n :: a). z ~ (:*:) n n =>
+        (:%*:) (Sing (n :: a)) (Sing (n :: a)) |
+        forall (n :: a) (n :: a). z ~ (:&:) n n =>
+        (Sing (n :: a)) :%&: (Sing (n :: a))
+    type SFoo2 = (Sing :: Foo2 a -> GHC.Types.Type)
+    instance SingKind a => SingKind (Foo2 a) where
+      type Demote (Foo2 a) = Foo2 (Demote a)
+      fromSing (SMkFoo2a b b) = (MkFoo2a (fromSing b)) (fromSing b)
+      fromSing (SMkFoo2b b b) = (MkFoo2b (fromSing b)) (fromSing b)
+      fromSing ((:%*:) b b) = ((:*:) (fromSing b)) (fromSing b)
+      fromSing ((:%&:) b b) = ((:&:) (fromSing b)) (fromSing b)
+      toSing (MkFoo2a b b)
+        = case
+              (GHC.Tuple.(,) (toSing b :: SomeSing a)) (toSing b :: SomeSing a)
+          of {
+            GHC.Tuple.(,) (SomeSing c) (SomeSing c)
+              -> SomeSing ((SMkFoo2a c) c) }
+      toSing (MkFoo2b b b)
+        = case
+              (GHC.Tuple.(,) (toSing b :: SomeSing a)) (toSing b :: SomeSing a)
+          of {
+            GHC.Tuple.(,) (SomeSing c) (SomeSing c)
+              -> SomeSing ((SMkFoo2b c) c) }
+      toSing ((:*:) b b)
+        = case
+              (GHC.Tuple.(,) (toSing b :: SomeSing a)) (toSing b :: SomeSing a)
+          of {
+            GHC.Tuple.(,) (SomeSing c) (SomeSing c)
+              -> SomeSing (((:%*:) c) c) }
+      toSing ((:&:) b b)
+        = case
+              (GHC.Tuple.(,) (toSing b :: SomeSing a)) (toSing b :: SomeSing a)
+          of {
+            GHC.Tuple.(,) (SomeSing c) (SomeSing c)
+              -> SomeSing (((:%&:) c) c) }
+    data instance Sing (z :: Foo3)
+      = forall (n :: Bool) (n :: Bool). z ~ MkFoo3 n n =>
+        SMkFoo3 {sGetFoo3a :: (Sing (n :: Bool)),
+                 %:*** :: (Sing (n :: Bool))}
+    type SFoo3 = (Sing :: Foo3 -> GHC.Types.Type)
+    instance SingKind Foo3 where
+      type Demote Foo3 = Foo3
+      fromSing (SMkFoo3 b b) = (MkFoo3 (fromSing b)) (fromSing b)
+      toSing (MkFoo3 b b)
+        = case
+              (GHC.Tuple.(,) (toSing b :: SomeSing Bool))
+                (toSing b :: SomeSing Bool)
+          of {
+            GHC.Tuple.(,) (SomeSing c) (SomeSing c)
+              -> SomeSing ((SMkFoo3 c) c) }
+    instance SShow Foo1 where
+      sShowsPrec ::
+        forall (t1 :: GHC.Types.Nat) (t2 :: Foo1) (t3 :: Symbol).
+        Sing t1
+        -> Sing t2
+           -> Sing t3
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat (TyFun Foo1 (TyFun Symbol Symbol
+                                                                                              -> GHC.Types.Type)
+                                                                                  -> GHC.Types.Type)
+                                                             -> GHC.Types.Type) t1 :: TyFun Foo1 (TyFun Symbol Symbol
+                                                                                                  -> GHC.Types.Type)
+                                                                                      -> GHC.Types.Type) t2 :: TyFun Symbol Symbol
+                                                                                                               -> GHC.Types.Type) t3 :: Symbol)
+      sShowsPrec
+        _
+        SMkFoo1
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "MkFoo1")))
+            sA_0123456789876543210
+    instance SShow a => SShow (Foo2 a) where
+      sShowsPrec ::
+        forall (t1 :: GHC.Types.Nat) (t2 :: Foo2 a) (t3 :: Symbol).
+        Sing t1
+        -> Sing t2
+           -> Sing t3
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat (TyFun (Foo2 a) (TyFun Symbol Symbol
+                                                                                                  -> GHC.Types.Type)
+                                                                                  -> GHC.Types.Type)
+                                                             -> GHC.Types.Type) t1 :: TyFun (Foo2 a) (TyFun Symbol Symbol
+                                                                                                      -> GHC.Types.Type)
+                                                                                      -> GHC.Types.Type) t2 :: TyFun Symbol Symbol
+                                                                                                               -> GHC.Types.Type) t3 :: Symbol)
+      sShowsPrec
+        (sP_0123456789876543210 :: Sing p_0123456789876543210)
+        (SMkFoo2a (sArg_0123456789876543210 :: Sing arg_0123456789876543210)
+                  (sArg_0123456789876543210 :: Sing arg_0123456789876543210))
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing
+                 ((applySing ((singFun3 @ShowParenSym0) sShowParen))
+                    ((applySing
+                        ((applySing ((singFun2 @(:>$)) (%:>))) sP_0123456789876543210))
+                       (sFromInteger (sing :: Sing 10)))))
+                ((applySing
+                    ((applySing ((singFun3 @(:.$)) (%:.)))
+                       ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                          (sing :: Sing "MkFoo2a "))))
+                   ((applySing
+                       ((applySing ((singFun3 @(:.$)) (%:.)))
+                          ((applySing
+                              ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
+                                 (sFromInteger (sing :: Sing 11))))
+                             sArg_0123456789876543210)))
+                      ((applySing
+                          ((applySing ((singFun3 @(:.$)) (%:.)))
+                             ((singFun1 @ShowSpaceSym0) sShowSpace)))
+                         ((applySing
+                             ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
+                                (sFromInteger (sing :: Sing 11))))
+                            sArg_0123456789876543210))))))
+            sA_0123456789876543210
+      sShowsPrec
+        (sP_0123456789876543210 :: Sing p_0123456789876543210)
+        (SMkFoo2b (sArgL_0123456789876543210 :: Sing argL_0123456789876543210)
+                  (sArgR_0123456789876543210 :: Sing argR_0123456789876543210))
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing
+                 ((applySing ((singFun3 @ShowParenSym0) sShowParen))
+                    ((applySing
+                        ((applySing ((singFun2 @(:>$)) (%:>))) sP_0123456789876543210))
+                       (sFromInteger (sing :: Sing 9)))))
+                ((applySing
+                    ((applySing ((singFun3 @(:.$)) (%:.)))
+                       ((applySing
+                           ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
+                              (sFromInteger (sing :: Sing 10))))
+                          sArgL_0123456789876543210)))
+                   ((applySing
+                       ((applySing ((singFun3 @(:.$)) (%:.)))
+                          ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                             (sing :: Sing " `MkFoo2b` "))))
+                      ((applySing
+                          ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
+                             (sFromInteger (sing :: Sing 10))))
+                         sArgR_0123456789876543210)))))
+            sA_0123456789876543210
+      sShowsPrec
+        (sP_0123456789876543210 :: Sing p_0123456789876543210)
+        ((:%*:) (sArg_0123456789876543210 :: Sing arg_0123456789876543210)
+                (sArg_0123456789876543210 :: Sing arg_0123456789876543210))
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing
+                 ((applySing ((singFun3 @ShowParenSym0) sShowParen))
+                    ((applySing
+                        ((applySing ((singFun2 @(:>$)) (%:>))) sP_0123456789876543210))
+                       (sFromInteger (sing :: Sing 10)))))
+                ((applySing
+                    ((applySing ((singFun3 @(:.$)) (%:.)))
+                       ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                          (sing :: Sing "(:*:) "))))
+                   ((applySing
+                       ((applySing ((singFun3 @(:.$)) (%:.)))
+                          ((applySing
+                              ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
+                                 (sFromInteger (sing :: Sing 11))))
+                             sArg_0123456789876543210)))
+                      ((applySing
+                          ((applySing ((singFun3 @(:.$)) (%:.)))
+                             ((singFun1 @ShowSpaceSym0) sShowSpace)))
+                         ((applySing
+                             ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
+                                (sFromInteger (sing :: Sing 11))))
+                            sArg_0123456789876543210))))))
+            sA_0123456789876543210
+      sShowsPrec
+        (sP_0123456789876543210 :: Sing p_0123456789876543210)
+        ((:%&:) (sArgL_0123456789876543210 :: Sing argL_0123456789876543210)
+                (sArgR_0123456789876543210 :: Sing argR_0123456789876543210))
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing
+                 ((applySing ((singFun3 @ShowParenSym0) sShowParen))
+                    ((applySing
+                        ((applySing ((singFun2 @(:>$)) (%:>))) sP_0123456789876543210))
+                       (sFromInteger (sing :: Sing 9)))))
+                ((applySing
+                    ((applySing ((singFun3 @(:.$)) (%:.)))
+                       ((applySing
+                           ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
+                              (sFromInteger (sing :: Sing 10))))
+                          sArgL_0123456789876543210)))
+                   ((applySing
+                       ((applySing ((singFun3 @(:.$)) (%:.)))
+                          ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                             (sing :: Sing " :&: "))))
+                      ((applySing
+                          ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
+                             (sFromInteger (sing :: Sing 10))))
+                         sArgR_0123456789876543210)))))
+            sA_0123456789876543210
+    instance SShow Bool => SShow Foo3 where
+      sShowsPrec ::
+        forall (t1 :: GHC.Types.Nat) (t2 :: Foo3) (t3 :: Symbol).
+        Sing t1
+        -> Sing t2
+           -> Sing t3
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat (TyFun Foo3 (TyFun Symbol Symbol
+                                                                                              -> GHC.Types.Type)
+                                                                                  -> GHC.Types.Type)
+                                                             -> GHC.Types.Type) t1 :: TyFun Foo3 (TyFun Symbol Symbol
+                                                                                                  -> GHC.Types.Type)
+                                                                                      -> GHC.Types.Type) t2 :: TyFun Symbol Symbol
+                                                                                                               -> GHC.Types.Type) t3 :: Symbol)
+      sShowsPrec
+        (sP_0123456789876543210 :: Sing p_0123456789876543210)
+        (SMkFoo3 (sArg_0123456789876543210 :: Sing arg_0123456789876543210)
+                 (sArg_0123456789876543210 :: Sing arg_0123456789876543210))
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing
+                 ((applySing ((singFun3 @ShowParenSym0) sShowParen))
+                    ((applySing
+                        ((applySing ((singFun2 @(:>$)) (%:>))) sP_0123456789876543210))
+                       (sFromInteger (sing :: Sing 10)))))
+                ((applySing
+                    ((applySing ((singFun3 @(:.$)) (%:.)))
+                       ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                          (sing :: Sing "MkFoo3 "))))
+                   ((applySing
+                       ((applySing ((singFun3 @(:.$)) (%:.)))
+                          ((applySing ((singFun2 @ShowCharSym0) sShowChar))
+                             (sing :: Sing "{"))))
+                      ((applySing
+                          ((applySing ((singFun3 @(:.$)) (%:.)))
+                             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                                (sing :: Sing "getFoo3a = "))))
+                         ((applySing
+                             ((applySing ((singFun3 @(:.$)) (%:.)))
+                                ((applySing
+                                    ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
+                                       (sFromInteger (sing :: Sing 0))))
+                                   sArg_0123456789876543210)))
+                            ((applySing
+                                ((applySing ((singFun3 @(:.$)) (%:.)))
+                                   ((singFun1 @ShowCommaSpaceSym0) sShowCommaSpace)))
+                               ((applySing
+                                   ((applySing ((singFun3 @(:.$)) (%:.)))
+                                      ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                                         (sing :: Sing "(***) = "))))
+                                  ((applySing
+                                      ((applySing ((singFun3 @(:.$)) (%:.)))
+                                         ((applySing
+                                             ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
+                                                (sFromInteger (sing :: Sing 0))))
+                                            sArg_0123456789876543210)))
+                                     ((applySing ((singFun2 @ShowCharSym0) sShowChar))
+                                        (sing :: Sing "}")))))))))))
+            sA_0123456789876543210
+    instance SingI MkFoo1 where
+      sing = SMkFoo1
+    instance (SingI n, SingI n) =>
+             SingI (MkFoo2a (n :: a) (n :: a)) where
+      sing = (SMkFoo2a sing) sing
+    instance (SingI n, SingI n) =>
+             SingI (MkFoo2b (n :: a) (n :: a)) where
+      sing = (SMkFoo2b sing) sing
+    instance (SingI n, SingI n) =>
+             SingI ((:*:) (n :: a) (n :: a)) where
+      sing = ((:%*:) sing) sing
+    instance (SingI n, SingI n) =>
+             SingI ((:&:) (n :: a) (n :: a)) where
+      sing = ((:%&:) sing) sing
+    instance (SingI n, SingI n) =>
+             SingI (MkFoo3 (n :: Bool) (n :: Bool)) where
+      sing = (SMkFoo3 sing) sing

--- a/tests/compile-and-dump/Singletons/ShowDeriving.hs
+++ b/tests/compile-and-dump/Singletons/ShowDeriving.hs
@@ -18,20 +18,20 @@ $(singletons [d|
 
     |])
 
-foo1 :: "MkFoo1" :~: Show' MkFoo1
+foo1 :: "MkFoo1" :~: Show_ MkFoo1
 foo1 = Refl
 
 foo2a :: "(MkFoo2a LT GT)" :~: ShowsPrec 11 (MkFoo2a LT GT) ""
 foo2a = Refl
 
-foo2b :: "True `MkFoo2b` False" :~: Show' (True `MkFoo2b` False)
+foo2b :: "True `MkFoo2b` False" :~: Show_ (True `MkFoo2b` False)
 foo2b = Refl
 
-foo2c :: "(:*:) () ()" :~: Show' ('() :*: '())
+foo2c :: "(:*:) () ()" :~: Show_ ('() :*: '())
 foo2c = Refl
 
 foo2d :: "(False :&: True)" :~: ShowsPrec 10 (False :&: True) ""
 foo2d = Refl
 
-foo3 :: "MkFoo3 {getFoo3a = True, (***) = False}" :~: Show' (MkFoo3 True False)
+foo3 :: "MkFoo3 {getFoo3a = True, (***) = False}" :~: Show_ (MkFoo3 True False)
 foo3 = Refl

--- a/tests/compile-and-dump/Singletons/ShowDeriving.hs
+++ b/tests/compile-and-dump/Singletons/ShowDeriving.hs
@@ -1,0 +1,36 @@
+module Singletons.ShowDeriving where
+
+import Data.Type.Equality
+import Data.Singletons.Prelude
+import Data.Singletons.TH
+
+$(singletons [d|
+    data Foo1 = MkFoo1 deriving Show
+
+    data Foo2 a = MkFoo2a a a
+                | a `MkFoo2b` a
+                | (:*:) a a
+                | a :&: a
+                deriving Show
+
+    data Foo3 = MkFoo3 { getFoo3a :: Bool, (***) :: Bool } deriving Show
+
+    |])
+
+foo1 :: "MkFoo1" :~: Show' MkFoo1
+foo1 = Refl
+
+foo2a :: "(MkFoo2a LT GT)" :~: ShowsPrec 11 (MkFoo2a LT GT) ""
+foo2a = Refl
+
+foo2b :: "True `MkFoo2b` False" :~: Show' (True `MkFoo2b` False)
+foo2b = Refl
+
+foo2c :: "(:*:) () ()" :~: Show' ('() :*: '())
+foo2c = Refl
+
+foo2d :: "(False :&: True)" :~: ShowsPrec 10 (False :&: True) ""
+foo2d = Refl
+
+foo3 :: "MkFoo3 {getFoo3a = True, (***) = False}" :~: Show' (MkFoo3 True False)
+foo3 = Refl

--- a/tests/compile-and-dump/Singletons/ShowDeriving.hs
+++ b/tests/compile-and-dump/Singletons/ShowDeriving.hs
@@ -2,6 +2,7 @@ module Singletons.ShowDeriving where
 
 import Data.Type.Equality
 import Data.Singletons.Prelude
+import Data.Singletons.Prelude.Show
 import Data.Singletons.TH
 
 $(singletons [d|

--- a/tests/compile-and-dump/Singletons/T159.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T159.ghc82.template
@@ -77,7 +77,7 @@ Singletons/T159.hs:0:0:: Splicing declarations
         forall (n :: T0) (n :: T1). z ~ C1 n n =>
         SC1 (Sing (n :: T0)) (Sing (n :: T1)) |
         forall (n :: T0) (n :: T1). z ~ (:&&) n n =>
-        (:%&&) (Sing (n :: T0)) (Sing (n :: T1))
+        (Sing (n :: T0)) :%&& (Sing (n :: T1))
     type ST1 = (Sing :: T1 -> GHC.Types.Type)
     instance SingKind T1 where
       type Demote T1 = T1
@@ -153,7 +153,7 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
         forall (n :: T0) (n :: T2). z ~ C2 n n =>
         SC2 (Sing (n :: T0)) (Sing (n :: T2)) |
         forall (n :: T0) (n :: T2). z ~ (:||) n n =>
-        (:%||) (Sing (n :: T0)) (Sing (n :: T2))
+        (Sing (n :: T0)) :%|| (Sing (n :: T2))
     type ST2 = (Sing :: T2 -> GHC.Types.Type)
     instance SingKind T2 where
       type Demote T2 = T2

--- a/tests/compile-and-dump/Singletons/T178.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T178.ghc82.template
@@ -60,6 +60,44 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
     instance POrd Occ where
       type Compare (a :: Occ) (a :: Occ) = Apply (Apply Compare_0123456789876543210Sym0 a) a
+    type family ShowsPrec_0123456789876543210 (a :: Nat) (a :: Occ) (a :: Symbol) :: Symbol where
+      ShowsPrec_0123456789876543210 _ Str a_0123456789876543210 = Apply (Apply ShowStringSym0 "Str") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ Opt a_0123456789876543210 = Apply (Apply ShowStringSym0 "Opt") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ Many a_0123456789876543210 = Apply (Apply ShowStringSym0 "Many") a_0123456789876543210
+    type ShowsPrec_0123456789876543210Sym3 (t :: Nat) (t :: Occ) (t :: Symbol) =
+        ShowsPrec_0123456789876543210 t t t
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym2 (l :: Nat) (l :: Occ) (l :: TyFun Symbol Symbol)
+      = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
+        ShowsPrec_0123456789876543210Sym2KindInference
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym1 (l :: Nat) (l :: TyFun Occ (TyFun Symbol Symbol
+                                                                       -> GHC.Types.Type))
+      = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
+        ShowsPrec_0123456789876543210Sym1KindInference
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun Nat (TyFun Occ (TyFun Symbol Symbol
+                                                                       -> GHC.Types.Type)
+                                                            -> GHC.Types.Type))
+      = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
+        ShowsPrec_0123456789876543210Sym0KindInference
+    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+    instance PShow Occ where
+      type ShowsPrec (a :: Nat) (a :: Occ) (a :: Symbol) = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     sEmpty :: Sing (EmptySym0 :: [(Symbol, Occ)])
     sEmpty = SNil
     data instance Sing (z :: Occ)
@@ -153,6 +191,43 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
       sCompare SOpt SMany = SLT
       sCompare SMany SStr = SGT
       sCompare SMany SOpt = SGT
+    instance SShow Occ where
+      sShowsPrec ::
+        forall (t1 :: Nat) (t2 :: Occ) (t3 :: Symbol).
+        Sing t1
+        -> Sing t2
+           -> Sing t3
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun Nat (TyFun Occ (TyFun Symbol Symbol
+                                                                                   -> GHC.Types.Type)
+                                                                        -> GHC.Types.Type)
+                                                             -> GHC.Types.Type) t1 :: TyFun Occ (TyFun Symbol Symbol
+                                                                                                 -> GHC.Types.Type)
+                                                                                      -> GHC.Types.Type) t2 :: TyFun Symbol Symbol
+                                                                                                               -> GHC.Types.Type) t3 :: Symbol)
+      sShowsPrec
+        _
+        SStr
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "Str")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SOpt
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "Opt")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SMany
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "Many")))
+            sA_0123456789876543210
     instance SingI Str where
       sing = SStr
     instance SingI Opt where


### PR DESCRIPTION
Now that `GHC.TypeLits` features an `AppendSymbol` type family, it's possible to promote/single 90% of the `Show` type class and its features. (For the 10% that isn't covered, see my comment above the `Show Symbol` instance, as well as the comment explaining the lack of a `PShow Nat` instance.)

This also adds support for `deriving Show`, along with some test cases to stress-test it.