### PR TITLE
Make the treatment of undefined less magical

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,11 @@ next
   would be promoted to `GHC.Exts.Any` and singled to `undefined`. Now, there is
   a proper `Undefined` type family and `sUndefined` singleton function.
 
+* As a consequence of not promoting `undefined` to `Any`, there is no need to
+  have a special `any_` function to distinguish the function on lists. The
+  corresponding promoted type, singleton function, and defunctionalization
+  symbols are now named `Any`, `sAny`, and `AnySym{0,1,2}`.
+
 * Add promoted and singled versions of `Show`, including `deriving` support.
 
 * Permit derived `Ord` instances for empty datatypes.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,10 @@ next
 
   This makes the treatment of `($)` consistent with other symbolic functions.
 
+* The treatment of `undefined` is less magical. Before, all uses of `undefined`
+  would be promoted to `GHC.Exts.Any` and singled to `undefined`. Now, there is
+  a proper `Undefined` type family and `sUndefined` singleton function.
+
 * Add promoted and singled versions of `Show`, including `deriving` support.
 
 * Permit derived `Ord` instances for empty datatypes.

--- a/README.md
+++ b/README.md
@@ -457,15 +457,6 @@ treatment):
 
    All tuples (including the 0-tuple, unit) are treated similarly.
 
-6. original value: `undefined`
-
-   promoted type\*: `Any`
-
-   singleton value\*: `undefined`
-
-   symbols\*: `Any`
-
-
 Supported Haskell constructs
 ----------------------------
 

--- a/src/Data/Promotion/Prelude.hs
+++ b/src/Data/Promotion/Prelude.hs
@@ -24,7 +24,7 @@ module Data.Promotion.Prelude (
   Fst, Snd, Curry, Uncurry,
 
   -- * Error reporting
-  Error, ErrorSym0,
+  Error, Undefined,
 
   -- * Promoted equality
   module Data.Promotion.Prelude.Eq,
@@ -55,7 +55,7 @@ module Data.Promotion.Prelude (
   -- ** Reducing lists (folds)
   Foldl, Foldl1, Foldr, Foldr1,
   -- *** Special folds
-  And, Or, any_, Any_, All,
+  And, Or, Any, All,
   Sum, Product,
   Concat, ConcatMap,
   Maximum, Minimum,
@@ -97,6 +97,8 @@ module Data.Promotion.Prelude (
   CurrySym0, CurrySym1, CurrySym2, CurrySym3,
   UncurrySym0, UncurrySym1, UncurrySym2,
 
+  ErrorSym0, ErrorSym1, UndefinedSym0,
+
   (:^@#@$), (:^@#@$$),
 
   ShowsPrecSym0, ShowsPrecSym1, ShowsPrecSym2, ShowsPrecSym3,
@@ -130,7 +132,7 @@ module Data.Promotion.Prelude (
   MaximumBySym0, MaximumBySym1, MaximumBySym2,
   MinimumBySym0, MinimumBySym1, MinimumBySym2,
   AndSym0, AndSym1, OrSym0, OrSym1,
-  Any_Sym0, Any_Sym1, Any_Sym2,
+  AnySym0, AnySym1, AnySym2,
   AllSym0, AllSym1, AllSym2,
 
   ScanlSym0, ScanlSym1, ScanlSym2, ScanlSym3,

--- a/src/Data/Promotion/Prelude/List.hs
+++ b/src/Data/Promotion/Prelude/List.hs
@@ -33,8 +33,7 @@ module Data.Promotion.Prelude.List (
   Foldl, Foldl', Foldl1, Foldl1', Foldr, Foldr1,
 
   -- ** Special folds
-  Concat, ConcatMap, And, Or, Any_, All, Sum, Product, Maximum, Minimum,
-  any_, -- equivalent of Data.List `any`. Avoids name clash with Any type
+  Concat, ConcatMap, And, Or, Any, All, Sum, Product, Maximum, Minimum,
 
   -- * Building lists
 
@@ -124,7 +123,7 @@ module Data.Promotion.Prelude.List (
   ConcatSym0, ConcatSym1,
   ConcatMapSym0, ConcatMapSym1, ConcatMapSym2,
   AndSym0, AndSym1, OrSym0, OrSym1,
-  Any_Sym0, Any_Sym1, Any_Sym2,
+  AnySym0, AnySym1, AnySym2,
   AllSym0, AllSym1, AllSym2,
 
   ScanlSym0, ScanlSym1, ScanlSym2, ScanlSym3,

--- a/src/Data/Promotion/TH.hs
+++ b/src/Data/Promotion/TH.hs
@@ -42,10 +42,10 @@ module Data.Promotion.TH (
 
   PEq(..), If, (:&&),
   POrd(..),
-  Any,
   Proxy(..), ThenCmp, Foldl,
 
   Error, ErrorSym0,
+  Undefined, UndefinedSym0,
   TrueSym0, FalseSym0,
   LTSym0, EQSym0, GTSym0,
   Tuple0Sym0,
@@ -69,4 +69,3 @@ import Data.Singletons.Prelude.Eq
 import Data.Singletons.Prelude.Ord
 import Data.Singletons.TypeLits
 import Data.Singletons.SuppressUnusedWarnings
-import GHC.Exts

--- a/src/Data/Singletons/Names.hs
+++ b/src/Data/Singletons/Names.hs
@@ -16,16 +16,16 @@ import Data.Singletons.Decide
 import Language.Haskell.TH.Syntax
 import Language.Haskell.TH.Desugar
 import GHC.TypeLits ( Nat, Symbol )
-import GHC.Exts ( Any, Constraint )
+import GHC.Exts ( Constraint )
 import GHC.Show ( showCommaSpace, showSpace )
 import Data.Typeable ( TypeRep )
 import Data.Singletons.Util
 import Control.Monad
 
-anyTypeName, boolName, andName, tyEqName, compareName, minBoundName,
+boolName, andName, tyEqName, compareName, minBoundName,
   maxBoundName, repName,
   nilName, consName, listName, tyFunName,
-  applyName, natName, symbolName, undefinedName, typeRepName, stringName,
+  applyName, natName, symbolName, typeRepName, stringName,
   eqName, ordName, boundedName, orderingName,
   singFamilyName, singIName, singMethName, demoteName,
   singKindClassName, sEqClassName, sEqMethName, sconsName, snilName,
@@ -41,7 +41,6 @@ anyTypeName, boolName, andName, tyEqName, compareName, minBoundName,
   equalsName, constraintName,
   showName, showCharName, showCommaSpaceName, showParenName, showsPrecName,
   showSpaceName, showStringName, composeName, gtName :: Name
-anyTypeName = ''Any
 boolName = ''Bool
 andName = '(&&)
 compareName = 'compare
@@ -56,7 +55,6 @@ tyFunName = ''TyFun
 applyName = ''Apply
 symbolName = ''Symbol
 natName = ''Nat
-undefinedName = 'undefined
 typeRepName = ''TypeRep
 stringName = ''String
 eqName = ''Eq
@@ -159,9 +157,6 @@ promoteValRhs name
 -- names.
 promoteTySym :: Name -> Int -> Name
 promoteTySym name sat
-    | name == undefinedName
-    = anyTypeName
-
     | name == nilName
     = mkName $ "NilSym" ++ (show sat)
 
@@ -221,7 +216,6 @@ singClassName = singTyConName
 
 singValName :: Name -> Name
 singValName n
-  | n == undefinedName       = undefinedName
      -- avoid unused variable warnings
   | head (nameBase n) == '_' = (prefixLCName "_s" "%") $ n
   | otherwise                = (prefixLCName "s" "%") $ upcase n

--- a/src/Data/Singletons/Prelude.hs
+++ b/src/Data/Singletons/Prelude.hs
@@ -36,7 +36,8 @@ module Data.Singletons.Prelude (
   If, sIf, Not, sNot, (:&&), (:||), (%:&&), (%:||), Otherwise, sOtherwise,
 
   -- * Error reporting
-  Error, ErrorSym0, sError,
+  Error, sError,
+  Undefined, sUndefined,
 
   -- * Singleton equality
   module Data.Singletons.Prelude.Eq,
@@ -69,7 +70,7 @@ module Data.Singletons.Prelude (
   -- ** Reducing lists (folds)
   Foldl, sFoldl, Foldl1, sFoldl1, Foldr, sFoldr, Foldr1, sFoldr1,
   -- *** Special folds
-  And, sAnd, Or, sOr, Any_, sAny_, All, sAll,
+  And, sAnd, Or, sOr, Any, sAny, All, sAll,
   Concat, sConcat, ConcatMap, sConcatMap,
   -- *** Scans
   Scanl, sScanl, Scanl1, sScanl1, Scanr, sScanr, Scanr1, sScanr1,
@@ -89,7 +90,6 @@ module Data.Singletons.Prelude (
   either_, -- reimplementation of either to be used with singletons library
   maybe_,
   bool_,
-  any_,
   show_,
 
   -- * Defunctionalization symbols
@@ -115,6 +115,8 @@ module Data.Singletons.Prelude (
   FstSym0, FstSym1, SndSym0, SndSym1,
   CurrySym0, CurrySym1, CurrySym2, CurrySym3,
   UncurrySym0, UncurrySym1, UncurrySym2,
+
+  ErrorSym0, ErrorSym1, UndefinedSym0,
 
   ShowsPrecSym0, ShowsPrecSym1, ShowsPrecSym2, ShowsPrecSym3,
   Show_Sym0, Show_Sym1,
@@ -145,7 +147,7 @@ module Data.Singletons.Prelude (
   ConcatSym0, ConcatSym1,
   ConcatMapSym0, ConcatMapSym1, ConcatMapSym2,
   AndSym0, AndSym1, OrSym0, OrSym1,
-  Any_Sym0, Any_Sym1, Any_Sym2,
+  AnySym0, AnySym1, AnySym2,
   AllSym0, AllSym1, AllSym2,
 
   ScanlSym0, ScanlSym1, ScanlSym2, ScanlSym3,

--- a/src/Data/Singletons/Prelude/List.hs
+++ b/src/Data/Singletons/Prelude/List.hs
@@ -50,10 +50,9 @@ module Data.Singletons.Prelude.List (
 
   -- ** Special folds
   Concat, sConcat, ConcatMap, sConcatMap,
-  And, sAnd, Or, sOr, Any_, sAny_, All, sAll,
+  And, sAnd, Or, sOr, Any, sAny, All, sAll,
   Sum, sSum, Product, sProduct, Maximum, sMaximum,
   Minimum, sMinimum,
-  any_, -- equivalent of Data.List `any`. Avoids name clash with Any type
 
   -- * Building lists
 
@@ -154,7 +153,7 @@ module Data.Singletons.Prelude.List (
   ConcatSym0, ConcatSym1,
   ConcatMapSym0, ConcatMapSym1, ConcatMapSym2,
   AndSym0, AndSym1, OrSym0, OrSym1,
-  Any_Sym0, Any_Sym1, Any_Sym2,
+  AnySym0, AnySym1, AnySym2,
   AllSym0, AllSym1, AllSym2,
   SumSym0, SumSym1,
   ProductSym0, ProductSym1,
@@ -249,12 +248,6 @@ import Data.Singletons.Prelude.Tuple
 import Data.Singletons.Prelude.Num
 import Data.Singletons.Prelude.Ord
 import Data.Maybe
-
-$(singletons [d|
-  any_                     :: (a -> Bool) -> [a] -> Bool
-  any_ _ []                = False
-  any_ p (x:xs)            = p x || any_ p xs
- |])
 
 $(singletonsOnly [d|
   head :: [a] -> a
@@ -360,6 +353,10 @@ $(singletonsOnly [d|
   all _ []                =  True
   all p (x:xs)            =  p x && all p xs
 
+  any                     :: (a -> Bool) -> [a] -> Bool
+  any _ []                = False
+  any p (x:xs)            = p x || any p xs
+
   scanl         :: (b -> a -> b) -> b -> [a] -> [b]
   scanl f q ls  =  q : (case ls of
                         []   -> []
@@ -425,7 +422,7 @@ $(singletonsOnly [d|
   isSuffixOf x y          =  reverse x `isPrefixOf` reverse y
 
   isInfixOf               :: (Eq a) => [a] -> [a] -> Bool
-  isInfixOf needle haystack = any_ (isPrefixOf needle) (tails haystack)
+  isInfixOf needle haystack = any (isPrefixOf needle) (tails haystack)
 
   elem                    :: (Eq a) => a -> [a] -> Bool
   elem _ []               = False
@@ -605,13 +602,13 @@ $(singletonsOnly [d|
 --  intersectBy _  [] []    =  []
 --  intersectBy _  [] (_:_) =  []
 --  intersectBy _  (_:_) [] =  []
---  intersectBy eq xs ys    =  [x | x <- xs, any_ (eq x) ys]
+--  intersectBy eq xs ys    =  [x | x <- xs, any (eq x) ys]
 
   intersectBy             :: (a -> a -> Bool) -> [a] -> [a] -> [a]
   intersectBy _  []       []       =  []
   intersectBy _  []       (_:_)    =  []
   intersectBy _  (_:_)    []       =  []
-  intersectBy eq xs@(_:_) ys@(_:_) =  filter (\x -> any_ (eq x) ys) xs
+  intersectBy eq xs@(_:_) ys@(_:_) =  filter (\x -> any (eq x) ys) xs
 
   takeWhile               :: (a -> Bool) -> [a] -> [a]
   takeWhile _ []          =  []

--- a/src/Data/Singletons/Single.hs
+++ b/src/Data/Singletons/Single.hs
@@ -590,7 +590,7 @@ sEqToSDecide p@(DConPr n)
 sEqToSDecide DWildCardPr = DWildCardPr
 
 isException :: DExp -> Bool
-isException (DVarE n)             = n == undefinedName
+isException (DVarE n)             = nameBase n == "sUndefined"
 isException (DConE {})            = False
 isException (DLitE {})            = False
 isException (DAppE (DVarE fun) _) | nameBase fun == "sError" = True

--- a/src/Data/Singletons/TH.hs
+++ b/src/Data/Singletons/TH.hs
@@ -56,11 +56,11 @@ module Data.Singletons.TH (
 
   PEq(..), If, sIf, (:&&), SEq(..),
   POrd(..), SOrd(..), ThenCmp, sThenCmp, Foldl, sFoldl,
-  Any,
   SDecide(..), (:~:)(..), Void, Refuted, Decision(..),
   SomeSing(..),
 
   Error, ErrorSym0,
+  Undefined, sUndefined, UndefinedSym0,
   TrueSym0, FalseSym0,
   LTSym0, EQSym0, GTSym0,
   Tuple0Sym0,
@@ -89,7 +89,6 @@ import Data.Singletons.SuppressUnusedWarnings
 import Data.Singletons.Names
 import Language.Haskell.TH.Desugar
 
-import GHC.Exts
 import Language.Haskell.TH
 import Data.Singletons.Util
 import Control.Arrow ( first )

--- a/src/Data/Singletons/TypeLits.hs
+++ b/src/Data/Singletons/TypeLits.hs
@@ -21,6 +21,7 @@ module Data.Singletons.TypeLits (
   Sing(SNat, SSym),
   SNat, SSymbol, withKnownNat, withKnownSymbol,
   Error, ErrorSym0, ErrorSym1, sError,
+  Undefined, UndefinedSym0, sUndefined,
   KnownNat, KnownNatSym0, KnownNatSym1, natVal,
   KnownSymbol, KnownSymbolSym0, KnownSymbolSym1, symbolVal,
 

--- a/src/Data/Singletons/TypeLits/Internal.hs
+++ b/src/Data/Singletons/TypeLits/Internal.hs
@@ -25,6 +25,7 @@ module Data.Singletons.TypeLits.Internal (
   Nat, Symbol,
   SNat, SSymbol, withKnownNat, withKnownSymbol,
   Error, ErrorSym0, ErrorSym1, sError,
+  Undefined, UndefinedSym0, sUndefined,
   KnownNat, natVal, KnownSymbol, symbolVal,
 
   (:^), (:^@#@$), (:^@#@$$), (:^@#@$$$)
@@ -145,12 +146,20 @@ withKnownSymbol SSym f = f
 
 -- | The promotion of 'error'. This version is more poly-kinded for
 -- easier use.
-type family Error (str :: k0) :: k
+type family Error (str :: k0) :: k where {}
 $(genDefunSymbols [''Error])
 
 -- | The singleton for 'error'
 sError :: Sing (str :: Symbol) -> a
 sError sstr = error (T.unpack (fromSing sstr))
+
+-- | The promotion of 'Undefined'.
+type family Undefined :: k where {}
+$(genDefunSymbols [''Undefined])
+
+-- | The singleton for 'undefined'.
+sUndefined :: a
+sUndefined = undefined
 
 -- TODO: move this to a better home:
 type a :^ b = a ^ b

--- a/tests/compile-and-dump/GradingClient/Database.ghc82.template
+++ b/tests/compile-and-dump/GradingClient/Database.ghc82.template
@@ -418,7 +418,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
         AppendSym0KindInference
     type instance Apply AppendSym0 l = AppendSym1 l
     type family Lookup (a :: [AChar]) (a :: Schema) :: U where
-      Lookup _ (Sch '[]) = Any
+      Lookup _ (Sch '[]) = UndefinedSym0
       Lookup name (Sch ((:) (Attr name' u) attrs)) = Case_0123456789876543210 name name' u attrs (Let0123456789876543210Scrutinee_0123456789876543210Sym4 name name' u attrs)
     type family Occurs (a :: [AChar]) (a :: Schema) :: Bool where
       Occurs _ (Sch '[]) = FalseSym0
@@ -584,7 +584,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     sAppend ::
       forall (t :: Schema) (t :: Schema).
       Sing t -> Sing t -> Sing (Apply (Apply AppendSym0 t) t :: Schema)
-    sLookup _ (SSch SNil) = undefined
+    sLookup _ (SSch SNil) = sUndefined
     sLookup
       (sName :: Sing name)
       (SSch (SCons (SAttr (sName' :: Sing name') (sU :: Sing u))

--- a/tests/compile-and-dump/Singletons/T167.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T167.ghc82.template
@@ -52,7 +52,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
         FooListSym0KindInference
     type instance Apply FooListSym0 l = FooListSym1 l
     type family FooList_0123456789876543210 (a :: a) (a :: [Bool]) :: [Bool] where
-      FooList_0123456789876543210 a_0123456789876543210 a_0123456789876543210 = Apply (Apply Any a_0123456789876543210) a_0123456789876543210
+      FooList_0123456789876543210 a_0123456789876543210 a_0123456789876543210 = Apply (Apply UndefinedSym0 a_0123456789876543210) a_0123456789876543210
     type FooList_0123456789876543210Sym2 (t :: a0123456789876543210) (t :: [Bool]) =
         FooList_0123456789876543210 t t
     instance SuppressUnusedWarnings FooList_0123456789876543210Sym1 where
@@ -131,7 +131,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
       sFooList
         (sA_0123456789876543210 :: Sing a_0123456789876543210)
         (sA_0123456789876543210 :: Sing a_0123456789876543210)
-        = undefined
+        = sUndefined
     instance SFoo a => SFoo [a] where
       sFoosPrec ::
         forall (t :: Nat) (t :: [a]) (t :: [Bool]).

--- a/tests/compile-and-dump/Singletons/Undef.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Undef.ghc82.template
@@ -28,7 +28,7 @@ Singletons/Undef.hs:(0,0)-(0,0): Splicing declarations
     type family Bar (a :: Bool) :: Bool where
       Bar a_0123456789876543210 = Apply (Apply ErrorSym0 "urk") a_0123456789876543210
     type family Foo (a :: Bool) :: Bool where
-      Foo a_0123456789876543210 = Apply Any a_0123456789876543210
+      Foo a_0123456789876543210 = Apply UndefinedSym0 a_0123456789876543210
     sBar ::
       forall (t :: Bool). Sing t -> Sing (Apply BarSym0 t :: Bool)
     sFoo ::
@@ -36,4 +36,4 @@ Singletons/Undef.hs:(0,0)-(0,0): Splicing declarations
     sBar (sA_0123456789876543210 :: Sing a_0123456789876543210)
       = sError (sing :: Sing "urk")
     sFoo (sA_0123456789876543210 :: Sing a_0123456789876543210)
-      = undefined
+      = sUndefined


### PR DESCRIPTION
This lets us remove some special-casing, which is always nice. Note that we can't remote _all_ special casing (see `isException`, for instance), but it's a fair deal better than before.

Fixes #202.