### PR TITLE
Fix #211, and document some subtleties of promoteMethod

### DIFF
--- a/tests/compile-and-dump/GradingClient/Database.ghc82.template
+++ b/tests/compile-and-dump/GradingClient/Database.ghc82.template
@@ -43,7 +43,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
         Compare_0123456789876543210Sym0KindInference
     type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
     instance POrd Nat where
-      type Compare (a :: Nat) (a :: Nat) = Apply (Apply Compare_0123456789876543210Sym0 a) a
+      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type family Equals_0123456789876543210 (a :: Nat) (b :: Nat) :: Bool where
       Equals_0123456789876543210 Zero Zero = TrueSym0
       Equals_0123456789876543210 (Succ a) (Succ b) = (:==) a b
@@ -461,7 +461,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
     instance PShow U where
-      type ShowsPrec (a :: GHC.Types.Nat) (a :: U) (a :: Symbol) = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: AChar) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 _ CA a_0123456789876543210 = Apply (Apply ShowStringSym0 "CA") a_0123456789876543210
       ShowsPrec_0123456789876543210 _ CB a_0123456789876543210 = Apply (Apply ShowStringSym0 "CB") a_0123456789876543210
@@ -522,7 +522,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
     instance PShow AChar where
-      type ShowsPrec (a :: GHC.Types.Nat) (a :: AChar) (a :: Symbol) = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type family Equals_0123456789876543210 (a :: U) (b :: U) :: Bool where
       Equals_0123456789876543210 BOOL BOOL = TrueSym0
       Equals_0123456789876543210 STRING STRING = TrueSym0

--- a/tests/compile-and-dump/Singletons/Classes.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Classes.ghc82.template
@@ -194,7 +194,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         Mycompare_0123456789876543210Sym0KindInference
     type instance Apply Mycompare_0123456789876543210Sym0 l = Mycompare_0123456789876543210Sym1 l
     instance PMyOrd Nat where
-      type Mycompare (a :: Nat) (a :: Nat) = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
+      type Mycompare a a = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
     type family Mycompare_0123456789876543210 (a :: ()) (a :: ()) :: Ordering where
       Mycompare_0123456789876543210 _ a_0123456789876543210 = Apply (Apply ConstSym0 EQSym0) a_0123456789876543210
     type Mycompare_0123456789876543210Sym2 (t :: ()) (t :: ()) =
@@ -219,7 +219,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         Mycompare_0123456789876543210Sym0KindInference
     type instance Apply Mycompare_0123456789876543210Sym0 l = Mycompare_0123456789876543210Sym1 l
     instance PMyOrd () where
-      type Mycompare (a :: ()) (a :: ()) = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
+      type Mycompare a a = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
     type family Mycompare_0123456789876543210 (a :: Foo) (a :: Foo) :: Ordering where
       Mycompare_0123456789876543210 a_0123456789876543210 a_0123456789876543210 = Apply (Apply FooCompareSym0 a_0123456789876543210) a_0123456789876543210
     type Mycompare_0123456789876543210Sym2 (t :: Foo) (t :: Foo) =
@@ -244,7 +244,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         Mycompare_0123456789876543210Sym0KindInference
     type instance Apply Mycompare_0123456789876543210Sym0 l = Mycompare_0123456789876543210Sym1 l
     instance PMyOrd Foo where
-      type Mycompare (a :: Foo) (a :: Foo) = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
+      type Mycompare a a = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
     type family TFHelper_0123456789876543210 (a :: Foo2) (a :: Foo2) :: Bool where
       TFHelper_0123456789876543210 F F = TrueSym0
       TFHelper_0123456789876543210 G G = TrueSym0
@@ -272,7 +272,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         TFHelper_0123456789876543210Sym0KindInference
     type instance Apply TFHelper_0123456789876543210Sym0 l = TFHelper_0123456789876543210Sym1 l
     instance PEq Foo2 where
-      type (:==) (a :: Foo2) (a :: Foo2) = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
+      type (:==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
     infix 4 %:<=>
     sFooCompare ::
       forall (t :: Foo) (t :: Foo).
@@ -420,7 +420,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         Mycompare_0123456789876543210Sym0KindInference
     type instance Apply Mycompare_0123456789876543210Sym0 l = Mycompare_0123456789876543210Sym1 l
     instance PMyOrd Foo2 where
-      type Mycompare (a :: Foo2) (a :: Foo2) = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
+      type Mycompare a a = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
     type family Compare_0123456789876543210 (a :: Foo2) (a :: Foo2) :: Ordering where
       Compare_0123456789876543210 F F = EQSym0
       Compare_0123456789876543210 F _ = LTSym0
@@ -447,7 +447,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         Compare_0123456789876543210Sym0KindInference
     type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
     instance POrd Foo2 where
-      type Compare (a :: Foo2) (a :: Foo2) = Apply (Apply Compare_0123456789876543210Sym0 a) a
+      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
 Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     singletons
       [d| data Nat' = Zero' | Succ' Nat'
@@ -500,7 +500,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         Mycompare_0123456789876543210Sym0KindInference
     type instance Apply Mycompare_0123456789876543210Sym0 l = Mycompare_0123456789876543210Sym1 l
     instance PMyOrd Nat' where
-      type Mycompare (a :: Nat') (a :: Nat') = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
+      type Mycompare a a = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
     data instance Sing (z :: Nat')
       where
         SZero' :: Sing Zero'

--- a/tests/compile-and-dump/Singletons/Classes2.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Classes2.ghc82.template
@@ -50,7 +50,7 @@ Singletons/Classes2.hs:(0,0)-(0,0): Splicing declarations
         Mycompare_0123456789876543210Sym0KindInference
     type instance Apply Mycompare_0123456789876543210Sym0 l = Mycompare_0123456789876543210Sym1 l
     instance PMyOrd NatFoo where
-      type Mycompare (a :: NatFoo) (a :: NatFoo) = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
+      type Mycompare a a = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
     data instance Sing (z :: NatFoo)
       where
         SZeroFoo :: Sing ZeroFoo

--- a/tests/compile-and-dump/Singletons/DataValues.ghc82.template
+++ b/tests/compile-and-dump/Singletons/DataValues.ghc82.template
@@ -80,7 +80,7 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
     instance PShow (Pair a b) where
-      type ShowsPrec (a :: GHC.Types.Nat) (a :: Pair a b) (a :: Symbol) = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     sAList :: Sing AListSym0
     sTuple :: Sing TupleSym0
     sComplex :: Sing ComplexSym0

--- a/tests/compile-and-dump/Singletons/EnumDeriving.ghc82.template
+++ b/tests/compile-and-dump/Singletons/EnumDeriving.ghc82.template
@@ -52,8 +52,8 @@ Singletons/EnumDeriving.hs:(0,0)-(0,0): Splicing declarations
         FromEnum_0123456789876543210Sym0KindInference
     type instance Apply FromEnum_0123456789876543210Sym0 l = FromEnum_0123456789876543210 l
     instance PEnum Foo where
-      type ToEnum (a :: GHC.Types.Nat) = Apply ToEnum_0123456789876543210Sym0 a
-      type FromEnum (a :: Foo) = Apply FromEnum_0123456789876543210Sym0 a
+      type ToEnum a = Apply ToEnum_0123456789876543210Sym0 a
+      type FromEnum a = Apply FromEnum_0123456789876543210Sym0 a
     data instance Sing (z :: Foo)
       where
         SBar :: Sing Bar
@@ -165,8 +165,8 @@ Singletons/EnumDeriving.hs:0:0:: Splicing declarations
         FromEnum_0123456789876543210Sym0KindInference
     type instance Apply FromEnum_0123456789876543210Sym0 l = FromEnum_0123456789876543210 l
     instance PEnum Quux where
-      type ToEnum (a :: GHC.Types.Nat) = Apply ToEnum_0123456789876543210Sym0 a
-      type FromEnum (a :: Quux) = Apply FromEnum_0123456789876543210Sym0 a
+      type ToEnum a = Apply ToEnum_0123456789876543210Sym0 a
+      type FromEnum a = Apply FromEnum_0123456789876543210Sym0 a
     instance SEnum Quux where
       sToEnum ::
         forall (t :: GHC.Types.Nat).

--- a/tests/compile-and-dump/Singletons/FunDeps.ghc82.template
+++ b/tests/compile-and-dump/Singletons/FunDeps.ghc82.template
@@ -69,8 +69,8 @@ Singletons/FunDeps.hs:(0,0)-(0,0): Splicing declarations
         L2r_0123456789876543210Sym0KindInference
     type instance Apply L2r_0123456789876543210Sym0 l = L2r_0123456789876543210 l
     instance PFD Bool Nat where
-      type Meth (a :: Bool) = Apply Meth_0123456789876543210Sym0 a
-      type L2r (a :: Bool) = Apply L2r_0123456789876543210Sym0 a
+      type Meth a = Apply Meth_0123456789876543210Sym0 a
+      type L2r a = Apply L2r_0123456789876543210Sym0 a
     sT1 :: Sing T1Sym0
     sT1 = (applySing ((singFun1 @MethSym0) sMeth)) STrue
     class SFD a b | a -> b where

--- a/tests/compile-and-dump/Singletons/Maybe.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Maybe.ghc82.template
@@ -52,7 +52,7 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
     instance PShow (Maybe a) where
-      type ShowsPrec (a :: GHC.Types.Nat) (a :: Maybe a) (a :: GHC.Types.Symbol) = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type family Equals_0123456789876543210 (a :: Maybe a) (b :: Maybe a) :: Bool where
       Equals_0123456789876543210 Nothing Nothing = TrueSym0
       Equals_0123456789876543210 (Just a) (Just b) = (:==) a b

--- a/tests/compile-and-dump/Singletons/Nat.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Nat.ghc82.template
@@ -98,7 +98,7 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
     instance PShow Nat where
-      type ShowsPrec (a :: GHC.Types.Nat) (a :: Nat) (a :: GHC.Types.Symbol) = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type family Equals_0123456789876543210 (a :: Nat) (b :: Nat) :: Bool where
       Equals_0123456789876543210 Zero Zero = TrueSym0
       Equals_0123456789876543210 (Succ a) (Succ b) = (:==) a b

--- a/tests/compile-and-dump/Singletons/OrdDeriving.ghc82.template
+++ b/tests/compile-and-dump/Singletons/OrdDeriving.ghc82.template
@@ -275,7 +275,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         Compare_0123456789876543210Sym0KindInference
     type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
     instance POrd Nat where
-      type Compare (a :: Nat) (a :: Nat) = Apply (Apply Compare_0123456789876543210Sym0 a) a
+      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type family Compare_0123456789876543210 (a :: Foo a b c d) (a :: Foo a b c d) :: Ordering where
       Compare_0123456789876543210 (A a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210) (A b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) '[]))))
       Compare_0123456789876543210 (B a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210) (B b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) '[]))))
@@ -335,7 +335,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         Compare_0123456789876543210Sym0KindInference
     type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
     instance POrd (Foo a b c d) where
-      type Compare (a :: Foo a b c d) (a :: Foo a b c d) = Apply (Apply Compare_0123456789876543210Sym0 a) a
+      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type family Equals_0123456789876543210 (a :: Nat) (b :: Nat) :: Bool where
       Equals_0123456789876543210 Zero Zero = TrueSym0
       Equals_0123456789876543210 (Succ a) (Succ b) = (:==) a b

--- a/tests/compile-and-dump/Singletons/PatternMatching.ghc82.template
+++ b/tests/compile-and-dump/Singletons/PatternMatching.ghc82.template
@@ -80,7 +80,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
     instance PShow (Pair a b) where
-      type ShowsPrec (a :: GHC.Types.Nat) (a :: Pair a b) (a :: Symbol) = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     sAList :: Sing AListSym0
     sTuple :: Sing TupleSym0
     sComplex :: Sing ComplexSym0

--- a/tests/compile-and-dump/Singletons/ShowDeriving.ghc82.template
+++ b/tests/compile-and-dump/Singletons/ShowDeriving.ghc82.template
@@ -166,7 +166,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
     instance PShow Foo1 where
-      type ShowsPrec (a :: GHC.Types.Nat) (a :: Foo1) (a :: Symbol) = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Foo2 a) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 p_0123456789876543210 (MkFoo2a arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (:>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (:.@#@$) (Apply ShowStringSym0 "MkFoo2a ")) (Apply (Apply (:.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (:.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
       ShowsPrec_0123456789876543210 p_0123456789876543210 (MkFoo2b argL_0123456789876543210 argR_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (:>@#@$) p_0123456789876543210) (FromInteger 5))) (Apply (Apply (:.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 6)) argL_0123456789876543210)) (Apply (Apply (:.@#@$) (Apply ShowStringSym0 " `MkFoo2b` ")) (Apply (Apply ShowsPrecSym0 (FromInteger 6)) argR_0123456789876543210)))) a_0123456789876543210
@@ -205,7 +205,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
     instance PShow (Foo2 a) where
-      type ShowsPrec (a :: GHC.Types.Nat) (a :: Foo2 a) (a :: Symbol) = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Foo3) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 p_0123456789876543210 (MkFoo3 arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (:>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (:.@#@$) (Apply ShowStringSym0 "MkFoo3 ")) (Apply (Apply (:.@#@$) (Apply ShowCharSym0 "{")) (Apply (Apply (:.@#@$) (Apply ShowStringSym0 "getFoo3a = ")) (Apply (Apply (:.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 0)) arg_0123456789876543210)) (Apply (Apply (:.@#@$) ShowCommaSpaceSym0) (Apply (Apply (:.@#@$) (Apply ShowStringSym0 "(***) = ")) (Apply (Apply (:.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 0)) arg_0123456789876543210)) (Apply ShowCharSym0 "}"))))))))) a_0123456789876543210
     type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: Foo3) (t :: Symbol) =
@@ -241,7 +241,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
     instance PShow Foo3 where
-      type ShowsPrec (a :: GHC.Types.Nat) (a :: Foo3) (a :: Symbol) = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     infixl 5 :%&:
     infixl 5 :%*:
     infixl 5 `SMkFoo2b`

--- a/tests/compile-and-dump/Singletons/StandaloneDeriving.ghc82.template
+++ b/tests/compile-and-dump/Singletons/StandaloneDeriving.ghc82.template
@@ -68,7 +68,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
         Compare_0123456789876543210Sym0KindInference
     type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
     instance POrd (T a ()) where
-      type Compare (a :: T a ()) (a :: T a ()) = Apply (Apply Compare_0123456789876543210Sym0 a) a
+      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: T a ()) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 p_0123456789876543210 ((:*:) argL_0123456789876543210 argR_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (:>@#@$) p_0123456789876543210) (FromInteger 6))) (Apply (Apply (:.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 7)) argL_0123456789876543210)) (Apply (Apply (:.@#@$) (Apply ShowStringSym0 " :*: ")) (Apply (Apply ShowsPrecSym0 (FromInteger 7)) argR_0123456789876543210)))) a_0123456789876543210
     type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: T a0123456789876543210 ()) (t :: Symbol) =
@@ -104,7 +104,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
     instance PShow (T a ()) where
-      type ShowsPrec (a :: GHC.Types.Nat) (a :: T a ()) (a :: Symbol) = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type family Compare_0123456789876543210 (a :: S) (a :: S) :: Ordering where
       Compare_0123456789876543210 S1 S1 = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) '[]
       Compare_0123456789876543210 S2 S2 = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) '[]
@@ -132,7 +132,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
         Compare_0123456789876543210Sym0KindInference
     type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
     instance POrd S where
-      type Compare (a :: S) (a :: S) = Apply (Apply Compare_0123456789876543210Sym0 a) a
+      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: S) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 _ S1 a_0123456789876543210 = Apply (Apply ShowStringSym0 "S1") a_0123456789876543210
       ShowsPrec_0123456789876543210 _ S2 a_0123456789876543210 = Apply (Apply ShowStringSym0 "S2") a_0123456789876543210
@@ -169,7 +169,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
     instance PShow S where
-      type ShowsPrec (a :: GHC.Types.Nat) (a :: S) (a :: Symbol) = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type family MinBound_0123456789876543210 :: S where
       = S1Sym0
     type MinBound_0123456789876543210Sym0 =
@@ -215,8 +215,8 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
         FromEnum_0123456789876543210Sym0KindInference
     type instance Apply FromEnum_0123456789876543210Sym0 l = FromEnum_0123456789876543210 l
     instance PEnum S where
-      type ToEnum (a :: GHC.Types.Nat) = Apply ToEnum_0123456789876543210Sym0 a
-      type FromEnum (a :: S) = Apply FromEnum_0123456789876543210Sym0 a
+      type ToEnum a = Apply ToEnum_0123456789876543210Sym0 a
+      type FromEnum a = Apply FromEnum_0123456789876543210Sym0 a
     type family Equals_0123456789876543210 (a :: T a ()) (b :: T a ()) :: Bool where
       Equals_0123456789876543210 ((:*:) a a) ((:*:) b b) = (:&&) ((:==) a b) ((:==) a b)
       Equals_0123456789876543210 (_ :: T a ()) (_ :: T a ()) = FalseSym0

--- a/tests/compile-and-dump/Singletons/Star.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Star.ghc82.template
@@ -91,7 +91,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
         Compare_0123456789876543210Sym0KindInference
     type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
     instance POrd Type where
-      type Compare (a :: Type) (a :: Type) = Apply (Apply Compare_0123456789876543210Sym0 a) a
+      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     instance (SOrd Type, SOrd Nat) => SOrd Type where
       sCompare ::
         forall (t1 :: Type) (t2 :: Type).

--- a/tests/compile-and-dump/Singletons/T136.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T136.ghc82.template
@@ -96,10 +96,10 @@ Singletons/T136.hs:(0,0)-(0,0): Splicing declarations
         FromEnum_0123456789876543210Sym0KindInference
     type instance Apply FromEnum_0123456789876543210Sym0 l = FromEnum_0123456789876543210 l
     instance PEnum [Bool] where
-      type Succ (a :: [Bool]) = Apply Succ_0123456789876543210Sym0 a
-      type Pred (a :: [Bool]) = Apply Pred_0123456789876543210Sym0 a
-      type ToEnum (a :: GHC.Types.Nat) = Apply ToEnum_0123456789876543210Sym0 a
-      type FromEnum (a :: [Bool]) = Apply FromEnum_0123456789876543210Sym0 a
+      type Succ a = Apply Succ_0123456789876543210Sym0 a
+      type Pred a = Apply Pred_0123456789876543210Sym0 a
+      type ToEnum a = Apply ToEnum_0123456789876543210Sym0 a
+      type FromEnum a = Apply FromEnum_0123456789876543210Sym0 a
     instance SEnum [Bool] where
       sSucc ::
         forall (t :: [Bool]).

--- a/tests/compile-and-dump/Singletons/T136b.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T136b.ghc82.template
@@ -38,7 +38,7 @@ Singletons/T136b.hs:(0,0)-(0,0): Splicing declarations
         Meth_0123456789876543210Sym0KindInference
     type instance Apply Meth_0123456789876543210Sym0 l = Meth_0123456789876543210 l
     instance PC Bool where
-      type Meth (a :: Bool) = Apply Meth_0123456789876543210Sym0 a
+      type Meth a = Apply Meth_0123456789876543210Sym0 a
     instance SC Bool where
       sMeth ::
         forall (t :: Bool).

--- a/tests/compile-and-dump/Singletons/T167.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T167.ghc82.template
@@ -113,7 +113,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
         FoosPrec_0123456789876543210Sym0KindInference
     type instance Apply FoosPrec_0123456789876543210Sym0 l = FoosPrec_0123456789876543210Sym1 l
     instance PFoo [a] where
-      type FoosPrec (a :: Nat) (a :: [a]) (a :: [Bool]) = Apply (Apply (Apply FoosPrec_0123456789876543210Sym0 a) a) a
+      type FoosPrec a a a = Apply (Apply (Apply FoosPrec_0123456789876543210Sym0 a) a) a
     class SFoo a where
       sFoosPrec ::
         forall (t :: Nat) (t :: a) (t :: [Bool]).

--- a/tests/compile-and-dump/Singletons/T178.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T178.ghc82.template
@@ -52,7 +52,7 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
         Compare_0123456789876543210Sym0KindInference
     type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
     instance POrd Occ where
-      type Compare (a :: Occ) (a :: Occ) = Apply (Apply Compare_0123456789876543210Sym0 a) a
+      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type family ShowsPrec_0123456789876543210 (a :: Nat) (a :: Occ) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 _ Str a_0123456789876543210 = Apply (Apply ShowStringSym0 "Str") a_0123456789876543210
       ShowsPrec_0123456789876543210 _ Opt a_0123456789876543210 = Apply (Apply ShowStringSym0 "Opt") a_0123456789876543210
@@ -90,7 +90,7 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
     instance PShow Occ where
-      type ShowsPrec (a :: Nat) (a :: Occ) (a :: Symbol) = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type family Equals_0123456789876543210 (a :: Occ) (b :: Occ) :: Bool where
       Equals_0123456789876543210 Str Str = TrueSym0
       Equals_0123456789876543210 Opt Opt = TrueSym0

--- a/tests/compile-and-dump/Singletons/T187.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T187.ghc82.template
@@ -32,7 +32,7 @@ Singletons/T187.hs:(0,0)-(0,0): Splicing declarations
         Compare_0123456789876543210Sym0KindInference
     type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
     instance POrd Empty where
-      type Compare (a :: Empty) (a :: Empty) = Apply (Apply Compare_0123456789876543210Sym0 a) a
+      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type family Equals_0123456789876543210 (a :: Empty) (b :: Empty) :: Bool where
       Equals_0123456789876543210 (_ :: Empty) (_ :: Empty) = TrueSym0
     instance PEq Empty where

--- a/tests/compile-and-dump/Singletons/T190.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T190.ghc82.template
@@ -32,7 +32,7 @@ Singletons/T190.hs:0:0:: Splicing declarations
         Compare_0123456789876543210Sym0KindInference
     type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
     instance POrd T where
-      type Compare (a :: T) (a :: T) = Apply (Apply Compare_0123456789876543210Sym0 a) a
+      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type family Case_0123456789876543210 n t where
       Case_0123456789876543210 n True = TSym0
       Case_0123456789876543210 n False = Apply ErrorSym0 "toEnum: bad argument"
@@ -63,8 +63,8 @@ Singletons/T190.hs:0:0:: Splicing declarations
         FromEnum_0123456789876543210Sym0KindInference
     type instance Apply FromEnum_0123456789876543210Sym0 l = FromEnum_0123456789876543210 l
     instance PEnum T where
-      type ToEnum (a :: GHC.Types.Nat) = Apply ToEnum_0123456789876543210Sym0 a
-      type FromEnum (a :: T) = Apply FromEnum_0123456789876543210Sym0 a
+      type ToEnum a = Apply ToEnum_0123456789876543210Sym0 a
+      type FromEnum a = Apply FromEnum_0123456789876543210Sym0 a
     type family MinBound_0123456789876543210 :: T where
       = TSym0
     type MinBound_0123456789876543210Sym0 =
@@ -111,7 +111,7 @@ Singletons/T190.hs:0:0:: Splicing declarations
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
     instance PShow T where
-      type ShowsPrec (a :: GHC.Types.Nat) (a :: T) (a :: GHC.Types.Symbol) = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type family Equals_0123456789876543210 (a :: T) (b :: T) :: Bool where
       Equals_0123456789876543210 T T = TrueSym0
       Equals_0123456789876543210 (_ :: T) (_ :: T) = FalseSym0


### PR DESCRIPTION
Now that [GHC Trac #9063](https://ghc.haskell.org/trac/ghc/ticket/9063) is fixed, we no longer need to put explicit kinds on the type variables in a promoted class instances' associated type family instances. Removing this hack simplifies the code slightly.

However, I opted not to remove the code that calculated the substitution needed for this hack entirely, since it does in fact serve a useful purpose outside of working around Trac #9063: it produces better kind signatures for helper type families used on the RHSes of these associated family instances. I added a Note explaining this.

Fixes #211.