### PR TITLE
Support OverloadedStrings in singletons

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,12 @@ next
   * Derived `SDecide` instances for empty data types now return `Proved bottom`,
     where `bottom` is a divergent computation, instead of `error`ing.
 
+* Add `Data.Singletons.Prelude.IsString` and `Data.Promotion.Prelude.IsString`
+  modules. `IsString.fromString` is now used when promoting or singling
+  string literals when the `-XOverloadedStrings` extension is enabled
+  (similarly to how `Num.fromInteger` is currently used when promoting or
+  singling numeric literals).
+
 * Add `Data.Singletons.Prelude.Void`.
 
 * Add promoted and singled versions of `div`, `mod`, `divMod`, `quot`, `rem`,

--- a/singletons.cabal
+++ b/singletons.cabal
@@ -67,6 +67,7 @@ library
                       Data.Singletons.Prelude.Enum
                       Data.Singletons.Prelude.Eq
                       Data.Singletons.Prelude.Function
+                      Data.Singletons.Prelude.IsString
                       Data.Singletons.Prelude.Ord
                       Data.Singletons.Prelude.List
                       Data.Singletons.Prelude.List.NonEmpty
@@ -82,6 +83,7 @@ library
                       Data.Promotion.Prelude.Either
                       Data.Promotion.Prelude.Eq
                       Data.Promotion.Prelude.Function
+                      Data.Promotion.Prelude.IsString
                       Data.Promotion.Prelude.Ord
                       Data.Promotion.Prelude.Enum
                       Data.Promotion.Prelude.List

--- a/src/Data/Promotion/Prelude/IsString.hs
+++ b/src/Data/Promotion/Prelude/IsString.hs
@@ -1,0 +1,22 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Promotion.Prelude.IsString
+-- Copyright   :  (C) 2017 Ryan Scott
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Defines and exports a promoted version of the 'IsString'
+-- type class from "Data.String".
+----------------------------------------------------------------------------
+
+module Data.Promotion.Prelude.IsString (
+  PIsString(..),
+
+  -- ** Defunctionalization symbols
+  FromStringSym0, FromStringSym1
+  ) where
+
+import Data.Singletons.Prelude.IsString
+import Data.Singletons.TypeLits ()   -- for the IsString instance!

--- a/src/Data/Singletons/Names.hs
+++ b/src/Data/Singletons/Names.hs
@@ -41,7 +41,7 @@ boolName, andName, tyEqName, compareName, minBoundName,
   equalsName, constraintName,
   showName, showCharName, showCommaSpaceName, showParenName, showsPrecName,
   showSpaceName, showStringName, showSingName, showsSingPrecName,
-  composeName, gtName :: Name
+  composeName, gtName, tyFromStringName, sFromStringName :: Name
 boolName = ''Bool
 andName = '(&&)
 compareName = 'compare
@@ -115,6 +115,8 @@ showsSingPrecName = mk_name_v "Data.Singletons.ShowSing" "showsSingPrec"
 composeName = '(.)
 gtName = '(>)
 showCommaSpaceName = 'showCommaSpace
+tyFromStringName = mk_name_tc "Data.Singletons.Prelude.IsString" "FromString"
+sFromStringName = mk_name_v "Data.Singletons.Prelude.IsString" "sFromString"
 
 singPkg :: String
 singPkg = $( (LitE . StringL . loc_package) `liftM` location )

--- a/src/Data/Singletons/Prelude/IsString.hs
+++ b/src/Data/Singletons/Prelude/IsString.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeInType #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Singletons.Prelude.IsString
+-- Copyright   :  (C) 2017 Ryan Scott
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Defines and exports a promoted and singled version of the 'IsString'
+-- type class from "Data.String".
+----------------------------------------------------------------------------
+
+module Data.Singletons.Prelude.IsString (
+  PIsString(..), SIsString(..),
+
+  -- ** Defunctionalization symbols
+  FromStringSym0, FromStringSym1
+  ) where
+
+import Data.Singletons.Single
+import Data.Singletons.TypeLits ()   -- for the IsString instance!
+import GHC.TypeLits (Symbol)
+
+$(singletonsOnly [d|
+  -- -| Class for string-like datastructures; used by the overloaded string
+  --    extension (-XOverloadedStrings in GHC).
+  class IsString a where
+      fromString :: Symbol -> a
+  |])
+
+-- PIsString instance
+instance PIsString Symbol where
+  type FromString a = a
+
+-- SIsString instance
+instance SIsString Symbol where
+  sFromString x = x

--- a/src/Data/Singletons/Single.hs
+++ b/src/Data/Singletons/Single.hs
@@ -674,9 +674,8 @@ singLit (StringL str) = do
   pure $ if os_enabled
          then DVarE sFromStringName `DAppE` sing_str_lit
          else sing_str_lit
-singLit lit = do
-  prom_lit <- promoteLitExp lit
-  return $ DVarE singMethName `DSigE` (singFamily `DAppT` prom_lit)
+singLit lit =
+  fail ("Only string and natural number literals can be singled: " ++ show lit)
 
 maybeSigT :: DType -> Maybe DKind -> DType
 maybeSigT ty Nothing   = ty

--- a/src/Data/Singletons/Single.hs
+++ b/src/Data/Singletons/Single.hs
@@ -36,6 +36,7 @@ import Data.Map.Strict ( Map )
 import Data.Maybe
 import Control.Monad
 import Data.List
+import qualified GHC.LanguageExtensions.Type as LangExt
 
 {-
 How singletons works
@@ -666,6 +667,13 @@ singLit (IntegerL n)
                  (singFamily `DAppT` DLitT (NumTyLit n)))
   | otherwise = do sLit <- singLit (IntegerL (-n))
                    return $ DVarE sNegateName `DAppE` sLit
+singLit (StringL str) = do
+  let sing_str_lit = DVarE singMethName `DSigE`
+                     (singFamily `DAppT` DLitT (StrTyLit str))
+  os_enabled <- qIsExtEnabled LangExt.OverloadedStrings
+  pure $ if os_enabled
+         then DVarE sFromStringName `DAppE` sing_str_lit
+         else sing_str_lit
 singLit lit = do
   prom_lit <- promoteLitExp lit
   return $ DVarE singMethName `DSigE` (singFamily `DAppT` prom_lit)

--- a/src/Data/Singletons/TypeLits.hs
+++ b/src/Data/Singletons/TypeLits.hs
@@ -52,6 +52,7 @@ import Data.Singletons.Promote
 import Data.Singletons.ShowSing ()      -- for ShowSing/Show instances
 import Data.Singletons.TypeLits.Internal
 
+import Data.String (IsString(..))
 import qualified GHC.TypeNats as TN
 import GHC.TypeNats (SomeNat(..))
 
@@ -84,6 +85,8 @@ instance Eq Symbol where
 instance Ord Symbol where
   compare     = no_term_level_syms
 
+instance IsString Symbol where
+  fromString  = no_term_level_syms
 
 no_term_level_nats :: a
 no_term_level_nats = error "The kind `Nat` may not be used at the term level."

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -82,6 +82,7 @@ tests =
     , compileAndDumpStdTest "T226"
     , compileAndDumpStdTest "T229"
     , compileAndDumpStdTest "T249"
+    , compileAndDumpStdTest "OverloadedStrings"
     ],
     testCompileAndDumpGroup "Promote"
     [ compileAndDumpStdTest "Constructors"

--- a/tests/compile-and-dump/Singletons/OverloadedStrings.ghc82.template
+++ b/tests/compile-and-dump/Singletons/OverloadedStrings.ghc82.template
@@ -1,0 +1,31 @@
+Singletons/OverloadedStrings.hs:(0,0)-(0,0): Splicing declarations
+    singletons
+      [d| symId :: Symbol -> Symbol
+          symId x = x
+          foo :: Symbol
+          foo = symId "foo" |]
+  ======>
+    symId :: Symbol -> Symbol
+    symId x = x
+    foo :: Symbol
+    foo = symId "foo"
+    type SymIdSym1 (t :: Symbol) = SymId t
+    instance SuppressUnusedWarnings SymIdSym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) SymIdSym0KindInference) GHC.Tuple.())
+    data SymIdSym0 (l :: TyFun Symbol Symbol)
+      = forall arg. SameKind (Apply SymIdSym0 arg) (SymIdSym1 arg) =>
+        SymIdSym0KindInference
+    type instance Apply SymIdSym0 l = SymId l
+    type FooSym0 = Foo
+    type family SymId (a :: Symbol) :: Symbol where
+      SymId x = x
+    type family Foo :: Symbol where
+      = Apply SymIdSym0 (Data.Singletons.Prelude.IsString.FromString "foo")
+    sSymId ::
+      forall (t :: Symbol). Sing t -> Sing (Apply SymIdSym0 t :: Symbol)
+    sFoo :: Sing (FooSym0 :: Symbol)
+    sSymId (sX :: Sing x) = sX
+    sFoo
+      = (applySing ((singFun1 @SymIdSym0) sSymId))
+          (Data.Singletons.Prelude.IsString.sFromString (sing :: Sing "foo"))

--- a/tests/compile-and-dump/Singletons/OverloadedStrings.hs
+++ b/tests/compile-and-dump/Singletons/OverloadedStrings.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE OverloadedStrings #-}
+module OverloadedStrings where
+
+import Data.Singletons.TH
+import Data.Singletons.TypeLits
+
+$(singletons
+  [d| symId :: Symbol -> Symbol
+      symId x = x
+
+      foo :: Symbol
+      foo = symId "foo"
+    |])


### PR DESCRIPTION
This has been requested enough times (see #247, #248, and #267) that I decided to just implement it.

Now, when the `-XOverloadedStrings` extension is enabled, occurrences of string literals will be promoted/singled using `fromSing` (e.g., you'd promote `"foo"` to `FromSing "foo"` and single `"foo"` to `sFromSing (sing :: Sing "foo")`).

Fixes #247.