### PR TITLE
Fix #249 by sprinkling more pattern signatures

### DIFF
--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -81,6 +81,7 @@ tests =
     , compileAndDumpStdTest "T209"
     , compileAndDumpStdTest "T226"
     , compileAndDumpStdTest "T229"
+    , compileAndDumpStdTest "T249"
     ],
     testCompileAndDumpGroup "Promote"
     [ compileAndDumpStdTest "Constructors"

--- a/tests/compile-and-dump/GradingClient/Database.ghc82.template
+++ b/tests/compile-and-dump/GradingClient/Database.ghc82.template
@@ -60,7 +60,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       fromSing SZero = Zero
       fromSing (SSucc b) = Succ (fromSing b)
       toSing Zero = SomeSing SZero
-      toSing (Succ b)
+      toSing (Succ (b :: Demote Nat))
         = case toSing b :: SomeSing Nat of {
             SomeSing c -> SomeSing (SSucc c) }
     instance SOrd Nat => SOrd Nat where
@@ -649,7 +649,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       toSing BOOL = SomeSing SBOOL
       toSing STRING = SomeSing SSTRING
       toSing NAT = SomeSing SNAT
-      toSing (VEC b b)
+      toSing (VEC (b :: Demote U) (b :: Demote Nat))
         = case
               (GHC.Tuple.(,) (toSing b :: SomeSing U)) (toSing b :: SomeSing Nat)
           of {
@@ -745,7 +745,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SingKind Attribute where
       type Demote Attribute = Attribute
       fromSing (SAttr b b) = (Attr (fromSing b)) (fromSing b)
-      toSing (Attr b b)
+      toSing (Attr (b :: Demote [AChar]) (b :: Demote U))
         = case
               (GHC.Tuple.(,) (toSing b :: SomeSing [AChar]))
                 (toSing b :: SomeSing U)
@@ -759,7 +759,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SingKind Schema where
       type Demote Schema = Schema
       fromSing (SSch b) = Sch (fromSing b)
-      toSing (Sch b)
+      toSing (Sch (b :: Demote [Attribute]))
         = case toSing b :: SomeSing [Attribute] of {
             SomeSing c -> SomeSing (SSch c) }
     instance (SShow U, SShow Nat) => SShow U where

--- a/tests/compile-and-dump/InsertionSort/InsertionSortImp.ghc82.template
+++ b/tests/compile-and-dump/InsertionSort/InsertionSortImp.ghc82.template
@@ -21,7 +21,7 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
       fromSing SZero = Zero
       fromSing (SSucc b) = Succ (fromSing b)
       toSing Zero = SomeSing SZero
-      toSing (Succ b)
+      toSing (Succ (b :: Demote Nat))
         = case toSing b :: SomeSing Nat of {
             SomeSing c -> SomeSing (SSucc c) }
     instance SingI Zero where

--- a/tests/compile-and-dump/Singletons/AsPattern.ghc82.template
+++ b/tests/compile-and-dump/Singletons/AsPattern.ghc82.template
@@ -339,7 +339,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
       type Demote Baz = Baz
       fromSing (SBaz b b b)
         = ((Baz (fromSing b)) (fromSing b)) (fromSing b)
-      toSing (Baz b b b)
+      toSing (Baz (b :: Demote Nat) (b :: Demote Nat) (b :: Demote Nat))
         = case
               ((GHC.Tuple.(,,) (toSing b :: SomeSing Nat))
                  (toSing b :: SomeSing Nat))

--- a/tests/compile-and-dump/Singletons/BoundedDeriving.ghc82.template
+++ b/tests/compile-and-dump/Singletons/BoundedDeriving.ghc82.template
@@ -149,7 +149,7 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SingKind a => SingKind (Foo3 a) where
       type Demote (Foo3 a) = Foo3 (Demote a)
       fromSing (SFoo3 b) = Foo3 (fromSing b)
-      toSing (Foo3 b)
+      toSing (Foo3 (b :: Demote a))
         = case toSing b :: SomeSing a of {
             SomeSing c -> SomeSing (SFoo3 c) }
     data instance Sing (z :: Foo4 a b)
@@ -171,7 +171,7 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SingKind Pair where
       type Demote Pair = Pair
       fromSing (SPair b b) = (Pair (fromSing b)) (fromSing b)
-      toSing (Pair b b)
+      toSing (Pair (b :: Demote Bool) (b :: Demote Bool))
         = case
               (GHC.Tuple.(,) (toSing b :: SomeSing Bool))
                 (toSing b :: SomeSing Bool)

--- a/tests/compile-and-dump/Singletons/BoxUnBox.ghc82.template
+++ b/tests/compile-and-dump/Singletons/BoxUnBox.ghc82.template
@@ -35,7 +35,7 @@ Singletons/BoxUnBox.hs:(0,0)-(0,0): Splicing declarations
     instance SingKind a => SingKind (Box a) where
       type Demote (Box a) = Box (Demote a)
       fromSing (SFBox b) = FBox (fromSing b)
-      toSing (FBox b)
+      toSing (FBox (b :: Demote a))
         = case toSing b :: SomeSing a of {
             SomeSing c -> SomeSing (SFBox c) }
     instance SingI n => SingI (FBox (n :: a)) where

--- a/tests/compile-and-dump/Singletons/Classes.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Classes.ghc82.template
@@ -509,7 +509,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       fromSing SZero' = Zero'
       fromSing (SSucc' b) = Succ' (fromSing b)
       toSing Zero' = SomeSing SZero'
-      toSing (Succ' b)
+      toSing (Succ' (b :: Demote Nat'))
         = case toSing b :: SomeSing Nat' of {
             SomeSing c -> SomeSing (SSucc' c) }
     instance SMyOrd Nat' where

--- a/tests/compile-and-dump/Singletons/Classes2.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Classes2.ghc82.template
@@ -62,7 +62,7 @@ Singletons/Classes2.hs:(0,0)-(0,0): Splicing declarations
       fromSing SZeroFoo = ZeroFoo
       fromSing (SSuccFoo b) = SuccFoo (fromSing b)
       toSing ZeroFoo = SomeSing SZeroFoo
-      toSing (SuccFoo b)
+      toSing (SuccFoo (b :: Demote NatFoo))
         = case toSing b :: SomeSing NatFoo of {
             SomeSing c -> SomeSing (SSuccFoo c) }
     instance SMyOrd NatFoo where

--- a/tests/compile-and-dump/Singletons/DataValues.ghc82.template
+++ b/tests/compile-and-dump/Singletons/DataValues.ghc82.template
@@ -121,7 +121,7 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
     instance (SingKind a, SingKind b) => SingKind (Pair a b) where
       type Demote (Pair a b) = Pair (Demote a) (Demote b)
       fromSing (SPair b b) = (Pair (fromSing b)) (fromSing b)
-      toSing (Pair b b)
+      toSing (Pair (b :: Demote a) (b :: Demote b))
         = case
               (GHC.Tuple.(,) (toSing b :: SomeSing a)) (toSing b :: SomeSing b)
           of {

--- a/tests/compile-and-dump/Singletons/HigherOrder.ghc82.template
+++ b/tests/compile-and-dump/Singletons/HigherOrder.ghc82.template
@@ -412,10 +412,10 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
       type Demote (Either a b) = Either (Demote a) (Demote b)
       fromSing (SLeft b) = Left (fromSing b)
       fromSing (SRight b) = Right (fromSing b)
-      toSing (Left b)
+      toSing (Left (b :: Demote a))
         = case toSing b :: SomeSing a of {
             SomeSing c -> SomeSing (SLeft c) }
-      toSing (Right b)
+      toSing (Right (b :: Demote b))
         = case toSing b :: SomeSing b of {
             SomeSing c -> SomeSing (SRight c) }
     instance SingI n => SingI (Left (n :: a)) where

--- a/tests/compile-and-dump/Singletons/Lambdas.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Lambdas.ghc82.template
@@ -695,7 +695,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance (SingKind a, SingKind b) => SingKind (Foo a b) where
       type Demote (Foo a b) = Foo (Demote a) (Demote b)
       fromSing (SFoo b b) = (Foo (fromSing b)) (fromSing b)
-      toSing (Foo b b)
+      toSing (Foo (b :: Demote a) (b :: Demote b))
         = case
               (GHC.Tuple.(,) (toSing b :: SomeSing a)) (toSing b :: SomeSing b)
           of {

--- a/tests/compile-and-dump/Singletons/Maybe.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Maybe.ghc82.template
@@ -69,7 +69,7 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
       fromSing SNothing = Nothing
       fromSing (SJust b) = Just (fromSing b)
       toSing Nothing = SomeSing SNothing
-      toSing (Just b)
+      toSing (Just (b :: Demote a))
         = case toSing b :: SomeSing a of {
             SomeSing c -> SomeSing (SJust c) }
     instance SShow a => SShow (Maybe a) where

--- a/tests/compile-and-dump/Singletons/Nat.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Nat.ghc82.template
@@ -126,7 +126,7 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
       fromSing SZero = Zero
       fromSing (SSucc b) = Succ (fromSing b)
       toSing Zero = SomeSing SZero
-      toSing (Succ b)
+      toSing (Succ (b :: Demote Nat))
         = case toSing b :: SomeSing Nat of {
             SomeSing c -> SomeSing (SSucc c) }
     instance SShow Nat => SShow Nat where

--- a/tests/compile-and-dump/Singletons/Operators.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Operators.ghc82.template
@@ -89,7 +89,7 @@ Singletons/Operators.hs:(0,0)-(0,0): Splicing declarations
       fromSing SFLeaf = FLeaf
       fromSing ((:%+:) b b) = ((:+:) (fromSing b)) (fromSing b)
       toSing FLeaf = SomeSing SFLeaf
-      toSing ((:+:) b b)
+      toSing ((:+:) (b :: Demote Foo) (b :: Demote Foo))
         = case
               (GHC.Tuple.(,) (toSing b :: SomeSing Foo))
                 (toSing b :: SomeSing Foo)

--- a/tests/compile-and-dump/Singletons/OrdDeriving.ghc82.template
+++ b/tests/compile-and-dump/Singletons/OrdDeriving.ghc82.template
@@ -362,7 +362,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       fromSing SZero = Zero
       fromSing (SSucc b) = Succ (fromSing b)
       toSing Zero = SomeSing SZero
-      toSing (Succ b)
+      toSing (Succ (b :: Demote Nat))
         = case toSing b :: SomeSing Nat of {
             SomeSing c -> SomeSing (SSucc c) }
     data instance Sing (z :: Foo a b c d)
@@ -407,7 +407,8 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         = (((E (fromSing b)) (fromSing b)) (fromSing b)) (fromSing b)
       fromSing (SF b b b b)
         = (((F (fromSing b)) (fromSing b)) (fromSing b)) (fromSing b)
-      toSing (A b b b b)
+      toSing
+        (A (b :: Demote a) (b :: Demote b) (b :: Demote c) (b :: Demote d))
         = case
               (((GHC.Tuple.(,,,) (toSing b :: SomeSing a))
                   (toSing b :: SomeSing b))
@@ -416,7 +417,8 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
           of {
             GHC.Tuple.(,,,) (SomeSing c) (SomeSing c) (SomeSing c) (SomeSing c)
               -> SomeSing ((((SA c) c) c) c) }
-      toSing (B b b b b)
+      toSing
+        (B (b :: Demote a) (b :: Demote b) (b :: Demote c) (b :: Demote d))
         = case
               (((GHC.Tuple.(,,,) (toSing b :: SomeSing a))
                   (toSing b :: SomeSing b))
@@ -425,7 +427,8 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
           of {
             GHC.Tuple.(,,,) (SomeSing c) (SomeSing c) (SomeSing c) (SomeSing c)
               -> SomeSing ((((SB c) c) c) c) }
-      toSing (C b b b b)
+      toSing
+        (C (b :: Demote a) (b :: Demote b) (b :: Demote c) (b :: Demote d))
         = case
               (((GHC.Tuple.(,,,) (toSing b :: SomeSing a))
                   (toSing b :: SomeSing b))
@@ -434,7 +437,8 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
           of {
             GHC.Tuple.(,,,) (SomeSing c) (SomeSing c) (SomeSing c) (SomeSing c)
               -> SomeSing ((((SC c) c) c) c) }
-      toSing (D b b b b)
+      toSing
+        (D (b :: Demote a) (b :: Demote b) (b :: Demote c) (b :: Demote d))
         = case
               (((GHC.Tuple.(,,,) (toSing b :: SomeSing a))
                   (toSing b :: SomeSing b))
@@ -443,7 +447,8 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
           of {
             GHC.Tuple.(,,,) (SomeSing c) (SomeSing c) (SomeSing c) (SomeSing c)
               -> SomeSing ((((SD c) c) c) c) }
-      toSing (E b b b b)
+      toSing
+        (E (b :: Demote a) (b :: Demote b) (b :: Demote c) (b :: Demote d))
         = case
               (((GHC.Tuple.(,,,) (toSing b :: SomeSing a))
                   (toSing b :: SomeSing b))
@@ -452,7 +457,8 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
           of {
             GHC.Tuple.(,,,) (SomeSing c) (SomeSing c) (SomeSing c) (SomeSing c)
               -> SomeSing ((((SE c) c) c) c) }
-      toSing (F b b b b)
+      toSing
+        (F (b :: Demote a) (b :: Demote b) (b :: Demote c) (b :: Demote d))
         = case
               (((GHC.Tuple.(,,,) (toSing b :: SomeSing a))
                   (toSing b :: SomeSing b))

--- a/tests/compile-and-dump/Singletons/PatternMatching.ghc82.template
+++ b/tests/compile-and-dump/Singletons/PatternMatching.ghc82.template
@@ -121,7 +121,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     instance (SingKind a, SingKind b) => SingKind (Pair a b) where
       type Demote (Pair a b) = Pair (Demote a) (Demote b)
       fromSing (SPair b b) = (Pair (fromSing b)) (fromSing b)
-      toSing (Pair b b)
+      toSing (Pair (b :: Demote a) (b :: Demote b))
         = case
               (GHC.Tuple.(,) (toSing b :: SomeSing a)) (toSing b :: SomeSing b)
           of {

--- a/tests/compile-and-dump/Singletons/Records.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Records.ghc82.template
@@ -49,7 +49,7 @@ Singletons/Records.hs:(0,0)-(0,0): Splicing declarations
     instance SingKind a => SingKind (Record a) where
       type Demote (Record a) = Record (Demote a)
       fromSing (SMkRecord b b) = (MkRecord (fromSing b)) (fromSing b)
-      toSing (MkRecord b b)
+      toSing (MkRecord (b :: Demote a) (b :: Demote Bool))
         = case
               (GHC.Tuple.(,) (toSing b :: SomeSing a))
                 (toSing b :: SomeSing Bool)

--- a/tests/compile-and-dump/Singletons/ShowDeriving.ghc82.template
+++ b/tests/compile-and-dump/Singletons/ShowDeriving.ghc82.template
@@ -268,25 +268,25 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
       fromSing (SMkFoo2b b b) = (MkFoo2b (fromSing b)) (fromSing b)
       fromSing ((:%*:) b b) = ((:*:) (fromSing b)) (fromSing b)
       fromSing ((:%&:) b b) = ((:&:) (fromSing b)) (fromSing b)
-      toSing (MkFoo2a b b)
+      toSing (MkFoo2a (b :: Demote a) (b :: Demote a))
         = case
               (GHC.Tuple.(,) (toSing b :: SomeSing a)) (toSing b :: SomeSing a)
           of {
             GHC.Tuple.(,) (SomeSing c) (SomeSing c)
               -> SomeSing ((SMkFoo2a c) c) }
-      toSing (MkFoo2b b b)
+      toSing (MkFoo2b (b :: Demote a) (b :: Demote a))
         = case
               (GHC.Tuple.(,) (toSing b :: SomeSing a)) (toSing b :: SomeSing a)
           of {
             GHC.Tuple.(,) (SomeSing c) (SomeSing c)
               -> SomeSing ((SMkFoo2b c) c) }
-      toSing ((:*:) b b)
+      toSing ((:*:) (b :: Demote a) (b :: Demote a))
         = case
               (GHC.Tuple.(,) (toSing b :: SomeSing a)) (toSing b :: SomeSing a)
           of {
             GHC.Tuple.(,) (SomeSing c) (SomeSing c)
               -> SomeSing (((:%*:) c) c) }
-      toSing ((:&:) b b)
+      toSing ((:&:) (b :: Demote a) (b :: Demote a))
         = case
               (GHC.Tuple.(,) (toSing b :: SomeSing a)) (toSing b :: SomeSing a)
           of {
@@ -301,7 +301,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SingKind Foo3 where
       type Demote Foo3 = Foo3
       fromSing (SMkFoo3 b b) = (MkFoo3 (fromSing b)) (fromSing b)
-      toSing (MkFoo3 b b)
+      toSing (MkFoo3 (b :: Demote Bool) (b :: Demote Bool))
         = case
               (GHC.Tuple.(,) (toSing b :: SomeSing Bool))
                 (toSing b :: SomeSing Bool)

--- a/tests/compile-and-dump/Singletons/StandaloneDeriving.ghc82.template
+++ b/tests/compile-and-dump/Singletons/StandaloneDeriving.ghc82.template
@@ -237,7 +237,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance (SingKind a, SingKind b) => SingKind (T a b) where
       type Demote (T a b) = T (Demote a) (Demote b)
       fromSing ((:%*:) b b) = ((:*:) (fromSing b)) (fromSing b)
-      toSing ((:*:) b b)
+      toSing ((:*:) (b :: Demote a) (b :: Demote b))
         = case
               (GHC.Tuple.(,) (toSing b :: SomeSing a)) (toSing b :: SomeSing b)
           of {

--- a/tests/compile-and-dump/Singletons/Star.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Star.ghc82.template
@@ -200,10 +200,10 @@ Singletons/Star.hs:0:0:: Splicing declarations
       toSing Singletons.Star.Nat = SomeSing SNat
       toSing Singletons.Star.Int = SomeSing SInt
       toSing Singletons.Star.String = SomeSing SString
-      toSing (Singletons.Star.Maybe b)
+      toSing (Singletons.Star.Maybe (b :: Demote Type))
         = case toSing b :: SomeSing Type of {
             SomeSing c -> SomeSing (SMaybe c) }
-      toSing (Singletons.Star.Vec b b)
+      toSing (Singletons.Star.Vec (b :: Demote Type) (b :: Demote Nat))
         = case
               (GHC.Tuple.(,) (toSing b :: SomeSing Type))
                 (toSing b :: SomeSing Nat)

--- a/tests/compile-and-dump/Singletons/T159.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T159.ghc82.template
@@ -87,12 +87,12 @@ Singletons/T159.hs:0:0:: Splicing declarations
       fromSing (SC1 b b) = (C1 (fromSing b)) (fromSing b)
       fromSing ((:%&&) b b) = ((:&&) (fromSing b)) (fromSing b)
       toSing N1 = SomeSing SN1
-      toSing (C1 b b)
+      toSing (C1 (b :: Demote T0) (b :: Demote T1))
         = case
               (GHC.Tuple.(,) (toSing b :: SomeSing T0)) (toSing b :: SomeSing T1)
           of {
             GHC.Tuple.(,) (SomeSing c) (SomeSing c) -> SomeSing ((SC1 c) c) }
-      toSing ((:&&) b b)
+      toSing ((:&&) (b :: Demote T0) (b :: Demote T1))
         = case
               (GHC.Tuple.(,) (toSing b :: SomeSing T0)) (toSing b :: SomeSing T1)
           of {
@@ -164,12 +164,12 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
       fromSing (SC2 b b) = (C2 (fromSing b)) (fromSing b)
       fromSing ((:%||) b b) = ((:||) (fromSing b)) (fromSing b)
       toSing N2 = SomeSing SN2
-      toSing (C2 b b)
+      toSing (C2 (b :: Demote T0) (b :: Demote T2))
         = case
               (GHC.Tuple.(,) (toSing b :: SomeSing T0)) (toSing b :: SomeSing T2)
           of {
             GHC.Tuple.(,) (SomeSing c) (SomeSing c) -> SomeSing ((SC2 c) c) }
-      toSing ((:||) b b)
+      toSing ((:||) (b :: Demote T0) (b :: Demote T2))
         = case
               (GHC.Tuple.(,) (toSing b :: SomeSing T0)) (toSing b :: SomeSing T2)
           of {

--- a/tests/compile-and-dump/Singletons/T163.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T163.ghc82.template
@@ -27,9 +27,9 @@ Singletons/T163.hs:0:0:: Splicing declarations
       type Demote ((+) a b) = (+) (Demote a) (Demote b)
       fromSing (SL b) = L (fromSing b)
       fromSing (SR b) = R (fromSing b)
-      toSing (L b)
+      toSing (L (b :: Demote a))
         = case toSing b :: SomeSing a of { SomeSing c -> SomeSing (SL c) }
-      toSing (R b)
+      toSing (R (b :: Demote b))
         = case toSing b :: SomeSing b of { SomeSing c -> SomeSing (SR c) }
     instance SingI n => SingI (L (n :: a)) where
       sing = SL sing

--- a/tests/compile-and-dump/Singletons/T197b.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T197b.ghc82.template
@@ -54,7 +54,7 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
     instance (SingKind a, SingKind b) => SingKind ((:*:) a b) where
       type Demote ((:*:) a b) = (:*:) (Demote a) (Demote b)
       fromSing ((:%*:) b b) = ((:*:) (fromSing b)) (fromSing b)
-      toSing ((:*:) b b)
+      toSing ((:*:) (b :: Demote a) (b :: Demote b))
         = case
               (GHC.Tuple.(,) (toSing b :: SomeSing a)) (toSing b :: SomeSing b)
           of {
@@ -68,7 +68,7 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
     instance (SingKind a, SingKind b) => SingKind (Pair a b) where
       type Demote (Pair a b) = Pair (Demote a) (Demote b)
       fromSing (SMkPair b b) = (MkPair (fromSing b)) (fromSing b)
-      toSing (MkPair b b)
+      toSing (MkPair (b :: Demote a) (b :: Demote b))
         = case
               (GHC.Tuple.(,) (toSing b :: SomeSing a)) (toSing b :: SomeSing b)
           of {

--- a/tests/compile-and-dump/Singletons/T200.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T200.ghc82.template
@@ -125,21 +125,23 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
       fromSing ((:%$$:) b b) = ((:$$:) (fromSing b)) (fromSing b)
       fromSing ((:%<>:) b b) = ((:<>:) (fromSing b)) (fromSing b)
       fromSing (SEM b) = EM (fromSing b)
-      toSing ((:$$:) b b)
+      toSing
+        ((:$$:) (b :: Demote ErrorMessage) (b :: Demote ErrorMessage))
         = case
               (GHC.Tuple.(,) (toSing b :: SomeSing ErrorMessage))
                 (toSing b :: SomeSing ErrorMessage)
           of {
             GHC.Tuple.(,) (SomeSing c) (SomeSing c)
               -> SomeSing (((:%$$:) c) c) }
-      toSing ((:<>:) b b)
+      toSing
+        ((:<>:) (b :: Demote ErrorMessage) (b :: Demote ErrorMessage))
         = case
               (GHC.Tuple.(,) (toSing b :: SomeSing ErrorMessage))
                 (toSing b :: SomeSing ErrorMessage)
           of {
             GHC.Tuple.(,) (SomeSing c) (SomeSing c)
               -> SomeSing (((:%<>:) c) c) }
-      toSing (EM b)
+      toSing (EM (b :: Demote [Bool]))
         = case toSing b :: SomeSing [Bool] of {
             SomeSing c -> SomeSing (SEM c) }
     instance (SingI n, SingI n) =>

--- a/tests/compile-and-dump/Singletons/T249.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T249.ghc82.template
@@ -1,0 +1,69 @@
+Singletons/T249.hs:(0,0)-(0,0): Splicing declarations
+    singletons
+      [d| data Foo1 a = MkFoo1 a
+          data Foo2 a where MkFoo2 :: x -> Foo2 x
+          data Foo3 a where MkFoo3 :: forall x. x -> Foo3 x |]
+  ======>
+    data Foo1 a = MkFoo1 a
+    data Foo2 a where MkFoo2 :: x -> Foo2 x
+    data Foo3 a where MkFoo3 :: forall x. x -> Foo3 x
+    type MkFoo1Sym1 (t :: a0123456789876543210) = MkFoo1 t
+    instance SuppressUnusedWarnings MkFoo1Sym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) MkFoo1Sym0KindInference) GHC.Tuple.())
+    data MkFoo1Sym0 (l :: TyFun a0123456789876543210 (Foo1 a0123456789876543210))
+      = forall arg. SameKind (Apply MkFoo1Sym0 arg) (MkFoo1Sym1 arg) =>
+        MkFoo1Sym0KindInference
+    type instance Apply MkFoo1Sym0 l = MkFoo1 l
+    type MkFoo2Sym1 (t :: x0123456789876543210) = MkFoo2 t
+    instance SuppressUnusedWarnings MkFoo2Sym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) MkFoo2Sym0KindInference) GHC.Tuple.())
+    data MkFoo2Sym0 (l :: TyFun x0123456789876543210 (Foo2 a0123456789876543210))
+      = forall arg. SameKind (Apply MkFoo2Sym0 arg) (MkFoo2Sym1 arg) =>
+        MkFoo2Sym0KindInference
+    type instance Apply MkFoo2Sym0 l = MkFoo2 l
+    type MkFoo3Sym1 (t :: x0123456789876543210) = MkFoo3 t
+    instance SuppressUnusedWarnings MkFoo3Sym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) MkFoo3Sym0KindInference) GHC.Tuple.())
+    data MkFoo3Sym0 (l :: TyFun x0123456789876543210 (Foo3 a0123456789876543210))
+      = forall arg. SameKind (Apply MkFoo3Sym0 arg) (MkFoo3Sym1 arg) =>
+        MkFoo3Sym0KindInference
+    type instance Apply MkFoo3Sym0 l = MkFoo3 l
+    data instance Sing (z :: Foo1 a)
+      where
+        SMkFoo1 :: forall (n :: a). (Sing (n :: a)) -> Sing (MkFoo1 n)
+    type SFoo1 = (Sing :: Foo1 a -> Type)
+    instance SingKind a => SingKind (Foo1 a) where
+      type Demote (Foo1 a) = Foo1 (Demote a)
+      fromSing (SMkFoo1 b) = MkFoo1 (fromSing b)
+      toSing (MkFoo1 (b :: Demote a))
+        = case toSing b :: SomeSing a of {
+            SomeSing c -> SomeSing (SMkFoo1 c) }
+    data instance Sing (z :: Foo2 a)
+      where
+        SMkFoo2 :: forall (n :: x). (Sing (n :: x)) -> Sing (MkFoo2 n)
+    type SFoo2 = (Sing :: Foo2 a -> Type)
+    instance SingKind a => SingKind (Foo2 a) where
+      type Demote (Foo2 a) = Foo2 (Demote a)
+      fromSing (SMkFoo2 b) = MkFoo2 (fromSing b)
+      toSing (MkFoo2 (b :: Demote x))
+        = case toSing b :: SomeSing x of {
+            SomeSing c -> SomeSing (SMkFoo2 c) }
+    data instance Sing (z :: Foo3 a)
+      where
+        SMkFoo3 :: forall (n :: x). (Sing (n :: x)) -> Sing (MkFoo3 n)
+    type SFoo3 = (Sing :: Foo3 a -> Type)
+    instance SingKind a => SingKind (Foo3 a) where
+      type Demote (Foo3 a) = Foo3 (Demote a)
+      fromSing (SMkFoo3 b) = MkFoo3 (fromSing b)
+      toSing (MkFoo3 (b :: Demote x))
+        = case toSing b :: SomeSing x of {
+            SomeSing c -> SomeSing (SMkFoo3 c) }
+    instance SingI n => SingI (MkFoo1 (n :: a)) where
+      sing = SMkFoo1 sing
+    instance SingI n => SingI (MkFoo2 (n :: x)) where
+      sing = SMkFoo2 sing
+    instance SingI n => SingI (MkFoo3 (n :: x)) where
+      sing = SMkFoo3 sing

--- a/tests/compile-and-dump/Singletons/T249.hs
+++ b/tests/compile-and-dump/Singletons/T249.hs
@@ -1,0 +1,12 @@
+module T249 where
+
+import Data.Kind
+import Data.Singletons.TH
+
+$(singletons
+  [d| data Foo1 a = MkFoo1 a
+      data Foo2 a where
+        MkFoo2 :: x -> Foo2 x
+      data Foo3 a where
+        MkFoo3 :: forall x. x -> Foo3 x
+    |])

--- a/tests/compile-and-dump/Singletons/TopLevelPatterns.ghc82.template
+++ b/tests/compile-and-dump/Singletons/TopLevelPatterns.ghc82.template
@@ -43,7 +43,7 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
     instance SingKind Foo where
       type Demote Foo = Foo
       fromSing (SBar b b) = (Bar (fromSing b)) (fromSing b)
-      toSing (Bar b b)
+      toSing (Bar (b :: Demote Bool) (b :: Demote Bool))
         = case
               (GHC.Tuple.(,) (toSing b :: SomeSing Bool))
                 (toSing b :: SomeSing Bool)


### PR DESCRIPTION
Previously, we were generating implementations of `toSing` like this:

```haskell
$(singletons [d| data Foo a = MkFoo a |])
===>
instance SingKind a => SingKind (Foo a) where
      ...
      toSing (MkFoo b)
        = case toSing b :: SomeSing a of
            SomeSing c -> SomeSing (SMkFoo c)
```

This works, provided that the types of the fields of `MkFoo` use the same type variables as in the data type itself. But this assumption does not hold true with GADTs, e.g.,

```haskell
$(singletons [d| data Foo a where MkFoo :: x -> Foo x |])
===>
instance SingKind a => SingKind (Foo a) where
      ...
      toSing (MkFoo b)
        = case toSing b :: SomeSing x of
            SomeSing c -> SomeSing (SMkFoo c)
```

This code will not typecheck, since we claim that `toSing b` has type `SomeSing x`, where `x` is a free variable. But this `x` has a legitimate origin, since it came from the GADT constructor type. To make this fact apparent, this PR changes the generated code to instead be:

```haskell
$(singletons [d| data Foo a where MkFoo :: x -> Foo x |])
===>
instance SingKind a => SingKind (Foo a) where
      ...
      toSing (MkFoo (b :: Demote x))
        = case toSing b :: SomeSing x of
            SomeSing c -> SomeSing (SMkFoo c)
```