### PR TITLE
Add special casing for $ when promoting fixity declarations

### DIFF
--- a/src/Data/Singletons/Promote.hs
+++ b/src/Data/Singletons/Promote.hs
@@ -426,8 +426,10 @@ promoteLetDecEnv prefixes (LetDecEnv { lde_defns = value_env
 
 promoteInfixDecl :: Fixity -> Name -> Maybe DDec
 promoteInfixDecl fixity name
- | isUpcase name = Nothing   -- no need to promote the decl
- | otherwise     = Just $ DLetDec $ DInfixD fixity (promoteValNameLhs name)
+ | isUpcase name || head (nameBase name) == '$' -- See #29 and #197
+ = Nothing   -- no need to promote the decl
+ | otherwise
+ = Just $ DLetDec $ DInfixD fixity (promoteValNameLhs name)
 
 -- This function is used both to promote class method defaults and normal
 -- let bindings. Thus, it can't quite do all the work locally and returns

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -72,6 +72,7 @@ tests =
     , compileAndDumpStdTest "ShowDeriving"
     , compileAndDumpStdTest "BadShowDeriving"
     , compileAndDumpStdTest "StandaloneDeriving"
+    , compileAndDumpStdTest "T197"
     ],
     testCompileAndDumpGroup "Promote"
     [ compileAndDumpStdTest "Constructors"

--- a/tests/compile-and-dump/Singletons/T197.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T197.ghc82.template
@@ -1,0 +1,32 @@
+Singletons/T197.hs:(0,0)-(0,0): Splicing declarations
+    singletons
+      [d| infixl 5 $$:
+          
+          ($$:) :: Bool -> Bool -> Bool
+          _ $$: _ = False |]
+  ======>
+    infixl 5 $$:
+    ($$:) :: Bool -> Bool -> Bool
+    ($$:) _ _ = False
+    type ($$:$$$) (t :: Bool) (t :: Bool) = ($$:) t t
+    instance SuppressUnusedWarnings ($$:$$) where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) (:$$:$$###)) GHC.Tuple.())
+    data ($$:$$) (l :: Bool) (l :: TyFun Bool Bool)
+      = forall arg. SameKind (Apply (($$:$$) l) arg) (($$:$$$) l arg) =>
+        (:$$:$$###)
+    type instance Apply (($$:$$) l) l = ($$:) l l
+    instance SuppressUnusedWarnings ($$:$) where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) (:$$:$###)) GHC.Tuple.())
+    data ($$:$) (l :: TyFun Bool (TyFun Bool Bool -> GHC.Types.Type))
+      = forall arg. SameKind (Apply ($$:$) arg) (($$:$$) arg) =>
+        (:$$:$###)
+    type instance Apply ($$:$) l = ($$:$$) l
+    type family ($$:) (a :: Bool) (a :: Bool) :: Bool where
+      ($$:) _ _ = FalseSym0
+    infixl 5 %$$:
+    (%$$:) ::
+      forall (t :: Bool) (t :: Bool).
+      Sing t -> Sing t -> Sing (Apply (Apply ($$:$) t) t :: Bool)
+    (%$$:) _ _ = SFalse

--- a/tests/compile-and-dump/Singletons/T197.hs
+++ b/tests/compile-and-dump/Singletons/T197.hs
@@ -1,0 +1,10 @@
+module T197 where
+
+import Data.Singletons.Prelude
+import Data.Singletons.TH
+
+$(singletons [d|
+  infixl 5 $$:
+  ($$:) :: Bool -> Bool -> Bool
+  _ $$: _ = False
+ |])


### PR DESCRIPTION
We needn't promote fixity declarations for identifiers that begin with `$`, since their promoted names are the same as their value-level names. This addresses the first part of #197.