### PR TITLE
Fix #271 by inferring instance contexts more intelligently

### DIFF
--- a/src/Data/Singletons/Deriving/Bounded.hs
+++ b/src/Data/Singletons/Deriving/Bounded.hs
@@ -13,7 +13,6 @@
 
 module Data.Singletons.Deriving.Bounded where
 
-import Language.Haskell.TH.Syntax
 import Language.Haskell.TH.Ppr
 import Language.Haskell.TH.Desugar
 import Data.Singletons.Names
@@ -24,7 +23,7 @@ import Control.Monad
 
 -- monadic only for failure and parallelism with other functions
 -- that make instances
-mkBoundedInstance :: Quasi q => Maybe DCxt -> DType -> [DCon] -> q UInstDecl
+mkBoundedInstance :: DsMonad q => Maybe DCxt -> DType -> [DCon] -> q UInstDecl
 mkBoundedInstance mb_ctxt ty cons = do
   -- We can derive instance of Bounded if datatype is an enumeration (all
   -- constructors must be nullary) or has only one constructor. See Section 11
@@ -50,7 +49,8 @@ mkBoundedInstance mb_ctxt ty cons = do
           in (minEqnRHS, maxEqnRHS)
 
       mk_rhs rhs = UFunction [DClause [] rhs]
-  return $ InstDecl { id_cxt = inferConstraintsDef mb_ctxt (DConPr boundedName) cons
+  constraints <- inferConstraintsDef mb_ctxt (DConPr boundedName) ty cons
+  return $ InstDecl { id_cxt = constraints
                     , id_name = boundedName
                     , id_arg_tys = [ty]
                     , id_meths = [ (minBoundName, mk_rhs minRHS)

--- a/src/Data/Singletons/Deriving/Infer.hs
+++ b/src/Data/Singletons/Deriving/Infer.hs
@@ -15,14 +15,10 @@
 
 module Data.Singletons.Deriving.Infer ( inferConstraints, inferConstraintsDef ) where
 
-import Language.Haskell.TH (Name)
 import Language.Haskell.TH.Desugar
 import Data.Singletons.Util
 import Data.List
-import qualified Data.Map as Map
-import Data.Map (Map)
 import Data.Generics.Twins
-import qualified Data.Set as Set
 
 -- @inferConstraints cls inst_ty cons@ infers the instance context for a
 -- derived type class instance of @cls@ for @inst_ty@, using the constructors
@@ -84,8 +80,8 @@ inferConstraints pr inst_ty = fmap (nubBy geq) . concatMapM infer_ct
     -- for this, when gathering @field_tys@ (from step 1 in the above algorithm)
     -- we perform the following extra steps:
     --
-    -- 1(a). Take the return type of @con@ and unify it with @inst_ty@ (e.g.,
-    --       unify @Bar b@ with @Bar a@). Doing so will produce a substitution
+    -- 1(a). Take the return type of @con@ and match it with @inst_ty@ (e.g.,
+    --       match @Bar b@ with @Bar a@). Doing so will produce a substitution
     --       that maps the universally quantified type variables in the GADT
     --       (i.e., @b@) to the corresponding type variables in the data type
     --       constructor (i.e., @a@).
@@ -99,8 +95,16 @@ inferConstraints pr inst_ty = fmap (nubBy geq) . concatMapM infer_ct
       let field_tys = tysOfConFields fields
       field_tys' <- case mb_res_ty of
                       Nothing -> pure field_tys
-                      Just res_ty -> do subst <- unify res_ty inst_ty
-                                        pure $ map (substType subst) field_tys
+                      Just res_ty -> do
+                        res_ty'  <- expandType res_ty
+                        inst_ty' <- expandType inst_ty
+                        case matchTy YesIgnore res_ty' inst_ty of
+                          Nothing -> fail $ showString "Unable to match type "
+                                          . showsPrec 11 res_ty'
+                                          . showString " with "
+                                          . showsPrec 11 inst_ty'
+                                          $ ""
+                          Just subst -> traverse (substTy subst) field_tys
       pure $ map (pr `DAppPr`) field_tys'
 
 -- For @inferConstraintsDef mb_cxt@, if @mb_cxt@ is 'Just' a context, then it will
@@ -109,52 +113,3 @@ inferConstraints pr inst_ty = fmap (nubBy geq) . concatMapM infer_ct
 inferConstraintsDef :: DsMonad q => Maybe DCxt -> DPred -> DType -> [DCon] -> q DCxt
 inferConstraintsDef mb_ctxt pr inst_ty cons =
   maybe (inferConstraints pr inst_ty cons) pure mb_ctxt
-
--- A thin wrapper around @unify'@ which expand through type synonyms in the
--- argument types beforehand, and if unification fails, produces a sensible
--- error message.
-unify :: DsMonad q => DType -> DType -> q (Map Name DType)
-unify t1 t2 = do
-  t1' <- expandType t1
-  t2' <- expandType t2
-  case unify' t1' t2' of
-    Right m -> pure m
-    Left (x, y) ->
-      fail $ showString "Unable to unify types "
-           . showsPrec 11 x
-           . showString " and "
-           . showsPrec 11 y
-           $ ""
-
--- An extremely simple unification algorithm. If unification succeeds, it will
--- produce a 'Right' substitution which maps type variable names to types.
--- Otherwise, it will fail with a 'Left' value containing the two subtypes
--- which failed to unify.
-unify' :: DType -> DType -> Either (DType, DType)
-                                   (Map Name DType)
-unify' (DVarT m) (DVarT n)
-  | m == n = pure Map.empty
-unify' (DVarT m) t
-  | m `Set.member` fvDType t = Left (DVarT m, t)
-  | otherwise                = pure (Map.singleton m t)
-unify' t (DVarT n)
-  | n `Set.member` fvDType t = Left (DVarT n, t)
-  | otherwise                = pure (Map.singleton n t)
--- For now, we don't attempt to unify kinds
-unify' (DSigT t _) u = unify' t u
-unify' t (DSigT u _) = unify' t u
-unify' (DConT m) (DConT n)
-  | m == n = pure Map.empty
-unify' (DAppT f1 x1) (DAppT f2 x2) = do
-  sub1 <- unify' f1 f2
-  sub2 <- unify' (substType sub1 x1) (substType sub1 x2)
-  pure (combineSubstitutions sub1 sub2)
-unify' DArrowT DArrowT = pure Map.empty
-unify' (DLitT m) (DLitT n)
-  | m == n = pure Map.empty
-unify' DStarT DStarT = pure Map.empty
--- Currently not handled: DForallT and DWildCardT
-unify' t u = Left (t, u)
-
-combineSubstitutions :: Map Name DType -> Map Name DType -> Map Name DType
-combineSubstitutions x y = Map.union (fmap (substType y) x) y

--- a/src/Data/Singletons/Deriving/Infer.hs
+++ b/src/Data/Singletons/Deriving/Infer.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Singletons.Deriving.Infer
@@ -13,16 +15,69 @@
 
 module Data.Singletons.Deriving.Infer ( inferConstraints, inferConstraintsDef ) where
 
+import Language.Haskell.TH (Name)
 import Language.Haskell.TH.Desugar
 import Data.Singletons.Util
 import Data.List
-import Data.Maybe (fromMaybe)
+import qualified Data.Map as Map
+import Data.Map (Map)
 import Data.Generics.Twins
+import qualified Data.Set as Set
 
-inferConstraints :: DPred -> [DCon] -> DCxt
-inferConstraints pr = nubBy geq . concatMap infer_ct
+inferConstraints :: forall q. DsMonad q => DPred -> DType -> [DCon] -> q DCxt
+inferConstraints pr inst_ty = fmap (nubBy geq) . concatMapM infer_ct
   where
-    infer_ct (DCon _ _ _ fields _) = map (pr `DAppPr`) (tysOfConFields fields)
+    infer_ct :: DCon -> q DCxt
+    infer_ct (DCon _ _ _ fields mb_res_ty) = do
+      let field_tys = tysOfConFields fields
+      field_tys' <- case mb_res_ty of
+                      Nothing -> pure field_tys
+                      Just res_ty -> do subst <- unify res_ty inst_ty
+                                        pure $ map (substType subst) field_tys
+      pure $ map (pr `DAppPr`) field_tys'
 
-inferConstraintsDef :: Maybe DCxt -> DPred -> [DCon] -> DCxt
-inferConstraintsDef mb_ctxt pr cons = fromMaybe (inferConstraints pr cons) mb_ctxt
+inferConstraintsDef :: DsMonad q => Maybe DCxt -> DPred -> DType -> [DCon] -> q DCxt
+inferConstraintsDef mb_ctxt pr inst_ty cons =
+  maybe (inferConstraints pr inst_ty cons) pure mb_ctxt
+
+unify :: DsMonad q => DType -> DType -> q (Map Name DType)
+unify t1 t2 = do
+  t1' <- expandType t1
+  t2' <- expandType t2
+  case unify' t1' t2' of
+    Right m -> pure m
+    Left (x, y) ->
+      fail $ showString "Unable to unify types "
+           . showsPrec 11 x
+           . showString " and "
+           . showsPrec 11 y
+           $ ""
+
+unify' :: DType -> DType -> Either (DType, DType)
+                                   (Map Name DType)
+unify' (DVarT m) (DVarT n)
+  | m == n = pure Map.empty
+unify' (DVarT m) t
+  | m `Set.member` fvDType t = Left (DVarT m, t)
+  | otherwise                = pure (Map.singleton m t)
+unify' t (DVarT n)
+  | n `Set.member` fvDType t = Left (DVarT n, t)
+  | otherwise                = pure (Map.singleton n t)
+-- For now, we don't attempt to unify kinds
+unify' (DSigT t _) u = unify' t u
+unify' t (DSigT u _) = unify' t u
+unify' (DConT m) (DConT n)
+  | m == n = pure Map.empty
+unify' (DAppT f1 x1) (DAppT f2 x2) = do
+  sub1 <- unify' f1 f2
+  sub2 <- unify' (substType sub1 x1) (substType sub1 x2)
+  pure (combineSubstitutions sub1 sub2)
+unify' DArrowT DArrowT = pure Map.empty
+unify' (DLitT m) (DLitT n)
+  | m == n = pure Map.empty
+unify' DStarT DStarT = pure Map.empty
+-- Currently not handled: DForallT and DWildCardT
+unify' t u = Left (t, u)
+
+combineSubstitutions :: Map Name DType -> Map Name DType -> Map Name DType
+combineSubstitutions x y = Map.union (fmap (substType y) x) y

--- a/src/Data/Singletons/Deriving/Infer.hs
+++ b/src/Data/Singletons/Deriving/Infer.hs
@@ -24,9 +24,76 @@ import Data.Map (Map)
 import Data.Generics.Twins
 import qualified Data.Set as Set
 
+-- @inferConstraints cls inst_ty cons@ infers the instance context for a
+-- derived type class instance of @cls@ for @inst_ty@, using the constructors
+-- @cons@. For instance, if @cls@ is 'Ord' and @inst_ty@ is @Either a b@, then
+-- that means we are attempting to derive the instance:
+--
+-- @
+-- instance ??? => Ord (Either a b)
+-- @
+--
+-- The role of 'inferConstraints' is to determine what @???@ should be in that
+-- derived instance. To accomplish this, the list of @cons@ (in this example,
+-- @cons@ would be @[Left a, Right b]@) is used as follows:
+--
+-- 1. For each @con@ in @cons@, find the types of each of its fields
+--    (call these @field_tys@), perhaps after renaming the type variables of
+--    @field_tys@.
+-- 2. For each @field_ty@ in @field_tys@, apply @cls@ to @field_ty@ to obtain
+--    a constraint.
+-- 3. The final instance context is the set of all such constraints obtained
+--    in step 2.
+--
+-- To complete the running example, this algorithm would produce the instance
+-- context @(Ord a, Ord b)@, since @Left a@ has one field of type @a@, and
+-- @Right b@ has one field of type @b@.
+--
+-- This algorithm is a crude approximation of what GHC actually does when
+-- deriving instances. It is crude in the sense that one can end up with
+-- redundant constraints. For instance, if the data type for which an 'Ord'
+-- instance is being derived is @data Foo = MkFoo Bool Foo@, then the
+-- inferred constraints would be @(Ord Bool, Ord Foo)@. Technically, neither
+-- constraint is necessary, but it is not simple in general to eliminate
+-- redundant constraints like these, so we do not attept to do so. (This is
+-- one reason why @singletons@ requires the use of the @UndecidableInstances@
+-- GHC extension.)
+--
+-- Observant readers will notice that the phrase \"perhaps afer renaming the
+-- type variables\" was casually dropped in step 1 of the above algorithm.
+-- For more information on what this means, refer to the documentation for
+-- infer_ct below.
 inferConstraints :: forall q. DsMonad q => DPred -> DType -> [DCon] -> q DCxt
 inferConstraints pr inst_ty = fmap (nubBy geq) . concatMapM infer_ct
   where
+    -- A thorny situation arises when attempting to infer an instance context
+    -- for a GADT. Consider the following example:
+    --
+    --   newtype Bar a where
+    --     MkBar :: b -> Bar b
+    --   deriving Show
+    --
+    -- If we blindly apply 'Show' to the field type of @MkBar@, we will end up
+    -- with a derived instance of:
+    --
+    --   instance Show b => Show (Bar a)
+    --
+    -- This is completely wrong, since the type variable @b@ is never used in
+    -- the instance head! This reveals that we need a slightly more nuanced
+    -- strategy for gathering constraints for GADT constructors. To account
+    -- for this, when gathering @field_tys@ (from step 1 in the above algorithm)
+    -- we perform the following extra steps:
+    --
+    -- 1(a). Take the return type of @con@ and unify it with @inst_ty@ (e.g.,
+    --       unify @Bar b@ with @Bar a@). Doing so will produce a substitution
+    --       that maps the universally quantified type variables in the GADT
+    --       (i.e., @b@) to the corresponding type variables in the data type
+    --       constructor (i.e., @a@).
+    -- 1(b). Use the resulting substitution to rename the universally
+    --       quantified type variables of @con@ as necessary.
+    --
+    -- After this renaming, the algorithm will produce an instance context of
+    -- @Show a@ (since @b@ was renamed to @a@), as expected.
     infer_ct :: DCon -> q DCxt
     infer_ct (DCon _ _ _ fields mb_res_ty) = do
       let field_tys = tysOfConFields fields
@@ -36,10 +103,16 @@ inferConstraints pr inst_ty = fmap (nubBy geq) . concatMapM infer_ct
                                         pure $ map (substType subst) field_tys
       pure $ map (pr `DAppPr`) field_tys'
 
+-- For @inferConstraintsDef mb_cxt@, if @mb_cxt@ is 'Just' a context, then it will
+-- simply return that context. Otherwise, if @mb_cxt@ is 'Nothing', then
+-- 'inferConstraintsDef' will infer an instance context (using 'inferConstraints').
 inferConstraintsDef :: DsMonad q => Maybe DCxt -> DPred -> DType -> [DCon] -> q DCxt
 inferConstraintsDef mb_ctxt pr inst_ty cons =
   maybe (inferConstraints pr inst_ty cons) pure mb_ctxt
 
+-- A thin wrapper around @unify'@ which expand through type synonyms in the
+-- argument types beforehand, and if unification fails, produces a sensible
+-- error message.
 unify :: DsMonad q => DType -> DType -> q (Map Name DType)
 unify t1 t2 = do
   t1' <- expandType t1
@@ -53,6 +126,10 @@ unify t1 t2 = do
            . showsPrec 11 y
            $ ""
 
+-- An extremely simple unification algorithm. If unification succeeds, it will
+-- produce a 'Right' substitution which maps type variable names to types.
+-- Otherwise, it will fail with a 'Left' value containing the two subtypes
+-- which failed to unify.
 unify' :: DType -> DType -> Either (DType, DType)
                                    (Map Name DType)
 unify' (DVarT m) (DVarT n)

--- a/src/Data/Singletons/Deriving/Ord.hs
+++ b/src/Data/Singletons/Deriving/Ord.hs
@@ -21,9 +21,9 @@ import Data.Singletons.Deriving.Infer
 import Data.Singletons.Syntax
 
 -- | Make a *non-singleton* Ord instance
-mkOrdInstance :: Quasi q => Maybe DCxt -> DType -> [DCon] -> q UInstDecl
+mkOrdInstance :: DsMonad q => Maybe DCxt -> DType -> [DCon] -> q UInstDecl
 mkOrdInstance mb_ctxt ty cons = do
-  let constraints = inferConstraintsDef mb_ctxt (DConPr ordName) cons
+  constraints <- inferConstraintsDef mb_ctxt (DConPr ordName) ty cons
   compare_eq_clauses <- mapM mk_equal_clause cons
   let compare_noneq_clauses = map (uncurry mk_nonequal_clause)
                                   [ (con1, con2)

--- a/src/Data/Singletons/Deriving/Show.hs
+++ b/src/Data/Singletons/Deriving/Show.hs
@@ -32,9 +32,10 @@ mkShowInstance :: DsMonad q
                -> q UInstDecl
 mkShowInstance mode mb_ctxt ty cons = do
   clauses <- mk_showsPrec mode cons
-  return $ InstDecl { id_cxt = inferConstraintsDef (fmap (mkShowContext mode) mb_ctxt)
-                                                   (DConPr (mk_Show_name mode))
-                                                   cons
+  constraints <- inferConstraintsDef (fmap (mkShowContext mode) mb_ctxt)
+                                     (DConPr (mk_Show_name mode))
+                                     ty cons
+  return $ InstDecl { id_cxt = constraints
                     , id_name = mk_Show_name mode
                     , id_arg_tys = [ty]
                     , id_meths = [ (mk_showsPrec_name mode, UFunction clauses) ] }

--- a/src/Data/Singletons/Util.hs
+++ b/src/Data/Singletons/Util.hs
@@ -271,7 +271,7 @@ substKind :: Map Name DKind -> DKind -> DKind
 substKind = substType
 
 -- | Non–capture-avoiding substitution. (If you want capture-avoiding
--- substitution, use @substTy@ from "Language.Haskell.TH.Desugar.Expand".
+-- substitution, use @substTy@ from "Language.Haskell.TH.Desugar.Subst".
 substType :: Map Name DType -> DType -> DType
 substType subst ty | Map.null subst = ty
 substType subst (DForallT tvbs cxt inner_ty)

--- a/src/Data/Singletons/Util.hs
+++ b/src/Data/Singletons/Util.hs
@@ -270,6 +270,8 @@ noExactTyVars = everywhere go
 substKind :: Map Name DKind -> DKind -> DKind
 substKind = substType
 
+-- | Non–capture-avoiding substitution. (If you want capture-avoiding
+-- substitution, use @substTy@ from "Language.Haskell.TH.Desugar.Expand".
 substType :: Map Name DType -> DType -> DType
 substType subst ty | Map.null subst = ty
 substType subst (DForallT tvbs cxt inner_ty)

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -83,6 +83,7 @@ tests =
     , compileAndDumpStdTest "T229"
     , compileAndDumpStdTest "T249"
     , compileAndDumpStdTest "OverloadedStrings"
+    , compileAndDumpStdTest "T271"
     ],
     testCompileAndDumpGroup "Promote"
     [ compileAndDumpStdTest "Constructors"

--- a/tests/compile-and-dump/GradingClient/Database.ghc82.template
+++ b/tests/compile-and-dump/GradingClient/Database.ghc82.template
@@ -96,12 +96,12 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
                SNil)
       sCompare SZero (SSucc _) = SLT
       sCompare (SSucc _) SZero = SGT
-    instance SEq Nat where
+    instance SEq Nat => SEq Nat where
       (%==) SZero SZero = STrue
       (%==) SZero (SSucc _) = SFalse
       (%==) (SSucc _) SZero = SFalse
       (%==) (SSucc a) (SSucc b) = ((%==) a) b
-    instance SDecide Nat where
+    instance SDecide Nat => SDecide Nat where
       (%~) SZero SZero = Proved Refl
       (%~) SZero (SSucc _) = Disproved (\ x -> case x of)
       (%~) (SSucc _) SZero = Disproved (\ x -> case x of)
@@ -1049,7 +1049,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
              ((applySing ((singFun2 @ShowStringSym0) sShowString))
                 (sing :: Sing "CZ")))
             sA_0123456789876543210
-    instance SEq U where
+    instance (SEq U, SEq Nat) => SEq U where
       (%==) SBOOL SBOOL = STrue
       (%==) SBOOL SSTRING = SFalse
       (%==) SBOOL SNAT = SFalse
@@ -1066,7 +1066,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       (%==) (SVEC _ _) SSTRING = SFalse
       (%==) (SVEC _ _) SNAT = SFalse
       (%==) (SVEC a a) (SVEC b b) = ((%&&) (((%==) a) b)) (((%==) a) b)
-    instance SDecide U where
+    instance (SDecide U, SDecide Nat) => SDecide U where
       (%~) SBOOL SBOOL = Proved Refl
       (%~) SBOOL SSTRING = Disproved (\ x -> case x of)
       (%~) SBOOL SNAT = Disproved (\ x -> case x of)

--- a/tests/compile-and-dump/Singletons/EqInstances.ghc82.template
+++ b/tests/compile-and-dump/Singletons/EqInstances.ghc82.template
@@ -1,7 +1,7 @@
 Singletons/EqInstances.hs:0:0:: Splicing declarations
     singEqInstances [''Foo, ''Empty]
   ======>
-    instance SEq Foo where
+    instance SEq Foo => SEq Foo where
       (%==) SFLeaf SFLeaf = STrue
       (%==) SFLeaf ((:%+:) _ _) = SFalse
       (%==) ((:%+:) _ _) SFLeaf = SFalse

--- a/tests/compile-and-dump/Singletons/Nat.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Nat.ghc82.template
@@ -231,12 +231,12 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
                Data.Singletons.Prelude.Instances.SNil)
       sCompare SZero (SSucc _) = SLT
       sCompare (SSucc _) SZero = SGT
-    instance SEq Nat where
+    instance SEq Nat => SEq Nat where
       (%==) SZero SZero = STrue
       (%==) SZero (SSucc _) = SFalse
       (%==) (SSucc _) SZero = SFalse
       (%==) (SSucc a) (SSucc b) = ((%==) a) b
-    instance SDecide Nat where
+    instance SDecide Nat => SDecide Nat where
       (%~) SZero SZero = Proved Refl
       (%~) SZero (SSucc _) = Disproved (\ x -> case x of)
       (%~) (SSucc _) SZero = Disproved (\ x -> case x of)

--- a/tests/compile-and-dump/Singletons/OrdDeriving.ghc82.template
+++ b/tests/compile-and-dump/Singletons/OrdDeriving.ghc82.template
@@ -774,12 +774,12 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       sCompare (SF _ _ _ _) (SC _ _ _ _) = SGT
       sCompare (SF _ _ _ _) (SD _ _ _ _) = SGT
       sCompare (SF _ _ _ _) (SE _ _ _ _) = SGT
-    instance SEq Nat where
+    instance SEq Nat => SEq Nat where
       (%==) SZero SZero = STrue
       (%==) SZero (SSucc _) = SFalse
       (%==) (SSucc _) SZero = SFalse
       (%==) (SSucc a) (SSucc b) = ((%==) a) b
-    instance SDecide Nat where
+    instance SDecide Nat => SDecide Nat where
       (%~) SZero SZero = Proved Refl
       (%~) SZero (SSucc _) = Disproved (\ x -> case x of)
       (%~) (SSucc _) SZero = Disproved (\ x -> case x of)

--- a/tests/compile-and-dump/Singletons/Star.ghc82.template
+++ b/tests/compile-and-dump/Singletons/Star.ghc82.template
@@ -161,7 +161,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
                 (toSing b :: SomeSing Nat)
           of {
             GHC.Tuple.(,) (SomeSing c) (SomeSing c) -> SomeSing ((SVec c) c) }
-    instance SEq Type where
+    instance (SEq Type, SEq Nat) => SEq Type where
       (%==) SNat SNat = STrue
       (%==) SNat SInt = SFalse
       (%==) SNat SString = SFalse
@@ -187,7 +187,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
       (%==) (SVec _ _) SString = SFalse
       (%==) (SVec _ _) (SMaybe _) = SFalse
       (%==) (SVec a a) (SVec b b) = ((%&&) (((%==) a) b)) (((%==) a) b)
-    instance SDecide Type where
+    instance (SDecide Type, SDecide Nat) => SDecide Type where
       (%~) SNat SNat = Proved Refl
       (%~) SNat SInt = Disproved (\ x -> case x of)
       (%~) SNat SString = Disproved (\ x -> case x of)

--- a/tests/compile-and-dump/Singletons/T271.ghc82.template
+++ b/tests/compile-and-dump/Singletons/T271.ghc82.template
@@ -1,0 +1,181 @@
+Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
+    singletons
+      [d| newtype Constant (a :: Type) (b :: Type)
+            = Constant a
+            deriving (Eq, Ord)
+          data Identity :: Type -> Type
+            where Identity :: a -> Identity a
+            deriving (Eq, Ord) |]
+  ======>
+    newtype Constant (a :: Type) (b :: Type)
+      = Constant a
+      deriving (Eq, Ord)
+    data Identity :: Type -> Type
+      where Identity :: a -> Identity a
+      deriving (Eq, Ord)
+    type ConstantSym1 (t :: a0123456789876543210) = Constant t
+    instance SuppressUnusedWarnings ConstantSym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) ConstantSym0KindInference) GHC.Tuple.())
+    data ConstantSym0 (l :: TyFun a0123456789876543210 (Constant a0123456789876543210 b0123456789876543210))
+      = forall arg. SameKind (Apply ConstantSym0 arg) (ConstantSym1 arg) =>
+        ConstantSym0KindInference
+    type instance Apply ConstantSym0 l = Constant l
+    type IdentitySym1 (t :: a0123456789876543210) = Identity t
+    instance SuppressUnusedWarnings IdentitySym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) IdentitySym0KindInference) GHC.Tuple.())
+    data IdentitySym0 (l :: TyFun a0123456789876543210 (Identity a0123456789876543210))
+      = forall arg. SameKind (Apply IdentitySym0 arg) (IdentitySym1 arg) =>
+        IdentitySym0KindInference
+    type instance Apply IdentitySym0 l = Identity l
+    type family Compare_0123456789876543210 (a :: Constant a b) (a :: Constant a b) :: Ordering where
+      Compare_0123456789876543210 (Constant a_0123456789876543210) (Constant b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) '[])
+    type Compare_0123456789876543210Sym2 (t :: Constant a0123456789876543210 b0123456789876543210) (t :: Constant a0123456789876543210 b0123456789876543210) =
+        Compare_0123456789876543210 t t
+    instance SuppressUnusedWarnings Compare_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Compare_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data Compare_0123456789876543210Sym1 (l :: Constant a0123456789876543210 b0123456789876543210) (l :: TyFun (Constant a0123456789876543210 b0123456789876543210) Ordering)
+      = forall arg. SameKind (Apply (Compare_0123456789876543210Sym1 l) arg) (Compare_0123456789876543210Sym2 l arg) =>
+        Compare_0123456789876543210Sym1KindInference
+    type instance Apply (Compare_0123456789876543210Sym1 l) l = Compare_0123456789876543210 l l
+    instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data Compare_0123456789876543210Sym0 (l :: TyFun (Constant a0123456789876543210 b0123456789876543210) (TyFun (Constant a0123456789876543210 b0123456789876543210) Ordering
+                                                                                                           -> Type))
+      = forall arg. SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
+        Compare_0123456789876543210Sym0KindInference
+    type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
+    instance POrd (Constant a b) where
+      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
+    type family Compare_0123456789876543210 (a :: Identity a) (a :: Identity a) :: Ordering where
+      Compare_0123456789876543210 (Identity a_0123456789876543210) (Identity b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) '[])
+    type Compare_0123456789876543210Sym2 (t :: Identity a0123456789876543210) (t :: Identity a0123456789876543210) =
+        Compare_0123456789876543210 t t
+    instance SuppressUnusedWarnings Compare_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Compare_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data Compare_0123456789876543210Sym1 (l :: Identity a0123456789876543210) (l :: TyFun (Identity a0123456789876543210) Ordering)
+      = forall arg. SameKind (Apply (Compare_0123456789876543210Sym1 l) arg) (Compare_0123456789876543210Sym2 l arg) =>
+        Compare_0123456789876543210Sym1KindInference
+    type instance Apply (Compare_0123456789876543210Sym1 l) l = Compare_0123456789876543210 l l
+    instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data Compare_0123456789876543210Sym0 (l :: TyFun (Identity a0123456789876543210) (TyFun (Identity a0123456789876543210) Ordering
+                                                                                      -> Type))
+      = forall arg. SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
+        Compare_0123456789876543210Sym0KindInference
+    type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
+    instance POrd (Identity a) where
+      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
+    type family Equals_0123456789876543210 (a :: Constant a b) (b :: Constant a b) :: Bool where
+      Equals_0123456789876543210 (Constant a) (Constant b) = (==) a b
+      Equals_0123456789876543210 (_ :: Constant a b) (_ :: Constant a b) = FalseSym0
+    instance PEq (Constant a b) where
+      type (==) a b = Equals_0123456789876543210 a b
+    type family Equals_0123456789876543210 (a :: Identity a) (b :: Identity a) :: Bool where
+      Equals_0123456789876543210 (Identity a) (Identity b) = (==) a b
+      Equals_0123456789876543210 (_ :: Identity a) (_ :: Identity a) = FalseSym0
+    instance PEq (Identity a) where
+      type (==) a b = Equals_0123456789876543210 a b
+    data instance Sing (z :: Constant a b)
+      where
+        SConstant :: forall (n :: a). (Sing (n :: a)) -> Sing (Constant n)
+    type SConstant = (Sing :: Constant a b -> Type)
+    instance (SingKind a, SingKind b) => SingKind (Constant a b) where
+      type Demote (Constant a b) = Constant (Demote a) (Demote b)
+      fromSing (SConstant b) = Constant (fromSing b)
+      toSing (Constant (b :: Demote a))
+        = case toSing b :: SomeSing a of {
+            SomeSing c -> SomeSing (SConstant c) }
+    data instance Sing (z :: Identity a)
+      where
+        SIdentity :: forall (n :: a). (Sing (n :: a)) -> Sing (Identity n)
+    type SIdentity = (Sing :: Identity a -> Type)
+    instance SingKind a => SingKind (Identity a) where
+      type Demote (Identity a) = Identity (Demote a)
+      fromSing (SIdentity b) = Identity (fromSing b)
+      toSing (Identity (b :: Demote a))
+        = case toSing b :: SomeSing a of {
+            SomeSing c -> SomeSing (SIdentity c) }
+    instance SOrd a => SOrd (Constant a b) where
+      sCompare ::
+        forall (t1 :: Constant a b) (t2 :: Constant a b).
+        Sing t1
+        -> Sing t2
+           -> Sing (Apply (Apply (CompareSym0 :: TyFun (Constant a b) (TyFun (Constant a b) Ordering
+                                                                       -> Type)
+                                                 -> Type) t1 :: TyFun (Constant a b) Ordering
+                                                                -> Type) t2 :: Ordering)
+      sCompare
+        (SConstant (sA_0123456789876543210 :: Sing a_0123456789876543210))
+        (SConstant (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        = (applySing
+             ((applySing
+                 ((applySing ((singFun3 @FoldlSym0) sFoldl))
+                    ((singFun2 @ThenCmpSym0) sThenCmp)))
+                SEQ))
+            ((applySing
+                ((applySing
+                    ((singFun2 @(:@#@$)) Data.Singletons.Prelude.Instances.SCons))
+                   ((applySing
+                       ((applySing ((singFun2 @CompareSym0) sCompare))
+                          sA_0123456789876543210))
+                      sB_0123456789876543210)))
+               Data.Singletons.Prelude.Instances.SNil)
+    instance SOrd a => SOrd (Identity a) where
+      sCompare ::
+        forall (t1 :: Identity a) (t2 :: Identity a).
+        Sing t1
+        -> Sing t2
+           -> Sing (Apply (Apply (CompareSym0 :: TyFun (Identity a) (TyFun (Identity a) Ordering
+                                                                     -> Type)
+                                                 -> Type) t1 :: TyFun (Identity a) Ordering
+                                                                -> Type) t2 :: Ordering)
+      sCompare
+        (SIdentity (sA_0123456789876543210 :: Sing a_0123456789876543210))
+        (SIdentity (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        = (applySing
+             ((applySing
+                 ((applySing ((singFun3 @FoldlSym0) sFoldl))
+                    ((singFun2 @ThenCmpSym0) sThenCmp)))
+                SEQ))
+            ((applySing
+                ((applySing
+                    ((singFun2 @(:@#@$)) Data.Singletons.Prelude.Instances.SCons))
+                   ((applySing
+                       ((applySing ((singFun2 @CompareSym0) sCompare))
+                          sA_0123456789876543210))
+                      sB_0123456789876543210)))
+               Data.Singletons.Prelude.Instances.SNil)
+    instance SEq a => SEq (Constant a b) where
+      (%==) (SConstant a) (SConstant b) = ((%==) a) b
+    instance SDecide a => SDecide (Constant a b) where
+      (%~) (SConstant a) (SConstant b)
+        = case ((%~) a) b of
+            Proved Refl -> Proved Refl
+            Disproved contra
+              -> Disproved (\ refl -> case refl of { Refl -> contra Refl })
+    instance SEq a => SEq (Identity a) where
+      (%==) (SIdentity a) (SIdentity b) = ((%==) a) b
+    instance SDecide a => SDecide (Identity a) where
+      (%~) (SIdentity a) (SIdentity b)
+        = case ((%~) a) b of
+            Proved Refl -> Proved Refl
+            Disproved contra
+              -> Disproved (\ refl -> case refl of { Refl -> contra Refl })
+    instance SingI n => SingI (Constant (n :: a)) where
+      sing = SConstant sing
+    instance SingI n => SingI (Identity (n :: a)) where
+      sing = SIdentity sing

--- a/tests/compile-and-dump/Singletons/T271.hs
+++ b/tests/compile-and-dump/Singletons/T271.hs
@@ -1,0 +1,13 @@
+module T271 where
+
+import Data.Kind
+import Data.Singletons.TH
+
+$(singletons
+    [d| newtype Constant (a :: Type) (b :: Type) =
+          Constant a deriving (Eq, Ord)
+
+        data Identity :: Type -> Type where
+          Identity :: a -> Identity a
+          deriving (Eq, Ord)
+      |])


### PR DESCRIPTION
`deriving Eq` wasn't using `inferConstraints`, which led to all sorts of shenanigans in #271. This is easily remedied.

Another problem documented in #271 was the fact that `inferConstraints` was fragile in the presence of GADTs, since each constructors' universally quantified type variables could be different from the data type constructor's type variables. To fix this, we apply a substitution on the inferred field types (see `Data.Singletons.Deriving.Infer`).