### PR TITLE
GHC's brain is now explosion-proof

### DIFF
--- a/src/Data/Singletons/Single.hs
+++ b/src/Data/Singletons/Single.hs
@@ -461,13 +461,6 @@ data PatternContext = LetBinding
                     | Parameter
                     deriving Eq
 
-checkIfBrainWillExplode :: Monad m => PatternContext -> m ()
-checkIfBrainWillExplode CaseStatement = return ()
-checkIfBrainWillExplode Parameter = return ()
-checkIfBrainWillExplode _ =
-  fail $ "Can't use a singleton pattern outside of a case-statement or\n" ++
-         "do expression: GHC's brain will explode if you try. (Do try it!)"
-
 singPat :: Map Name Name   -- from term-level names to type-level names
         -> PatternContext
         -> DPat
@@ -481,7 +474,6 @@ singPat var_proms _patCxt (DVarPa name) = do
               Just tyname -> return tyname
   return $ DVarPa (singValName name) `DSigPa` (singFamily `DAppT` DVarT tyname)
 singPat var_proms patCxt (DConPa name pats) = do
-  checkIfBrainWillExplode patCxt
   pats' <- mapM (singPat var_proms patCxt) pats
   return $ DConPa (singDataConName name) pats'
 singPat var_proms patCxt (DTildePa pat) = do


### PR DESCRIPTION
Many mysteries surround the inner machinations of GHC's brain, but as of 8.2, one thing is sure: it will no longer explode. It might panic or become exhausted<sup>of simplifier ticks</sup>, but explosions ain't no thing.

As such, the `checkIfBrainWillExplode` check doesn't serve much of a useful purpose anymore. Let's axe it.

Fixes #210.