### PR TITLE
Fix #208 by adding a ShowSing class

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,9 @@ next
 
 * Add promoted and singled versions of `Show`, including `deriving` support.
 
+* Add a `ShowSing` class, which facilitates the ability to write `Show` instances
+  for `Sing` instances.
+
 * Permit derived `Ord` instances for empty datatypes.
 
 * Permit standalone `deriving` declarations.

--- a/README.md
+++ b/README.md
@@ -213,12 +213,12 @@ addition, there is a `ShowSing` class provided in the
 `Show` instances for `Sing` instances.
 
 What is the difference between the two? Let's use the `False` constructor as an
-example. If you used the `PShow Bool`, then the output of calling `Show_` on
-`False` is `"False"`, much like the value-level `Show Bool` instance (similarly
-for the `SShow Bool` instance). However, the `ShowSing Bool` instance is
-intended for printing the value of the _singleton_ constructor `SFalse`, so
-calling `showsSingPrec 0 SFalse` yields `"SFalse"` (simiarly for the
-`Show (Sing (SBool z))` instance).
+example. If you used the `PShow Bool` instance, then the output of calling
+`Show_` on `False` is `"False"`, much like the value-level `Show Bool` instance
+(similarly for the `SShow Bool` instance). However, the `ShowSing Bool`
+instance is intended for printing the value of the _singleton_ constructor
+`SFalse`, so calling `showsSingPrec 0 SFalse` yields `"SFalse"` (simiarly for
+the `Show (Sing (SBool z))` instance).
 
 Instance of `PShow`, `SShow`, `ShowSing`, and `Show` (for the singleton type)
 are generated when `singletons` is called on a datatype that has

--- a/README.md
+++ b/README.md
@@ -203,6 +203,36 @@ on a datatype that has `deriving Eq`. You can also generate these instances
 directly through functions exported from `Data.Singletons.TH`.
 
 
+`Show` classes
+--------------
+
+Promoted and singled versions of the `Show` class (`PShow` and `SShow`,
+respectively) are provided in the `Data.Singletons.Prelude.Show` module. In
+addition, there is a `ShowSing` class provided in the
+`Data.Singletons.ShowSing` module, which facilitates the ability to write
+`Show` instances for `Sing` instances.
+
+What is the difference between the two? Let's use the `False` constructor as an
+example. If you used the `PShow Bool`, then the output of calling `Show_` on
+`False` is `"False"`, much like the value-level `Show Bool` instance (similarly
+for the `SShow Bool` instance). However, the `ShowSing Bool` instance is
+intended for printing the value of the _singleton_ constructor `SFalse`, so
+calling `showsSingPrec 0 SFalse` yields `"SFalse"` (simiarly for the
+`Show (Sing (SBool z))` instance).
+
+Instance of `PShow`, `SShow`, `ShowSing`, and `Show` (for the singleton type)
+are generated when `singletons` is called on a datatype that has
+`deriving Show`. You can also generate these instances directly through
+functions exported from `Data.Singletons.TH`.
+
+A promoted and singled `Show` instance is provided for `Symbol`, but it is only
+a crude approximation of the value-level `Show` instance for `String`. On the
+value level, showing `String`s escapes special characters (such as double
+quotes), but implementing this requires pattern-matching on character literals,
+something which is currently impossible at the type level. As a consequence, the
+type-level `Show` instance for `Symbol`s does not do any character escaping.
+
+
 Pre-defined singletons
 ----------------------
 
@@ -587,13 +617,6 @@ use the promoted definition, but not the original, term-level one.
 This is the same line of reasoning that forbids the use of `Nat` or `Symbol`
 in datatype definitions. But, see [this bug
 report](https://github.com/goldfirere/singletons/issues/76) for a workaround.
-
-A promoted and singled `Show` instance is provided for `Symbol`, but it is only
-a crude approximation of the value-level `Show` instance for `String`. On the
-value level, showing `String`s escapes special characters (such as double
-quotes), but implementing this requires pattern-matching on character literals,
-something which is currently impossible at the type level. As a consequence, the
-type-level `Show` instance for `Symbol`s does not do any character escaping.
 
 Support for `*`
 ---------------

--- a/singletons.cabal
+++ b/singletons.cabal
@@ -93,6 +93,7 @@ library
                       Data.Promotion.Prelude.Void,
                       Data.Singletons.TypeLits,
                       Data.Singletons.Decide,
+                      Data.Singletons.ShowSing,
                       Data.Singletons.SuppressUnusedWarnings
 
   other-modules:      Data.Singletons.Deriving.Infer,

--- a/src/Data/Singletons.hs
+++ b/src/Data/Singletons.hs
@@ -64,6 +64,7 @@ import Data.Singletons.Prelude.Enum
 import Data.Singletons.Prelude.Eq
 import Data.Singletons.Prelude.Ord
 import Data.Singletons.Prelude.Num
+import Data.Singletons.ShowSing
 
 ----------------------------------------------------------------------
 ---- SomeSing instances ----------------------------------------------
@@ -102,3 +103,7 @@ instance SNum k => Num (SomeSing k) where
   abs    (SomeSing a) = SomeSing (sAbs a)
   signum (SomeSing a) = SomeSing (sSignum a)
   fromInteger n = withSomeSing (fromIntegral n) (SomeSing . sFromInteger)
+
+instance ShowSing k => Show (SomeSing k) where
+  showsPrec p (SomeSing s) =
+    showParen (p > 10) $ showString "SomeSing " . showsSingPrec 11 s

--- a/src/Data/Singletons/CustomStar.hs
+++ b/src/Data/Singletons/CustomStar.hs
@@ -76,7 +76,7 @@ singletonStar names = do
   fakeCtors <- zipWithM (mkCtor False) names kinds
   let dataDecl = DataDecl Data repName [] fakeCtors
                           [DConPr ''Show, DConPr ''Read]
-      dataDeclEqInst = DerivedEqDecl Nothing (DConT repName) fakeCtors
+      dataDeclEqInst = DerivedDecl Nothing (DConT repName) fakeCtors
   ordInst <- mkOrdInstance Nothing (DConT repName) fakeCtors
   (pOrdInst, promDecls) <- promoteM [] $ do promoteDataDec dataDecl
                                             promoteDerivedEqDec dataDeclEqInst

--- a/src/Data/Singletons/Deriving/Show.hs
+++ b/src/Data/Singletons/Deriving/Show.hs
@@ -11,70 +11,93 @@
 --
 ----------------------------------------------------------------------------
 {-# LANGUAGE ScopedTypeVariables #-}
-module Data.Singletons.Deriving.Show (mkShowInstance) where
+module Data.Singletons.Deriving.Show (
+    mkShowInstance
+  , ShowMode(..)
+  , mkShowContext
+  ) where
 
 import Language.Haskell.TH.Syntax hiding (showName)
-import Language.Haskell.TH.Ppr (pprint)
 import Language.Haskell.TH.Desugar
 import Data.Singletons.Names
 import Data.Singletons.Util
 import Data.Singletons.Syntax
 import Data.Singletons.Deriving.Infer
-import Control.Monad (when)
 import Data.Maybe (fromMaybe)
 import GHC.Lexeme (startsConSym, startsVarSym)
 import GHC.Show (appPrec, appPrec1)
 
-mkShowInstance :: DsMonad q => Maybe DCxt -> DType -> [DCon] -> q UInstDecl
-mkShowInstance mb_ctxt ty cons = do
-  when (null cons) $
-    fail ("Can't derive Show instance for " ++ pprint (typeToTH ty) ++ ".")
-  clauses <- mk_showsPrec cons
-  return $ InstDecl { id_cxt = inferConstraintsDef mb_ctxt (DConPr showName) cons
-                    , id_name = showName
+mkShowInstance :: DsMonad q
+               => ShowMode -> Maybe DCxt -> DType -> [DCon]
+               -> q UInstDecl
+mkShowInstance mode mb_ctxt ty cons = do
+  clauses <- mk_showsPrec mode cons
+  return $ InstDecl { id_cxt = inferConstraintsDef (fmap (mkShowContext mode) mb_ctxt)
+                                                   (DConPr (mk_Show_name mode))
+                                                   cons
+                    , id_name = mk_Show_name mode
                     , id_arg_tys = [ty]
-                    , id_meths = [ (showsPrecName, UFunction clauses) ] }
+                    , id_meths = [ (mk_showsPrec_name mode, UFunction clauses) ] }
 
-mk_showsPrec :: DsMonad q => [DCon] -> q [DClause]
-mk_showsPrec cons = do
+mk_showsPrec :: DsMonad q => ShowMode -> [DCon] -> q [DClause]
+mk_showsPrec mode cons = do
     p <- newUniqueName "p" -- The precedence argument (not always used)
-    mapM (mk_showsPrec_clause p) cons
+    if null cons
+       then do v <- newUniqueName "v"
+               pure [DClause [DWildPa, DVarPa v] (DCaseE (DVarE v) [])]
+       else mapM (mk_showsPrec_clause mode p) cons
 
-mk_showsPrec_clause :: forall q. DsMonad q => Name -> DCon -> q DClause
-mk_showsPrec_clause p (DCon _ _ con_name con_fields _) = go con_fields
+mk_showsPrec_clause :: forall q. DsMonad q
+                    => ShowMode -> Name -> DCon
+                    -> q DClause
+mk_showsPrec_clause mode p (DCon _ _ con_name con_fields _) = go con_fields
   where
+    con_name' :: Name
+    con_name' = case mode of
+                  ForPromotion -> con_name
+                  ForShowSing  -> singDataConName con_name
+
     go :: DConFields -> q DClause
 
     -- No fields: print just the constructor name, with no parentheses
     go (DNormalC _ []) = return $
-      DClause [DWildPa, DConPa con_name []] $
-        DVarE showStringName `DAppE` dStringE (parenInfixConName con_name "")
+      DClause [DWildPa, DConPa con_name' []] $
+        DVarE showStringName `DAppE` dStringE (parenInfixConName con_name' "")
 
     -- Infix constructors have special Show treatment.
-    go (DNormalC True [_, _]) = do
-      argL <- newUniqueName "argL"
-      argR <- newUniqueName "argR"
-      fi <- fromMaybe defaultFixity <$> reifyFixityWithLocals con_name
-      let con_prec = case fi of Fixity prec _ -> prec
-          op_name  = nameBase con_name
-          infixOpE = DAppE (DVarE showStringName) . dStringE $
-                       if isInfixDataCon op_name
-                          then " "  ++ op_name ++ " "
-                          -- Make sure to handle infix data constructors
-                          -- like (Int `Foo` Int)
-                          else " `" ++ op_name ++ "` "
-      return $ DClause [DVarPa p, DConPa con_name [DVarPa argL, DVarPa argR]] $
-        (DVarE showParenName `DAppE` (DVarE gtName `DAppE` DVarE p
-                                                   `DAppE` dIntegerE con_prec))
-          `DAppE` (DVarE composeName
-                     `DAppE` showsPrecE (con_prec + 1) argL
-                     `DAppE` (DVarE composeName
-                                `DAppE` infixOpE
-                                `DAppE` showsPrecE (con_prec + 1) argR))
+    go (DNormalC True tys@[_, _])
+        -- Although the (:) constructor is infix, its singled counterpart SCons
+        -- is not, which matters if we're deriving a ShowSing instance.
+        -- Unless we remove this special case (see #234), we will simply
+        -- shunt it along as if we were dealing with a prefix constructor.
+      | ForShowSing <- mode
+      , con_name == consName
+      = go (DNormalC False tys)
+
+      | otherwise
+      = do argL <- newUniqueName "argL"
+           argR <- newUniqueName "argR"
+           fi <- fromMaybe defaultFixity <$> reifyFixityWithLocals con_name'
+           let con_prec = case fi of Fixity prec _ -> prec
+               op_name  = nameBase con_name'
+               infixOpE = DAppE (DVarE showStringName) . dStringE $
+                            if isInfixDataCon op_name
+                               then " "  ++ op_name ++ " "
+                               -- Make sure to handle infix data constructors
+                               -- like (Int `Foo` Int)
+                               else " `" ++ op_name ++ "` "
+           return $ DClause [DVarPa p, DConPa con_name' [DVarPa argL, DVarPa argR]] $
+             (DVarE showParenName `DAppE` (DVarE gtName `DAppE` DVarE p
+                                                        `DAppE` dIntegerE con_prec))
+               `DAppE` (DVarE composeName
+                          `DAppE` showsPrecE mode (con_prec + 1) argL
+                          `DAppE` (DVarE composeName
+                                     `DAppE` infixOpE
+                                     `DAppE` showsPrecE mode (con_prec + 1) argR))
 
     go (DNormalC _ tys) = do
       args <- mapM (const $ newUniqueName "arg") tys
-      let show_args     = map (showsPrecE appPrec1) args
+      let show_args     = map (showsPrecE mode appPrec1) args
           composed_args = foldr1 (\v q -> DVarE composeName
                                            `DAppE` v
                                            `DAppE` (DVarE composeName
@@ -82,9 +105,9 @@ mk_showsPrec_clause p (DCon _ _ con_name con_fields _) = go con_fields
                                                      `DAppE` q)) show_args
           named_args = DVarE composeName
                          `DAppE` (DVarE showStringName
-                                   `DAppE` dStringE (parenInfixConName con_name " "))
+                                   `DAppE` dStringE (parenInfixConName con_name' " "))
                          `DAppE` composed_args
-      return $ DClause [DVarPa p, DConPa con_name $ map DVarPa args] $
+      return $ DClause [DVarPa p, DConPa con_name' $ map DVarPa args] $
         DVarE showParenName
           `DAppE` (DVarE gtName `DAppE` DVarE p `DAppE` dIntegerE appPrec)
           `DAppE` named_args
@@ -97,24 +120,27 @@ mk_showsPrec_clause p (DCon _ _ con_name con_fields _) = go con_fields
       args <- mapM (const $ newUniqueName "arg") tys
       let show_args =
             concatMap (\((arg_name, _, _), arg) ->
-                        let arg_nameBase = nameBase arg_name
+                        let arg_name'    = case mode of
+                                             ForPromotion -> arg_name
+                                             ForShowSing  -> singValName arg_name
+                            arg_nameBase = nameBase arg_name'
                             infix_rec    = showParen (isSym arg_nameBase)
                                                      (showString arg_nameBase) ""
                         in [ DVarE showStringName `DAppE` dStringE (infix_rec ++ " = ")
-                           , showsPrecE 0 arg
+                           , showsPrecE mode 0 arg
                            , DVarE showCommaSpaceName
                            ])
                       (zip tys args)
-          brace_comma_args =   (DVarE showCharName `DAppE` dStringE "{")
+          brace_comma_args =   (DVarE showCharName `DAppE` dCharE mode '{')
                              : take (length show_args - 1) show_args
           composed_args = foldr (\x y -> DVarE composeName `DAppE` x `DAppE` y)
-                                (DVarE showCharName `DAppE` dStringE "}")
+                                (DVarE showCharName `DAppE` dCharE mode '}')
                                 brace_comma_args
           named_args = DVarE composeName
                          `DAppE` (DVarE showStringName
-                                   `DAppE` dStringE (parenInfixConName con_name " "))
+                                   `DAppE` dStringE (parenInfixConName con_name' " "))
                          `DAppE` composed_args
-      return $ DClause [DVarPa p, DConPa con_name $ map DVarPa args] $
+      return $ DClause [DVarPa p, DConPa con_name' $ map DVarPa args] $
         DVarE showParenName
           `DAppE` (DVarE gtName `DAppE` DVarE p `DAppE` dIntegerE appPrec)
           `DAppE` named_args
@@ -126,8 +152,17 @@ parenInfixConName conName =
     let conNameBase = nameBase conName
     in showParen (isInfixDataCon conNameBase) $ showString conNameBase
 
-showsPrecE :: Int -> Name -> DExp
-showsPrecE prec n = DVarE showsPrecName `DAppE` dIntegerE prec `DAppE` DVarE n
+showsPrecE :: ShowMode -> Int -> Name -> DExp
+showsPrecE mode prec n = DVarE (mk_showsPrec_name mode) `DAppE` dIntegerE prec `DAppE` DVarE n
+
+dCharE :: ShowMode -> Char -> DExp
+dCharE mode = DLitE . to_lit
+  where
+    to_lit :: Char -> Lit
+    to_lit c = case mode of
+                 ForPromotion -> StringL [c] -- There aren't type-level characters yet,
+                                             -- so fake it with a string
+                 ForShowSing  -> CharL c
 
 dStringE :: String -> DExp
 dStringE = DLitE . StringL
@@ -138,3 +173,32 @@ dIntegerE = DLitE . IntegerL . fromIntegral
 isSym :: String -> Bool
 isSym ""      = False
 isSym (c : _) = startsVarSym c || startsConSym c
+
+-----
+-- ShowMode
+-----
+
+-- | Is a 'Show' instance being generated to be promoted/singled, or is it
+-- being generated to create a @ShowSing@/'Show' instance for a singleton type?
+data ShowMode = ForPromotion -- ^ For promotion/singling
+              | ForShowSing  -- ^ For a @ShowSing@/'Show' instance
+
+-- | Turn a context like @('Show' a, 'Show' b)@ into @('ShowSing' a, 'ShowSing' b)@.
+-- This is necessary for standalone-derived instances.
+mkShowContext :: ShowMode -> DCxt -> DCxt
+mkShowContext ForPromotion = id
+mkShowContext ForShowSing  = map show_to_SingShow
+  where
+    show_to_SingShow :: DPred -> DPred
+    show_to_SingShow = modifyConNameDPred $ \n ->
+                         if n == showName
+                            then showSingName
+                            else n
+
+mk_Show_name :: ShowMode -> Name
+mk_Show_name ForPromotion = showName
+mk_Show_name ForShowSing  = showSingName
+
+mk_showsPrec_name :: ShowMode -> Name
+mk_showsPrec_name ForPromotion = showsPrecName
+mk_showsPrec_name ForShowSing  = showsSingPrecName

--- a/src/Data/Singletons/Names.hs
+++ b/src/Data/Singletons/Names.hs
@@ -40,7 +40,8 @@ boolName, andName, tyEqName, compareName, minBoundName,
   singletonsToEnumName, singletonsFromEnumName, enumName, singletonsEnumName,
   equalsName, constraintName,
   showName, showCharName, showCommaSpaceName, showParenName, showsPrecName,
-  showSpaceName, showStringName, composeName, gtName :: Name
+  showSpaceName, showStringName, showSingName, showsSingPrecName,
+  composeName, gtName :: Name
 boolName = ''Bool
 andName = '(&&)
 compareName = 'compare
@@ -109,6 +110,8 @@ showParenName = 'showParen
 showSpaceName = 'showSpace
 showsPrecName = 'showsPrec
 showStringName = 'showString
+showSingName = mk_name_tc "Data.Singletons.ShowSing" "ShowSing"
+showsSingPrecName = mk_name_v "Data.Singletons.ShowSing" "showsSingPrec"
 composeName = '(.)
 gtName = '(>)
 showCommaSpaceName = 'showCommaSpace
@@ -284,6 +287,16 @@ splitUnderscores :: String -> Maybe (String, String)
 splitUnderscores s = case span (== '_') s of
                        ([], _) -> Nothing
                        res     -> Just res
+
+-- Walk a DPred, applying a function to all occurrences of constructor names.
+modifyConNameDPred :: (Name -> Name) -> DPred -> DPred
+modifyConNameDPred mod_con_name = go
+  where
+    go (DAppPr p t)  = DAppPr (go p) t
+    go (DSigPr p k)  = DSigPr (go p) k
+    go p@(DVarPr _)  = p
+    go (DConPr n)    = DConPr (mod_con_name n)
+    go p@DWildCardPr = p
 
 {-
 Note [Defunctionalization symbol suffixes]

--- a/src/Data/Singletons/Prelude/Show.hs
+++ b/src/Data/Singletons/Prelude/Show.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE PolyKinds #-}
@@ -58,7 +59,6 @@ import           Data.Singletons.Prelude.Base
 import           Data.Singletons.Prelude.Instances
 import           Data.Singletons.Prelude.List
 import           Data.Singletons.Prelude.Ord
-import           Data.Singletons.Prelude.Void
 import           Data.Singletons.Promote
 import           Data.Singletons.Single
 import           Data.Singletons.TypeLits
@@ -154,9 +154,6 @@ $(singletonsOnly [d|
           => Show (a,b,c,d,e,f,g) where
     showsPrec _ (a,b,c,d,e,f,g) s
           = show_tuple [shows a, shows b, shows c, shows d, shows e, shows f, shows g] s
-
-  instance Show Void where
-    showsPrec _ = absurd
   |])
 
 $(promoteOnly [d|
@@ -193,4 +190,5 @@ instance SShow Nat where
 show_ :: P.Show a => a -> String
 show_ = P.show
 
-$(singShowInstances [ ''(), ''Maybe, ''Either, ''NonEmpty, ''Bool, ''Ordering ])
+$(singShowInstances [ ''(), ''Maybe, ''Either, ''NonEmpty, ''Bool,
+                      ''Ordering, ''Void ])

--- a/src/Data/Singletons/ShowSing.hs
+++ b/src/Data/Singletons/ShowSing.hs
@@ -1,0 +1,117 @@
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeInType #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Singletons.Showsing
+-- Copyright   :  (C) 2017 Ryan Scot
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Defines the class 'ShowSing', allowing for conversion of 'Sing' values to
+-- readable 'String's.
+--
+----------------------------------------------------------------------------
+
+module Data.Singletons.ShowSing (
+  -- * The 'ShowSing' class
+  ShowSing(..),
+  ) where
+
+import Data.Singletons.Internal
+import Data.Singletons.Prelude.Instances
+import Data.Singletons.Single
+import Data.Singletons.TypeLits.Internal
+import Data.Singletons.Util
+
+import GHC.Show (appPrec, appPrec1)
+import GHC.TypeLits (symbolVal)
+import qualified GHC.TypeNats as TN (natVal)
+
+----------------------------------------------------------------------
+---- ShowSing --------------------------------------------------------
+----------------------------------------------------------------------
+
+-- | Members of the 'ShowSing' kind class can have their 'Sing' values
+-- converted to 'String's in a fashion similar to that of the 'Show' class.
+-- (In fact, this class only exists because one cannot write 'Show' instances
+-- for 'Sing's of the form
+-- @instance (forall z. Show (Sing (z :: k))) => Show (Sing (x :: [k]))@.)
+--
+-- This class should not be confused with the promoted or singled versions of
+-- 'Show' from "Data.Singletons.Prelude.Show" (@PShow@ and @SShow@, respectively).
+-- The output of 'ShowSing' is intended to reflect the singleton type, whereas
+-- the output of @PShow@ and @SShow@ reflects the original type. That is, showing
+-- @SFalse@ with 'ShowSing' would yield @\"SFalse\"@, whereas @PShow@ and @SShow@
+-- would yield @\"False\"@.
+--
+-- Instances of this class are generated alongside singleton definitions for
+-- datatypes that derive a 'Show' instance. Moreover, having a 'ShowSing'
+-- instances makes it simple to define a 'Show' instance. For instance:
+--
+-- @
+-- instance 'ShowSing' a => 'ShowSing' [a] where
+--   'showsSingPrec' = ...
+-- instance 'ShowSing' a => 'Show' ('Sing' (x :: [a])) where
+--   'showsPrec' = 'showsSingPrec'
+-- @
+--
+-- As a result, singleton definitions for datatypes that derive a 'Show'
+-- instance also get a 'Show' instance for the singleton type as well
+-- (in addition to promoted and singled 'Show' instances).
+--
+-- To recap: 'singletons' will give you all of these for a datatype that derives
+-- a 'Show' instance:
+--
+-- * A promoted (@PShow@) instance
+-- * A singled (@SShow@) instance
+-- * A 'ShowSing' instance for the singleton type
+-- * A 'Show' instance for the singleton type
+--
+-- What a bargain!
+class ShowSing k where
+  -- | @'showsSingPrec' p s@ convert a 'Sing' value @p@ to a readable 'String'
+  -- with precedence @p@.
+  showsSingPrec :: Int -> Sing (a :: k) -> ShowS
+
+------------------------------------------------------------
+-- TypeLits instances
+------------------------------------------------------------
+
+-- These are a bit special because the singleton constructor does not uniquely
+-- determine the type being used in the constructor's return type (e.g., all Nats
+-- have the same singleton constructor, SNat). To compensate for this, we display
+-- the type being used using visible type application. (Thanks to @cumber on #179
+-- for suggesting this implementation.)
+
+instance ShowSing Nat where
+  showsSingPrec p n@SNat
+    = showParen (p > appPrec)
+      ( showString "SNat @"
+        . showsPrec appPrec1 (TN.natVal n)
+      )
+instance Show (SNat n) where
+  showsPrec = showsSingPrec
+
+instance ShowSing Symbol where
+  showsSingPrec p s@SSym
+    = showParen (p > appPrec)
+      ( showString "SSym @"
+        . showsPrec appPrec1 (symbolVal s)
+      )
+instance Show (SSymbol s) where
+  showsPrec = showsSingPrec
+
+------------------------------------------------------------
+-- Template Haskell-generated instances
+------------------------------------------------------------
+
+$(showSingInstances basicTypes)

--- a/src/Data/Singletons/TypeLits.hs
+++ b/src/Data/Singletons/TypeLits.hs
@@ -49,6 +49,7 @@ import Data.Singletons.Internal
 import Data.Singletons.Prelude.Num
 import Data.Singletons.Prelude.Tuple
 import Data.Singletons.Promote
+import Data.Singletons.ShowSing ()      -- for ShowSing/Show instances
 import Data.Singletons.TypeLits.Internal
 
 import qualified GHC.TypeNats as TN

--- a/src/Data/Singletons/TypeLits/Internal.hs
+++ b/src/Data/Singletons/TypeLits/Internal.hs
@@ -199,28 +199,3 @@ sa %<> sb =
 infixr 6 %<>
 
 $(genDefunSymbols [''(<>)])
-
-------------------------------------------------------------
--- TypeLits singleton non-singleton instances
-------------------------------------------------------------
-
--- Thanks to @cumber on #179
-
-instance Show (SNat n) where
-  showsPrec p n@SNat
-    = showParen (p > atPrec)
-      ( showString "SNat @"
-        . showsPrec (atPrec + 1) (TN.natVal n)
-      )
-    where atPrec = 10
-
-instance Show (SSymbol s) where
-  showsPrec p s@SSym
-    = showParen (p > atPrec)
-      ( showString "SSym @"
-        . showsPrec (atPrec + 1) (symbolVal s)
-      )
-    where atPrec = 10
-
-deriving instance Show (SomeSing Nat)
-deriving instance Show (SomeSing Symbol)

--- a/src/Data/Singletons/TypeRepStar.hs
+++ b/src/Data/Singletons/TypeRepStar.hs
@@ -35,6 +35,7 @@ import Data.Singletons.Prelude.Instances
 import Data.Singletons.Internal
 import Data.Singletons.Prelude.Eq
 import Data.Singletons.Decide
+import Data.Singletons.ShowSing
 import Type.Reflection
 import Unsafe.Coerce
 
@@ -45,6 +46,7 @@ import Data.Type.Equality ((:~:)(..))
 
 newtype instance Sing (a :: *) where
   STypeRep :: TypeRep a -> Sing a
+    deriving Show
 
 -- | A variant of 'SomeTypeRep' whose underlying 'TypeRep' is restricted to
 -- kind @*@.
@@ -74,6 +76,9 @@ instance SDecide Type where
     case eqTypeRep tra trb of
       Just HRefl -> Proved Refl
       Nothing    -> Disproved (\Refl -> error "Type.Reflection.eqTypeRep failed")
+
+instance ShowSing Type where
+  showsSingPrec = showsPrec
 
 -- TestEquality instance already defined, but we need this one:
 instance TestCoercion Sing where

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -72,7 +72,7 @@ tests =
     , compileAndDumpStdTest "T187"
     , compileAndDumpStdTest "T190"
     , compileAndDumpStdTest "ShowDeriving"
-    , compileAndDumpStdTest "BadShowDeriving"
+    , compileAndDumpStdTest "EmptyShowDeriving"
     , compileAndDumpStdTest "StandaloneDeriving"
     , compileAndDumpStdTest "T197"
     , compileAndDumpStdTest "T197b"

--- a/tests/compile-and-dump/GradingClient/Database.ghc82.template
+++ b/tests/compile-and-dump/GradingClient/Database.ghc82.template
@@ -2443,6 +2443,57 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       (%~) SCZ SCX = Disproved (\ x -> case x of)
       (%~) SCZ SCY = Disproved (\ x -> case x of)
       (%~) SCZ SCZ = Proved Refl
+    instance (Data.Singletons.ShowSing.ShowSing U,
+              Data.Singletons.ShowSing.ShowSing Nat) =>
+             Data.Singletons.ShowSing.ShowSing U where
+      Data.Singletons.ShowSing.showsSingPrec _ SBOOL = showString "SBOOL"
+      Data.Singletons.ShowSing.showsSingPrec _ SSTRING
+        = showString "SSTRING"
+      Data.Singletons.ShowSing.showsSingPrec _ SNAT = showString "SNAT"
+      Data.Singletons.ShowSing.showsSingPrec
+        p_0123456789876543210
+        (SVEC arg_0123456789876543210 arg_0123456789876543210)
+        = (showParen (((>) p_0123456789876543210) 10))
+            (((.) (showString "SVEC "))
+               (((.)
+                   ((Data.Singletons.ShowSing.showsSingPrec 11)
+                      arg_0123456789876543210))
+                  (((.) GHC.Show.showSpace)
+                     ((Data.Singletons.ShowSing.showsSingPrec 11)
+                        arg_0123456789876543210))))
+    instance (Data.Singletons.ShowSing.ShowSing U,
+              Data.Singletons.ShowSing.ShowSing Nat) =>
+             Show (Sing (z :: U)) where
+      showsPrec = Data.Singletons.ShowSing.showsSingPrec
+    instance Data.Singletons.ShowSing.ShowSing AChar where
+      Data.Singletons.ShowSing.showsSingPrec _ SCA = showString "SCA"
+      Data.Singletons.ShowSing.showsSingPrec _ SCB = showString "SCB"
+      Data.Singletons.ShowSing.showsSingPrec _ SCC = showString "SCC"
+      Data.Singletons.ShowSing.showsSingPrec _ SCD = showString "SCD"
+      Data.Singletons.ShowSing.showsSingPrec _ SCE = showString "SCE"
+      Data.Singletons.ShowSing.showsSingPrec _ SCF = showString "SCF"
+      Data.Singletons.ShowSing.showsSingPrec _ SCG = showString "SCG"
+      Data.Singletons.ShowSing.showsSingPrec _ SCH = showString "SCH"
+      Data.Singletons.ShowSing.showsSingPrec _ SCI = showString "SCI"
+      Data.Singletons.ShowSing.showsSingPrec _ SCJ = showString "SCJ"
+      Data.Singletons.ShowSing.showsSingPrec _ SCK = showString "SCK"
+      Data.Singletons.ShowSing.showsSingPrec _ SCL = showString "SCL"
+      Data.Singletons.ShowSing.showsSingPrec _ SCM = showString "SCM"
+      Data.Singletons.ShowSing.showsSingPrec _ SCN = showString "SCN"
+      Data.Singletons.ShowSing.showsSingPrec _ SCO = showString "SCO"
+      Data.Singletons.ShowSing.showsSingPrec _ SCP = showString "SCP"
+      Data.Singletons.ShowSing.showsSingPrec _ SCQ = showString "SCQ"
+      Data.Singletons.ShowSing.showsSingPrec _ SCR = showString "SCR"
+      Data.Singletons.ShowSing.showsSingPrec _ SCS = showString "SCS"
+      Data.Singletons.ShowSing.showsSingPrec _ SCT = showString "SCT"
+      Data.Singletons.ShowSing.showsSingPrec _ SCU = showString "SCU"
+      Data.Singletons.ShowSing.showsSingPrec _ SCV = showString "SCV"
+      Data.Singletons.ShowSing.showsSingPrec _ SCW = showString "SCW"
+      Data.Singletons.ShowSing.showsSingPrec _ SCX = showString "SCX"
+      Data.Singletons.ShowSing.showsSingPrec _ SCY = showString "SCY"
+      Data.Singletons.ShowSing.showsSingPrec _ SCZ = showString "SCZ"
+    instance Show (Sing (z :: AChar)) where
+      showsPrec = Data.Singletons.ShowSing.showsSingPrec
     instance SingI BOOL where
       sing = SBOOL
     instance SingI STRING where

--- a/tests/compile-and-dump/Singletons/BadShowDeriving.ghc82.template
+++ b/tests/compile-and-dump/Singletons/BadShowDeriving.ghc82.template
@@ -1,6 +1,0 @@
-
-Singletons/BadShowDeriving.hs:0:0: error:
-    Can't derive Show instance for Foo_0.
-  |
-5 | $(singletons [d| data Foo deriving Show |])
-  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/compile-and-dump/Singletons/BadShowDeriving.hs
+++ b/tests/compile-and-dump/Singletons/BadShowDeriving.hs
@@ -1,5 +1,0 @@
-module Singletons.BadShowDeriving where
-
-import Data.Singletons.TH
-
-$(singletons [d| data Foo deriving Show |])

--- a/tests/compile-and-dump/Singletons/DataValues.ghc82.template
+++ b/tests/compile-and-dump/Singletons/DataValues.ghc82.template
@@ -168,5 +168,23 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
                                 (sFromInteger (sing :: Sing 11))))
                             sArg_0123456789876543210))))))
             sA_0123456789876543210
+    instance (Data.Singletons.ShowSing.ShowSing a,
+              Data.Singletons.ShowSing.ShowSing b) =>
+             Data.Singletons.ShowSing.ShowSing (Pair a b) where
+      Data.Singletons.ShowSing.showsSingPrec
+        p_0123456789876543210
+        (SPair arg_0123456789876543210 arg_0123456789876543210)
+        = (showParen (((>) p_0123456789876543210) 10))
+            (((.) (showString "SPair "))
+               (((.)
+                   ((Data.Singletons.ShowSing.showsSingPrec 11)
+                      arg_0123456789876543210))
+                  (((.) GHC.Show.showSpace)
+                     ((Data.Singletons.ShowSing.showsSingPrec 11)
+                        arg_0123456789876543210))))
+    instance (Data.Singletons.ShowSing.ShowSing a,
+              Data.Singletons.ShowSing.ShowSing b) =>
+             Show (Sing (z :: Pair a b)) where
+      showsPrec = Data.Singletons.ShowSing.showsSingPrec
     instance (SingI n, SingI n) => SingI (Pair (n :: a) (n :: b)) where
       sing = (SPair sing) sing

--- a/tests/compile-and-dump/Singletons/EmptyShowDeriving.ghc82.template
+++ b/tests/compile-and-dump/Singletons/EmptyShowDeriving.ghc82.template
@@ -1,0 +1,77 @@
+Singletons/EmptyShowDeriving.hs:(0,0)-(0,0): Splicing declarations
+    singletons
+      [d| data Foo
+          
+          deriving instance Show Foo |]
+  ======>
+    data Foo
+    deriving instance Show Foo
+    type family Case_0123456789876543210 v_0123456789876543210 a_0123456789876543210 t where
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Foo) (a :: GHC.Types.Symbol) :: GHC.Types.Symbol where
+      ShowsPrec_0123456789876543210 _ v_0123456789876543210 a_0123456789876543210 = Apply (Case_0123456789876543210 v_0123456789876543210 a_0123456789876543210 v_0123456789876543210) a_0123456789876543210
+    type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: Foo) (t :: GHC.Types.Symbol) =
+        ShowsPrec_0123456789876543210 t t t
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym2 (l :: GHC.Types.Nat) (l :: Foo) (l :: TyFun GHC.Types.Symbol GHC.Types.Symbol)
+      = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
+        ShowsPrec_0123456789876543210Sym2KindInference
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun Foo (TyFun GHC.Types.Symbol GHC.Types.Symbol
+                                                                                 -> GHC.Types.Type))
+      = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
+        ShowsPrec_0123456789876543210Sym1KindInference
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat (TyFun Foo (TyFun GHC.Types.Symbol GHC.Types.Symbol
+                                                                                 -> GHC.Types.Type)
+                                                                      -> GHC.Types.Type))
+      = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
+        ShowsPrec_0123456789876543210Sym0KindInference
+    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+    instance PShow Foo where
+      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+    data instance Sing (z :: Foo)
+    type SFoo = (Sing :: Foo -> GHC.Types.Type)
+    instance SingKind Foo where
+      type Demote Foo = Foo
+      fromSing x = case x of
+      toSing x = SomeSing (case x of)
+    instance SShow Foo where
+      sShowsPrec ::
+        forall (t1 :: GHC.Types.Nat) (t2 :: Foo) (t3 :: GHC.Types.Symbol).
+        Sing t1
+        -> Sing t2
+           -> Sing t3
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat (TyFun Foo (TyFun GHC.Types.Symbol GHC.Types.Symbol
+                                                                                             -> GHC.Types.Type)
+                                                                                  -> GHC.Types.Type)
+                                                             -> GHC.Types.Type) t1 :: TyFun Foo (TyFun GHC.Types.Symbol GHC.Types.Symbol
+                                                                                                 -> GHC.Types.Type)
+                                                                                      -> GHC.Types.Type) t2 :: TyFun GHC.Types.Symbol GHC.Types.Symbol
+                                                                                                               -> GHC.Types.Type) t3 :: GHC.Types.Symbol)
+      sShowsPrec
+        _
+        (sV_0123456789876543210 :: Sing v_0123456789876543210)
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             (case sV_0123456789876543210 of ::
+                Sing (Case_0123456789876543210 v_0123456789876543210 a_0123456789876543210 v_0123456789876543210)))
+            sA_0123456789876543210
+    instance Data.Singletons.ShowSing.ShowSing Foo where
+      Data.Singletons.ShowSing.showsSingPrec _ v_0123456789876543210
+        = case v_0123456789876543210 of
+    instance Show (Sing (z :: Foo)) where
+      showsPrec = Data.Singletons.ShowSing.showsSingPrec

--- a/tests/compile-and-dump/Singletons/EmptyShowDeriving.hs
+++ b/tests/compile-and-dump/Singletons/EmptyShowDeriving.hs
@@ -1,0 +1,7 @@
+module Singletons.EmptyShowDeriving where
+
+import Data.Singletons.TH
+
+$(singletons [d| data Foo
+                 deriving instance Show Foo
+               |])

--- a/tests/compile-and-dump/Singletons/Maybe.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Maybe.ghc82.template
@@ -128,6 +128,20 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
             Proved Refl -> Proved Refl
             Disproved contra
               -> Disproved (\ refl -> case refl of { Refl -> contra Refl })
+    instance Data.Singletons.ShowSing.ShowSing a =>
+             Data.Singletons.ShowSing.ShowSing (Maybe a) where
+      Data.Singletons.ShowSing.showsSingPrec _ SNothing
+        = showString "SNothing"
+      Data.Singletons.ShowSing.showsSingPrec
+        p_0123456789876543210
+        (SJust arg_0123456789876543210)
+        = (showParen (((>) p_0123456789876543210) 10))
+            (((.) (showString "SJust "))
+               ((Data.Singletons.ShowSing.showsSingPrec 11)
+                  arg_0123456789876543210))
+    instance Data.Singletons.ShowSing.ShowSing a =>
+             Show (Sing (z :: Maybe a)) where
+      showsPrec = Data.Singletons.ShowSing.showsSingPrec
     instance SingI Nothing where
       sing = SNothing
     instance SingI n => SingI (Just (n :: a)) where

--- a/tests/compile-and-dump/Singletons/Nat.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Nat.ghc82.template
@@ -183,6 +183,19 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
             Proved Refl -> Proved Refl
             Disproved contra
               -> Disproved (\ refl -> case refl of { Refl -> contra Refl })
+    instance Data.Singletons.ShowSing.ShowSing Nat =>
+             Data.Singletons.ShowSing.ShowSing Nat where
+      Data.Singletons.ShowSing.showsSingPrec _ SZero = showString "SZero"
+      Data.Singletons.ShowSing.showsSingPrec
+        p_0123456789876543210
+        (SSucc arg_0123456789876543210)
+        = (showParen (((>) p_0123456789876543210) 10))
+            (((.) (showString "SSucc "))
+               ((Data.Singletons.ShowSing.showsSingPrec 11)
+                  arg_0123456789876543210))
+    instance Data.Singletons.ShowSing.ShowSing Nat =>
+             Show (Sing (z :: Nat)) where
+      showsPrec = Data.Singletons.ShowSing.showsSingPrec
     instance SingI Zero where
       sing = SZero
     instance SingI n => SingI (Succ (n :: Nat)) where

--- a/tests/compile-and-dump/Singletons/PatternMatching.ghc82.template
+++ b/tests/compile-and-dump/Singletons/PatternMatching.ghc82.template
@@ -168,6 +168,24 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
                                 (sFromInteger (sing :: Sing 11))))
                             sArg_0123456789876543210))))))
             sA_0123456789876543210
+    instance (Data.Singletons.ShowSing.ShowSing a,
+              Data.Singletons.ShowSing.ShowSing b) =>
+             Data.Singletons.ShowSing.ShowSing (Pair a b) where
+      Data.Singletons.ShowSing.showsSingPrec
+        p_0123456789876543210
+        (SPair arg_0123456789876543210 arg_0123456789876543210)
+        = (showParen (((>) p_0123456789876543210) 10))
+            (((.) (showString "SPair "))
+               (((.)
+                   ((Data.Singletons.ShowSing.showsSingPrec 11)
+                      arg_0123456789876543210))
+                  (((.) GHC.Show.showSpace)
+                     ((Data.Singletons.ShowSing.showsSingPrec 11)
+                        arg_0123456789876543210))))
+    instance (Data.Singletons.ShowSing.ShowSing a,
+              Data.Singletons.ShowSing.ShowSing b) =>
+             Show (Sing (z :: Pair a b)) where
+      showsPrec = Data.Singletons.ShowSing.showsSingPrec
     instance (SingI n, SingI n) => SingI (Pair (n :: a) (n :: b)) where
       sing = (SPair sing) sing
 Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations

--- a/tests/compile-and-dump/Singletons/ShowDeriving.ghc82.template
+++ b/tests/compile-and-dump/Singletons/ShowDeriving.ghc82.template
@@ -510,6 +510,79 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                                      ((applySing ((singFun2 @ShowCharSym0) sShowChar))
                                         (sing :: Sing "}")))))))))))
             sA_0123456789876543210
+    instance Data.Singletons.ShowSing.ShowSing Foo1 where
+      Data.Singletons.ShowSing.showsSingPrec _ SMkFoo1
+        = showString "SMkFoo1"
+    instance Show (Sing (z :: Foo1)) where
+      showsPrec = Data.Singletons.ShowSing.showsSingPrec
+    instance Data.Singletons.ShowSing.ShowSing a =>
+             Data.Singletons.ShowSing.ShowSing (Foo2 a) where
+      Data.Singletons.ShowSing.showsSingPrec
+        p_0123456789876543210
+        (SMkFoo2a arg_0123456789876543210 arg_0123456789876543210)
+        = (showParen (((>) p_0123456789876543210) 10))
+            (((.) (showString "SMkFoo2a "))
+               (((.)
+                   ((Data.Singletons.ShowSing.showsSingPrec 11)
+                      arg_0123456789876543210))
+                  (((.) GHC.Show.showSpace)
+                     ((Data.Singletons.ShowSing.showsSingPrec 11)
+                        arg_0123456789876543210))))
+      Data.Singletons.ShowSing.showsSingPrec
+        p_0123456789876543210
+        (SMkFoo2b argL_0123456789876543210 argR_0123456789876543210)
+        = (showParen (((>) p_0123456789876543210) 9))
+            (((.)
+                ((Data.Singletons.ShowSing.showsSingPrec 10)
+                   argL_0123456789876543210))
+               (((.) (showString " `SMkFoo2b` "))
+                  ((Data.Singletons.ShowSing.showsSingPrec 10)
+                     argR_0123456789876543210)))
+      Data.Singletons.ShowSing.showsSingPrec
+        p_0123456789876543210
+        ((:%*:) arg_0123456789876543210 arg_0123456789876543210)
+        = (showParen (((>) p_0123456789876543210) 10))
+            (((.) (showString "(:%*:) "))
+               (((.)
+                   ((Data.Singletons.ShowSing.showsSingPrec 11)
+                      arg_0123456789876543210))
+                  (((.) GHC.Show.showSpace)
+                     ((Data.Singletons.ShowSing.showsSingPrec 11)
+                        arg_0123456789876543210))))
+      Data.Singletons.ShowSing.showsSingPrec
+        p_0123456789876543210
+        ((:%&:) argL_0123456789876543210 argR_0123456789876543210)
+        = (showParen (((>) p_0123456789876543210) 9))
+            (((.)
+                ((Data.Singletons.ShowSing.showsSingPrec 10)
+                   argL_0123456789876543210))
+               (((.) (showString " :%&: "))
+                  ((Data.Singletons.ShowSing.showsSingPrec 10)
+                     argR_0123456789876543210)))
+    instance Data.Singletons.ShowSing.ShowSing a =>
+             Show (Sing (z :: Foo2 a)) where
+      showsPrec = Data.Singletons.ShowSing.showsSingPrec
+    instance Data.Singletons.ShowSing.ShowSing Bool =>
+             Data.Singletons.ShowSing.ShowSing Foo3 where
+      Data.Singletons.ShowSing.showsSingPrec
+        p_0123456789876543210
+        (SMkFoo3 arg_0123456789876543210 arg_0123456789876543210)
+        = (showParen (((>) p_0123456789876543210) 10))
+            (((.) (showString "SMkFoo3 "))
+               (((.) (showChar '{'))
+                  (((.) (showString "sGetFoo3a = "))
+                     (((.)
+                         ((Data.Singletons.ShowSing.showsSingPrec 0)
+                            arg_0123456789876543210))
+                        (((.) GHC.Show.showCommaSpace)
+                           (((.) (showString "(%***) = "))
+                              (((.)
+                                  ((Data.Singletons.ShowSing.showsSingPrec 0)
+                                     arg_0123456789876543210))
+                                 (showChar '}'))))))))
+    instance Data.Singletons.ShowSing.ShowSing Bool =>
+             Show (Sing (z :: Foo3)) where
+      showsPrec = Data.Singletons.ShowSing.showsSingPrec
     instance SingI MkFoo1 where
       sing = SMkFoo1
     instance (SingI n, SingI n) =>

--- a/tests/compile-and-dump/Singletons/StandaloneDeriving.ghc82.template
+++ b/tests/compile-and-dump/Singletons/StandaloneDeriving.ghc82.template
@@ -433,6 +433,26 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
       (%~) SS1 SS2 = Disproved (\ x -> case x of)
       (%~) SS2 SS1 = Disproved (\ x -> case x of)
       (%~) SS2 SS2 = Proved Refl
+    instance Data.Singletons.ShowSing.ShowSing a =>
+             Data.Singletons.ShowSing.ShowSing (T a ()) where
+      Data.Singletons.ShowSing.showsSingPrec
+        p_0123456789876543210
+        ((:%*:) argL_0123456789876543210 argR_0123456789876543210)
+        = (showParen (((>) p_0123456789876543210) 9))
+            (((.)
+                ((Data.Singletons.ShowSing.showsSingPrec 10)
+                   argL_0123456789876543210))
+               (((.) (showString " :%*: "))
+                  ((Data.Singletons.ShowSing.showsSingPrec 10)
+                     argR_0123456789876543210)))
+    instance Data.Singletons.ShowSing.ShowSing a =>
+             Show (Sing (z :: T a ())) where
+      showsPrec = Data.Singletons.ShowSing.showsSingPrec
+    instance Data.Singletons.ShowSing.ShowSing S where
+      Data.Singletons.ShowSing.showsSingPrec _ SS1 = showString "SS1"
+      Data.Singletons.ShowSing.showsSingPrec _ SS2 = showString "SS2"
+    instance Show (Sing (z :: S)) where
+      showsPrec = Data.Singletons.ShowSing.showsSingPrec
     instance (SingI n, SingI n) =>
              SingI ((:*:) (n :: a) (n :: b)) where
       sing = ((:%*:) sing) sing

--- a/tests/compile-and-dump/Singletons/T178.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T178.ghc82.template
@@ -207,6 +207,12 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
       (%~) SMany SStr = Disproved (\ x -> case x of)
       (%~) SMany SOpt = Disproved (\ x -> case x of)
       (%~) SMany SMany = Proved Refl
+    instance Data.Singletons.ShowSing.ShowSing Occ where
+      Data.Singletons.ShowSing.showsSingPrec _ SStr = showString "SStr"
+      Data.Singletons.ShowSing.showsSingPrec _ SOpt = showString "SOpt"
+      Data.Singletons.ShowSing.showsSingPrec _ SMany = showString "SMany"
+    instance Show (Sing (z :: Occ)) where
+      showsPrec = Data.Singletons.ShowSing.showsSingPrec
     instance SingI Str where
       sing = SStr
     instance SingI Opt where

--- a/tests/compile-and-dump/Singletons/T190.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T190.ghc82.template
@@ -190,5 +190,9 @@ Singletons/T190.hs:0:0:: Splicing declarations
       (%==) ST ST = STrue
     instance SDecide T where
       (%~) ST ST = Proved Refl
+    instance Data.Singletons.ShowSing.ShowSing T where
+      Data.Singletons.ShowSing.showsSingPrec _ ST = showString "ST"
+    instance Show (Sing (z :: T)) where
+      showsPrec = Data.Singletons.ShowSing.showsSingPrec
     instance SingI T where
       sing = ST


### PR DESCRIPTION
This implements the ideas laid out in #208. Some highlights:

* There is now a `Data.Singletons.ShowSing` module that exports the `ShowSing` class.
* The Template Haskell machinery has been updated so that calling `$(singletons [d| ... |])` on a datatype with a derived `Show` instance will also generate `ShowSing` and `Show` instances for the singleton type. (See `Note [DerivedDecl]`.)
* Along the way, I found it convenient to make deriving `Show` instances for empty datatypes work (instead of simply erroring as before), so I opted to do this.