### PR TITLE
Add Data.Singletons.Sigma

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -111,6 +111,8 @@ next
 
 * Add a `demote` function, which is a convenient shorthand for `fromSing sing`.
 
+* Add a `Data.Singletons.Sigma` module with a `Sigma` (dependent pair) data type.
+
 2.3
 ---
 * Documentation clarifiation in `Data.Singletons.TypeLits`, thanks to @ivan-m.

--- a/singletons.cabal
+++ b/singletons.cabal
@@ -94,6 +94,7 @@ library
                       Data.Singletons.TypeLits
                       Data.Singletons.Decide
                       Data.Singletons.ShowSing
+                      Data.Singletons.Sigma
                       Data.Singletons.SuppressUnusedWarnings
 
   other-modules:      Data.Singletons.Deriving.Infer

--- a/src/Data/Singletons/ShowSing.hs
+++ b/src/Data/Singletons/ShowSing.hs
@@ -9,8 +9,8 @@
 
 -----------------------------------------------------------------------------
 -- |
--- Module      :  Data.Singletons.Showsing
--- Copyright   :  (C) 2017 Ryan Scot
+-- Module      :  Data.Singletons.ShowSing
+-- Copyright   :  (C) 2017 Ryan Scott
 -- License     :  BSD-style (see LICENSE)
 -- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
 -- Stability   :  experimental

--- a/src/Data/Singletons/Sigma.hs
+++ b/src/Data/Singletons/Sigma.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeInType #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Singletons.Sigma
+-- Copyright   :  (C) 2017 Ryan Scott
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Defines 'Sigma', a dependent pair data type, and related functions.
+--
+----------------------------------------------------------------------------
+
+module Data.Singletons.Sigma
+    ( Sigma(..), Σ
+    , projSigma1, projSigma2
+    , mapSigma, zipSigma
+    ) where
+
+import Data.Kind
+import Data.Singletons.Internal
+
+-- | A dependent pair.
+data Sigma (s :: Type) :: (s ~> Type) -> Type where
+  (:&:) :: forall s t fst. Sing (fst :: s) -> t @@ fst -> Sigma s t
+infixr 4 :&:
+
+-- | Unicode shorthand for 'Sigma'.
+type Σ (s :: Type) (t :: s ~> Type) = Sigma s t
+-- We can't define defunctionalization symbols for this at the moment due
+-- to #216
+
+-- | Project the first element out of a dependent pair.
+projSigma1 :: forall s t. SingKind s => Sigma s t -> Demote s
+projSigma1 (a :&: _) = fromSing a
+
+-- | Project the second element out of a dependent pair.
+--
+-- In an ideal setting, the type of 'projSigma2' would be closer to:
+--
+-- @
+-- 'projSigma2' :: 'Sing' (sig :: 'Sigma' s t) -> t @@ ProjSigma1 sig
+-- @
+--
+-- But promoting 'projSigma1' to a type family is not a simple task. Instead,
+-- we do the next-best thing, which is to use Church-style elimination.
+projSigma2 :: forall s t r. (forall (fst :: s). t @@ fst -> r) -> Sigma s t -> r
+projSigma2 f ((_ :: Sing (fst :: s)) :&: b) = f @fst b
+
+-- | Map across a 'Sigma' value in a dependent fashion.
+mapSigma :: Sing (f :: a ~> b) -> (forall (x :: a). p @@ x -> q @@ (f @@ x))
+         -> Sigma a p -> Sigma b q
+mapSigma f g ((x :: Sing (fst :: a)) :&: y) = (f @@ x) :&: (g @fst y)
+
+-- | Zip two 'Sigma' values together in a dependent fashion.
+zipSigma :: Sing (f :: a ~> b ~> c)
+         -> (forall (x :: a) (y :: b). p @@ x -> q @@ y -> r @@ (f @@ x @@ y))
+         -> Sigma a p -> Sigma b q -> Sigma c r
+zipSigma f g ((a :: Sing (fstA :: a)) :&: p) ((b :: Sing (fstB :: b)) :&: q) =
+  (f @@ a @@ b) :&: (g @fstA @fstB p q)


### PR DESCRIPTION
This fixes #256 by adding a `Data.Singletons.Sigma` module that defines `Sigma`, along with some definitions from Agda that were easy to port over to a `singletons` setting.