### PR TITLE
Add Div, Mod, DivMod to Data.Singletons.TypeLits. Fix #195

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ Changelog for singletons project
 
 next
 ----
+* Add `Div`, `Mod`, `DivMod` to `Data.Singletons.TypeLits`.
+
 * `Demote Nat` is now `Natural` (from `Numeric.Natural`) instead of `Integer`.
 
 * The naming conventions for infix identifiers (e.g., `(&*)`) have been overhauled.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@ Changelog for singletons project
 
 next
 ----
-* Add `Div`, `Mod`, `DivMod` to `Data.Singletons.TypeLits`.
+* Add `Div`, `Mod`, `DivMod`, `Quot`, `Rem`, `QuotRem` to `Data.Singletons.TypeLits`.
 
 * `Demote Nat` is now `Natural` (from `Numeric.Natural`) instead of `Integer`.
 

--- a/src/Data/Singletons/Prelude/Show.hs
+++ b/src/Data/Singletons/Prelude/Show.hs
@@ -57,9 +57,7 @@ import           Data.Singletons.Internal
 import           Data.Singletons.Prelude.Base
 import           Data.Singletons.Prelude.Instances
 import           Data.Singletons.Prelude.List
-import           Data.Singletons.Prelude.Num
 import           Data.Singletons.Prelude.Ord
-import           Data.Singletons.Prelude.Tuple
 import           Data.Singletons.Prelude.Void
 import           Data.Singletons.Promote
 import           Data.Singletons.Single

--- a/src/Data/Singletons/Prelude/Show.hs
+++ b/src/Data/Singletons/Prelude/Show.hs
@@ -174,22 +174,6 @@ $(promoteOnly [d|
   showsNat 8 = showChar "8"
   showsNat 9 = showChar "9"
   showsNat n = showsNat (n `div` 10) . showsNat (n `mod` 10)
-
-  -- https://ghc.haskell.org/trac/ghc/ticket/13652 asks for these in GHC.TypeLits.
-  -- That would be nice, since this implementation is horribly slow.
-  divmod :: Nat -> Nat -> Nat -> Nat -> (Nat, Nat)
-  divmod 0 _ q u = (q, u)
-  divmod n y q 0 = divmod (n-1) y (q+1) y
-  divmod n y q u = divmod (n-1) y q     (u-1)
-
-  div :: Nat -> Nat -> Nat
-  div _ 0 = 0
-  div x y = fst (divmod x (y-1) 0 (y-1))
-
-  mod :: Nat -> Nat -> Nat
-  mod _ 0 = 0
-  mod x y = (y-1) - snd (divmod x (y-1) 0 (y-1))
-
   |])
 
 -- | Note that this instance is really, really slow, since it uses an inefficient,

--- a/src/Data/Singletons/TypeLits.hs
+++ b/src/Data/Singletons/TypeLits.hs
@@ -28,7 +28,7 @@ module Data.Singletons.TypeLits (
   type (^), (%^),
   type (<>), (%<>),
 
-  Div, Mod, DivMod,
+  Div, Mod, DivMod, Quot, Rem, QuotRem,
 
   -- * Defunctionalization symbols
   ErrorSym0, ErrorSym1, UndefinedSym0,
@@ -38,7 +38,10 @@ module Data.Singletons.TypeLits (
   type (<>@#@$), type (<>@#@$$), type (<>@#@$$$),
   DivSym0, DivSym1, DivSym2,
   ModSym0, ModSym1, ModSym2,
-  DivModSym0, DivModSym1, DivModSym2
+  DivModSym0, DivModSym1, DivModSym2,
+  QuotSym0, QuotSym1, QuotSym2,
+  RemSym0, RemSym1, RemSym2,
+  QuotRemSym0, QuotRemSym1, QuotRemSym2
   ) where
 
 import Data.Singletons.TypeLits.Internal
@@ -109,5 +112,13 @@ $(promoteOnly [d|
   mod _ 0 = error "Division by zero."
   mod x y = snd (divMod x y)
 
+  quotRem :: Nat -> Nat -> (Nat, Nat)
+  quotRem = divMod
+
+  quot :: Nat -> Nat -> Nat
+  quot = div
+
+  rem :: Nat -> Nat -> Nat
+  rem = mod
   |])
   

--- a/src/Data/Singletons/TypeLits.hs
+++ b/src/Data/Singletons/TypeLits.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE TemplateHaskell, ScopedTypeVariables, TypeInType, ConstraintKinds,
-             GADTs, TypeFamilies #-}
+             GADTs, TypeFamilies, UndecidableInstances #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -28,16 +28,22 @@ module Data.Singletons.TypeLits (
   type (^), (%^),
   type (<>), (%<>),
 
+  Div, Mod, DivMod,
+
   -- * Defunctionalization symbols
   ErrorSym0, ErrorSym1, UndefinedSym0,
   KnownNatSym0, KnownNatSym1,
   KnownSymbolSym0, KnownSymbolSym1,
   type (^@#@$), type (^@#@$$), type (^@#@$$$),
   type (<>@#@$), type (<>@#@$$), type (<>@#@$$$),
+  DivSym0, DivSym1, DivSym2,
+  ModSym0, ModSym1, ModSym2,
+  DivModSym0, DivModSym1, DivModSym2
   ) where
 
 import Data.Singletons.TypeLits.Internal
-import Data.Singletons.Prelude.Num ()   -- for typelits instances
+import Data.Singletons.Prelude.Num
+import Data.Singletons.Prelude.Tuple
 
 import Data.Singletons.Promote
 
@@ -77,3 +83,31 @@ no_term_level_syms = error "The kind `Symbol` may not be used at the term level.
 
 -- These are often useful in TypeLits-heavy code
 $(genDefunSymbols [''KnownNat, ''KnownSymbol])
+
+------------------------------------------------------------
+-- Div, Mod, DivMod type families.
+------------------------------------------------------------
+$(promoteOnly [d|
+  -- https://ghc.haskell.org/trac/ghc/ticket/13652 asks for these in GHC.TypeLits.
+  -- That would be nice, since this implementation is horribly slow.
+  divMod :: Nat -> Nat -> (Nat, Nat)
+  divMod _ 0 = error "Division by zero."
+  divMod x y =
+    let (d, m) = (divMod' x (y-1) 0 (y-1))
+    in (d, (y-1) - m)
+
+  divMod' :: Nat -> Nat -> Nat -> Nat -> (Nat, Nat)
+  divMod' 0 _ q u = (q, u)
+  divMod' n y q 0 = divMod' (n-1) y (q+1) y
+  divMod' n y q u = divMod' (n-1) y q     (u-1)
+
+  div :: Nat -> Nat -> Nat
+  div _ 0 = error "Division by zero."
+  div x y = fst (divMod x y)
+
+  mod :: Nat -> Nat -> Nat
+  mod _ 0 = error "Division by zero."
+  mod x y = snd (divMod x y)
+
+  |])
+  


### PR DESCRIPTION
This fixes #195 
I moved `div`, `mod`, `divMod` definitions from `Data.Singletons.Prelude.Show` to `Data.Singletons.TypeLits`.
Also, I added division by zero errors.