### PR TITLE
Add unwords and unlines

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,11 @@ next
   corresponding promoted type, singleton function, and defunctionalization
   symbols are now named `Any`, `sAny`, and `AnySym{0,1,2}`.
 
+* Add `(:<>)` and `(%:<>)`, the promoted and singled versions of `AppendSymbol`
+  from `GHC.TypeLits`.
+
+* Add `unlines` and `unwords` to `Data.Singletons.Prelude.List`.
+
 * Add promoted and singled versions of `Show`, including `deriving` support.
 
 * Permit derived `Ord` instances for empty datatypes.

--- a/src/Data/Promotion/Prelude.hs
+++ b/src/Data/Promotion/Prelude.hs
@@ -72,6 +72,8 @@ module Data.Promotion.Prelude (
   Elem, NotElem, Lookup,
   -- ** Zipping and unzipping lists
   Zip, Zip3, ZipWith, ZipWith3, Unzip, Unzip3,
+  -- ** Functions on 'Symbol's
+  Unlines, Unwords,
 
   -- * Defunctionalization symbols
   FalseSym0, TrueSym0,
@@ -148,6 +150,8 @@ module Data.Promotion.Prelude (
   ZipWithSym0, ZipWithSym1, ZipWithSym2, ZipWithSym3,
   ZipWith3Sym0, ZipWith3Sym1, ZipWith3Sym2, ZipWith3Sym3,
   UnzipSym0, UnzipSym1,
+
+  UnlinesSym0, UnlinesSym1, UnwordsSym0, UnwordsSym1,
 
   UntilSym0, UntilSym1, UntilSym2, UntilSym3,
   LengthSym0, LengthSym1,

--- a/src/Data/Promotion/Prelude/List.hs
+++ b/src/Data/Promotion/Prelude/List.hs
@@ -79,6 +79,9 @@ module Data.Promotion.Prelude.List (
 
   -- * Special lists
 
+  -- ** Functions on 'Symbol's
+  Unlines, Unwords,
+
   -- ** \"Set\" operations
   Nub, Delete, (:\\), Union, Intersect,
 
@@ -209,6 +212,9 @@ module Data.Promotion.Prelude.List (
   ZipWith5Sym0, ZipWith5Sym1, ZipWith5Sym2, ZipWith5Sym3, ZipWith5Sym4, ZipWith5Sym5, ZipWith5Sym6,
   ZipWith6Sym0, ZipWith6Sym1, ZipWith6Sym2, ZipWith6Sym3, ZipWith6Sym4, ZipWith6Sym5, ZipWith6Sym6, ZipWith6Sym7,
   ZipWith7Sym0, ZipWith7Sym1, ZipWith7Sym2, ZipWith7Sym3, ZipWith7Sym4, ZipWith7Sym5, ZipWith7Sym6, ZipWith7Sym7, ZipWith7Sym8,
+
+  UnlinesSym0, UnlinesSym1,
+  UnwordsSym0, UnwordsSym1,
 
   NubSym0, NubSym1,
   NubBySym0, NubBySym1, NubBySym2,

--- a/src/Data/Singletons/Prelude.hs
+++ b/src/Data/Singletons/Prelude.hs
@@ -79,6 +79,8 @@ module Data.Singletons.Prelude (
   -- ** Zipping and unzipping lists
   Zip, sZip, Zip3, sZip3, ZipWith, sZipWith, ZipWith3, sZipWith3,
   Unzip, sUnzip, Unzip3, sUnzip3,
+  -- ** Functions on 'Symbol's
+  Unlines, sUnlines, Unwords, sUnwords,
 
   -- * Other datatypes
   Maybe_, sMaybe_,
@@ -162,7 +164,9 @@ module Data.Singletons.Prelude (
   Zip3Sym0, Zip3Sym1, Zip3Sym2, Zip3Sym3,
   ZipWithSym0, ZipWithSym1, ZipWithSym2, ZipWithSym3,
   ZipWith3Sym0, ZipWith3Sym1, ZipWith3Sym2, ZipWith3Sym3,
-  UnzipSym0, UnzipSym1
+  UnzipSym0, UnzipSym1,
+
+  UnlinesSym0, UnlinesSym1, UnwordsSym0, UnwordsSym1
   ) where
 
 import Data.Singletons

--- a/src/Data/Singletons/Prelude/List.hs
+++ b/src/Data/Singletons/Prelude/List.hs
@@ -99,6 +99,10 @@ module Data.Singletons.Prelude.List (
 
   -- * Special lists
 
+  -- ** Functions on 'Symbol's
+  Unlines, sUnlines,
+  Unwords, sUnwords,
+
   -- ** \"Set\" operations
   Nub, sNub, Delete, sDelete, (:\\), (%:\\),
   Union, sUnion, Intersect, sIntersect,
@@ -211,6 +215,9 @@ module Data.Singletons.Prelude.List (
   Unzip5Sym0, Unzip5Sym1,
   Unzip6Sym0, Unzip6Sym1,
   Unzip7Sym0, Unzip7Sym1,
+
+  UnlinesSym0, UnlinesSym1,
+  UnwordsSym0, UnwordsSym1,
 
   NubSym0, NubSym1,
   DeleteSym0, DeleteSym1, DeleteSym2,
@@ -506,19 +513,23 @@ $(singletonsOnly [d|
 --      where
 --        cons ~(h, t)        =  h : t
 --
---  unlines                 :: [String] -> String
---  unlines                 =  concatMap (++ "\n")
---
 --  words                   :: String -> [String]
 --  words s                 =  case dropWhile isSpace s of
 --                                  "" -> []
 --                                  s' -> w : words s''
 --                                        where (w, s'') =
 --                                               break isSpace s'
---
---  unwords                 :: [String] -> String
---  unwords []              =  ""
---  unwords ws              =  foldr1 (\w s -> w ++ ' ':s) ws
+
+  unlines                 :: [Symbol] -> Symbol
+  unlines []              = ""
+  unlines (l:ls)          = l <> "\n" <> unlines ls
+
+  unwords                 :: [Symbol] -> Symbol
+  unwords []              = ""
+  unwords (w:ws)          = w <> go ws
+    where
+      go []     = ""
+      go (v:vs) = " " <> (v <> go vs)
 
   delete                  :: (Eq a) => a -> [a] -> [a]
   delete                  =  deleteBy (==)

--- a/src/Data/Singletons/Prelude/Show.hs
+++ b/src/Data/Singletons/Prelude/Show.hs
@@ -52,7 +52,6 @@ module Data.Singletons.Prelude.Show (
   ) where
 
 import           Data.List.NonEmpty (NonEmpty)
-import           Data.Monoid ((<>))
 import           Data.Singletons.Prelude.Base
 import           Data.Singletons.Prelude.Instances
 import           Data.Singletons.Prelude.List
@@ -70,23 +69,6 @@ import qualified Prelude as P
 import           Prelude hiding (Show(..))
 
 import           Unsafe.Coerce (unsafeCoerce)
-
--- | The promoted analogue of '(<>)' for 'Symbol's. This uses the special
--- 'AppendSymbol' type family from "GHC.TypeLits".
-type a :<> b = AppendSymbol a b
-infixr 6 :<>
-
--- | The singleton analogue of '(<>)' for 'Symbol's.
-(%:<>) :: Sing a -> Sing b -> Sing (a :<> b)
-sa %:<> sb =
-    let a  = fromSing sa
-        b  = fromSing sb
-        ex = someSymbolVal $ T.unpack $ a <> b
-    in case ex of
-         SomeSymbol (_ :: Proxy ab) -> unsafeCoerce (SSym :: Sing ab)
-infixr 6 %:<>
-
-$(genDefunSymbols [''(:<>)])
 
 -- | The @shows@ functions return a function that prepends the
 -- output 'Symbol' to an existing 'Symbol'.  This allows constant-time

--- a/src/Data/Singletons/TypeLits.hs
+++ b/src/Data/Singletons/TypeLits.hs
@@ -20,12 +20,20 @@ module Data.Singletons.TypeLits (
   Nat, Symbol,
   Sing(SNat, SSym),
   SNat, SSymbol, withKnownNat, withKnownSymbol,
-  Error, ErrorSym0, ErrorSym1, sError,
-  Undefined, UndefinedSym0, sUndefined,
-  KnownNat, KnownNatSym0, KnownNatSym1, natVal,
-  KnownSymbol, KnownSymbolSym0, KnownSymbolSym1, symbolVal,
+  Error, sError,
+  Undefined, sUndefined,
+  KnownNat, natVal,
+  KnownSymbol, symbolVal,
 
-  (:^), (:^@#@$), (:^@#@$$), (:^@#@$$$)
+  (:^),
+  (:<>), (%:<>),
+
+  -- * Defunctionalization symbols
+  ErrorSym0, ErrorSym1, UndefinedSym0,
+  KnownNatSym0, KnownNatSym1,
+  KnownSymbolSym0, KnownSymbolSym1,
+  (:^@#@$), (:^@#@$$), (:^@#@$$$),
+  (:<>@#@$), (:<>@#@$$), (:<>@#@$$$),
   ) where
 
 import Data.Singletons.TypeLits.Internal

--- a/src/Data/Singletons/TypeLits/Internal.hs
+++ b/src/Data/Singletons/TypeLits/Internal.hs
@@ -24,11 +24,16 @@ module Data.Singletons.TypeLits.Internal (
 
   Nat, Symbol,
   SNat, SSymbol, withKnownNat, withKnownSymbol,
-  Error, ErrorSym0, ErrorSym1, sError,
-  Undefined, UndefinedSym0, sUndefined,
+  Error, sError,
+  Undefined, sUndefined,
   KnownNat, natVal, KnownSymbol, symbolVal,
+  (:^),
+  (:<>), (%:<>),
 
-  (:^), (:^@#@$), (:^@#@$$), (:^@#@$$$)
+  -- * Defunctionalization symbols
+  ErrorSym0, ErrorSym1, UndefinedSym0,
+  (:^@#@$), (:^@#@$$), (:^@#@$$$),
+  (:<>@#@$), (:<>@#@$$), (:<>@#@$$$)
   ) where
 
 import Data.Singletons.Promote
@@ -38,6 +43,7 @@ import Data.Singletons.Prelude.Ord
 import Data.Singletons.Decide
 import Data.Singletons.Prelude.Bool
 import GHC.TypeLits as TL
+import Data.Monoid ((<>))
 import Data.Type.Equality
 import Data.Proxy ( Proxy(..) )
 import Unsafe.Coerce
@@ -165,6 +171,23 @@ sUndefined = undefined
 type a :^ b = a ^ b
 infixr 8 :^
 $(genDefunSymbols [''(:^)])
+
+-- | The promoted analogue of '(<>)' for 'Symbol's. This uses the special
+-- 'TL.AppendSymbol' type family from "GHC.TypeLits".
+type a :<> b = TL.AppendSymbol a b
+infixr 6 :<>
+
+-- | The singleton analogue of '(<>)' for 'Symbol's.
+(%:<>) :: Sing a -> Sing b -> Sing (a :<> b)
+sa %:<> sb =
+    let a  = fromSing sa
+        b  = fromSing sb
+        ex = someSymbolVal $ T.unpack $ a <> b
+    in case ex of
+         SomeSymbol (_ :: Proxy ab) -> unsafeCoerce (SSym :: Sing ab)
+infixr 6 %:<>
+
+$(genDefunSymbols [''(:<>)])
 
 ------------------------------------------------------------
 -- TypeLits singleton non-singleton instances


### PR DESCRIPTION
I broke the import cycle between `Data.Singletons.Prelude.List` and `Data.Singletons.Prelude.Show` by migrating `:<>` to `Data.Singletons.Prelude.TypeLits`, which is probably a better home for it anyways.

Note that I had to use an alternative implementation of `unwords`, since the one from the `Prelude` doesn't singletonize due to #219.

Fixes #212.