### PR TITLE
Fix #264; or, Data.Singletons.CustomTypeStar fixes

### DIFF
--- a/tests/compile-and-dump/Singletons/Nat.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Nat.ghc82.template
@@ -11,13 +11,13 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
             where
               Zero :: Nat
               Succ :: Nat -> Nat
-            deriving (Eq, Show, Read) |]
+            deriving (Eq, Show, Read, Ord) |]
   ======>
     data Nat
       where
         Zero :: Nat
         Succ :: Nat -> Nat
-      deriving (Eq, Show, Read)
+      deriving (Eq, Show, Read, Ord)
     plus :: Nat -> Nat -> Nat
     plus Zero m = m
     plus (Succ n) m = Succ ((plus n) m)
@@ -99,6 +99,34 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
     instance PShow Nat where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+    type family Compare_0123456789876543210 (a :: Nat) (a :: Nat) :: Ordering where
+      Compare_0123456789876543210 Zero Zero = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) '[]
+      Compare_0123456789876543210 (Succ a_0123456789876543210) (Succ b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) '[])
+      Compare_0123456789876543210 Zero (Succ _) = LTSym0
+      Compare_0123456789876543210 (Succ _) Zero = GTSym0
+    type Compare_0123456789876543210Sym2 (t :: Nat) (t :: Nat) =
+        Compare_0123456789876543210 t t
+    instance SuppressUnusedWarnings Compare_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Compare_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data Compare_0123456789876543210Sym1 (l :: Nat) (l :: TyFun Nat Ordering)
+      = forall arg. SameKind (Apply (Compare_0123456789876543210Sym1 l) arg) (Compare_0123456789876543210Sym2 l arg) =>
+        Compare_0123456789876543210Sym1KindInference
+    type instance Apply (Compare_0123456789876543210Sym1 l) l = Compare_0123456789876543210 l l
+    instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data Compare_0123456789876543210Sym0 (l :: TyFun Nat (TyFun Nat Ordering
+                                                          -> GHC.Types.Type))
+      = forall arg. SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
+        Compare_0123456789876543210Sym0KindInference
+    type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
+    instance POrd Nat where
+      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type family Equals_0123456789876543210 (a :: Nat) (b :: Nat) :: Bool where
       Equals_0123456789876543210 Zero Zero = TrueSym0
       Equals_0123456789876543210 (Succ a) (Succ b) = (==) a b
@@ -169,6 +197,40 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
                           (Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 11))))
                       sArg_0123456789876543210))))
             sA_0123456789876543210
+    instance SOrd Nat => SOrd Nat where
+      sCompare ::
+        forall (t1 :: Nat) (t2 :: Nat).
+        Sing t1
+        -> Sing t2
+           -> Sing (Apply (Apply (CompareSym0 :: TyFun Nat (TyFun Nat Ordering
+                                                            -> GHC.Types.Type)
+                                                 -> GHC.Types.Type) t1 :: TyFun Nat Ordering
+                                                                          -> GHC.Types.Type) t2 :: Ordering)
+      sCompare SZero SZero
+        = (applySing
+             ((applySing
+                 ((applySing ((singFun3 @FoldlSym0) sFoldl))
+                    ((singFun2 @ThenCmpSym0) sThenCmp)))
+                SEQ))
+            Data.Singletons.Prelude.Instances.SNil
+      sCompare
+        (SSucc (sA_0123456789876543210 :: Sing a_0123456789876543210))
+        (SSucc (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        = (applySing
+             ((applySing
+                 ((applySing ((singFun3 @FoldlSym0) sFoldl))
+                    ((singFun2 @ThenCmpSym0) sThenCmp)))
+                SEQ))
+            ((applySing
+                ((applySing
+                    ((singFun2 @(:@#@$)) Data.Singletons.Prelude.Instances.SCons))
+                   ((applySing
+                       ((applySing ((singFun2 @CompareSym0) sCompare))
+                          sA_0123456789876543210))
+                      sB_0123456789876543210)))
+               Data.Singletons.Prelude.Instances.SNil)
+      sCompare SZero (SSucc _) = SLT
+      sCompare (SSucc _) SZero = SGT
     instance SEq Nat where
       (%==) SZero SZero = STrue
       (%==) SZero (SSucc _) = SFalse

--- a/tests/compile-and-dump/Singletons/Nat.hs
+++ b/tests/compile-and-dump/Singletons/Nat.hs
@@ -6,7 +6,7 @@ $(singletons [d|
   data Nat where
     Zero :: Nat
     Succ :: Nat -> Nat
-      deriving (Eq, Show, Read)
+      deriving (Eq, Show, Read, Ord)
 
   plus :: Nat -> Nat -> Nat
   plus Zero m = m

--- a/tests/compile-and-dump/Singletons/Star.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Star.ghc82.template
@@ -7,28 +7,28 @@ Singletons/Star.hs:0:0:: Splicing declarations
         Singletons.Star.String |
         Singletons.Star.Maybe Rep |
         Singletons.Star.Vec Rep Nat
-      deriving (Eq, Show, Read)
+      deriving (Eq, Ord, Read, Show)
     type NatSym0 = Nat
     type IntSym0 = Int
     type StringSym0 = String
     type MaybeSym1 (t :: Type) = Maybe t
-    instance Data.Singletons.SuppressUnusedWarnings.SuppressUnusedWarnings MaybeSym0 where
-      Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings
+    instance SuppressUnusedWarnings MaybeSym0 where
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MaybeSym0KindInference) GHC.Tuple.())
     data MaybeSym0 (l :: TyFun Type Type)
       = forall arg. SameKind (Apply MaybeSym0 arg) (MaybeSym1 arg) =>
         MaybeSym0KindInference
     type instance Apply MaybeSym0 l = Maybe l
     type VecSym2 (t :: Type) (t :: Nat) = Vec t t
-    instance Data.Singletons.SuppressUnusedWarnings.SuppressUnusedWarnings VecSym1 where
-      Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings
+    instance SuppressUnusedWarnings VecSym1 where
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) VecSym1KindInference) GHC.Tuple.())
     data VecSym1 (l :: Type) (l :: TyFun Nat Type)
       = forall arg. SameKind (Apply (VecSym1 l) arg) (VecSym2 l arg) =>
         VecSym1KindInference
     type instance Apply (VecSym1 l) l = Vec l l
-    instance Data.Singletons.SuppressUnusedWarnings.SuppressUnusedWarnings VecSym0 where
-      Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings
+    instance SuppressUnusedWarnings VecSym0 where
+      suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) VecSym0KindInference) GHC.Tuple.())
     data VecSym0 (l :: TyFun Type (TyFun Nat Type -> Type))
       = forall arg. SameKind (Apply VecSym0 arg) (VecSym1 arg) =>
@@ -71,8 +71,8 @@ Singletons/Star.hs:0:0:: Splicing declarations
       Compare_0123456789876543210 (Vec _ _) (Maybe _) = GTSym0
     type Compare_0123456789876543210Sym2 (t :: Type) (t :: Type) =
         Compare_0123456789876543210 t t
-    instance Data.Singletons.SuppressUnusedWarnings.SuppressUnusedWarnings Compare_0123456789876543210Sym1 where
-      Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings
+    instance SuppressUnusedWarnings Compare_0123456789876543210Sym1 where
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
@@ -80,8 +80,8 @@ Singletons/Star.hs:0:0:: Splicing declarations
       = forall arg. SameKind (Apply (Compare_0123456789876543210Sym1 l) arg) (Compare_0123456789876543210Sym2 l arg) =>
         Compare_0123456789876543210Sym1KindInference
     type instance Apply (Compare_0123456789876543210Sym1 l) l = Compare_0123456789876543210 l l
-    instance Data.Singletons.SuppressUnusedWarnings.SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
-      Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings
+    instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
+      suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
@@ -92,94 +92,46 @@ Singletons/Star.hs:0:0:: Splicing declarations
     type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
     instance POrd Type where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
-    instance (SOrd Type, SOrd Nat) => SOrd Type where
-      sCompare ::
-        forall (t1 :: Type) (t2 :: Type).
-        Sing t1
-        -> Sing t2
-           -> Sing (Apply (Apply (CompareSym0 :: TyFun Type (TyFun Type Ordering
-                                                             -> Type)
-                                                 -> Type) t1 :: TyFun Type Ordering
-                                                                -> Type) t2 :: Ordering)
-      sCompare SNat SNat
-        = (applySing
-             ((applySing
-                 ((applySing ((singFun3 @FoldlSym0) sFoldl))
-                    ((singFun2 @ThenCmpSym0) sThenCmp)))
-                SEQ))
-            SNil
-      sCompare SInt SInt
-        = (applySing
-             ((applySing
-                 ((applySing ((singFun3 @FoldlSym0) sFoldl))
-                    ((singFun2 @ThenCmpSym0) sThenCmp)))
-                SEQ))
-            SNil
-      sCompare SString SString
-        = (applySing
-             ((applySing
-                 ((applySing ((singFun3 @FoldlSym0) sFoldl))
-                    ((singFun2 @ThenCmpSym0) sThenCmp)))
-                SEQ))
-            SNil
-      sCompare
-        (SMaybe (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SMaybe (sB_0123456789876543210 :: Sing b_0123456789876543210))
-        = (applySing
-             ((applySing
-                 ((applySing ((singFun3 @FoldlSym0) sFoldl))
-                    ((singFun2 @ThenCmpSym0) sThenCmp)))
-                SEQ))
-            ((applySing
-                ((applySing ((singFun2 @(:@#@$)) SCons))
-                   ((applySing
-                       ((applySing ((singFun2 @CompareSym0) sCompare))
-                          sA_0123456789876543210))
-                      sB_0123456789876543210)))
-               SNil)
-      sCompare
-        (SVec (sA_0123456789876543210 :: Sing a_0123456789876543210)
-              (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SVec (sB_0123456789876543210 :: Sing b_0123456789876543210)
-              (sB_0123456789876543210 :: Sing b_0123456789876543210))
-        = (applySing
-             ((applySing
-                 ((applySing ((singFun3 @FoldlSym0) sFoldl))
-                    ((singFun2 @ThenCmpSym0) sThenCmp)))
-                SEQ))
-            ((applySing
-                ((applySing ((singFun2 @(:@#@$)) SCons))
-                   ((applySing
-                       ((applySing ((singFun2 @CompareSym0) sCompare))
-                          sA_0123456789876543210))
-                      sB_0123456789876543210)))
-               ((applySing
-                   ((applySing ((singFun2 @(:@#@$)) SCons))
-                      ((applySing
-                          ((applySing ((singFun2 @CompareSym0) sCompare))
-                             sA_0123456789876543210))
-                         sB_0123456789876543210)))
-                  SNil))
-      sCompare SNat SInt = SLT
-      sCompare SNat SString = SLT
-      sCompare SNat (SMaybe _) = SLT
-      sCompare SNat (SVec _ _) = SLT
-      sCompare SInt SNat = SGT
-      sCompare SInt SString = SLT
-      sCompare SInt (SMaybe _) = SLT
-      sCompare SInt (SVec _ _) = SLT
-      sCompare SString SNat = SGT
-      sCompare SString SInt = SGT
-      sCompare SString (SMaybe _) = SLT
-      sCompare SString (SVec _ _) = SLT
-      sCompare (SMaybe _) SNat = SGT
-      sCompare (SMaybe _) SInt = SGT
-      sCompare (SMaybe _) SString = SGT
-      sCompare (SMaybe _) (SVec _ _) = SLT
-      sCompare (SVec _ _) SNat = SGT
-      sCompare (SVec _ _) SInt = SGT
-      sCompare (SVec _ _) SString = SGT
-      sCompare (SVec _ _) (SMaybe _) = SGT
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Type) (a :: Symbol) :: Symbol where
+      ShowsPrec_0123456789876543210 _ Nat a_0123456789876543210 = Apply (Apply ShowStringSym0 "Nat") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ Int a_0123456789876543210 = Apply (Apply ShowStringSym0 "Int") a_0123456789876543210
+      ShowsPrec_0123456789876543210 _ String a_0123456789876543210 = Apply (Apply ShowStringSym0 "String") a_0123456789876543210
+      ShowsPrec_0123456789876543210 p_0123456789876543210 (Maybe arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Maybe ")) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
+      ShowsPrec_0123456789876543210 p_0123456789876543210 (Vec arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Vec ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
+    type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: Type) (t :: Symbol) =
+        ShowsPrec_0123456789876543210 t t t
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym2 (l :: GHC.Types.Nat) (l :: Type) (l :: TyFun Symbol Symbol)
+      = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
+        ShowsPrec_0123456789876543210Sym2KindInference
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun Type (TyFun Symbol Symbol
+                                                                                  -> Type))
+      = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
+        ShowsPrec_0123456789876543210Sym1KindInference
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat (TyFun Type (TyFun Symbol Symbol
+                                                                                  -> Type)
+                                                                      -> Type))
+      = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
+        ShowsPrec_0123456789876543210Sym0KindInference
+    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+    instance PShow Type where
+      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     data instance Sing (z :: Type)
       where
         SNat :: Sing Nat
@@ -271,6 +223,179 @@ Singletons/Star.hs:0:0:: Splicing declarations
               -> Disproved (\ refl -> case refl of { Refl -> contra Refl })
             GHC.Tuple.(,) _ (Disproved contra)
               -> Disproved (\ refl -> case refl of { Refl -> contra Refl })
+    instance (SOrd Type, SOrd Nat) => SOrd Type where
+      sCompare ::
+        forall (t1 :: Type) (t2 :: Type).
+        Sing t1
+        -> Sing t2
+           -> Sing (Apply (Apply (CompareSym0 :: TyFun Type (TyFun Type Ordering
+                                                             -> Type)
+                                                 -> Type) t1 :: TyFun Type Ordering
+                                                                -> Type) t2 :: Ordering)
+      sCompare SNat SNat
+        = (applySing
+             ((applySing
+                 ((applySing ((singFun3 @FoldlSym0) sFoldl))
+                    ((singFun2 @ThenCmpSym0) sThenCmp)))
+                SEQ))
+            SNil
+      sCompare SInt SInt
+        = (applySing
+             ((applySing
+                 ((applySing ((singFun3 @FoldlSym0) sFoldl))
+                    ((singFun2 @ThenCmpSym0) sThenCmp)))
+                SEQ))
+            SNil
+      sCompare SString SString
+        = (applySing
+             ((applySing
+                 ((applySing ((singFun3 @FoldlSym0) sFoldl))
+                    ((singFun2 @ThenCmpSym0) sThenCmp)))
+                SEQ))
+            SNil
+      sCompare
+        (SMaybe (sA_0123456789876543210 :: Sing a_0123456789876543210))
+        (SMaybe (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        = (applySing
+             ((applySing
+                 ((applySing ((singFun3 @FoldlSym0) sFoldl))
+                    ((singFun2 @ThenCmpSym0) sThenCmp)))
+                SEQ))
+            ((applySing
+                ((applySing ((singFun2 @(:@#@$)) SCons))
+                   ((applySing
+                       ((applySing ((singFun2 @CompareSym0) sCompare))
+                          sA_0123456789876543210))
+                      sB_0123456789876543210)))
+               SNil)
+      sCompare
+        (SVec (sA_0123456789876543210 :: Sing a_0123456789876543210)
+              (sA_0123456789876543210 :: Sing a_0123456789876543210))
+        (SVec (sB_0123456789876543210 :: Sing b_0123456789876543210)
+              (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        = (applySing
+             ((applySing
+                 ((applySing ((singFun3 @FoldlSym0) sFoldl))
+                    ((singFun2 @ThenCmpSym0) sThenCmp)))
+                SEQ))
+            ((applySing
+                ((applySing ((singFun2 @(:@#@$)) SCons))
+                   ((applySing
+                       ((applySing ((singFun2 @CompareSym0) sCompare))
+                          sA_0123456789876543210))
+                      sB_0123456789876543210)))
+               ((applySing
+                   ((applySing ((singFun2 @(:@#@$)) SCons))
+                      ((applySing
+                          ((applySing ((singFun2 @CompareSym0) sCompare))
+                             sA_0123456789876543210))
+                         sB_0123456789876543210)))
+                  SNil))
+      sCompare SNat SInt = SLT
+      sCompare SNat SString = SLT
+      sCompare SNat (SMaybe _) = SLT
+      sCompare SNat (SVec _ _) = SLT
+      sCompare SInt SNat = SGT
+      sCompare SInt SString = SLT
+      sCompare SInt (SMaybe _) = SLT
+      sCompare SInt (SVec _ _) = SLT
+      sCompare SString SNat = SGT
+      sCompare SString SInt = SGT
+      sCompare SString (SMaybe _) = SLT
+      sCompare SString (SVec _ _) = SLT
+      sCompare (SMaybe _) SNat = SGT
+      sCompare (SMaybe _) SInt = SGT
+      sCompare (SMaybe _) SString = SGT
+      sCompare (SMaybe _) (SVec _ _) = SLT
+      sCompare (SVec _ _) SNat = SGT
+      sCompare (SVec _ _) SInt = SGT
+      sCompare (SVec _ _) SString = SGT
+      sCompare (SVec _ _) (SMaybe _) = SGT
+    instance (SShow Type, SShow Nat) => SShow Type where
+      sShowsPrec ::
+        forall (t1 :: GHC.Types.Nat) (t2 :: Type) (t3 :: Symbol).
+        Sing t1
+        -> Sing t2
+           -> Sing t3
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat (TyFun Type (TyFun Symbol Symbol
+                                                                                              -> Type)
+                                                                                  -> Type)
+                                                             -> Type) t1 :: TyFun Type (TyFun Symbol Symbol
+                                                                                        -> Type)
+                                                                            -> Type) t2 :: TyFun Symbol Symbol
+                                                                                           -> Type) t3 :: Symbol)
+      sShowsPrec
+        _
+        SNat
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "Nat")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SInt
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "Int")))
+            sA_0123456789876543210
+      sShowsPrec
+        _
+        SString
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                (sing :: Sing "String")))
+            sA_0123456789876543210
+      sShowsPrec
+        (sP_0123456789876543210 :: Sing p_0123456789876543210)
+        (SMaybe (sArg_0123456789876543210 :: Sing arg_0123456789876543210))
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing
+                 ((applySing ((singFun3 @ShowParenSym0) sShowParen))
+                    ((applySing
+                        ((applySing ((singFun2 @(>@#@$)) (%>))) sP_0123456789876543210))
+                       (sFromInteger (sing :: Sing 10)))))
+                ((applySing
+                    ((applySing ((singFun3 @(.@#@$)) (%.)))
+                       ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                          (sing :: Sing "Maybe "))))
+                   ((applySing
+                       ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
+                          (sFromInteger (sing :: Sing 11))))
+                      sArg_0123456789876543210))))
+            sA_0123456789876543210
+      sShowsPrec
+        (sP_0123456789876543210 :: Sing p_0123456789876543210)
+        (SVec (sArg_0123456789876543210 :: Sing arg_0123456789876543210)
+              (sArg_0123456789876543210 :: Sing arg_0123456789876543210))
+        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        = (applySing
+             ((applySing
+                 ((applySing ((singFun3 @ShowParenSym0) sShowParen))
+                    ((applySing
+                        ((applySing ((singFun2 @(>@#@$)) (%>))) sP_0123456789876543210))
+                       (sFromInteger (sing :: Sing 10)))))
+                ((applySing
+                    ((applySing ((singFun3 @(.@#@$)) (%.)))
+                       ((applySing ((singFun2 @ShowStringSym0) sShowString))
+                          (sing :: Sing "Vec "))))
+                   ((applySing
+                       ((applySing ((singFun3 @(.@#@$)) (%.)))
+                          ((applySing
+                              ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
+                                 (sFromInteger (sing :: Sing 11))))
+                             sArg_0123456789876543210)))
+                      ((applySing
+                          ((applySing ((singFun3 @(.@#@$)) (%.)))
+                             ((singFun1 @ShowSpaceSym0) sShowSpace)))
+                         ((applySing
+                             ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
+                                (sFromInteger (sing :: Sing 11))))
+                            sArg_0123456789876543210))))))
+            sA_0123456789876543210
     instance SingI Nat where
       sing = SNat
     instance SingI Int where


### PR DESCRIPTION
* Export all of `Data.Singletons.TH` from `Data.Singletons.CustomTypeStar`, since the code that `singletonStar` generates needs it
* Bring some uniformity to the instances that `Rep` derives and the instances that it promotes
* Apply various documentation fixes to `Data.Singletons.CustomTypeStar`