### PR TITLE
Fix #192 by increasing the scope of withLocalDeclarations

### DIFF
--- a/src/Data/Singletons/Single.hs
+++ b/src/Data/Singletons/Single.hs
@@ -202,8 +202,8 @@ singInfo (DPatSynI {}) =
   fail "Singling of pattern synonym info not supported"
 
 singTopLevelDecs :: DsMonad q => [Dec] -> [DDec] -> q [DDec]
-singTopLevelDecs locals raw_decls = do
-  decls <- withLocalDeclarations locals $ expand raw_decls     -- expand type synonyms
+singTopLevelDecs locals raw_decls = withLocalDeclarations locals $ do
+  decls <- expand raw_decls     -- expand type synonyms
   PDecs { pd_let_decs              = letDecls
         , pd_class_decs            = classes
         , pd_instance_decs         = insts

--- a/tests/compile-and-dump/Singletons/ShowDeriving.ghc82.template
+++ b/tests/compile-and-dump/Singletons/ShowDeriving.ghc82.template
@@ -1,6 +1,10 @@
 Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     singletons
-      [d| data Foo1
+      [d| infixl 5 `MkFoo2b`
+          infixl 5 :*:
+          infixl 5 :&:
+          
+          data Foo1
             = MkFoo1
             deriving Show
           data Foo2 a
@@ -13,6 +17,9 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     data Foo1
       = MkFoo1
       deriving Show
+    infixl 5 `MkFoo2b`
+    infixl 5 :*:
+    infixl 5 :&:
     data Foo2 a
       = MkFoo2a a a | a `MkFoo2b` a | (:*:) a a | a :&: a
       deriving Show
@@ -162,9 +169,9 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
       type ShowsPrec (a :: GHC.Types.Nat) (a :: Foo1) (a :: Symbol) = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Foo2 a) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 p_0123456789876543210 (MkFoo2a arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (:>$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (:.$) (Apply ShowStringSym0 "MkFoo2a ")) (Apply (Apply (:.$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (:.$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
-      ShowsPrec_0123456789876543210 p_0123456789876543210 (MkFoo2b argL_0123456789876543210 argR_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (:>$) p_0123456789876543210) (FromInteger 9))) (Apply (Apply (:.$) (Apply (Apply ShowsPrecSym0 (FromInteger 10)) argL_0123456789876543210)) (Apply (Apply (:.$) (Apply ShowStringSym0 " `MkFoo2b` ")) (Apply (Apply ShowsPrecSym0 (FromInteger 10)) argR_0123456789876543210)))) a_0123456789876543210
+      ShowsPrec_0123456789876543210 p_0123456789876543210 (MkFoo2b argL_0123456789876543210 argR_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (:>$) p_0123456789876543210) (FromInteger 5))) (Apply (Apply (:.$) (Apply (Apply ShowsPrecSym0 (FromInteger 6)) argL_0123456789876543210)) (Apply (Apply (:.$) (Apply ShowStringSym0 " `MkFoo2b` ")) (Apply (Apply ShowsPrecSym0 (FromInteger 6)) argR_0123456789876543210)))) a_0123456789876543210
       ShowsPrec_0123456789876543210 p_0123456789876543210 ((:*:) arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (:>$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (:.$) (Apply ShowStringSym0 "(:*:) ")) (Apply (Apply (:.$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (:.$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
-      ShowsPrec_0123456789876543210 p_0123456789876543210 ((:&:) argL_0123456789876543210 argR_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (:>$) p_0123456789876543210) (FromInteger 9))) (Apply (Apply (:.$) (Apply (Apply ShowsPrecSym0 (FromInteger 10)) argL_0123456789876543210)) (Apply (Apply (:.$) (Apply ShowStringSym0 " :&: ")) (Apply (Apply ShowsPrecSym0 (FromInteger 10)) argR_0123456789876543210)))) a_0123456789876543210
+      ShowsPrec_0123456789876543210 p_0123456789876543210 ((:&:) argL_0123456789876543210 argR_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (:>$) p_0123456789876543210) (FromInteger 5))) (Apply (Apply (:.$) (Apply (Apply ShowsPrecSym0 (FromInteger 6)) argL_0123456789876543210)) (Apply (Apply (:.$) (Apply ShowStringSym0 " :&: ")) (Apply (Apply ShowsPrecSym0 (FromInteger 6)) argR_0123456789876543210)))) a_0123456789876543210
     type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: Foo2 a0123456789876543210) (t :: Symbol) =
         ShowsPrec_0123456789876543210 t t t
     instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
@@ -235,6 +242,9 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
     instance PShow Foo3 where
       type ShowsPrec (a :: GHC.Types.Nat) (a :: Foo3) (a :: Symbol) = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+    infixl 5 :%&:
+    infixl 5 :%*:
+    infixl 5 `SMkFoo2b`
     data instance Sing (z :: Foo1) = z ~ MkFoo1 => SMkFoo1
     type SFoo1 = (Sing :: Foo1 -> GHC.Types.Type)
     instance SingKind Foo1 where
@@ -369,12 +379,12 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                  ((applySing ((singFun3 @ShowParenSym0) sShowParen))
                     ((applySing
                         ((applySing ((singFun2 @(:>$)) (%:>))) sP_0123456789876543210))
-                       (sFromInteger (sing :: Sing 9)))))
+                       (sFromInteger (sing :: Sing 5)))))
                 ((applySing
                     ((applySing ((singFun3 @(:.$)) (%:.)))
                        ((applySing
                            ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
-                              (sFromInteger (sing :: Sing 10))))
+                              (sFromInteger (sing :: Sing 6))))
                           sArgL_0123456789876543210)))
                    ((applySing
                        ((applySing ((singFun3 @(:.$)) (%:.)))
@@ -382,7 +392,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                              (sing :: Sing " `MkFoo2b` "))))
                       ((applySing
                           ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
-                             (sFromInteger (sing :: Sing 10))))
+                             (sFromInteger (sing :: Sing 6))))
                          sArgR_0123456789876543210)))))
             sA_0123456789876543210
       sShowsPrec
@@ -424,12 +434,12 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                  ((applySing ((singFun3 @ShowParenSym0) sShowParen))
                     ((applySing
                         ((applySing ((singFun2 @(:>$)) (%:>))) sP_0123456789876543210))
-                       (sFromInteger (sing :: Sing 9)))))
+                       (sFromInteger (sing :: Sing 5)))))
                 ((applySing
                     ((applySing ((singFun3 @(:.$)) (%:.)))
                        ((applySing
                            ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
-                              (sFromInteger (sing :: Sing 10))))
+                              (sFromInteger (sing :: Sing 6))))
                           sArgL_0123456789876543210)))
                    ((applySing
                        ((applySing ((singFun3 @(:.$)) (%:.)))
@@ -437,7 +447,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                              (sing :: Sing " :&: "))))
                       ((applySing
                           ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
-                             (sFromInteger (sing :: Sing 10))))
+                             (sFromInteger (sing :: Sing 6))))
                          sArgR_0123456789876543210)))))
             sA_0123456789876543210
     instance SShow Bool => SShow Foo3 where

--- a/tests/compile-and-dump/Singletons/ShowDeriving.hs
+++ b/tests/compile-and-dump/Singletons/ShowDeriving.hs
@@ -8,6 +8,7 @@ import Data.Singletons.TH
 $(singletons [d|
     data Foo1 = MkFoo1 deriving Show
 
+    infixl 5 `MkFoo2b`, :*:, :&:
     data Foo2 a = MkFoo2a a a
                 | a `MkFoo2b` a
                 | (:*:) a a
@@ -30,8 +31,11 @@ foo2b = Refl
 foo2c :: "(:*:) () ()" :~: Show_ ('() :*: '())
 foo2c = Refl
 
-foo2d :: "(False :&: True)" :~: ShowsPrec 10 (False :&: True) ""
-foo2d = Refl
+foo2d' :: "False :&: True" :~: ShowsPrec 5 (False :&: True) ""
+foo2d' = Refl
+
+foo2d'' :: "(False :&: True)" :~: ShowsPrec 6 (False :&: True) ""
+foo2d'' = Refl
 
 foo3 :: "MkFoo3 {getFoo3a = True, (***) = False}" :~: Show_ (MkFoo3 True False)
 foo3 = Refl


### PR DESCRIPTION
Previously, we were calling `mkShowInstance` without a surrounding `withLocalDeclarations` to bring in locally declared fixity declarations, which led to incorrect fixity reification. I've fixed this by making `withLocalDeclarations` have a wider berth.