### PR TITLE
Add Eq, Ord, Num, Enum, and Bounded instances for SomeSing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,10 @@ next
 
 * Add a value-level `(@@)`, which is a synonym for `applySing`.
 
+* Add `Eq`, `Ord`, `Num`, `Enum`, and `Bounded` instances for `SomeSing`, which
+  leverage the `SEq`, `SOrd`, `SNum`, `SEnum`, and `SBounded` instances,
+  respectively, for the underlying `Sing`.
+
 2.3
 ---
 * Documentation clarifiation in `Data.Singletons.TypeLits`, thanks to @ivan-m.

--- a/singletons.cabal
+++ b/singletons.cabal
@@ -97,6 +97,7 @@ library
                       Data.Singletons.Deriving.Enum,
                       Data.Singletons.Deriving.Ord,
                       Data.Singletons.Deriving.Show,
+                      Data.Singletons.Internal,
                       Data.Singletons.Prelude.List.NonEmpty.Internal,
                       Data.Singletons.Promote,
                       Data.Singletons.Promote.Monad,

--- a/src/Data/Promotion/TH.hs
+++ b/src/Data/Promotion/TH.hs
@@ -79,7 +79,7 @@ module Data.Promotion.TH (
 
  ) where
 
-import Data.Singletons
+import Data.Singletons.Internal
 import Data.Singletons.Promote
 import Data.Singletons.Prelude.Base
 import Data.Singletons.Prelude.Instances

--- a/src/Data/Singletons.hs
+++ b/src/Data/Singletons.hs
@@ -1,7 +1,6 @@
-{-# LANGUAGE MagicHash, RankNTypes, PolyKinds, GADTs, DataKinds,
-             FlexibleContexts, FlexibleInstances,
-             TypeFamilies, TypeOperators, TypeFamilyDependencies,
-             UndecidableInstances, TypeInType, ConstraintKinds #-}
+{-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE MagicHash #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -26,8 +25,7 @@
 module Data.Singletons (
   -- * Main singleton definitions
 
-  Sing(SLambda, applySing), (@@),
-  -- | See also 'Data.Singletons.Prelude.Sing' for exported constructors
+  Sing(..), (@@),
 
   SingI(..), SingKind(..),
 
@@ -61,263 +59,46 @@ module Data.Singletons (
   Proxy(..)
   ) where
 
-import Data.Kind
-import Unsafe.Coerce
-import Data.Proxy ( Proxy(..) )
-import GHC.Exts ( Proxy#, Constraint )
-
--- | Convenient synonym to refer to the kind of a type variable:
--- @type KindOf (a :: k) = k@
-type KindOf (a :: k) = k
-
--- | Force GHC to unify the kinds of @a@ and @b@. Note that @SameKind a b@ is
--- different from @KindOf a ~ KindOf b@ in that the former makes the kinds
--- unify immediately, whereas the latter is a proposition that GHC considers
--- as possibly false.
-type SameKind (a :: k) (b :: k) = (() :: Constraint)
+import Data.Singletons.Internal
+import Data.Singletons.Prelude.Enum
+import Data.Singletons.Prelude.Eq
+import Data.Singletons.Prelude.Ord
+import Data.Singletons.Prelude.Num
 
 ----------------------------------------------------------------------
----- Sing & friends --------------------------------------------------
+---- SomeSing instances ----------------------------------------------
 ----------------------------------------------------------------------
 
--- | The singleton kind-indexed data family.
-data family Sing (a :: k)
+instance SEq k => Eq (SomeSing k) where
+  SomeSing a == SomeSing b = fromSing (a %:== b)
+  SomeSing a /= SomeSing b = fromSing (a %:/= b)
 
--- | A 'SingI' constraint is essentially an implicitly-passed singleton.
--- If you need to satisfy this constraint with an explicit singleton, please
--- see 'withSingI'.
-class SingI (a :: k) where
-  -- | Produce the singleton explicitly. You will likely need the @ScopedTypeVariables@
-  -- extension to use this method the way you want.
-  sing :: Sing a
+instance SOrd k => Ord (SomeSing k) where
+  SomeSing a `compare` SomeSing b = fromSing (a `sCompare` b)
+  SomeSing a <         SomeSing b = fromSing (a %:<  b)
+  SomeSing a <=        SomeSing b = fromSing (a %:<= b)
+  SomeSing a >         SomeSing b = fromSing (a %:>  b)
+  SomeSing a >=        SomeSing b = fromSing (a %:>= b)
 
--- | The 'SingKind' class is a /kind/ class. It classifies all kinds
--- for which singletons are defined. The class supports converting between a singleton
--- type and the base (unrefined) type which it is built from.
-class SingKind k where
-  -- | Get a base type from the promoted kind. For example,
-  -- @Demote Bool@ will be the type @Bool@. Rarely, the type and kind do not
-  -- match. For example, @Demote Nat@ is @Integer@.
-  type Demote k = (r :: *) | r -> k
+instance SBounded k => Bounded (SomeSing k) where
+  minBound = SomeSing sMinBound
+  maxBound = SomeSing sMaxBound
 
-  -- | Convert a singleton to its unrefined version.
-  fromSing :: Sing (a :: k) -> Demote k
+instance (SEnum k, SingKind k) => Enum (SomeSing k) where
+  succ (SomeSing a) = SomeSing (sSucc a)
+  pred (SomeSing a) = SomeSing (sPred a)
+  toEnum n = withSomeSing (fromIntegral n) (SomeSing . sToEnum)
+  fromEnum (SomeSing a) = fromIntegral (fromSing (sFromEnum a))
+  enumFromTo (SomeSing from) (SomeSing to) =
+    map toSing (fromSing (sEnumFromTo from to))
+  enumFromThenTo (SomeSing from) (SomeSing then_) (SomeSing to) =
+    map toSing (fromSing (sEnumFromThenTo from then_ to))
 
-  -- | Convert an unrefined type to an existentially-quantified singleton type.
-  toSing   :: Demote k -> SomeSing k
-
--- | An /existentially-quantified/ singleton. This type is useful when you want a
--- singleton type, but there is no way of knowing, at compile-time, what the type
--- index will be. To make use of this type, you will generally have to use a
--- pattern-match:
---
--- > foo :: Bool -> ...
--- > foo b = case toSing b of
--- >           SomeSing sb -> {- fancy dependently-typed code with sb -}
---
--- An example like the one above may be easier to write using 'withSomeSing'.
-data SomeSing k where
-  SomeSing :: Sing (a :: k) -> SomeSing k
-
-----------------------------------------------------------------------
----- SingInstance ----------------------------------------------------
-----------------------------------------------------------------------
-
--- | A 'SingInstance' wraps up a 'SingI' instance for explicit handling.
-data SingInstance (a :: k) where
-  SingInstance :: SingI a => SingInstance a
-
--- dirty implementation of explicit-to-implicit conversion
-newtype DI a = Don'tInstantiate (SingI a => SingInstance a)
-
--- | Get an implicit singleton (a 'SingI' instance) from an explicit one.
-singInstance :: forall (a :: k). Sing a -> SingInstance a
-singInstance s = with_sing_i SingInstance
-  where
-    with_sing_i :: (SingI a => SingInstance a) -> SingInstance a
-    with_sing_i si = unsafeCoerce (Don'tInstantiate si) s
-
-----------------------------------------------------------------------
----- Defunctionalization ---------------------------------------------
-----------------------------------------------------------------------
-
--- | Representation of the kind of a type-level function. The difference
--- between term-level arrows and this type-level arrow is that at the term
--- level applications can be unsaturated, whereas at the type level all
--- applications have to be fully saturated.
-data TyFun :: * -> * -> *
-
--- | Something of kind `a ~> b` is a defunctionalized type function that is
--- not necessarily generative or injective.
-type a ~> b = TyFun a b -> *
-infixr 0 ~>
-
--- | Wrapper for converting the normal type-level arrow into a '~>'.
--- For example, given:
---
--- > data Nat = Zero | Succ Nat
--- > type family Map (a :: a ~> b) (a :: [a]) :: [b]
--- >   Map f '[] = '[]
--- >   Map f (x ': xs) = Apply f x ': Map f xs
---
--- We can write:
---
--- > Map (TyCon1 Succ) [Zero, Succ Zero]
-data TyCon1 :: (k1 -> k2) -> (k1 ~> k2)
-
--- | Similar to 'TyCon1', but for two-parameter type constructors.
-data TyCon2 :: (k1 -> k2 -> k3) -> (k1 ~> k2 ~> k3)
-data TyCon3 :: (k1 -> k2 -> k3 -> k4) -> (k1 ~> k2 ~> k3 ~> k4)
-data TyCon4 :: (k1 -> k2 -> k3 -> k4 -> k5) -> (k1 ~> k2 ~> k3 ~> k4 ~> k5)
-data TyCon5 :: (k1 -> k2 -> k3 -> k4 -> k5 -> k6)
-            -> (k1 ~> k2 ~> k3 ~> k4 ~> k5 ~> k6)
-data TyCon6 :: (k1 -> k2 -> k3 -> k4 -> k5 -> k6 -> k7)
-            -> (k1 ~> k2 ~> k3 ~> k4 ~> k5 ~> k6 ~> k7)
-data TyCon7 :: (k1 -> k2 -> k3 -> k4 -> k5 -> k6 -> k7 -> k8)
-            -> (k1 ~> k2 ~> k3 ~> k4 ~> k5 ~> k6 ~> k7 ~> k8)
-data TyCon8 :: (k1 -> k2 -> k3 -> k4 -> k5 -> k6 -> k7 -> k8 -> k9)
-            -> (k1 ~> k2 ~> k3 ~> k4 ~> k5 ~> k6 ~> k7 ~> k8 ~> k9)
-
--- | Type level function application
-type family Apply (f :: k1 ~> k2) (x :: k1) :: k2
-type instance Apply (TyCon1 f) x = f x
-type instance Apply (TyCon2 f) x = TyCon1 (f x)
-type instance Apply (TyCon3 f) x = TyCon2 (f x)
-type instance Apply (TyCon4 f) x = TyCon3 (f x)
-type instance Apply (TyCon5 f) x = TyCon4 (f x)
-type instance Apply (TyCon6 f) x = TyCon5 (f x)
-type instance Apply (TyCon7 f) x = TyCon6 (f x)
-type instance Apply (TyCon8 f) x = TyCon7 (f x)
-
--- | An infix synonym for `Apply`
-type a @@ b = Apply a b
-infixl 9 @@
-
-----------------------------------------------------------------------
----- Defunctionalized Sing instance and utilities --------------------
-----------------------------------------------------------------------
-
-newtype instance Sing (f :: k1 ~> k2) =
-  SLambda { applySing :: forall t. Sing t -> Sing (f @@ t) }
-
--- | An infix synonym for `applySing`
-(@@) :: forall (f :: k1 ~> k2) (t :: k1). Sing f -> Sing t -> Sing (f @@ t)
-(@@) = applySing
-
-instance (SingKind k1, SingKind k2) => SingKind (k1 ~> k2) where
-  type Demote (k1 ~> k2) = Demote k1 -> Demote k2
-  fromSing sFun x = withSomeSing x (fromSing . applySing sFun)
-  toSing _ = error "Cannot create existentially-quantified singleton functions."
-
-type SingFunction1 f = forall t. Sing t -> Sing (f @@ t)
-
--- | Use this function when passing a function on singletons as
--- a higher-order function. You will need visible type application
--- to get this to work. For example:
---
--- > falses = sMap (singFun1 @NotSym0 sNot)
--- >               (STrue `SCons` STrue `SCons` SNil)
---
--- There are a family of @singFun...@ functions, keyed by the number
--- of parameters of the function.
-singFun1 :: forall f. SingFunction1 f -> Sing f
-singFun1 f = SLambda f
-
-type SingFunction2 f = forall t. Sing t -> SingFunction1 (f @@ t)
-singFun2 :: forall f. SingFunction2 f -> Sing f
-singFun2 f = SLambda (\x -> singFun1 (f x))
-
-type SingFunction3 f = forall t. Sing t -> SingFunction2 (f @@ t)
-singFun3 :: forall f. SingFunction3 f -> Sing f
-singFun3 f = SLambda (\x -> singFun2 (f x))
-
-type SingFunction4 f = forall t. Sing t -> SingFunction3 (f @@ t)
-singFun4 :: forall f. SingFunction4 f -> Sing f
-singFun4 f = SLambda (\x -> singFun3 (f x))
-
-type SingFunction5 f = forall t. Sing t -> SingFunction4 (f @@ t)
-singFun5 :: forall f. SingFunction5 f -> Sing f
-singFun5 f = SLambda (\x -> singFun4 (f x))
-
-type SingFunction6 f = forall t. Sing t -> SingFunction5 (f @@ t)
-singFun6 :: forall f. SingFunction6 f -> Sing f
-singFun6 f = SLambda (\x -> singFun5 (f x))
-
-type SingFunction7 f = forall t. Sing t -> SingFunction6 (f @@ t)
-singFun7 :: forall f. SingFunction7 f -> Sing f
-singFun7 f = SLambda (\x -> singFun6 (f x))
-
-type SingFunction8 f = forall t. Sing t -> SingFunction7 (f @@ t)
-singFun8 :: forall f. SingFunction8 f -> Sing f
-singFun8 f = SLambda (\x -> singFun7 (f x))
-
--- | This is the inverse of 'singFun1', and likewise for the other
--- @unSingFun...@ functions.
-unSingFun1 :: forall f. Sing f -> SingFunction1 f
-unSingFun1 sf = applySing sf
-
-unSingFun2 :: forall f. Sing f -> SingFunction2 f
-unSingFun2 sf x = unSingFun1 (sf @@ x)
-
-unSingFun3 :: forall f. Sing f -> SingFunction3 f
-unSingFun3 sf x = unSingFun2 (sf @@ x)
-
-unSingFun4 :: forall f. Sing f -> SingFunction4 f
-unSingFun4 sf x = unSingFun3 (sf @@ x)
-
-unSingFun5 :: forall f. Sing f -> SingFunction5 f
-unSingFun5 sf x = unSingFun4 (sf @@ x)
-
-unSingFun6 :: forall f. Sing f -> SingFunction6 f
-unSingFun6 sf x = unSingFun5 (sf @@ x)
-
-unSingFun7 :: forall f. Sing f -> SingFunction7 f
-unSingFun7 sf x = unSingFun6 (sf @@ x)
-
-unSingFun8 :: forall f. Sing f -> SingFunction8 f
-unSingFun8 sf x = unSingFun7 (sf @@ x)
-
-----------------------------------------------------------------------
----- Convenience -----------------------------------------------------
-----------------------------------------------------------------------
-
--- | Convenience function for creating a context with an implicit singleton
--- available.
-withSingI :: Sing n -> (SingI n => r) -> r
-withSingI sn r =
-  case singInstance sn of
-    SingInstance -> r
-
--- | Convert a normal datatype (like 'Bool') to a singleton for that datatype,
--- passing it into a continuation.
-withSomeSing :: forall k r
-              . SingKind k
-             => Demote k                          -- ^ The original datatype
-             -> (forall (a :: k). Sing a -> r)    -- ^ Function expecting a singleton
-             -> r
-withSomeSing x f =
-  case toSing x of
-    SomeSing x' -> f x'
-
--- | A convenience function useful when we need to name a singleton value
--- multiple times. Without this function, each use of 'sing' could potentially
--- refer to a different singleton, and one has to use type signatures (often
--- with @ScopedTypeVariables@) to ensure that they are the same.
-withSing :: SingI a => (Sing a -> b) -> b
-withSing f = f sing
-
--- | A convenience function that names a singleton satisfying a certain
--- property.  If the singleton does not satisfy the property, then the function
--- returns 'Nothing'. The property is expressed in terms of the underlying
--- representation of the singleton.
-singThat :: forall (a :: k). (SingKind k, SingI a)
-         => (Demote k -> Bool) -> Maybe (Sing a)
-singThat p = withSing $ \x -> if p (fromSing x) then Just x else Nothing
-
--- | Allows creation of a singleton when a proxy is at hand.
-singByProxy :: SingI a => proxy a -> Sing a
-singByProxy _ = sing
-
--- | Allows creation of a singleton when a @proxy#@ is at hand.
-singByProxy# :: SingI a => Proxy# a -> Sing a
-singByProxy# _ = sing
+instance SNum k => Num (SomeSing k) where
+  SomeSing a + SomeSing b = SomeSing (a %:+ b)
+  SomeSing a - SomeSing b = SomeSing (a %:- b)
+  SomeSing a * SomeSing b = SomeSing (a %:* b)
+  negate (SomeSing a) = SomeSing (sNegate a)
+  abs    (SomeSing a) = SomeSing (sAbs a)
+  signum (SomeSing a) = SomeSing (sSignum a)
+  fromInteger n = withSomeSing n (SomeSing . sFromInteger)

--- a/src/Data/Singletons/Decide.hs
+++ b/src/Data/Singletons/Decide.hs
@@ -24,7 +24,7 @@ module Data.Singletons.Decide (
   ) where
 
 import Data.Kind
-import Data.Singletons
+import Data.Singletons.Internal
 import Data.Type.Equality
 import Data.Void
 

--- a/src/Data/Singletons/Internal.hs
+++ b/src/Data/Singletons/Internal.hs
@@ -1,0 +1,318 @@
+{-# LANGUAGE MagicHash, RankNTypes, PolyKinds, GADTs, DataKinds,
+             FlexibleContexts, FlexibleInstances,
+             TypeFamilies, TypeOperators, TypeFamilyDependencies,
+             UndecidableInstances, TypeInType, ConstraintKinds #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Singletons.Internal
+-- Copyright   :  (C) 2013 Richard Eisenberg
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- This module exports the basic definitions to use singletons. This module
+-- exists since we need to define instances for 'SomeSing' in
+-- "Data.Singletons", as defining them elsewhere would almost inevitably lead
+-- to import cycles.
+--
+----------------------------------------------------------------------------
+
+module Data.Singletons.Internal (
+  -- * Main singleton definitions
+
+  Sing(SLambda, applySing), (@@),
+
+  SingI(..), SingKind(..),
+
+  -- * Working with singletons
+  KindOf, SameKind,
+  SingInstance(..), SomeSing(..),
+  singInstance, withSingI, withSomeSing, singByProxy,
+
+  singByProxy#,
+  withSing, singThat,
+
+  -- ** Defunctionalization
+  TyFun, type (~>),
+  TyCon1, TyCon2, TyCon3, TyCon4, TyCon5, TyCon6, TyCon7, TyCon8,
+  Apply, type (@@),
+
+  -- ** Defunctionalized singletons
+  -- | When calling a higher-order singleton function, you need to use a
+  -- @singFun...@ function to wrap it. See 'singFun1'.
+  singFun1, singFun2, singFun3, singFun4, singFun5, singFun6, singFun7,
+  singFun8,
+  unSingFun1, unSingFun2, unSingFun3, unSingFun4, unSingFun5,
+  unSingFun6, unSingFun7, unSingFun8,
+
+  -- | These type synonyms are exported only to improve error messages; users
+  -- should not have to mention them.
+  SingFunction1, SingFunction2, SingFunction3, SingFunction4, SingFunction5,
+  SingFunction6, SingFunction7, SingFunction8,
+
+  -- * Auxiliary functions
+  Proxy(..)
+  ) where
+
+import Data.Kind
+import Unsafe.Coerce
+import Data.Proxy ( Proxy(..) )
+import GHC.Exts ( Proxy#, Constraint )
+
+-- | Convenient synonym to refer to the kind of a type variable:
+-- @type KindOf (a :: k) = k@
+type KindOf (a :: k) = k
+
+-- | Force GHC to unify the kinds of @a@ and @b@. Note that @SameKind a b@ is
+-- different from @KindOf a ~ KindOf b@ in that the former makes the kinds
+-- unify immediately, whereas the latter is a proposition that GHC considers
+-- as possibly false.
+type SameKind (a :: k) (b :: k) = (() :: Constraint)
+
+----------------------------------------------------------------------
+---- Sing & friends --------------------------------------------------
+----------------------------------------------------------------------
+
+-- | The singleton kind-indexed data family.
+data family Sing (a :: k)
+
+-- | A 'SingI' constraint is essentially an implicitly-passed singleton.
+-- If you need to satisfy this constraint with an explicit singleton, please
+-- see 'withSingI'.
+class SingI (a :: k) where
+  -- | Produce the singleton explicitly. You will likely need the @ScopedTypeVariables@
+  -- extension to use this method the way you want.
+  sing :: Sing a
+
+-- | The 'SingKind' class is a /kind/ class. It classifies all kinds
+-- for which singletons are defined. The class supports converting between a singleton
+-- type and the base (unrefined) type which it is built from.
+class SingKind k where
+  -- | Get a base type from the promoted kind. For example,
+  -- @Demote Bool@ will be the type @Bool@. Rarely, the type and kind do not
+  -- match. For example, @Demote Nat@ is @Integer@.
+  type Demote k = (r :: *) | r -> k
+
+  -- | Convert a singleton to its unrefined version.
+  fromSing :: Sing (a :: k) -> Demote k
+
+  -- | Convert an unrefined type to an existentially-quantified singleton type.
+  toSing   :: Demote k -> SomeSing k
+
+-- | An /existentially-quantified/ singleton. This type is useful when you want a
+-- singleton type, but there is no way of knowing, at compile-time, what the type
+-- index will be. To make use of this type, you will generally have to use a
+-- pattern-match:
+--
+-- > foo :: Bool -> ...
+-- > foo b = case toSing b of
+-- >           SomeSing sb -> {- fancy dependently-typed code with sb -}
+--
+-- An example like the one above may be easier to write using 'withSomeSing'.
+data SomeSing k where
+  SomeSing :: Sing (a :: k) -> SomeSing k
+
+----------------------------------------------------------------------
+---- SingInstance ----------------------------------------------------
+----------------------------------------------------------------------
+
+-- | A 'SingInstance' wraps up a 'SingI' instance for explicit handling.
+data SingInstance (a :: k) where
+  SingInstance :: SingI a => SingInstance a
+
+-- dirty implementation of explicit-to-implicit conversion
+newtype DI a = Don'tInstantiate (SingI a => SingInstance a)
+
+-- | Get an implicit singleton (a 'SingI' instance) from an explicit one.
+singInstance :: forall (a :: k). Sing a -> SingInstance a
+singInstance s = with_sing_i SingInstance
+  where
+    with_sing_i :: (SingI a => SingInstance a) -> SingInstance a
+    with_sing_i si = unsafeCoerce (Don'tInstantiate si) s
+
+----------------------------------------------------------------------
+---- Defunctionalization ---------------------------------------------
+----------------------------------------------------------------------
+
+-- | Representation of the kind of a type-level function. The difference
+-- between term-level arrows and this type-level arrow is that at the term
+-- level applications can be unsaturated, whereas at the type level all
+-- applications have to be fully saturated.
+data TyFun :: * -> * -> *
+
+-- | Something of kind `a ~> b` is a defunctionalized type function that is
+-- not necessarily generative or injective.
+type a ~> b = TyFun a b -> *
+infixr 0 ~>
+
+-- | Wrapper for converting the normal type-level arrow into a '~>'.
+-- For example, given:
+--
+-- > data Nat = Zero | Succ Nat
+-- > type family Map (a :: a ~> b) (a :: [a]) :: [b]
+-- >   Map f '[] = '[]
+-- >   Map f (x ': xs) = Apply f x ': Map f xs
+--
+-- We can write:
+--
+-- > Map (TyCon1 Succ) [Zero, Succ Zero]
+data TyCon1 :: (k1 -> k2) -> (k1 ~> k2)
+
+-- | Similar to 'TyCon1', but for two-parameter type constructors.
+data TyCon2 :: (k1 -> k2 -> k3) -> (k1 ~> k2 ~> k3)
+data TyCon3 :: (k1 -> k2 -> k3 -> k4) -> (k1 ~> k2 ~> k3 ~> k4)
+data TyCon4 :: (k1 -> k2 -> k3 -> k4 -> k5) -> (k1 ~> k2 ~> k3 ~> k4 ~> k5)
+data TyCon5 :: (k1 -> k2 -> k3 -> k4 -> k5 -> k6)
+            -> (k1 ~> k2 ~> k3 ~> k4 ~> k5 ~> k6)
+data TyCon6 :: (k1 -> k2 -> k3 -> k4 -> k5 -> k6 -> k7)
+            -> (k1 ~> k2 ~> k3 ~> k4 ~> k5 ~> k6 ~> k7)
+data TyCon7 :: (k1 -> k2 -> k3 -> k4 -> k5 -> k6 -> k7 -> k8)
+            -> (k1 ~> k2 ~> k3 ~> k4 ~> k5 ~> k6 ~> k7 ~> k8)
+data TyCon8 :: (k1 -> k2 -> k3 -> k4 -> k5 -> k6 -> k7 -> k8 -> k9)
+            -> (k1 ~> k2 ~> k3 ~> k4 ~> k5 ~> k6 ~> k7 ~> k8 ~> k9)
+
+-- | Type level function application
+type family Apply (f :: k1 ~> k2) (x :: k1) :: k2
+type instance Apply (TyCon1 f) x = f x
+type instance Apply (TyCon2 f) x = TyCon1 (f x)
+type instance Apply (TyCon3 f) x = TyCon2 (f x)
+type instance Apply (TyCon4 f) x = TyCon3 (f x)
+type instance Apply (TyCon5 f) x = TyCon4 (f x)
+type instance Apply (TyCon6 f) x = TyCon5 (f x)
+type instance Apply (TyCon7 f) x = TyCon6 (f x)
+type instance Apply (TyCon8 f) x = TyCon7 (f x)
+
+-- | An infix synonym for `Apply`
+type a @@ b = Apply a b
+infixl 9 @@
+
+----------------------------------------------------------------------
+---- Defunctionalized Sing instance and utilities --------------------
+----------------------------------------------------------------------
+
+newtype instance Sing (f :: k1 ~> k2) =
+  SLambda { applySing :: forall t. Sing t -> Sing (f @@ t) }
+
+-- | An infix synonym for `applySing`
+(@@) :: forall (f :: k1 ~> k2) (t :: k1). Sing f -> Sing t -> Sing (f @@ t)
+(@@) = applySing
+
+instance (SingKind k1, SingKind k2) => SingKind (k1 ~> k2) where
+  type Demote (k1 ~> k2) = Demote k1 -> Demote k2
+  fromSing sFun x = withSomeSing x (fromSing . applySing sFun)
+  toSing _ = error "Cannot create existentially-quantified singleton functions."
+
+type SingFunction1 f = forall t. Sing t -> Sing (f @@ t)
+
+-- | Use this function when passing a function on singletons as
+-- a higher-order function. You will need visible type application
+-- to get this to work. For example:
+--
+-- > falses = sMap (singFun1 @NotSym0 sNot)
+-- >               (STrue `SCons` STrue `SCons` SNil)
+--
+-- There are a family of @singFun...@ functions, keyed by the number
+-- of parameters of the function.
+singFun1 :: forall f. SingFunction1 f -> Sing f
+singFun1 f = SLambda f
+
+type SingFunction2 f = forall t. Sing t -> SingFunction1 (f @@ t)
+singFun2 :: forall f. SingFunction2 f -> Sing f
+singFun2 f = SLambda (\x -> singFun1 (f x))
+
+type SingFunction3 f = forall t. Sing t -> SingFunction2 (f @@ t)
+singFun3 :: forall f. SingFunction3 f -> Sing f
+singFun3 f = SLambda (\x -> singFun2 (f x))
+
+type SingFunction4 f = forall t. Sing t -> SingFunction3 (f @@ t)
+singFun4 :: forall f. SingFunction4 f -> Sing f
+singFun4 f = SLambda (\x -> singFun3 (f x))
+
+type SingFunction5 f = forall t. Sing t -> SingFunction4 (f @@ t)
+singFun5 :: forall f. SingFunction5 f -> Sing f
+singFun5 f = SLambda (\x -> singFun4 (f x))
+
+type SingFunction6 f = forall t. Sing t -> SingFunction5 (f @@ t)
+singFun6 :: forall f. SingFunction6 f -> Sing f
+singFun6 f = SLambda (\x -> singFun5 (f x))
+
+type SingFunction7 f = forall t. Sing t -> SingFunction6 (f @@ t)
+singFun7 :: forall f. SingFunction7 f -> Sing f
+singFun7 f = SLambda (\x -> singFun6 (f x))
+
+type SingFunction8 f = forall t. Sing t -> SingFunction7 (f @@ t)
+singFun8 :: forall f. SingFunction8 f -> Sing f
+singFun8 f = SLambda (\x -> singFun7 (f x))
+
+-- | This is the inverse of 'singFun1', and likewise for the other
+-- @unSingFun...@ functions.
+unSingFun1 :: forall f. Sing f -> SingFunction1 f
+unSingFun1 sf = applySing sf
+
+unSingFun2 :: forall f. Sing f -> SingFunction2 f
+unSingFun2 sf x = unSingFun1 (sf @@ x)
+
+unSingFun3 :: forall f. Sing f -> SingFunction3 f
+unSingFun3 sf x = unSingFun2 (sf @@ x)
+
+unSingFun4 :: forall f. Sing f -> SingFunction4 f
+unSingFun4 sf x = unSingFun3 (sf @@ x)
+
+unSingFun5 :: forall f. Sing f -> SingFunction5 f
+unSingFun5 sf x = unSingFun4 (sf @@ x)
+
+unSingFun6 :: forall f. Sing f -> SingFunction6 f
+unSingFun6 sf x = unSingFun5 (sf @@ x)
+
+unSingFun7 :: forall f. Sing f -> SingFunction7 f
+unSingFun7 sf x = unSingFun6 (sf @@ x)
+
+unSingFun8 :: forall f. Sing f -> SingFunction8 f
+unSingFun8 sf x = unSingFun7 (sf @@ x)
+
+----------------------------------------------------------------------
+---- Convenience -----------------------------------------------------
+----------------------------------------------------------------------
+
+-- | Convenience function for creating a context with an implicit singleton
+-- available.
+withSingI :: Sing n -> (SingI n => r) -> r
+withSingI sn r =
+  case singInstance sn of
+    SingInstance -> r
+
+-- | Convert a normal datatype (like 'Bool') to a singleton for that datatype,
+-- passing it into a continuation.
+withSomeSing :: forall k r
+              . SingKind k
+             => Demote k                          -- ^ The original datatype
+             -> (forall (a :: k). Sing a -> r)    -- ^ Function expecting a singleton
+             -> r
+withSomeSing x f =
+  case toSing x of
+    SomeSing x' -> f x'
+
+-- | A convenience function useful when we need to name a singleton value
+-- multiple times. Without this function, each use of 'sing' could potentially
+-- refer to a different singleton, and one has to use type signatures (often
+-- with @ScopedTypeVariables@) to ensure that they are the same.
+withSing :: SingI a => (Sing a -> b) -> b
+withSing f = f sing
+
+-- | A convenience function that names a singleton satisfying a certain
+-- property.  If the singleton does not satisfy the property, then the function
+-- returns 'Nothing'. The property is expressed in terms of the underlying
+-- representation of the singleton.
+singThat :: forall (a :: k). (SingKind k, SingI a)
+         => (Demote k -> Bool) -> Maybe (Sing a)
+singThat p = withSing $ \x -> if p (fromSing x) then Just x else Nothing
+
+-- | Allows creation of a singleton when a proxy is at hand.
+singByProxy :: SingI a => proxy a -> Sing a
+singByProxy _ = sing
+
+-- | Allows creation of a singleton when a @proxy#@ is at hand.
+singByProxy# :: SingI a => Proxy# a -> Sing a
+singByProxy# _ = sing

--- a/src/Data/Singletons/Names.hs
+++ b/src/Data/Singletons/Names.hs
@@ -10,7 +10,7 @@ Defining names and manipulations on names for use in promotion and singling.
 
 module Data.Singletons.Names where
 
-import Data.Singletons
+import Data.Singletons.Internal
 import Data.Singletons.SuppressUnusedWarnings
 import Data.Singletons.Decide
 import Language.Haskell.TH.Syntax

--- a/src/Data/Singletons/Prelude/Bool.hs
+++ b/src/Data/Singletons/Prelude/Bool.hs
@@ -54,7 +54,7 @@ module Data.Singletons.Prelude.Bool (
   OtherwiseSym0
   ) where
 
-import Data.Singletons
+import Data.Singletons.Internal
 import Data.Singletons.Prelude.Instances
 import Data.Singletons.Single
 import Data.Type.Bool ( If )

--- a/src/Data/Singletons/Prelude/List.hs
+++ b/src/Data/Singletons/Prelude/List.hs
@@ -243,7 +243,7 @@ module Data.Singletons.Prelude.List (
   GenericLengthSym0, GenericLengthSym1
   ) where
 
-import Data.Singletons
+import Data.Singletons.Internal
 import Data.Singletons.Prelude.Instances
 import Data.Singletons.Single
 import Data.Singletons.TypeLits

--- a/src/Data/Singletons/Prelude/Num.hs
+++ b/src/Data/Singletons/Prelude/Num.hs
@@ -32,7 +32,7 @@ module Data.Singletons.Prelude.Num (
   ) where
 
 import Data.Singletons.Single
-import Data.Singletons
+import Data.Singletons.Internal
 import Data.Singletons.TypeLits.Internal
 import Data.Singletons.Decide
 import GHC.TypeLits

--- a/src/Data/Singletons/Prelude/Show.hs
+++ b/src/Data/Singletons/Prelude/Show.hs
@@ -53,7 +53,7 @@ module Data.Singletons.Prelude.Show (
 
 import           Data.List.NonEmpty (NonEmpty)
 import           Data.Proxy
-import           Data.Singletons
+import           Data.Singletons.Internal
 import           Data.Singletons.Prelude.Base
 import           Data.Singletons.Prelude.Instances
 import           Data.Singletons.Prelude.List

--- a/src/Data/Singletons/Single/Monad.hs
+++ b/src/Data/Singletons/Single/Monad.hs
@@ -23,7 +23,7 @@ import qualified Data.Map as Map
 import Data.Singletons.Promote.Monad ( emitDecs, emitDecsM )
 import Data.Singletons.Names
 import Data.Singletons.Util
-import Data.Singletons
+import Data.Singletons.Internal
 import Language.Haskell.TH.Syntax hiding ( lift )
 import Language.Haskell.TH.Desugar
 import Control.Monad.Reader

--- a/src/Data/Singletons/TypeLits/Internal.hs
+++ b/src/Data/Singletons/TypeLits/Internal.hs
@@ -37,7 +37,7 @@ module Data.Singletons.TypeLits.Internal (
   ) where
 
 import Data.Singletons.Promote
-import Data.Singletons
+import Data.Singletons.Internal
 import Data.Singletons.Prelude.Eq
 import Data.Singletons.Prelude.Ord
 import Data.Singletons.Decide

--- a/src/Data/Singletons/TypeRepStar.hs
+++ b/src/Data/Singletons/TypeRepStar.hs
@@ -30,7 +30,7 @@ module Data.Singletons.TypeRepStar (
   ) where
 
 import Data.Singletons.Prelude.Instances
-import Data.Singletons
+import Data.Singletons.Internal
 import Data.Singletons.Prelude.Eq
 import Data.Typeable
 import Unsafe.Coerce

--- a/tests/compile-and-dump/Promote/GenDefunSymbols.ghc82.template
+++ b/tests/compile-and-dump/Promote/GenDefunSymbols.ghc82.template
@@ -9,7 +9,7 @@ Promote/GenDefunSymbols.hs:0:0:: Splicing declarations
         = snd ((GHC.Tuple.(,) LiftMaybeSym1KindInference) GHC.Tuple.())
     data LiftMaybeSym1 (l :: TyFun a0123456789876543210 b0123456789876543210
                              -> Type) (l :: TyFun (Maybe a0123456789876543210) (Maybe b0123456789876543210))
-      = forall arg. Data.Singletons.SameKind (Apply (LiftMaybeSym1 l) arg) (LiftMaybeSym2 l arg) =>
+      = forall arg. Data.Singletons.Internal.SameKind (Apply (LiftMaybeSym1 l) arg) (LiftMaybeSym2 l arg) =>
         LiftMaybeSym1KindInference
     type instance Apply (LiftMaybeSym1 l) l = LiftMaybe l l
     instance SuppressUnusedWarnings LiftMaybeSym0 where
@@ -18,7 +18,7 @@ Promote/GenDefunSymbols.hs:0:0:: Splicing declarations
     data LiftMaybeSym0 (l :: TyFun (TyFun a0123456789876543210 b0123456789876543210
                                     -> Type) (TyFun (Maybe a0123456789876543210) (Maybe b0123456789876543210)
                                               -> Type))
-      = forall arg. Data.Singletons.SameKind (Apply LiftMaybeSym0 arg) (LiftMaybeSym1 arg) =>
+      = forall arg. Data.Singletons.Internal.SameKind (Apply LiftMaybeSym0 arg) (LiftMaybeSym1 arg) =>
         LiftMaybeSym0KindInference
     type instance Apply LiftMaybeSym0 l = LiftMaybeSym1 l
     type ZeroSym0 = Zero
@@ -27,7 +27,7 @@ Promote/GenDefunSymbols.hs:0:0:: Splicing declarations
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SuccSym0KindInference) GHC.Tuple.())
     data SuccSym0 (l :: TyFun NatT NatT)
-      = forall arg. Data.Singletons.SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
+      = forall arg. Data.Singletons.Internal.SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
         SuccSym0KindInference
     type instance Apply SuccSym0 l = Succ l
     type (:+@#@$$$) (t :: Nat) (t :: Nat) = (:+) t t
@@ -35,13 +35,13 @@ Promote/GenDefunSymbols.hs:0:0:: Splicing declarations
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:+@#@$$###)) GHC.Tuple.())
     data (:+@#@$$) (l :: Nat) l
-      = forall arg. Data.Singletons.SameKind (Apply ((:+@#@$$) l) arg) ((:+@#@$$$) l arg) =>
+      = forall arg. Data.Singletons.Internal.SameKind (Apply ((:+@#@$$) l) arg) ((:+@#@$$$) l arg) =>
         (:+@#@$$###)
     type instance Apply ((:+@#@$$) l) l = (:+) l l
     instance SuppressUnusedWarnings (:+@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:+@#@$###)) GHC.Tuple.())
     data (:+@#@$) l
-      = forall arg. Data.Singletons.SameKind (Apply (:+@#@$) arg) ((:+@#@$$) arg) =>
+      = forall arg. Data.Singletons.Internal.SameKind (Apply (:+@#@$) arg) ((:+@#@$$) arg) =>
         (:+@#@$###)
     type instance Apply (:+@#@$) l = (:+@#@$$) l

--- a/tests/compile-and-dump/Promote/Prelude.ghc82.template
+++ b/tests/compile-and-dump/Promote/Prelude.ghc82.template
@@ -9,7 +9,7 @@ Promote/Prelude.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) OddSym0KindInference) GHC.Tuple.())
     data OddSym0 (l :: TyFun Nat Bool)
-      = forall arg. Data.Singletons.SameKind (Apply OddSym0 arg) (OddSym1 arg) =>
+      = forall arg. Data.Singletons.Internal.SameKind (Apply OddSym0 arg) (OddSym1 arg) =>
         OddSym0KindInference
     type instance Apply OddSym0 l = Odd l
     type family Odd (a :: Nat) :: Bool where


### PR DESCRIPTION
To accomplish this, I created a new `Data.Singletons.Internal` module to avoid the import cycle that would otherwise ensue when you combine `SomeSing` with `SEq`, `SOrd`, etc.

Fixes #215.