### PR TITLE
Generalize the TestCoercion instance for Sing

### DIFF
--- a/src/Data/Singletons/Decide.hs
+++ b/src/Data/Singletons/Decide.hs
@@ -25,6 +25,7 @@ module Data.Singletons.Decide (
 
 import Data.Kind
 import Data.Singletons.Internal
+import Data.Type.Coercion
 import Data.Type.Equality
 import Data.Void
 
@@ -54,4 +55,10 @@ instance SDecide k => TestEquality (Sing :: k -> Type) where
   testEquality a b =
     case a %~ b of
       Proved Refl -> Just Refl
+      Disproved _ -> Nothing
+
+instance SDecide k => TestCoercion (Sing :: k -> Type) where
+  testCoercion a b =
+    case a %~ b of
+      Proved Refl -> Just Coercion
       Disproved _ -> Nothing

--- a/src/Data/Singletons/TypeRepStar.hs
+++ b/src/Data/Singletons/TypeRepStar.hs
@@ -41,7 +41,6 @@ import Type.Reflection.Unsafe
 import Unsafe.Coerce
 
 import Data.Kind
-import Data.Type.Coercion
 import Data.Type.Equality ((:~:)(..))
 
 newtype instance Sing (a :: *) where
@@ -96,10 +95,3 @@ instance SDecide Type where
 
 instance ShowSing Type where
   showsSingPrec = showsPrec
-
--- TestEquality instance already defined, but we need this one:
-instance TestCoercion Sing where
-  testCoercion (STypeRep tra) (STypeRep trb) =
-    case eqTypeRep tra trb of
-      Just HRefl -> Just Coercion
-      Nothing    -> Nothing


### PR DESCRIPTION
Currently, the `TestCoercion Sing` instance only works if `Sing` is of kind `Type -> Type`. But this can quite easily work over `Sing`s of any kind... why not do so?