### PR TITLE
Rework Data.Singletons.TypeRepStar to use type-indexed Typeable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,6 +57,30 @@ next
   leverage the `SEq`, `SOrd`, `SNum`, `SEnum`, and `SBounded` instances,
   respectively, for the underlying `Sing`.
 
+* Rework the `Sing (a :: *)` instance in `Data.Singletons.TypeRepStar` such
+  that it now uses type-indexed `Typeable`. The new `Sing` instance is now:
+
+  ```haskell
+  newtype instance Sing (a :: *) where
+    STypeRep :: TypeRep a -> Sing a
+  ```
+
+  Accordingly, the `SingKind` instance has also been changed:
+
+  ```haskell
+  instance SingKind Type where
+    type Demote Type = SomeTypeRepStar
+    ...
+
+  data SomeTypeRepStar where
+    SomeTypeRepStar :: forall (a :: *). !(TypeRep a) -> SomeTypeRepStar
+  ```
+
+  Aside from cleaning up some implementation details, this change assures
+  that `toSing` can only be called on `TypeRep`s whose kind is of kind `*`.
+  The previous implementation did not enforce this, which could lead to
+  segfaults if used carelessly.
+
 2.3
 ---
 * Documentation clarifiation in `Data.Singletons.TypeLits`, thanks to @ivan-m.

--- a/README.md
+++ b/README.md
@@ -574,10 +574,10 @@ experiment with this feature have two options:
 making `*` the promoted version of `TypeRep`, as `TypeRep` is currently implemented.
 The singleton associated with `TypeRep` has one constructor:
 
-    data instance Sing (a :: *) where
-      STypeRep :: Typeable a => Sing a
+    newtype instance Sing (a :: *) where
+      STypeRep :: TypeRep a -> Sing a
 
-Thus, an implicit `TypeRep` is stored in the singleton constructor. However,
+Thus, a `TypeRep` is stored in the singleton constructor. However,
 any datatypes that store `TypeRep`s will not generally work as expected; the
 built-in promotion mechanism will not promote `TypeRep` to `*`.
 

--- a/src/Data/Singletons/TypeRepStar.hs
+++ b/src/Data/Singletons/TypeRepStar.hs
@@ -12,75 +12,71 @@
 -- Stability   :  experimental
 -- Portability :  non-portable
 --
--- This module defines singleton instances making 'Typeable' the singleton for
+-- This module defines singleton instances making 'TypeRep' the singleton for
 -- the kind @*@. The definitions don't fully line up with what is expected
 -- within the singletons library, so expect unusual results!
 --
 ----------------------------------------------------------------------------
 
 module Data.Singletons.TypeRepStar (
-  Sing(STypeRep)
+  Sing(STypeRep),
   -- | Here is the definition of the singleton for @*@:
   --
-  -- > data instance Sing (a :: *) where
-  -- >   STypeRep :: Typeable a => Sing a
+  -- > newtype instance Sing (a :: *) where
+  -- >   STypeRep :: TypeRep a -> Sing a
   --
   -- Instances for 'SingI', 'SingKind', 'SEq', 'SDecide', and 'TestCoercion' are
   -- also supplied.
+
+  SomeTypeRepStar(..)
   ) where
 
 import Data.Singletons.Prelude.Instances
 import Data.Singletons.Internal
 import Data.Singletons.Prelude.Eq
-import Data.Typeable
-import Unsafe.Coerce
 import Data.Singletons.Decide
+import Type.Reflection
+import Unsafe.Coerce
 
 import Data.Kind
-import GHC.Exts ( Proxy# )
 import Data.Type.Coercion
 import Data.Type.Equality
 
-data instance Sing (a :: *) where
-  STypeRep :: Typeable a => Sing a
+newtype instance Sing (a :: *) where
+  STypeRep :: TypeRep a -> Sing a
+
+-- | A variant of 'SomeTypeRep' whose underlying 'TypeRep' is restricted to
+-- kind @*@.
+data SomeTypeRepStar where
+  SomeTypeRepStar :: forall (a :: *). !(TypeRep a) -> SomeTypeRepStar
 
 instance Typeable a => SingI (a :: *) where
-  sing = STypeRep
+  sing = STypeRep typeRep
 instance SingKind Type where
-  type Demote Type = TypeRep
-  fromSing (STypeRep :: Sing a) = typeOf (undefined :: a)
-  toSing = dirty_mk_STypeRep
+  type Demote Type = SomeTypeRepStar
+  fromSing (STypeRep tr) = SomeTypeRepStar tr
+  toSing (SomeTypeRepStar tr) = SomeSing $ STypeRep tr
 
 instance PEq Type where
   type (a :: *) :== (b :: *) = a == b
 
 instance SEq Type where
-  (STypeRep :: Sing a) %:== (STypeRep :: Sing b) =
-    case (eqT :: Maybe (a :~: b)) of
-      Just Refl -> STrue
-      Nothing   -> unsafeCoerce SFalse
+  STypeRep tra %:== STypeRep trb =
+    case eqTypeRep tra trb of
+      Just HRefl -> STrue
+      Nothing    -> unsafeCoerce SFalse
                     -- the Data.Typeable interface isn't strong enough
                     -- to enable us to define this without unsafeCoerce
 
 instance SDecide Type where
-  (STypeRep :: Sing a) %~ (STypeRep :: Sing b) =
-    case (eqT :: Maybe (a :~: b)) of
-      Just Refl -> Proved Refl
-      Nothing   -> Disproved (\Refl -> error "Data.Typeable.eqT failed")
+  STypeRep tra %~ STypeRep trb =
+    case eqTypeRep tra trb of
+      Just HRefl -> Proved Refl
+      Nothing    -> Disproved (\Refl -> error "Type.Reflection.eqTypeRep failed")
 
 -- TestEquality instance already defined, but we need this one:
 instance TestCoercion Sing where
-  testCoercion (STypeRep :: Sing a) (STypeRep :: Sing b) =
-    case (eqT :: Maybe (a :~: b)) of
-      Just Refl -> Just Coercion
-      Nothing   -> Nothing
-
--- everything below here is private and dirty. Don't look!
-
-newtype DI = Don'tInstantiate (forall a. Typeable a => Sing a)
-dirty_mk_STypeRep :: TypeRep -> SomeSing *
-dirty_mk_STypeRep rep =
-  let justLikeTypeable :: Proxy# a -> TypeRep
-      justLikeTypeable _ = rep
-  in
-  unsafeCoerce (Don'tInstantiate STypeRep) justLikeTypeable
+  testCoercion (STypeRep tra) (STypeRep trb) =
+    case eqTypeRep tra trb of
+      Just HRefl -> Just Coercion
+      Nothing    -> Nothing


### PR DESCRIPTION
This leverages the power of the new type-indexed `TypeRep` in GHC 8.2 to make the `SingKind Type` kind-safe. Fixes #236.