### PR TITLE
Promote the type synonyms in Data.Singletons

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -111,6 +111,9 @@ next
 
 * Add a `demote` function, which is a convenient shorthand for `fromSing sing`.
 
+* Export defunctionalization symbols for `SameKind, `KindOf`, `(~>)`, and `(@@)`
+  from `Data.Singletons`.
+
 2.3
 ---
 * Documentation clarifiation in `Data.Singletons.TypeLits`, thanks to @ivan-m.

--- a/src/Data/Singletons.hs
+++ b/src/Data/Singletons.hs
@@ -1,5 +1,11 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE ExplicitNamespaces #-}
 {-# LANGUAGE MagicHash #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeInType #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -----------------------------------------------------------------------------
@@ -56,9 +62,16 @@ module Data.Singletons (
   SingFunction6, SingFunction7, SingFunction8,
 
   -- * Auxiliary functions
-  Proxy(..)
+  Proxy(..),
+
+  -- * Defunctionalization symbols
+  SameKindSym0, SameKindSym1, SameKindSym2,
+  KindOfSym0, KindOfSym1,
+  type (~>@#@$), type (~>@#@$$), type (~>@#@$$$),
+  type (@@@#@$), type (@@@#@$$), type (@@@#@$$$)
   ) where
 
+import Data.Singletons.Promote
 import Data.Singletons.Internal
 import Data.Singletons.Prelude.Enum
 import Data.Singletons.Prelude.Eq
@@ -107,3 +120,10 @@ instance SNum k => Num (SomeSing k) where
 instance ShowSing k => Show (SomeSing k) where
   showsPrec p (SomeSing s) =
     showParen (p > 10) $ showString "SomeSing " . showsSingPrec 11 s
+
+----------------------------------------------------------------------
+---- Defunctionalization symbols -------------------------------------
+----------------------------------------------------------------------
+
+$(genDefunSymbols [''SameKind, ''KindOf, ''(~>), ''(@@)])
+-- SingFunction1 et al. are not defunctionalizable at the moment due to #198

--- a/src/Data/Singletons/Internal.hs
+++ b/src/Data/Singletons/Internal.hs
@@ -21,40 +21,8 @@
 ----------------------------------------------------------------------------
 
 module Data.Singletons.Internal (
-  -- * Main singleton definitions
-
-  Sing(SLambda, applySing), (@@),
-
-  SingI(..), SingKind(..),
-
-  -- * Working with singletons
-  KindOf, SameKind,
-  SingInstance(..), SomeSing(..),
-  singInstance, withSingI, withSomeSing, singByProxy, demote,
-
-  singByProxy#,
-  withSing, singThat,
-
-  -- ** Defunctionalization
-  TyFun, type (~>),
-  TyCon1, TyCon2, TyCon3, TyCon4, TyCon5, TyCon6, TyCon7, TyCon8,
-  Apply, type (@@),
-
-  -- ** Defunctionalized singletons
-  -- | When calling a higher-order singleton function, you need to use a
-  -- @singFun...@ function to wrap it. See 'singFun1'.
-  singFun1, singFun2, singFun3, singFun4, singFun5, singFun6, singFun7,
-  singFun8,
-  unSingFun1, unSingFun2, unSingFun3, unSingFun4, unSingFun5,
-  unSingFun6, unSingFun7, unSingFun8,
-
-  -- | These type synonyms are exported only to improve error messages; users
-  -- should not have to mention them.
-  SingFunction1, SingFunction2, SingFunction3, SingFunction4, SingFunction5,
-  SingFunction6, SingFunction7, SingFunction8,
-
-  -- * Auxiliary functions
-  Proxy(..)
+    module Data.Singletons.Internal
+  , Proxy(..)
   ) where
 
 import Data.Kind


### PR DESCRIPTION
In https://github.com/goldfirere/singletons/issues/257#issuecomment-335919128, I lamented the lack of defunctionalization symbols for `(~>)`, so this PR adds them, as well as symbols for the other type synonyms in `Data.Singletons`.

Along the way, I realized that we were duplicating the export list for `Data.Singletons` in `Data.Singletons.Internal`, which seems silly, so I axed the explicit export list in `Data.Singletons.Internal`. (No one will notice, after all, since it's internal.)

Fixes #257.