### PR TITLE
Fix #263 by eta expanding exception expressions (like undefined/error)

### DIFF
--- a/src/Data/Singletons/Single.hs
+++ b/src/Data/Singletons/Single.hs
@@ -551,9 +551,9 @@ singExp (ADAppE e1 e2) _res_ki = do
   e1' <- singExp e1 Nothing
   e2' <- singExp e2 Nothing
   -- `applySing undefined x` kills type inference, because GHC can't figure
-  -- out the type of `undefined`. So we don't emit that code.
+  -- out the type of `undefined`. So we don't emit `applySing` there.
   if isException e1'
-  then return e1'
+  then return $ e1' `DAppE` e2'
   else return $ (DVarE applySingName) `DAppE` e1' `DAppE` e2'
 singExp (ADLamE ty_names prom_lam names exp) _res_ki = do
   let sNames = map singValName names

--- a/tests/compile-and-dump/Singletons/T167.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T167.ghc82.template
@@ -131,7 +131,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
       sFooList
         (sA_0123456789876543210 :: Sing a_0123456789876543210)
         (sA_0123456789876543210 :: Sing a_0123456789876543210)
-        = sUndefined
+        = (sUndefined sA_0123456789876543210) sA_0123456789876543210
     instance SFoo a => SFoo [a] where
       sFoosPrec ::
         forall (t :: Nat) (t :: [a]) (t :: [Bool]).

--- a/tests/compile-and-dump/Singletons/Undef.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Undef.ghc82.template
@@ -34,6 +34,6 @@ Singletons/Undef.hs:(0,0)-(0,0): Splicing declarations
     sFoo ::
       forall (t :: Bool). Sing t -> Sing (Apply FooSym0 t :: Bool)
     sBar (sA_0123456789876543210 :: Sing a_0123456789876543210)
-      = sError (sing :: Sing "urk")
+      = (sError (sing :: Sing "urk")) sA_0123456789876543210
     sFoo (sA_0123456789876543210 :: Sing a_0123456789876543210)
-      = sUndefined
+      = sUndefined sA_0123456789876543210

--- a/tests/compile-and-dump/Singletons/Undef.hs
+++ b/tests/compile-and-dump/Singletons/Undef.hs
@@ -1,7 +1,7 @@
+{-# OPTIONS_GHC -Wall #-}
 module Singletons.Undef where
 
 import Data.Singletons.TH
-import Data.Singletons.Prelude
 
 $(singletons [d|
   foo :: Bool -> Bool


### PR DESCRIPTION
For reasons described in [`Note [Why error is so special]`](https://github.com/goldfirere/singletons/blob/4e31cde5dfd56584599876b58133221963f5c519/src/Data/Singletons/Single.hs#L527), we shouldn't single applications of `error` or `undefined` to use `applySing`. But in implementing this special case, we totally discarded the arguments of `error`/`undefined`, leading to #263. Fixing this is simple: just apply `error`/`undefined` to their arguments using normal function application.