### PR TITLE
Remove the TyConN family in favor of TyCon

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -138,6 +138,9 @@ Changelog for singletons project
   `SLambda{2..8}`. Pattern matching on any defunctionalized singleton
   yields a term-level Haskell function on singletons.
 
+* Remove the family of `TyCon1`, `TyCon2`, ..., in favor of just `TyCon`.
+  GHC 8.4's type system is powerful enough to allow this nice simplification.
+
 2.3
 ---
 * Documentation clarifiation in `Data.Singletons.TypeLits`, thanks to @ivan-m.

--- a/src/Data/Singletons.hs
+++ b/src/Data/Singletons.hs
@@ -48,8 +48,7 @@ module Data.Singletons (
 
   -- ** Defunctionalization
   TyFun, type (~>),
-  TyCon1, TyCon2, TyCon3, TyCon4, TyCon5, TyCon6, TyCon7, TyCon8,
-  Apply, type (@@),
+  TyCon, Apply, type (@@),
 
   -- ** Defunctionalized singletons
   -- | When calling a higher-order singleton function, you need to use a

--- a/src/Data/Singletons/Internal.hs
+++ b/src/Data/Singletons/Internal.hs
@@ -202,7 +202,10 @@ data family TyCon :: (k1 -> k2) -> unmatchable_fun
 -- because GHC is too stupid to remember that f's kind can't
 -- have more than one argument when kind-checking the RHS of
 -- the second equation. Note that this infelicity is independent
--- of the problem in the kind of TyCon
+-- of the problem in the kind of TyCon. There is no GHC ticket
+-- here because dealing with inequality like this is hard, and
+-- I (Richard) wasn't sure what concrete value the ticket would
+-- have, given that we don't know how to begin fixing it.
 type family ApplyTyCon (f :: k1 -> k2) (x :: k1) :: k3 where
   ApplyTyCon (f :: k1 -> k2 -> k3) x = TyCon (f x)
   ApplyTyCon f x                     = f x

--- a/tests/compile-and-dump/Singletons/HigherOrder.hs
+++ b/tests/compile-and-dump/Singletons/HigherOrder.hs
@@ -38,13 +38,13 @@ $(singletons [d|
 
  |])
 
-foo1a :: Proxy (ZipWith (TyCon2 Either) '[Int, Bool] '[Char, Double])
+foo1a :: Proxy (ZipWith (TyCon Either) '[Int, Bool] '[Char, Double])
 foo1a = Proxy
 
 foo1b :: Proxy ('[Either Int Char, Either Bool Double])
 foo1b = foo1a
 
-foo2a :: Proxy (Map (TyCon1 (Either Int)) '[Bool, Double])
+foo2a :: Proxy (Map (TyCon (Either Int)) '[Bool, Double])
 foo2a = Proxy
 
 foo2b :: Proxy ('[Either Int Bool, Either Int Double])


### PR DESCRIPTION
I've been wanting to make this simplification for a while. Sadly, we're not yet powerful enough to remove the `singFun` family.

Do you see any downsides?