### PR TITLE
Fix #287 by preferring `a ~> b` over `TyFun a b -> Type`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 Changelog for singletons project
 ================================
 
+next
+----
+* `singletons` now generates `a ~> b` instead of `TyFun a b -> Type` whenever
+  possible. This may require enabling `TypeInType` in code which did not
+  previously need it.
+
 2.4.1
 -----
 * Restore the `TyCon1`, `TyCon2`, etc. types. It turns out that the new

--- a/src/Data/Promotion/Prelude/Base.hs
+++ b/src/Data/Promotion/Prelude/Base.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE TemplateHaskell, KindSignatures, PolyKinds, TypeOperators,
-             DataKinds, ScopedTypeVariables, TypeFamilies, GADTs,
+{-# LANGUAGE TemplateHaskell, TypeInType, TypeOperators,
+             ScopedTypeVariables, TypeFamilies, GADTs,
              UndecidableInstances #-}
 
 -----------------------------------------------------------------------------

--- a/src/Data/Promotion/Prelude/List.hs
+++ b/src/Data/Promotion/Prelude/List.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeOperators, DataKinds, PolyKinds, TypeFamilies,
+{-# LANGUAGE TypeOperators, TypeFamilies, TypeInType,
              TemplateHaskell, GADTs, UndecidableInstances, RankNTypes,
              ScopedTypeVariables, MultiWayIf #-}
 

--- a/src/Data/Singletons/Names.hs
+++ b/src/Data/Singletons/Names.hs
@@ -24,7 +24,7 @@ import Control.Monad
 
 boolName, andName, tyEqName, compareName, minBoundName,
   maxBoundName, repName,
-  nilName, consName, listName, tyFunName,
+  nilName, consName, listName, tyFunName, tyFunArrowName,
   applyName, natName, symbolName, typeRepName, stringName,
   eqName, ordName, boundedName, orderingName,
   singFamilyName, singIName, singMethName, demoteName,
@@ -53,6 +53,7 @@ nilName = '[]
 consName = '(:)
 listName = ''[]
 tyFunName = ''TyFun
+tyFunArrowName = ''(~>)
 applyName = ''Apply
 symbolName = ''Symbol
 natName = ''Nat

--- a/src/Data/Singletons/Prelude/Base.hs
+++ b/src/Data/Singletons/Prelude/Base.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE TemplateHaskell, KindSignatures, PolyKinds, TypeOperators,
-             DataKinds, ScopedTypeVariables, TypeFamilies, GADTs,
+{-# LANGUAGE TemplateHaskell, TypeInType, TypeOperators,
+             ScopedTypeVariables, TypeFamilies, GADTs,
              UndecidableInstances, BangPatterns #-}
 
 -----------------------------------------------------------------------------

--- a/src/Data/Singletons/Prelude/Bool.hs
+++ b/src/Data/Singletons/Prelude/Bool.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TemplateHaskell, DataKinds, PolyKinds, TypeFamilies, TypeOperators,
+{-# LANGUAGE TemplateHaskell, TypeFamilies, TypeInType, TypeOperators,
              GADTs, ScopedTypeVariables, DeriveDataTypeable, UndecidableInstances #-}
 
 -----------------------------------------------------------------------------

--- a/src/Data/Singletons/Prelude/Either.hs
+++ b/src/Data/Singletons/Prelude/Either.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE TemplateHaskell, ScopedTypeVariables, TypeFamilies, GADTs,
-             DataKinds, PolyKinds, RankNTypes, UndecidableInstances #-}
+             TypeInType, RankNTypes, UndecidableInstances #-}
 
 -----------------------------------------------------------------------------
 -- |

--- a/src/Data/Singletons/Promote/Type.hs
+++ b/src/Data/Singletons/Promote/Type.hs
@@ -49,7 +49,7 @@ promoteType = go []
       = return $ foldType (DConT (tupleTypeName n)) args
       | otherwise
       = return $ foldType (DConT name) args
-    go [k1, k2] DArrowT = return $ addStar (DConT tyFunName `DAppT` k1 `DAppT` k2)
+    go [k1, k2] DArrowT = return $ DConT tyFunArrowName `DAppT` k1 `DAppT` k2
     go _ (DLitT _) = fail "Cannot promote a type-level literal"
 
     go args     hd = fail $ "Illegal Haskell construct encountered:\n" ++

--- a/src/Data/Singletons/Util.hs
+++ b/src/Data/Singletons/Util.hs
@@ -319,12 +319,6 @@ substKindInTvb :: Map Name DKind -> DTyVarBndr -> DTyVarBndr
 substKindInTvb _ tvb@(DPlainTV _) = tvb
 substKindInTvb subst (DKindedTV n ki) = DKindedTV n (substKind subst ki)
 
-addStar :: DKind -> DKind
-addStar t = DAppT (DAppT DArrowT t) DStarT
-
-addStar_maybe :: Maybe DKind -> Maybe DKind
-addStar_maybe = fmap addStar
-
 -- apply a type to a list of types
 foldType :: DType -> [DType] -> DType
 foldType = foldl DAppT

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -94,6 +94,7 @@ tests rootDir =
     , stdTest "T249"
     , stdTest "OverloadedStrings"
     , stdTest "T271"
+    , stdTest "T287"
     ],
     testCompileAndDumpGroup "Promote"
     [ stdTest "Constructors"

--- a/tests/compile-and-dump/GradingClient/Database.ghc84.template
+++ b/tests/compile-and-dump/GradingClient/Database.ghc84.template
@@ -37,8 +37,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym0 (l :: TyFun Nat (TyFun Nat Ordering
-                                                          -> Type))
+    data Compare_0123456789876543210Sym0 (l :: TyFun Nat ((~>) Nat Ordering))
       = forall arg. SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
         Compare_0123456789876543210Sym0KindInference
     type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
@@ -68,8 +67,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
         forall (t1 :: Nat) (t2 :: Nat).
         Sing t1
         -> Sing t2
-           -> Sing (Apply (Apply (CompareSym0 :: TyFun Nat (TyFun Nat Ordering
-                                                            -> Type)
+           -> Sing (Apply (Apply (CompareSym0 :: TyFun Nat ((~>) Nat Ordering)
                                                  -> Type) t1) t2)
       sCompare SZero SZero
         = (applySing
@@ -232,7 +230,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings VECSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) VECSym0KindInference) GHC.Tuple.())
-    data VECSym0 (l :: TyFun U (TyFun Nat U -> Type))
+    data VECSym0 (l :: TyFun U ((~>) Nat U))
       = forall arg. SameKind (Apply VECSym0 arg) (VECSym1 arg) =>
         VECSym0KindInference
     type instance Apply VECSym0 l = VECSym1 l
@@ -273,7 +271,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings AttrSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) AttrSym0KindInference) GHC.Tuple.())
-    data AttrSym0 (l :: TyFun [AChar] (TyFun U Attribute -> Type))
+    data AttrSym0 (l :: TyFun [AChar] ((~>) U Attribute))
       = forall arg. SameKind (Apply AttrSym0 arg) (AttrSym1 arg) =>
         AttrSym0KindInference
     type instance Apply AttrSym0 l = AttrSym1 l
@@ -343,7 +341,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings LookupSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) LookupSym0KindInference) GHC.Tuple.())
-    data LookupSym0 (l :: TyFun [AChar] (TyFun Schema U -> Type))
+    data LookupSym0 (l :: TyFun [AChar] ((~>) Schema U))
       = forall arg. SameKind (Apply LookupSym0 arg) (LookupSym1 arg) =>
         LookupSym0KindInference
     type instance Apply LookupSym0 l = LookupSym1 l
@@ -358,7 +356,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings OccursSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) OccursSym0KindInference) GHC.Tuple.())
-    data OccursSym0 (l :: TyFun [AChar] (TyFun Schema Bool -> Type))
+    data OccursSym0 (l :: TyFun [AChar] ((~>) Schema Bool))
       = forall arg. SameKind (Apply OccursSym0 arg) (OccursSym1 arg) =>
         OccursSym0KindInference
     type instance Apply OccursSym0 l = OccursSym1 l
@@ -373,8 +371,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings AttrNotInSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) AttrNotInSym0KindInference) GHC.Tuple.())
-    data AttrNotInSym0 (l :: TyFun Attribute (TyFun Schema Bool
-                                              -> Type))
+    data AttrNotInSym0 (l :: TyFun Attribute ((~>) Schema Bool))
       = forall arg. SameKind (Apply AttrNotInSym0 arg) (AttrNotInSym1 arg) =>
         AttrNotInSym0KindInference
     type instance Apply AttrNotInSym0 l = AttrNotInSym1 l
@@ -389,7 +386,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings DisjointSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) DisjointSym0KindInference) GHC.Tuple.())
-    data DisjointSym0 (l :: TyFun Schema (TyFun Schema Bool -> Type))
+    data DisjointSym0 (l :: TyFun Schema ((~>) Schema Bool))
       = forall arg. SameKind (Apply DisjointSym0 arg) (DisjointSym1 arg) =>
         DisjointSym0KindInference
     type instance Apply DisjointSym0 l = DisjointSym1 l
@@ -404,7 +401,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings AppendSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) AppendSym0KindInference) GHC.Tuple.())
-    data AppendSym0 (l :: TyFun Schema (TyFun Schema Schema -> Type))
+    data AppendSym0 (l :: TyFun Schema ((~>) Schema Schema))
       = forall arg. SameKind (Apply AppendSym0 arg) (AppendSym1 arg) =>
         AppendSym0KindInference
     type instance Apply AppendSym0 l = AppendSym1 l
@@ -443,8 +440,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun U (TyFun Symbol Symbol
-                                                                               -> Type))
+    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun U ((~>) Symbol Symbol))
       = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
         ShowsPrec_0123456789876543210Sym1KindInference
     type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
@@ -453,9 +449,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat (TyFun U (TyFun Symbol Symbol
-                                                                               -> Type)
-                                                                      -> Type))
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) U ((~>) Symbol Symbol)))
       = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
@@ -504,8 +498,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun AChar (TyFun Symbol Symbol
-                                                                                   -> Type))
+    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun AChar ((~>) Symbol Symbol))
       = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
         ShowsPrec_0123456789876543210Sym1KindInference
     type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
@@ -514,9 +507,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat (TyFun AChar (TyFun Symbol Symbol
-                                                                                   -> Type)
-                                                                      -> Type))
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) AChar ((~>) Symbol Symbol)))
       = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
@@ -767,9 +758,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
         Sing t1
         -> Sing t2
            -> Sing t3
-              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat (TyFun U (TyFun Symbol Symbol
-                                                                                           -> Type)
-                                                                                  -> Type)
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat ((~>) U ((~>) Symbol Symbol))
                                                              -> Type) t1) t2) t3)
       sShowsPrec
         _
@@ -830,9 +819,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
         Sing t1
         -> Sing t2
            -> Sing t3
-              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat (TyFun AChar (TyFun Symbol Symbol
-                                                                                               -> Type)
-                                                                                  -> Type)
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat ((~>) AChar ((~>) Symbol Symbol))
                                                              -> Type) t1) t2) t3)
       sShowsPrec
         _

--- a/tests/compile-and-dump/InsertionSort/InsertionSortImp.ghc84.template
+++ b/tests/compile-and-dump/InsertionSort/InsertionSortImp.ghc84.template
@@ -104,7 +104,7 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings LeqSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) LeqSym0KindInference) GHC.Tuple.())
-    data LeqSym0 (l :: TyFun Nat (TyFun Nat Bool -> Type))
+    data LeqSym0 (l :: TyFun Nat ((~>) Nat Bool))
       = forall arg. SameKind (Apply LeqSym0 arg) (LeqSym1 arg) =>
         LeqSym0KindInference
     type instance Apply LeqSym0 l = LeqSym1 l
@@ -119,7 +119,7 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings InsertSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) InsertSym0KindInference) GHC.Tuple.())
-    data InsertSym0 (l :: TyFun Nat (TyFun [Nat] [Nat] -> Type))
+    data InsertSym0 (l :: TyFun Nat ((~>) [Nat] [Nat]))
       = forall arg. SameKind (Apply InsertSym0 arg) (InsertSym1 arg) =>
         InsertSym0KindInference
     type instance Apply InsertSym0 l = InsertSym1 l

--- a/tests/compile-and-dump/Promote/Constructors.ghc84.template
+++ b/tests/compile-and-dump/Promote/Constructors.ghc84.template
@@ -17,7 +17,7 @@ Promote/Constructors.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (:+@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::+@#@$###)) GHC.Tuple.())
-    data (:+@#@$) (l :: TyFun Foo (TyFun Foo Foo -> GHC.Types.Type))
+    data (:+@#@$) (l :: TyFun Foo ((~>) Foo Foo))
       = forall arg. SameKind (Apply (:+@#@$) arg) ((:+@#@$$) arg) =>
         (::+@#@$###)
     type instance Apply (:+@#@$) l = (:+@#@$$) l
@@ -33,38 +33,28 @@ Promote/Constructors.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings BarSym3 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BarSym3KindInference) GHC.Tuple.())
-    data BarSym3 (l :: Bar) (l :: Bar) (l :: Bar) (l :: TyFun Bar (TyFun Foo Bar
-                                                                   -> GHC.Types.Type))
+    data BarSym3 (l :: Bar) (l :: Bar) (l :: Bar) (l :: TyFun Bar ((~>) Foo Bar))
       = forall arg. SameKind (Apply (BarSym3 l l l) arg) (BarSym4 l l l arg) =>
         BarSym3KindInference
     type instance Apply (BarSym3 l l l) l = BarSym4 l l l l
     instance SuppressUnusedWarnings BarSym2 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BarSym2KindInference) GHC.Tuple.())
-    data BarSym2 (l :: Bar) (l :: Bar) (l :: TyFun Bar (TyFun Bar (TyFun Foo Bar
-                                                                   -> GHC.Types.Type)
-                                                        -> GHC.Types.Type))
+    data BarSym2 (l :: Bar) (l :: Bar) (l :: TyFun Bar ((~>) Bar ((~>) Foo Bar)))
       = forall arg. SameKind (Apply (BarSym2 l l) arg) (BarSym3 l l arg) =>
         BarSym2KindInference
     type instance Apply (BarSym2 l l) l = BarSym3 l l l
     instance SuppressUnusedWarnings BarSym1 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BarSym1KindInference) GHC.Tuple.())
-    data BarSym1 (l :: Bar) (l :: TyFun Bar (TyFun Bar (TyFun Bar (TyFun Foo Bar
-                                                                   -> GHC.Types.Type)
-                                                        -> GHC.Types.Type)
-                                             -> GHC.Types.Type))
+    data BarSym1 (l :: Bar) (l :: TyFun Bar ((~>) Bar ((~>) Bar ((~>) Foo Bar))))
       = forall arg. SameKind (Apply (BarSym1 l) arg) (BarSym2 l arg) =>
         BarSym1KindInference
     type instance Apply (BarSym1 l) l = BarSym2 l l
     instance SuppressUnusedWarnings BarSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BarSym0KindInference) GHC.Tuple.())
-    data BarSym0 (l :: TyFun Bar (TyFun Bar (TyFun Bar (TyFun Bar (TyFun Foo Bar
-                                                                   -> GHC.Types.Type)
-                                                        -> GHC.Types.Type)
-                                             -> GHC.Types.Type)
-                                  -> GHC.Types.Type))
+    data BarSym0 (l :: TyFun Bar ((~>) Bar ((~>) Bar ((~>) Bar ((~>) Foo Bar)))))
       = forall arg. SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
         BarSym0KindInference
     type instance Apply BarSym0 l = BarSym1 l

--- a/tests/compile-and-dump/Promote/GenDefunSymbols.ghc84.template
+++ b/tests/compile-and-dump/Promote/GenDefunSymbols.ghc84.template
@@ -16,8 +16,7 @@ Promote/GenDefunSymbols.hs:0:0:: Splicing declarations
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) LiftMaybeSym0KindInference) GHC.Tuple.())
     data LiftMaybeSym0 (l :: TyFun (TyFun a0123456789876543210 b0123456789876543210
-                                    -> Type) (TyFun (Maybe a0123456789876543210) (Maybe b0123456789876543210)
-                                              -> Type))
+                                    -> Type) ((Data.Singletons.Internal.~>) (Maybe a0123456789876543210) (Maybe b0123456789876543210)))
       = forall arg. Data.Singletons.Internal.SameKind (Apply LiftMaybeSym0 arg) (LiftMaybeSym1 arg) =>
         LiftMaybeSym0KindInference
     type instance Apply LiftMaybeSym0 l = LiftMaybeSym1 l

--- a/tests/compile-and-dump/Singletons/AsPattern.ghc84.template
+++ b/tests/compile-and-dump/Singletons/AsPattern.ghc84.template
@@ -45,17 +45,14 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings BazSym1 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BazSym1KindInference) GHC.Tuple.())
-    data BazSym1 (l :: Nat) (l :: TyFun Nat (TyFun Nat Baz
-                                             -> GHC.Types.Type))
+    data BazSym1 (l :: Nat) (l :: TyFun Nat ((~>) Nat Baz))
       = forall arg. SameKind (Apply (BazSym1 l) arg) (BazSym2 l arg) =>
         BazSym1KindInference
     type instance Apply (BazSym1 l) l = BazSym2 l l
     instance SuppressUnusedWarnings BazSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BazSym0KindInference) GHC.Tuple.())
-    data BazSym0 (l :: TyFun Nat (TyFun Nat (TyFun Nat Baz
-                                             -> GHC.Types.Type)
-                                  -> GHC.Types.Type))
+    data BazSym0 (l :: TyFun Nat ((~>) Nat ((~>) Nat Baz)))
       = forall arg. SameKind (Apply BazSym0 arg) (BazSym1 arg) =>
         BazSym0KindInference
     type instance Apply BazSym0 l = BazSym1 l

--- a/tests/compile-and-dump/Singletons/BoundedDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/BoundedDeriving.ghc84.template
@@ -58,7 +58,7 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings PairSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) PairSym0KindInference) GHC.Tuple.())
-    data PairSym0 (l :: TyFun Bool (TyFun Bool Pair -> Type))
+    data PairSym0 (l :: TyFun Bool ((~>) Bool Pair))
       = forall arg. SameKind (Apply PairSym0 arg) (PairSym1 arg) =>
         PairSym0KindInference
     type instance Apply PairSym0 l = PairSym1 l

--- a/tests/compile-and-dump/Singletons/CaseExpressions.ghc84.template
+++ b/tests/compile-and-dump/Singletons/CaseExpressions.ghc84.template
@@ -168,8 +168,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo3Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo3Sym0KindInference) GHC.Tuple.())
-    data Foo3Sym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 a0123456789876543210
-                                                    -> GHC.Types.Type))
+    data Foo3Sym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 a0123456789876543210))
       = forall arg. SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
         Foo3Sym0KindInference
     type instance Apply Foo3Sym0 l = Foo3Sym1 l
@@ -185,8 +184,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo2Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo2Sym0KindInference) GHC.Tuple.())
-    data Foo2Sym0 (l :: TyFun a0123456789876543210 (TyFun (Maybe a0123456789876543210) a0123456789876543210
-                                                    -> GHC.Types.Type))
+    data Foo2Sym0 (l :: TyFun a0123456789876543210 ((~>) (Maybe a0123456789876543210) a0123456789876543210))
       = forall arg. SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) =>
         Foo2Sym0KindInference
     type instance Apply Foo2Sym0 l = Foo2Sym1 l
@@ -202,8 +200,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo1Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo1Sym0KindInference) GHC.Tuple.())
-    data Foo1Sym0 (l :: TyFun a0123456789876543210 (TyFun (Maybe a0123456789876543210) a0123456789876543210
-                                                    -> GHC.Types.Type))
+    data Foo1Sym0 (l :: TyFun a0123456789876543210 ((~>) (Maybe a0123456789876543210) a0123456789876543210))
       = forall arg. SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
         Foo1Sym0KindInference
     type instance Apply Foo1Sym0 l = Foo1Sym1 l

--- a/tests/compile-and-dump/Singletons/Classes.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Classes.ghc84.template
@@ -76,8 +76,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FooCompareSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooCompareSym0KindInference) GHC.Tuple.())
-    data FooCompareSym0 (l :: TyFun Foo (TyFun Foo Ordering
-                                         -> GHC.Types.Type))
+    data FooCompareSym0 (l :: TyFun Foo ((~>) Foo Ordering))
       = forall arg. SameKind (Apply FooCompareSym0 arg) (FooCompareSym1 arg) =>
         FooCompareSym0KindInference
     type instance Apply FooCompareSym0 l = FooCompareSym1 l
@@ -93,8 +92,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ConstSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ConstSym0KindInference) GHC.Tuple.())
-    data ConstSym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 a0123456789876543210
-                                                     -> GHC.Types.Type))
+    data ConstSym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 a0123456789876543210))
       = forall arg. SameKind (Apply ConstSym0 arg) (ConstSym1 arg) =>
         ConstSym0KindInference
     type instance Apply ConstSym0 l = ConstSym1 l
@@ -117,8 +115,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings MycompareSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MycompareSym0KindInference) GHC.Tuple.())
-    data MycompareSym0 (l :: TyFun a0123456789876543210 (TyFun a0123456789876543210 Ordering
-                                                         -> GHC.Types.Type))
+    data MycompareSym0 (l :: TyFun a0123456789876543210 ((~>) a0123456789876543210 Ordering))
       = forall arg. SameKind (Apply MycompareSym0 arg) (MycompareSym1 arg) =>
         MycompareSym0KindInference
     type instance Apply MycompareSym0 l = MycompareSym1 l
@@ -134,8 +131,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (<=>@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:<=>@#@$###)) GHC.Tuple.())
-    data (<=>@#@$) (l :: TyFun a0123456789876543210 (TyFun a0123456789876543210 Ordering
-                                                     -> GHC.Types.Type))
+    data (<=>@#@$) (l :: TyFun a0123456789876543210 ((~>) a0123456789876543210 Ordering))
       = forall arg. SameKind (Apply (<=>@#@$) arg) ((<=>@#@$$) arg) =>
         (:<=>@#@$###)
     type instance Apply (<=>@#@$) l = (<=>@#@$$) l
@@ -157,8 +153,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) TFHelper_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data TFHelper_0123456789876543210Sym0 (l :: TyFun a0123456789876543210 (TyFun a0123456789876543210 Ordering
-                                                                            -> GHC.Types.Type))
+    data TFHelper_0123456789876543210Sym0 (l :: TyFun a0123456789876543210 ((~>) a0123456789876543210 Ordering))
       = forall arg. SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
         TFHelper_0123456789876543210Sym0KindInference
     type instance Apply TFHelper_0123456789876543210Sym0 l = TFHelper_0123456789876543210Sym1 l
@@ -187,8 +182,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Mycompare_0123456789876543210Sym0 (l :: TyFun Nat (TyFun Nat Ordering
-                                                            -> GHC.Types.Type))
+    data Mycompare_0123456789876543210Sym0 (l :: TyFun Nat ((~>) Nat Ordering))
       = forall arg. SameKind (Apply Mycompare_0123456789876543210Sym0 arg) (Mycompare_0123456789876543210Sym1 arg) =>
         Mycompare_0123456789876543210Sym0KindInference
     type instance Apply Mycompare_0123456789876543210Sym0 l = Mycompare_0123456789876543210Sym1 l
@@ -212,8 +206,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Mycompare_0123456789876543210Sym0 (l :: TyFun () (TyFun () Ordering
-                                                           -> GHC.Types.Type))
+    data Mycompare_0123456789876543210Sym0 (l :: TyFun () ((~>) () Ordering))
       = forall arg. SameKind (Apply Mycompare_0123456789876543210Sym0 arg) (Mycompare_0123456789876543210Sym1 arg) =>
         Mycompare_0123456789876543210Sym0KindInference
     type instance Apply Mycompare_0123456789876543210Sym0 l = Mycompare_0123456789876543210Sym1 l
@@ -237,8 +230,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Mycompare_0123456789876543210Sym0 (l :: TyFun Foo (TyFun Foo Ordering
-                                                            -> GHC.Types.Type))
+    data Mycompare_0123456789876543210Sym0 (l :: TyFun Foo ((~>) Foo Ordering))
       = forall arg. SameKind (Apply Mycompare_0123456789876543210Sym0 arg) (Mycompare_0123456789876543210Sym1 arg) =>
         Mycompare_0123456789876543210Sym0KindInference
     type instance Apply Mycompare_0123456789876543210Sym0 l = Mycompare_0123456789876543210Sym1 l
@@ -265,8 +257,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) TFHelper_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data TFHelper_0123456789876543210Sym0 (l :: TyFun Foo2 (TyFun Foo2 Bool
-                                                            -> GHC.Types.Type))
+    data TFHelper_0123456789876543210Sym0 (l :: TyFun Foo2 ((~>) Foo2 Bool))
       = forall arg. SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
         TFHelper_0123456789876543210Sym0KindInference
     type instance Apply TFHelper_0123456789876543210Sym0 l = TFHelper_0123456789876543210Sym1 l
@@ -412,8 +403,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Mycompare_0123456789876543210Sym0 (l :: TyFun Foo2 (TyFun Foo2 Ordering
-                                                             -> GHC.Types.Type))
+    data Mycompare_0123456789876543210Sym0 (l :: TyFun Foo2 ((~>) Foo2 Ordering))
       = forall arg. SameKind (Apply Mycompare_0123456789876543210Sym0 arg) (Mycompare_0123456789876543210Sym1 arg) =>
         Mycompare_0123456789876543210Sym0KindInference
     type instance Apply Mycompare_0123456789876543210Sym0 l = Mycompare_0123456789876543210Sym1 l
@@ -439,8 +429,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym0 (l :: TyFun Foo2 (TyFun Foo2 Ordering
-                                                           -> GHC.Types.Type))
+    data Compare_0123456789876543210Sym0 (l :: TyFun Foo2 ((~>) Foo2 Ordering))
       = forall arg. SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
         Compare_0123456789876543210Sym0KindInference
     type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
@@ -492,8 +481,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Mycompare_0123456789876543210Sym0 (l :: TyFun Nat' (TyFun Nat' Ordering
-                                                             -> GHC.Types.Type))
+    data Mycompare_0123456789876543210Sym0 (l :: TyFun Nat' ((~>) Nat' Ordering))
       = forall arg. SameKind (Apply Mycompare_0123456789876543210Sym0 arg) (Mycompare_0123456789876543210Sym1 arg) =>
         Mycompare_0123456789876543210Sym0KindInference
     type instance Apply Mycompare_0123456789876543210Sym0 l = Mycompare_0123456789876543210Sym1 l
@@ -517,8 +505,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         forall (t :: Nat') (t :: Nat').
         Sing t
         -> Sing t
-           -> Sing (Apply (Apply (MycompareSym0 :: TyFun Nat' (TyFun Nat' Ordering
-                                                               -> GHC.Types.Type)
+           -> Sing (Apply (Apply (MycompareSym0 :: TyFun Nat' ((~>) Nat' Ordering)
                                                    -> GHC.Types.Type) t) t)
       sMycompare SZero' SZero' = SEQ
       sMycompare SZero' (SSucc' _) = SLT

--- a/tests/compile-and-dump/Singletons/Classes2.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Classes2.ghc84.template
@@ -44,8 +44,7 @@ Singletons/Classes2.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Mycompare_0123456789876543210Sym0 (l :: TyFun NatFoo (TyFun NatFoo Ordering
-                                                               -> GHC.Types.Type))
+    data Mycompare_0123456789876543210Sym0 (l :: TyFun NatFoo ((~>) NatFoo Ordering))
       = forall arg. SameKind (Apply Mycompare_0123456789876543210Sym0 arg) (Mycompare_0123456789876543210Sym1 arg) =>
         Mycompare_0123456789876543210Sym0KindInference
     type instance Apply Mycompare_0123456789876543210Sym0 l = Mycompare_0123456789876543210Sym1 l
@@ -70,8 +69,7 @@ Singletons/Classes2.hs:(0,0)-(0,0): Splicing declarations
         forall (t1 :: NatFoo) (t2 :: NatFoo).
         Sing t1
         -> Sing t2
-           -> Sing (Apply (Apply (MycompareSym0 :: TyFun NatFoo (TyFun NatFoo Ordering
-                                                                 -> GHC.Types.Type)
+           -> Sing (Apply (Apply (MycompareSym0 :: TyFun NatFoo ((~>) NatFoo Ordering)
                                                    -> GHC.Types.Type) t1) t2)
       sMycompare SZeroFoo SZeroFoo = SEQ
       sMycompare SZeroFoo (SSuccFoo _) = SLT

--- a/tests/compile-and-dump/Singletons/Contains.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Contains.ghc84.template
@@ -19,8 +19,7 @@ Singletons/Contains.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ContainsSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ContainsSym0KindInference) GHC.Tuple.())
-    data ContainsSym0 (l :: TyFun a0123456789876543210 (TyFun [a0123456789876543210] Bool
-                                                        -> GHC.Types.Type))
+    data ContainsSym0 (l :: TyFun a0123456789876543210 ((~>) [a0123456789876543210] Bool))
       = forall arg. SameKind (Apply ContainsSym0 arg) (ContainsSym1 arg) =>
         ContainsSym0KindInference
     type instance Apply ContainsSym0 l = ContainsSym1 l

--- a/tests/compile-and-dump/Singletons/DataValues.ghc84.template
+++ b/tests/compile-and-dump/Singletons/DataValues.ghc84.template
@@ -28,8 +28,7 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings PairSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) PairSym0KindInference) GHC.Tuple.())
-    data PairSym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 (Pair a0123456789876543210 b0123456789876543210)
-                                                    -> GHC.Types.Type))
+    data PairSym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 (Pair a0123456789876543210 b0123456789876543210)))
       = forall arg. SameKind (Apply PairSym0 arg) (PairSym1 arg) =>
         PairSym0KindInference
     type instance Apply PairSym0 l = PairSym1 l
@@ -63,8 +62,7 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun (Pair a0123456789876543210 b0123456789876543210) (TyFun Symbol Symbol
-                                                                                                                              -> GHC.Types.Type))
+    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun (Pair a0123456789876543210 b0123456789876543210) ((~>) Symbol Symbol))
       = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
         ShowsPrec_0123456789876543210Sym1KindInference
     type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
@@ -73,9 +71,7 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat (TyFun (Pair a0123456789876543210 b0123456789876543210) (TyFun Symbol Symbol
-                                                                                                                              -> GHC.Types.Type)
-                                                                      -> GHC.Types.Type))
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) (Pair a0123456789876543210 b0123456789876543210) ((~>) Symbol Symbol)))
       = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
@@ -132,9 +128,7 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
         Sing t1
         -> Sing t2
            -> Sing t3
-              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat (TyFun (Pair a b) (TyFun Symbol Symbol
-                                                                                                    -> GHC.Types.Type)
-                                                                                  -> GHC.Types.Type)
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat ((~>) (Pair a b) ((~>) Symbol Symbol))
                                                              -> GHC.Types.Type) t1) t2) t3)
       sShowsPrec
         (sP_0123456789876543210 :: Sing p_0123456789876543210)

--- a/tests/compile-and-dump/Singletons/EmptyShowDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/EmptyShowDeriving.ghc84.template
@@ -25,8 +25,7 @@ Singletons/EmptyShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun Foo (TyFun GHC.Types.Symbol GHC.Types.Symbol
-                                                                                 -> GHC.Types.Type))
+    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun Foo ((~>) GHC.Types.Symbol GHC.Types.Symbol))
       = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
         ShowsPrec_0123456789876543210Sym1KindInference
     type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
@@ -35,9 +34,7 @@ Singletons/EmptyShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat (TyFun Foo (TyFun GHC.Types.Symbol GHC.Types.Symbol
-                                                                                 -> GHC.Types.Type)
-                                                                      -> GHC.Types.Type))
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) Foo ((~>) GHC.Types.Symbol GHC.Types.Symbol)))
       = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
@@ -55,9 +52,7 @@ Singletons/EmptyShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         Sing t1
         -> Sing t2
            -> Sing t3
-              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat (TyFun Foo (TyFun GHC.Types.Symbol GHC.Types.Symbol
-                                                                                             -> GHC.Types.Type)
-                                                                                  -> GHC.Types.Type)
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat ((~>) Foo ((~>) GHC.Types.Symbol GHC.Types.Symbol))
                                                              -> GHC.Types.Type) t1) t2) t3)
       sShowsPrec
         _

--- a/tests/compile-and-dump/Singletons/Fixity.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Fixity.ghc84.template
@@ -28,8 +28,7 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (====@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:====@#@$###)) GHC.Tuple.())
-    data (====@#@$) (l :: TyFun a0123456789876543210 (TyFun a0123456789876543210 a0123456789876543210
-                                                      -> GHC.Types.Type))
+    data (====@#@$) (l :: TyFun a0123456789876543210 ((~>) a0123456789876543210 a0123456789876543210))
       = forall arg. SameKind (Apply (====@#@$) arg) ((====@#@$$) arg) =>
         (:====@#@$###)
     type instance Apply (====@#@$) l = (====@#@$$) l
@@ -47,8 +46,7 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (<=>@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:<=>@#@$###)) GHC.Tuple.())
-    data (<=>@#@$) (l :: TyFun a0123456789876543210 (TyFun a0123456789876543210 Ordering
-                                                     -> GHC.Types.Type))
+    data (<=>@#@$) (l :: TyFun a0123456789876543210 ((~>) a0123456789876543210 Ordering))
       = forall arg. SameKind (Apply (<=>@#@$) arg) ((<=>@#@$$) arg) =>
         (:<=>@#@$###)
     type instance Apply (<=>@#@$) l = (<=>@#@$$) l

--- a/tests/compile-and-dump/Singletons/HigherOrder.ghc84.template
+++ b/tests/compile-and-dump/Singletons/HigherOrder.ghc84.template
@@ -143,79 +143,49 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
       = forall arg. SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
         Lambda_0123456789876543210Sym0KindInference
     type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
-    type FooSym3 (t :: TyFun (TyFun a0123456789876543210 b0123456789876543210
-                              -> GHC.Types.Type) (TyFun a0123456789876543210 b0123456789876543210
-                                                  -> GHC.Types.Type)
-                       -> GHC.Types.Type) (t :: TyFun a0123456789876543210 b0123456789876543210
-                                                -> GHC.Types.Type) (t :: a0123456789876543210) =
+    type FooSym3 (t :: (~>) ((~>) a0123456789876543210 b0123456789876543210) ((~>) a0123456789876543210 b0123456789876543210)) (t :: (~>) a0123456789876543210 b0123456789876543210) (t :: a0123456789876543210) =
         Foo t t t
     instance SuppressUnusedWarnings FooSym2 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym2KindInference) GHC.Tuple.())
-    data FooSym2 (l :: TyFun (TyFun a0123456789876543210 b0123456789876543210
-                              -> GHC.Types.Type) (TyFun a0123456789876543210 b0123456789876543210
-                                                  -> GHC.Types.Type)
-                       -> GHC.Types.Type) (l :: TyFun a0123456789876543210 b0123456789876543210
-                                                -> GHC.Types.Type) (l :: TyFun a0123456789876543210 b0123456789876543210)
+    data FooSym2 (l :: (~>) ((~>) a0123456789876543210 b0123456789876543210) ((~>) a0123456789876543210 b0123456789876543210)) (l :: (~>) a0123456789876543210 b0123456789876543210) (l :: TyFun a0123456789876543210 b0123456789876543210)
       = forall arg. SameKind (Apply (FooSym2 l l) arg) (FooSym3 l l arg) =>
         FooSym2KindInference
     type instance Apply (FooSym2 l l) l = Foo l l l
     instance SuppressUnusedWarnings FooSym1 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym1KindInference) GHC.Tuple.())
-    data FooSym1 (l :: TyFun (TyFun a0123456789876543210 b0123456789876543210
-                              -> GHC.Types.Type) (TyFun a0123456789876543210 b0123456789876543210
-                                                  -> GHC.Types.Type)
-                       -> GHC.Types.Type) (l :: TyFun (TyFun a0123456789876543210 b0123456789876543210
-                                                       -> GHC.Types.Type) (TyFun a0123456789876543210 b0123456789876543210
-                                                                           -> GHC.Types.Type))
+    data FooSym1 (l :: (~>) ((~>) a0123456789876543210 b0123456789876543210) ((~>) a0123456789876543210 b0123456789876543210)) (l :: TyFun ((~>) a0123456789876543210 b0123456789876543210) ((~>) a0123456789876543210 b0123456789876543210))
       = forall arg. SameKind (Apply (FooSym1 l) arg) (FooSym2 l arg) =>
         FooSym1KindInference
     type instance Apply (FooSym1 l) l = FooSym2 l l
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym0KindInference) GHC.Tuple.())
-    data FooSym0 (l :: TyFun (TyFun (TyFun a0123456789876543210 b0123456789876543210
-                                     -> GHC.Types.Type) (TyFun a0123456789876543210 b0123456789876543210
-                                                         -> GHC.Types.Type)
-                              -> GHC.Types.Type) (TyFun (TyFun a0123456789876543210 b0123456789876543210
-                                                         -> GHC.Types.Type) (TyFun a0123456789876543210 b0123456789876543210
-                                                                             -> GHC.Types.Type)
-                                                  -> GHC.Types.Type))
+    data FooSym0 (l :: TyFun ((~>) ((~>) a0123456789876543210 b0123456789876543210) ((~>) a0123456789876543210 b0123456789876543210)) ((~>) ((~>) a0123456789876543210 b0123456789876543210) ((~>) a0123456789876543210 b0123456789876543210)))
       = forall arg. SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
         FooSym0KindInference
     type instance Apply FooSym0 l = FooSym1 l
-    type ZipWithSym3 (t :: TyFun a0123456789876543210 (TyFun b0123456789876543210 c0123456789876543210
-                                                       -> GHC.Types.Type)
-                           -> GHC.Types.Type) (t :: [a0123456789876543210]) (t :: [b0123456789876543210]) =
+    type ZipWithSym3 (t :: (~>) a0123456789876543210 ((~>) b0123456789876543210 c0123456789876543210)) (t :: [a0123456789876543210]) (t :: [b0123456789876543210]) =
         ZipWith t t t
     instance SuppressUnusedWarnings ZipWithSym2 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ZipWithSym2KindInference) GHC.Tuple.())
-    data ZipWithSym2 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 c0123456789876543210
-                                                       -> GHC.Types.Type)
-                           -> GHC.Types.Type) (l :: [a0123456789876543210]) (l :: TyFun [b0123456789876543210] [c0123456789876543210])
+    data ZipWithSym2 (l :: (~>) a0123456789876543210 ((~>) b0123456789876543210 c0123456789876543210)) (l :: [a0123456789876543210]) (l :: TyFun [b0123456789876543210] [c0123456789876543210])
       = forall arg. SameKind (Apply (ZipWithSym2 l l) arg) (ZipWithSym3 l l arg) =>
         ZipWithSym2KindInference
     type instance Apply (ZipWithSym2 l l) l = ZipWith l l l
     instance SuppressUnusedWarnings ZipWithSym1 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ZipWithSym1KindInference) GHC.Tuple.())
-    data ZipWithSym1 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 c0123456789876543210
-                                                       -> GHC.Types.Type)
-                           -> GHC.Types.Type) (l :: TyFun [a0123456789876543210] (TyFun [b0123456789876543210] [c0123456789876543210]
-                                                                                  -> GHC.Types.Type))
+    data ZipWithSym1 (l :: (~>) a0123456789876543210 ((~>) b0123456789876543210 c0123456789876543210)) (l :: TyFun [a0123456789876543210] ((~>) [b0123456789876543210] [c0123456789876543210]))
       = forall arg. SameKind (Apply (ZipWithSym1 l) arg) (ZipWithSym2 l arg) =>
         ZipWithSym1KindInference
     type instance Apply (ZipWithSym1 l) l = ZipWithSym2 l l
     instance SuppressUnusedWarnings ZipWithSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ZipWithSym0KindInference) GHC.Tuple.())
-    data ZipWithSym0 (l :: TyFun (TyFun a0123456789876543210 (TyFun b0123456789876543210 c0123456789876543210
-                                                              -> GHC.Types.Type)
-                                  -> GHC.Types.Type) (TyFun [a0123456789876543210] (TyFun [b0123456789876543210] [c0123456789876543210]
-                                                                                    -> GHC.Types.Type)
-                                                      -> GHC.Types.Type))
+    data ZipWithSym0 (l :: TyFun ((~>) a0123456789876543210 ((~>) b0123456789876543210 c0123456789876543210)) ((~>) [a0123456789876543210] ((~>) [b0123456789876543210] [c0123456789876543210])))
       = forall arg. SameKind (Apply ZipWithSym0 arg) (ZipWithSym1 arg) =>
         ZipWithSym0KindInference
     type instance Apply ZipWithSym0 l = ZipWithSym1 l
@@ -230,8 +200,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings SplungeSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SplungeSym0KindInference) GHC.Tuple.())
-    data SplungeSym0 (l :: TyFun [Nat] (TyFun [Bool] [Nat]
-                                        -> GHC.Types.Type))
+    data SplungeSym0 (l :: TyFun [Nat] ((~>) [Bool] [Nat]))
       = forall arg. SameKind (Apply SplungeSym0 arg) (SplungeSym1 arg) =>
         SplungeSym0KindInference
     type instance Apply SplungeSym0 l = SplungeSym1 l
@@ -246,58 +215,45 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings EtadSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) EtadSym0KindInference) GHC.Tuple.())
-    data EtadSym0 (l :: TyFun [Nat] (TyFun [Bool] [Nat]
-                                     -> GHC.Types.Type))
+    data EtadSym0 (l :: TyFun [Nat] ((~>) [Bool] [Nat]))
       = forall arg. SameKind (Apply EtadSym0 arg) (EtadSym1 arg) =>
         EtadSym0KindInference
     type instance Apply EtadSym0 l = EtadSym1 l
-    type LiftMaybeSym2 (t :: TyFun a0123456789876543210 b0123456789876543210
-                             -> GHC.Types.Type) (t :: Maybe a0123456789876543210) =
+    type LiftMaybeSym2 (t :: (~>) a0123456789876543210 b0123456789876543210) (t :: Maybe a0123456789876543210) =
         LiftMaybe t t
     instance SuppressUnusedWarnings LiftMaybeSym1 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) LiftMaybeSym1KindInference) GHC.Tuple.())
-    data LiftMaybeSym1 (l :: TyFun a0123456789876543210 b0123456789876543210
-                             -> GHC.Types.Type) (l :: TyFun (Maybe a0123456789876543210) (Maybe b0123456789876543210))
+    data LiftMaybeSym1 (l :: (~>) a0123456789876543210 b0123456789876543210) (l :: TyFun (Maybe a0123456789876543210) (Maybe b0123456789876543210))
       = forall arg. SameKind (Apply (LiftMaybeSym1 l) arg) (LiftMaybeSym2 l arg) =>
         LiftMaybeSym1KindInference
     type instance Apply (LiftMaybeSym1 l) l = LiftMaybe l l
     instance SuppressUnusedWarnings LiftMaybeSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) LiftMaybeSym0KindInference) GHC.Tuple.())
-    data LiftMaybeSym0 (l :: TyFun (TyFun a0123456789876543210 b0123456789876543210
-                                    -> GHC.Types.Type) (TyFun (Maybe a0123456789876543210) (Maybe b0123456789876543210)
-                                                        -> GHC.Types.Type))
+    data LiftMaybeSym0 (l :: TyFun ((~>) a0123456789876543210 b0123456789876543210) ((~>) (Maybe a0123456789876543210) (Maybe b0123456789876543210)))
       = forall arg. SameKind (Apply LiftMaybeSym0 arg) (LiftMaybeSym1 arg) =>
         LiftMaybeSym0KindInference
     type instance Apply LiftMaybeSym0 l = LiftMaybeSym1 l
-    type MapSym2 (t :: TyFun a0123456789876543210 b0123456789876543210
-                       -> GHC.Types.Type) (t :: [a0123456789876543210]) =
+    type MapSym2 (t :: (~>) a0123456789876543210 b0123456789876543210) (t :: [a0123456789876543210]) =
         Map t t
     instance SuppressUnusedWarnings MapSym1 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MapSym1KindInference) GHC.Tuple.())
-    data MapSym1 (l :: TyFun a0123456789876543210 b0123456789876543210
-                       -> GHC.Types.Type) (l :: TyFun [a0123456789876543210] [b0123456789876543210])
+    data MapSym1 (l :: (~>) a0123456789876543210 b0123456789876543210) (l :: TyFun [a0123456789876543210] [b0123456789876543210])
       = forall arg. SameKind (Apply (MapSym1 l) arg) (MapSym2 l arg) =>
         MapSym1KindInference
     type instance Apply (MapSym1 l) l = Map l l
     instance SuppressUnusedWarnings MapSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MapSym0KindInference) GHC.Tuple.())
-    data MapSym0 (l :: TyFun (TyFun a0123456789876543210 b0123456789876543210
-                              -> GHC.Types.Type) (TyFun [a0123456789876543210] [b0123456789876543210]
-                                                  -> GHC.Types.Type))
+    data MapSym0 (l :: TyFun ((~>) a0123456789876543210 b0123456789876543210) ((~>) [a0123456789876543210] [b0123456789876543210]))
       = forall arg. SameKind (Apply MapSym0 arg) (MapSym1 arg) =>
         MapSym0KindInference
     type instance Apply MapSym0 l = MapSym1 l
-    type family Foo (a :: TyFun (TyFun a b
-                                 -> GHC.Types.Type) (TyFun a b -> GHC.Types.Type)
-                          -> GHC.Types.Type) (a :: TyFun a b
-                                                   -> GHC.Types.Type) (a :: a) :: b where
+    type family Foo (a :: (~>) ((~>) a b) ((~>) a b)) (a :: (~>) a b) (a :: a) :: b where
       Foo f g a = Apply (Apply f g) a
-    type family ZipWith (a :: TyFun a (TyFun b c -> GHC.Types.Type)
-                              -> GHC.Types.Type) (a :: [a]) (a :: [b]) :: [c] where
+    type family ZipWith (a :: (~>) a ((~>) b c)) (a :: [a]) (a :: [b]) :: [c] where
       ZipWith f ((:) x xs) ((:) y ys) = Apply (Apply (:@#@$) (Apply (Apply f x) y)) (Apply (Apply (Apply ZipWithSym0 f) xs) ys)
       ZipWith _ '[] '[] = '[]
       ZipWith _ ((:) _ _) '[] = '[]
@@ -306,28 +262,19 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
       Splunge ns bs = Apply (Apply (Apply ZipWithSym0 (Apply (Apply Lambda_0123456789876543210Sym0 ns) bs)) ns) bs
     type family Etad (a :: [Nat]) (a :: [Bool]) :: [Nat] where
       Etad a_0123456789876543210 a_0123456789876543210 = Apply (Apply (Apply ZipWithSym0 (Apply (Apply Lambda_0123456789876543210Sym0 a_0123456789876543210) a_0123456789876543210)) a_0123456789876543210) a_0123456789876543210
-    type family LiftMaybe (a :: TyFun a b
-                                -> GHC.Types.Type) (a :: Maybe a) :: Maybe b where
+    type family LiftMaybe (a :: (~>) a b) (a :: Maybe a) :: Maybe b where
       LiftMaybe f (Just x) = Apply JustSym0 (Apply f x)
       LiftMaybe _ Nothing = NothingSym0
-    type family Map (a :: TyFun a b
-                          -> GHC.Types.Type) (a :: [a]) :: [b] where
+    type family Map (a :: (~>) a b) (a :: [a]) :: [b] where
       Map _ '[] = '[]
       Map f ((:) h t) = Apply (Apply (:@#@$) (Apply f h)) (Apply (Apply MapSym0 f) t)
     sFoo ::
-      forall (t :: TyFun (TyFun a b -> GHC.Types.Type) (TyFun a b
-                                                        -> GHC.Types.Type)
-                   -> GHC.Types.Type)
-             (t :: TyFun a b -> GHC.Types.Type)
-             (t :: a).
+      forall (t :: (~>) ((~>) a b) ((~>) a b)) (t :: (~>) a b) (t :: a).
       Sing t
       -> Sing t
          -> Sing t -> Sing (Apply (Apply (Apply FooSym0 t) t) t :: b)
     sZipWith ::
-      forall (t :: TyFun a (TyFun b c -> GHC.Types.Type)
-                   -> GHC.Types.Type)
-             (t :: [a])
-             (t :: [b]).
+      forall (t :: (~>) a ((~>) b c)) (t :: [a]) (t :: [b]).
       Sing t
       -> Sing t
          -> Sing t -> Sing (Apply (Apply (Apply ZipWithSym0 t) t) t :: [c])
@@ -338,11 +285,11 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
       forall (t :: [Nat]) (t :: [Bool]).
       Sing t -> Sing t -> Sing (Apply (Apply EtadSym0 t) t :: [Nat])
     sLiftMaybe ::
-      forall (t :: TyFun a b -> GHC.Types.Type) (t :: Maybe a).
+      forall (t :: (~>) a b) (t :: Maybe a).
       Sing t
       -> Sing t -> Sing (Apply (Apply LiftMaybeSym0 t) t :: Maybe b)
     sMap ::
-      forall (t :: TyFun a b -> GHC.Types.Type) (t :: [a]).
+      forall (t :: (~>) a b) (t :: [a]).
       Sing t -> Sing t -> Sing (Apply (Apply MapSym0 t) t :: [b])
     sFoo (sF :: Sing f) (sG :: Sing g) (sA :: Sing a)
       = (applySing ((applySing sF) sG)) sA

--- a/tests/compile-and-dump/Singletons/LambdaCase.ghc84.template
+++ b/tests/compile-and-dump/Singletons/LambdaCase.ghc84.template
@@ -133,8 +133,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo3Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo3Sym0KindInference) GHC.Tuple.())
-    data Foo3Sym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 a0123456789876543210
-                                                    -> GHC.Types.Type))
+    data Foo3Sym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 a0123456789876543210))
       = forall arg. SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
         Foo3Sym0KindInference
     type instance Apply Foo3Sym0 l = Foo3Sym1 l
@@ -150,8 +149,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo2Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo2Sym0KindInference) GHC.Tuple.())
-    data Foo2Sym0 (l :: TyFun a0123456789876543210 (TyFun (Maybe a0123456789876543210) a0123456789876543210
-                                                    -> GHC.Types.Type))
+    data Foo2Sym0 (l :: TyFun a0123456789876543210 ((~>) (Maybe a0123456789876543210) a0123456789876543210))
       = forall arg. SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) =>
         Foo2Sym0KindInference
     type instance Apply Foo2Sym0 l = Foo2Sym1 l
@@ -167,8 +165,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo1Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo1Sym0KindInference) GHC.Tuple.())
-    data Foo1Sym0 (l :: TyFun a0123456789876543210 (TyFun (Maybe a0123456789876543210) a0123456789876543210
-                                                    -> GHC.Types.Type))
+    data Foo1Sym0 (l :: TyFun a0123456789876543210 ((~>) (Maybe a0123456789876543210) a0123456789876543210))
       = forall arg. SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
         Foo1Sym0KindInference
     type instance Apply Foo1Sym0 l = Foo1Sym1 l

--- a/tests/compile-and-dump/Singletons/Lambdas.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Lambdas.ghc84.template
@@ -52,8 +52,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym0KindInference) GHC.Tuple.())
-    data FooSym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 (Foo a0123456789876543210 b0123456789876543210)
-                                                   -> GHC.Types.Type))
+    data FooSym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 (Foo a0123456789876543210 b0123456789876543210)))
       = forall arg. SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
         FooSym0KindInference
     type instance Apply FooSym0 l = FooSym1 l
@@ -419,8 +418,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo7Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo7Sym0KindInference) GHC.Tuple.())
-    data Foo7Sym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 b0123456789876543210
-                                                    -> GHC.Types.Type))
+    data Foo7Sym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210))
       = forall arg. SameKind (Apply Foo7Sym0 arg) (Foo7Sym1 arg) =>
         Foo7Sym0KindInference
     type instance Apply Foo7Sym0 l = Foo7Sym1 l
@@ -436,8 +434,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo6Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo6Sym0KindInference) GHC.Tuple.())
-    data Foo6Sym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 a0123456789876543210
-                                                    -> GHC.Types.Type))
+    data Foo6Sym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 a0123456789876543210))
       = forall arg. SameKind (Apply Foo6Sym0 arg) (Foo6Sym1 arg) =>
         Foo6Sym0KindInference
     type instance Apply Foo6Sym0 l = Foo6Sym1 l
@@ -453,8 +450,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo5Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo5Sym0KindInference) GHC.Tuple.())
-    data Foo5Sym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 b0123456789876543210
-                                                    -> GHC.Types.Type))
+    data Foo5Sym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210))
       = forall arg. SameKind (Apply Foo5Sym0 arg) (Foo5Sym1 arg) =>
         Foo5Sym0KindInference
     type instance Apply Foo5Sym0 l = Foo5Sym1 l
@@ -470,17 +466,14 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo4Sym1 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo4Sym1KindInference) GHC.Tuple.())
-    data Foo4Sym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 (TyFun c0123456789876543210 a0123456789876543210
-                                                                                -> GHC.Types.Type))
+    data Foo4Sym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 ((~>) c0123456789876543210 a0123456789876543210))
       = forall arg. SameKind (Apply (Foo4Sym1 l) arg) (Foo4Sym2 l arg) =>
         Foo4Sym1KindInference
     type instance Apply (Foo4Sym1 l) l = Foo4Sym2 l l
     instance SuppressUnusedWarnings Foo4Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo4Sym0KindInference) GHC.Tuple.())
-    data Foo4Sym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 (TyFun c0123456789876543210 a0123456789876543210
-                                                                                -> GHC.Types.Type)
-                                                    -> GHC.Types.Type))
+    data Foo4Sym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 ((~>) c0123456789876543210 a0123456789876543210)))
       = forall arg. SameKind (Apply Foo4Sym0 arg) (Foo4Sym1 arg) =>
         Foo4Sym0KindInference
     type instance Apply Foo4Sym0 l = Foo4Sym1 l
@@ -504,8 +497,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo2Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo2Sym0KindInference) GHC.Tuple.())
-    data Foo2Sym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 a0123456789876543210
-                                                    -> GHC.Types.Type))
+    data Foo2Sym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 a0123456789876543210))
       = forall arg. SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) =>
         Foo2Sym0KindInference
     type instance Apply Foo2Sym0 l = Foo2Sym1 l
@@ -521,8 +513,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo1Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo1Sym0KindInference) GHC.Tuple.())
-    data Foo1Sym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 a0123456789876543210
-                                                    -> GHC.Types.Type))
+    data Foo1Sym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 a0123456789876543210))
       = forall arg. SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
         Foo1Sym0KindInference
     type instance Apply Foo1Sym0 l = Foo1Sym1 l
@@ -538,8 +529,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo0Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo0Sym0KindInference) GHC.Tuple.())
-    data Foo0Sym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 a0123456789876543210
-                                                    -> GHC.Types.Type))
+    data Foo0Sym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 a0123456789876543210))
       = forall arg. SameKind (Apply Foo0Sym0 arg) (Foo0Sym1 arg) =>
         Foo0Sym0KindInference
     type instance Apply Foo0Sym0 l = Foo0Sym1 l

--- a/tests/compile-and-dump/Singletons/LetStatements.ghc84.template
+++ b/tests/compile-and-dump/Singletons/LetStatements.ghc84.template
@@ -259,8 +259,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$###)) GHC.Tuple.())
-    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l (l :: TyFun Nat (TyFun Nat Nat
-                                                           -> GHC.Types.Type))
+    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l (l :: TyFun Nat ((~>) Nat Nat))
       = forall arg. SameKind (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l) arg) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) l arg) =>
         (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$###)
     type instance Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l) l = (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) l l
@@ -299,8 +298,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$###)) GHC.Tuple.())
-    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l (l :: TyFun Nat (TyFun Nat Nat
-                                                           -> GHC.Types.Type))
+    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l (l :: TyFun Nat ((~>) Nat Nat))
       = forall arg. SameKind (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l) arg) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) l arg) =>
         (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$###)
     type instance Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l) l = (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) l l
@@ -331,8 +329,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$###)) GHC.Tuple.())
-    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l (l :: TyFun Nat (TyFun Nat Nat
-                                                           -> GHC.Types.Type))
+    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l (l :: TyFun Nat ((~>) Nat Nat))
       = forall arg. SameKind (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l) arg) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) l arg) =>
         (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$###)
     type instance Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l) l = (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) l l

--- a/tests/compile-and-dump/Singletons/Maybe.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Maybe.ghc84.template
@@ -35,8 +35,7 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun (Maybe a0123456789876543210) (TyFun GHC.Types.Symbol GHC.Types.Symbol
-                                                                                                          -> GHC.Types.Type))
+    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun (Maybe a0123456789876543210) ((~>) GHC.Types.Symbol GHC.Types.Symbol))
       = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
         ShowsPrec_0123456789876543210Sym1KindInference
     type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
@@ -45,9 +44,7 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat (TyFun (Maybe a0123456789876543210) (TyFun GHC.Types.Symbol GHC.Types.Symbol
-                                                                                                          -> GHC.Types.Type)
-                                                                      -> GHC.Types.Type))
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) (Maybe a0123456789876543210) ((~>) GHC.Types.Symbol GHC.Types.Symbol)))
       = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
@@ -80,9 +77,7 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
         Sing t1
         -> Sing t2
            -> Sing t3
-              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat (TyFun (Maybe a) (TyFun GHC.Types.Symbol GHC.Types.Symbol
-                                                                                                   -> GHC.Types.Type)
-                                                                                  -> GHC.Types.Type)
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat ((~>) (Maybe a) ((~>) GHC.Types.Symbol GHC.Types.Symbol))
                                                              -> GHC.Types.Type) t1) t2) t3)
       sShowsPrec
         _

--- a/tests/compile-and-dump/Singletons/Nat.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Nat.ghc84.template
@@ -52,7 +52,7 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings PlusSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) PlusSym0KindInference) GHC.Tuple.())
-    data PlusSym0 (l :: TyFun Nat (TyFun Nat Nat -> GHC.Types.Type))
+    data PlusSym0 (l :: TyFun Nat ((~>) Nat Nat))
       = forall arg. SameKind (Apply PlusSym0 arg) (PlusSym1 arg) =>
         PlusSym0KindInference
     type instance Apply PlusSym0 l = PlusSym1 l
@@ -81,8 +81,7 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun Nat (TyFun GHC.Types.Symbol GHC.Types.Symbol
-                                                                                 -> GHC.Types.Type))
+    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun Nat ((~>) GHC.Types.Symbol GHC.Types.Symbol))
       = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
         ShowsPrec_0123456789876543210Sym1KindInference
     type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
@@ -91,9 +90,7 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat (TyFun Nat (TyFun GHC.Types.Symbol GHC.Types.Symbol
-                                                                                 -> GHC.Types.Type)
-                                                                      -> GHC.Types.Type))
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) Nat ((~>) GHC.Types.Symbol GHC.Types.Symbol)))
       = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
@@ -120,8 +117,7 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym0 (l :: TyFun Nat (TyFun Nat Ordering
-                                                          -> GHC.Types.Type))
+    data Compare_0123456789876543210Sym0 (l :: TyFun Nat ((~>) Nat Ordering))
       = forall arg. SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
         Compare_0123456789876543210Sym0KindInference
     type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
@@ -163,9 +159,7 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
         Sing t1
         -> Sing t2
            -> Sing t3
-              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat (TyFun Nat (TyFun GHC.Types.Symbol GHC.Types.Symbol
-                                                                                             -> GHC.Types.Type)
-                                                                                  -> GHC.Types.Type)
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat ((~>) Nat ((~>) GHC.Types.Symbol GHC.Types.Symbol))
                                                              -> GHC.Types.Type) t1) t2) t3)
       sShowsPrec
         _
@@ -199,8 +193,7 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
         forall (t1 :: Nat) (t2 :: Nat).
         Sing t1
         -> Sing t2
-           -> Sing (Apply (Apply (CompareSym0 :: TyFun Nat (TyFun Nat Ordering
-                                                            -> GHC.Types.Type)
+           -> Sing (Apply (Apply (CompareSym0 :: TyFun Nat ((~>) Nat Ordering)
                                                  -> GHC.Types.Type) t1) t2)
       sCompare SZero SZero
         = (applySing

--- a/tests/compile-and-dump/Singletons/Operators.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Operators.ghc84.template
@@ -34,7 +34,7 @@ Singletons/Operators.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (:+:@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::+:@#@$###)) GHC.Tuple.())
-    data (:+:@#@$) (l :: TyFun Foo (TyFun Foo Foo -> GHC.Types.Type))
+    data (:+:@#@$) (l :: TyFun Foo ((~>) Foo Foo))
       = forall arg. SameKind (Apply (:+:@#@$) arg) ((:+:@#@$$) arg) =>
         (::+:@#@$###)
     type instance Apply (:+:@#@$) l = (:+:@#@$$) l
@@ -49,7 +49,7 @@ Singletons/Operators.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (+@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:+@#@$###)) GHC.Tuple.())
-    data (+@#@$) (l :: TyFun Nat (TyFun Nat Nat -> GHC.Types.Type))
+    data (+@#@$) (l :: TyFun Nat ((~>) Nat Nat))
       = forall arg. SameKind (Apply (+@#@$) arg) ((+@#@$$) arg) =>
         (:+@#@$###)
     type instance Apply (+@#@$) l = (+@#@$$) l

--- a/tests/compile-and-dump/Singletons/OrdDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/OrdDeriving.ghc84.template
@@ -44,27 +44,21 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ASym2 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ASym2KindInference) GHC.Tuple.())
-    data ASym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
-                                                                                                         -> GHC.Types.Type))
+    data ASym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)))
       = forall arg. SameKind (Apply (ASym2 l l) arg) (ASym3 l l arg) =>
         ASym2KindInference
     type instance Apply (ASym2 l l) l = ASym3 l l l
     instance SuppressUnusedWarnings ASym1 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ASym1KindInference) GHC.Tuple.())
-    data ASym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 (TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
-                                                                                                         -> GHC.Types.Type)
-                                                                             -> GHC.Types.Type))
+    data ASym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))))
       = forall arg. SameKind (Apply (ASym1 l) arg) (ASym2 l arg) =>
         ASym1KindInference
     type instance Apply (ASym1 l) l = ASym2 l l
     instance SuppressUnusedWarnings ASym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ASym0KindInference) GHC.Tuple.())
-    data ASym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 (TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
-                                                                                                         -> GHC.Types.Type)
-                                                                             -> GHC.Types.Type)
-                                                 -> GHC.Types.Type))
+    data ASym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)))))
       = forall arg. SameKind (Apply ASym0 arg) (ASym1 arg) =>
         ASym0KindInference
     type instance Apply ASym0 l = ASym1 l
@@ -80,27 +74,21 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings BSym2 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BSym2KindInference) GHC.Tuple.())
-    data BSym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
-                                                                                                         -> GHC.Types.Type))
+    data BSym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)))
       = forall arg. SameKind (Apply (BSym2 l l) arg) (BSym3 l l arg) =>
         BSym2KindInference
     type instance Apply (BSym2 l l) l = BSym3 l l l
     instance SuppressUnusedWarnings BSym1 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BSym1KindInference) GHC.Tuple.())
-    data BSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 (TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
-                                                                                                         -> GHC.Types.Type)
-                                                                             -> GHC.Types.Type))
+    data BSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))))
       = forall arg. SameKind (Apply (BSym1 l) arg) (BSym2 l arg) =>
         BSym1KindInference
     type instance Apply (BSym1 l) l = BSym2 l l
     instance SuppressUnusedWarnings BSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BSym0KindInference) GHC.Tuple.())
-    data BSym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 (TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
-                                                                                                         -> GHC.Types.Type)
-                                                                             -> GHC.Types.Type)
-                                                 -> GHC.Types.Type))
+    data BSym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)))))
       = forall arg. SameKind (Apply BSym0 arg) (BSym1 arg) =>
         BSym0KindInference
     type instance Apply BSym0 l = BSym1 l
@@ -116,27 +104,21 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings CSym2 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) CSym2KindInference) GHC.Tuple.())
-    data CSym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
-                                                                                                         -> GHC.Types.Type))
+    data CSym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)))
       = forall arg. SameKind (Apply (CSym2 l l) arg) (CSym3 l l arg) =>
         CSym2KindInference
     type instance Apply (CSym2 l l) l = CSym3 l l l
     instance SuppressUnusedWarnings CSym1 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) CSym1KindInference) GHC.Tuple.())
-    data CSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 (TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
-                                                                                                         -> GHC.Types.Type)
-                                                                             -> GHC.Types.Type))
+    data CSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))))
       = forall arg. SameKind (Apply (CSym1 l) arg) (CSym2 l arg) =>
         CSym1KindInference
     type instance Apply (CSym1 l) l = CSym2 l l
     instance SuppressUnusedWarnings CSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) CSym0KindInference) GHC.Tuple.())
-    data CSym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 (TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
-                                                                                                         -> GHC.Types.Type)
-                                                                             -> GHC.Types.Type)
-                                                 -> GHC.Types.Type))
+    data CSym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)))))
       = forall arg. SameKind (Apply CSym0 arg) (CSym1 arg) =>
         CSym0KindInference
     type instance Apply CSym0 l = CSym1 l
@@ -152,27 +134,21 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings DSym2 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) DSym2KindInference) GHC.Tuple.())
-    data DSym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
-                                                                                                         -> GHC.Types.Type))
+    data DSym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)))
       = forall arg. SameKind (Apply (DSym2 l l) arg) (DSym3 l l arg) =>
         DSym2KindInference
     type instance Apply (DSym2 l l) l = DSym3 l l l
     instance SuppressUnusedWarnings DSym1 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) DSym1KindInference) GHC.Tuple.())
-    data DSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 (TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
-                                                                                                         -> GHC.Types.Type)
-                                                                             -> GHC.Types.Type))
+    data DSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))))
       = forall arg. SameKind (Apply (DSym1 l) arg) (DSym2 l arg) =>
         DSym1KindInference
     type instance Apply (DSym1 l) l = DSym2 l l
     instance SuppressUnusedWarnings DSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) DSym0KindInference) GHC.Tuple.())
-    data DSym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 (TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
-                                                                                                         -> GHC.Types.Type)
-                                                                             -> GHC.Types.Type)
-                                                 -> GHC.Types.Type))
+    data DSym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)))))
       = forall arg. SameKind (Apply DSym0 arg) (DSym1 arg) =>
         DSym0KindInference
     type instance Apply DSym0 l = DSym1 l
@@ -188,27 +164,21 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ESym2 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ESym2KindInference) GHC.Tuple.())
-    data ESym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
-                                                                                                         -> GHC.Types.Type))
+    data ESym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)))
       = forall arg. SameKind (Apply (ESym2 l l) arg) (ESym3 l l arg) =>
         ESym2KindInference
     type instance Apply (ESym2 l l) l = ESym3 l l l
     instance SuppressUnusedWarnings ESym1 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ESym1KindInference) GHC.Tuple.())
-    data ESym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 (TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
-                                                                                                         -> GHC.Types.Type)
-                                                                             -> GHC.Types.Type))
+    data ESym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))))
       = forall arg. SameKind (Apply (ESym1 l) arg) (ESym2 l arg) =>
         ESym1KindInference
     type instance Apply (ESym1 l) l = ESym2 l l
     instance SuppressUnusedWarnings ESym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ESym0KindInference) GHC.Tuple.())
-    data ESym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 (TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
-                                                                                                         -> GHC.Types.Type)
-                                                                             -> GHC.Types.Type)
-                                                 -> GHC.Types.Type))
+    data ESym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)))))
       = forall arg. SameKind (Apply ESym0 arg) (ESym1 arg) =>
         ESym0KindInference
     type instance Apply ESym0 l = ESym1 l
@@ -224,27 +194,21 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FSym2 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FSym2KindInference) GHC.Tuple.())
-    data FSym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
-                                                                                                         -> GHC.Types.Type))
+    data FSym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)))
       = forall arg. SameKind (Apply (FSym2 l l) arg) (FSym3 l l arg) =>
         FSym2KindInference
     type instance Apply (FSym2 l l) l = FSym3 l l l
     instance SuppressUnusedWarnings FSym1 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FSym1KindInference) GHC.Tuple.())
-    data FSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 (TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
-                                                                                                         -> GHC.Types.Type)
-                                                                             -> GHC.Types.Type))
+    data FSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))))
       = forall arg. SameKind (Apply (FSym1 l) arg) (FSym2 l arg) =>
         FSym1KindInference
     type instance Apply (FSym1 l) l = FSym2 l l
     instance SuppressUnusedWarnings FSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FSym0KindInference) GHC.Tuple.())
-    data FSym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 (TyFun c0123456789876543210 (TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
-                                                                                                         -> GHC.Types.Type)
-                                                                             -> GHC.Types.Type)
-                                                 -> GHC.Types.Type))
+    data FSym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)))))
       = forall arg. SameKind (Apply FSym0 arg) (FSym1 arg) =>
         FSym0KindInference
     type instance Apply FSym0 l = FSym1 l
@@ -269,8 +233,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym0 (l :: TyFun Nat (TyFun Nat Ordering
-                                                          -> GHC.Types.Type))
+    data Compare_0123456789876543210Sym0 (l :: TyFun Nat ((~>) Nat Ordering))
       = forall arg. SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
         Compare_0123456789876543210Sym0KindInference
     type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
@@ -329,8 +292,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym0 (l :: TyFun (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210) (TyFun (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210) Ordering
-                                                                                                                                                -> GHC.Types.Type))
+    data Compare_0123456789876543210Sym0 (l :: TyFun (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210) ((~>) (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210) Ordering))
       = forall arg. SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
         Compare_0123456789876543210Sym0KindInference
     type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
@@ -472,8 +434,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         forall (t1 :: Nat) (t2 :: Nat).
         Sing t1
         -> Sing t2
-           -> Sing (Apply (Apply (CompareSym0 :: TyFun Nat (TyFun Nat Ordering
-                                                            -> GHC.Types.Type)
+           -> Sing (Apply (Apply (CompareSym0 :: TyFun Nat ((~>) Nat Ordering)
                                                  -> GHC.Types.Type) t1) t2)
       sCompare SZero SZero
         = (applySing
@@ -505,8 +466,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         forall (t1 :: Foo a b c d) (t2 :: Foo a b c d).
         Sing t1
         -> Sing t2
-           -> Sing (Apply (Apply (CompareSym0 :: TyFun (Foo a b c d) (TyFun (Foo a b c d) Ordering
-                                                                      -> GHC.Types.Type)
+           -> Sing (Apply (Apply (CompareSym0 :: TyFun (Foo a b c d) ((~>) (Foo a b c d) Ordering)
                                                  -> GHC.Types.Type) t1) t2)
       sCompare
         (SA (sA_0123456789876543210 :: Sing a_0123456789876543210)

--- a/tests/compile-and-dump/Singletons/PatternMatching.ghc84.template
+++ b/tests/compile-and-dump/Singletons/PatternMatching.ghc84.template
@@ -28,8 +28,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings PairSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) PairSym0KindInference) GHC.Tuple.())
-    data PairSym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 (Pair a0123456789876543210 b0123456789876543210)
-                                                    -> GHC.Types.Type))
+    data PairSym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 (Pair a0123456789876543210 b0123456789876543210)))
       = forall arg. SameKind (Apply PairSym0 arg) (PairSym1 arg) =>
         PairSym0KindInference
     type instance Apply PairSym0 l = PairSym1 l
@@ -63,8 +62,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun (Pair a0123456789876543210 b0123456789876543210) (TyFun Symbol Symbol
-                                                                                                                              -> GHC.Types.Type))
+    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun (Pair a0123456789876543210 b0123456789876543210) ((~>) Symbol Symbol))
       = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
         ShowsPrec_0123456789876543210Sym1KindInference
     type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
@@ -73,9 +71,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat (TyFun (Pair a0123456789876543210 b0123456789876543210) (TyFun Symbol Symbol
-                                                                                                                              -> GHC.Types.Type)
-                                                                      -> GHC.Types.Type))
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) (Pair a0123456789876543210 b0123456789876543210) ((~>) Symbol Symbol)))
       = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
@@ -132,9 +128,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
         Sing t1
         -> Sing t2
            -> Sing t3
-              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat (TyFun (Pair a b) (TyFun Symbol Symbol
-                                                                                                    -> GHC.Types.Type)
-                                                                                  -> GHC.Types.Type)
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat ((~>) (Pair a b) ((~>) Symbol Symbol))
                                                              -> GHC.Types.Type) t1) t2) t3)
       sShowsPrec
         (sP_0123456789876543210 :: Sing p_0123456789876543210)

--- a/tests/compile-and-dump/Singletons/Records.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Records.ghc84.template
@@ -35,8 +35,7 @@ Singletons/Records.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings MkRecordSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MkRecordSym0KindInference) GHC.Tuple.())
-    data MkRecordSym0 (l :: TyFun a0123456789876543210 (TyFun Bool (Record a0123456789876543210)
-                                                        -> GHC.Types.Type))
+    data MkRecordSym0 (l :: TyFun a0123456789876543210 ((~>) Bool (Record a0123456789876543210)))
       = forall arg. SameKind (Apply MkRecordSym0 arg) (MkRecordSym1 arg) =>
         MkRecordSym0KindInference
     type instance Apply MkRecordSym0 l = MkRecordSym1 l

--- a/tests/compile-and-dump/Singletons/ReturnFunc.ghc84.template
+++ b/tests/compile-and-dump/Singletons/ReturnFunc.ghc84.template
@@ -33,8 +33,7 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings IdFooSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) IdFooSym0KindInference) GHC.Tuple.())
-    data IdFooSym0 (l :: TyFun c0123456789876543210 (TyFun a0123456789876543210 a0123456789876543210
-                                                     -> GHC.Types.Type))
+    data IdFooSym0 (l :: TyFun c0123456789876543210 ((~>) a0123456789876543210 a0123456789876543210))
       = forall arg. SameKind (Apply IdFooSym0 arg) (IdFooSym1 arg) =>
         IdFooSym0KindInference
     type instance Apply IdFooSym0 l = IdFooSym1 l
@@ -49,8 +48,7 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ReturnFuncSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ReturnFuncSym0KindInference) GHC.Tuple.())
-    data ReturnFuncSym0 (l :: TyFun Nat (TyFun Nat Nat
-                                         -> GHC.Types.Type))
+    data ReturnFuncSym0 (l :: TyFun Nat ((~>) Nat Nat))
       = forall arg. SameKind (Apply ReturnFuncSym0 arg) (ReturnFuncSym1 arg) =>
         ReturnFuncSym0KindInference
     type instance Apply ReturnFuncSym0 l = ReturnFuncSym1 l

--- a/tests/compile-and-dump/Singletons/Sections.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Sections.ghc84.template
@@ -43,7 +43,7 @@ Singletons/Sections.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (+@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:+@#@$###)) GHC.Tuple.())
-    data (+@#@$) (l :: TyFun Nat (TyFun Nat Nat -> GHC.Types.Type))
+    data (+@#@$) (l :: TyFun Nat ((~>) Nat Nat))
       = forall arg. SameKind (Apply (+@#@$) arg) ((+@#@$$) arg) =>
         (:+@#@$###)
     type instance Apply (+@#@$) l = (+@#@$$) l

--- a/tests/compile-and-dump/Singletons/ShowDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/ShowDeriving.ghc84.template
@@ -57,8 +57,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings MkFoo2aSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MkFoo2aSym0KindInference) GHC.Tuple.())
-    data MkFoo2aSym0 (l :: TyFun a0123456789876543210 (TyFun a0123456789876543210 (Foo2 a0123456789876543210)
-                                                       -> GHC.Types.Type))
+    data MkFoo2aSym0 (l :: TyFun a0123456789876543210 ((~>) a0123456789876543210 (Foo2 a0123456789876543210)))
       = forall arg. SameKind (Apply MkFoo2aSym0 arg) (MkFoo2aSym1 arg) =>
         MkFoo2aSym0KindInference
     type instance Apply MkFoo2aSym0 l = MkFoo2aSym1 l
@@ -74,8 +73,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings MkFoo2bSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MkFoo2bSym0KindInference) GHC.Tuple.())
-    data MkFoo2bSym0 (l :: TyFun a0123456789876543210 (TyFun a0123456789876543210 (Foo2 a0123456789876543210)
-                                                       -> GHC.Types.Type))
+    data MkFoo2bSym0 (l :: TyFun a0123456789876543210 ((~>) a0123456789876543210 (Foo2 a0123456789876543210)))
       = forall arg. SameKind (Apply MkFoo2bSym0 arg) (MkFoo2bSym1 arg) =>
         MkFoo2bSym0KindInference
     type instance Apply MkFoo2bSym0 l = MkFoo2bSym1 l
@@ -91,8 +89,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (:*:@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::*:@#@$###)) GHC.Tuple.())
-    data (:*:@#@$) (l :: TyFun a0123456789876543210 (TyFun a0123456789876543210 (Foo2 a0123456789876543210)
-                                                     -> GHC.Types.Type))
+    data (:*:@#@$) (l :: TyFun a0123456789876543210 ((~>) a0123456789876543210 (Foo2 a0123456789876543210)))
       = forall arg. SameKind (Apply (:*:@#@$) arg) ((:*:@#@$$) arg) =>
         (::*:@#@$###)
     type instance Apply (:*:@#@$) l = (:*:@#@$$) l
@@ -108,8 +105,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (:&:@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::&:@#@$###)) GHC.Tuple.())
-    data (:&:@#@$) (l :: TyFun a0123456789876543210 (TyFun a0123456789876543210 (Foo2 a0123456789876543210)
-                                                     -> GHC.Types.Type))
+    data (:&:@#@$) (l :: TyFun a0123456789876543210 ((~>) a0123456789876543210 (Foo2 a0123456789876543210)))
       = forall arg. SameKind (Apply (:&:@#@$) arg) ((:&:@#@$$) arg) =>
         (::&:@#@$###)
     type instance Apply (:&:@#@$) l = (:&:@#@$$) l
@@ -124,8 +120,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings MkFoo3Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MkFoo3Sym0KindInference) GHC.Tuple.())
-    data MkFoo3Sym0 (l :: TyFun Bool (TyFun Bool Foo3
-                                      -> GHC.Types.Type))
+    data MkFoo3Sym0 (l :: TyFun Bool ((~>) Bool Foo3))
       = forall arg. SameKind (Apply MkFoo3Sym0 arg) (MkFoo3Sym1 arg) =>
         MkFoo3Sym0KindInference
     type instance Apply MkFoo3Sym0 l = MkFoo3Sym1 l
@@ -147,8 +142,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun Foo1 (TyFun Symbol Symbol
-                                                                                  -> GHC.Types.Type))
+    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun Foo1 ((~>) Symbol Symbol))
       = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
         ShowsPrec_0123456789876543210Sym1KindInference
     type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
@@ -157,9 +151,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat (TyFun Foo1 (TyFun Symbol Symbol
-                                                                                  -> GHC.Types.Type)
-                                                                      -> GHC.Types.Type))
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) Foo1 ((~>) Symbol Symbol)))
       = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
@@ -186,8 +178,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun (Foo2 a0123456789876543210) (TyFun Symbol Symbol
-                                                                                                         -> GHC.Types.Type))
+    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun (Foo2 a0123456789876543210) ((~>) Symbol Symbol))
       = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
         ShowsPrec_0123456789876543210Sym1KindInference
     type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
@@ -196,9 +187,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat (TyFun (Foo2 a0123456789876543210) (TyFun Symbol Symbol
-                                                                                                         -> GHC.Types.Type)
-                                                                      -> GHC.Types.Type))
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) (Foo2 a0123456789876543210) ((~>) Symbol Symbol)))
       = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
@@ -222,8 +211,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun Foo3 (TyFun Symbol Symbol
-                                                                                  -> GHC.Types.Type))
+    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun Foo3 ((~>) Symbol Symbol))
       = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
         ShowsPrec_0123456789876543210Sym1KindInference
     type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
@@ -232,9 +220,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat (TyFun Foo3 (TyFun Symbol Symbol
-                                                                                  -> GHC.Types.Type)
-                                                                      -> GHC.Types.Type))
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) Foo3 ((~>) Symbol Symbol)))
       = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
@@ -312,9 +298,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         Sing t1
         -> Sing t2
            -> Sing t3
-              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat (TyFun Foo1 (TyFun Symbol Symbol
-                                                                                              -> GHC.Types.Type)
-                                                                                  -> GHC.Types.Type)
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat ((~>) Foo1 ((~>) Symbol Symbol))
                                                              -> GHC.Types.Type) t1) t2) t3)
       sShowsPrec
         _
@@ -330,9 +314,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         Sing t1
         -> Sing t2
            -> Sing t3
-              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat (TyFun (Foo2 a) (TyFun Symbol Symbol
-                                                                                                  -> GHC.Types.Type)
-                                                                                  -> GHC.Types.Type)
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat ((~>) (Foo2 a) ((~>) Symbol Symbol))
                                                              -> GHC.Types.Type) t1) t2) t3)
       sShowsPrec
         (sP_0123456789876543210 :: Sing p_0123456789876543210)
@@ -450,9 +432,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         Sing t1
         -> Sing t2
            -> Sing t3
-              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat (TyFun Foo3 (TyFun Symbol Symbol
-                                                                                              -> GHC.Types.Type)
-                                                                                  -> GHC.Types.Type)
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat ((~>) Foo3 ((~>) Symbol Symbol))
                                                              -> GHC.Types.Type) t1) t2) t3)
       sShowsPrec
         (sP_0123456789876543210 :: Sing p_0123456789876543210)

--- a/tests/compile-and-dump/Singletons/StandaloneDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/StandaloneDeriving.ghc84.template
@@ -37,8 +37,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (:*:@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::*:@#@$###)) GHC.Tuple.())
-    data (:*:@#@$) (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 (T a0123456789876543210 b0123456789876543210)
-                                                     -> GHC.Types.Type))
+    data (:*:@#@$) (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 (T a0123456789876543210 b0123456789876543210)))
       = forall arg. SameKind (Apply (:*:@#@$) arg) ((:*:@#@$$) arg) =>
         (::*:@#@$###)
     type instance Apply (:*:@#@$) l = (:*:@#@$$) l
@@ -62,8 +61,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym0 (l :: TyFun (T a0123456789876543210 ()) (TyFun (T a0123456789876543210 ()) Ordering
-                                                                                  -> GHC.Types.Type))
+    data Compare_0123456789876543210Sym0 (l :: TyFun (T a0123456789876543210 ()) ((~>) (T a0123456789876543210 ()) Ordering))
       = forall arg. SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
         Compare_0123456789876543210Sym0KindInference
     type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
@@ -87,8 +85,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun (T a0123456789876543210 ()) (TyFun Symbol Symbol
-                                                                                                         -> GHC.Types.Type))
+    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun (T a0123456789876543210 ()) ((~>) Symbol Symbol))
       = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
         ShowsPrec_0123456789876543210Sym1KindInference
     type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
@@ -97,9 +94,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat (TyFun (T a0123456789876543210 ()) (TyFun Symbol Symbol
-                                                                                                         -> GHC.Types.Type)
-                                                                      -> GHC.Types.Type))
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) (T a0123456789876543210 ()) ((~>) Symbol Symbol)))
       = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
@@ -126,8 +121,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym0 (l :: TyFun S (TyFun S Ordering
-                                                        -> GHC.Types.Type))
+    data Compare_0123456789876543210Sym0 (l :: TyFun S ((~>) S Ordering))
       = forall arg. SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
         Compare_0123456789876543210Sym0KindInference
     type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
@@ -152,8 +146,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun S (TyFun Symbol Symbol
-                                                                               -> GHC.Types.Type))
+    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun S ((~>) Symbol Symbol))
       = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
         ShowsPrec_0123456789876543210Sym1KindInference
     type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
@@ -162,9 +155,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat (TyFun S (TyFun Symbol Symbol
-                                                                               -> GHC.Types.Type)
-                                                                      -> GHC.Types.Type))
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) S ((~>) Symbol Symbol)))
       = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
@@ -259,8 +250,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
         forall (t1 :: T a ()) (t2 :: T a ()).
         Sing t1
         -> Sing t2
-           -> Sing (Apply (Apply (CompareSym0 :: TyFun (T a ()) (TyFun (T a ()) Ordering
-                                                                 -> GHC.Types.Type)
+           -> Sing (Apply (Apply (CompareSym0 :: TyFun (T a ()) ((~>) (T a ()) Ordering)
                                                  -> GHC.Types.Type) t1) t2)
       sCompare
         ((:%*:) (sA_0123456789876543210 :: Sing a_0123456789876543210)
@@ -291,9 +281,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
         Sing t1
         -> Sing t2
            -> Sing t3
-              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat (TyFun (T a ()) (TyFun Symbol Symbol
-                                                                                                  -> GHC.Types.Type)
-                                                                                  -> GHC.Types.Type)
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat ((~>) (T a ()) ((~>) Symbol Symbol))
                                                              -> GHC.Types.Type) t1) t2) t3)
       sShowsPrec
         (sP_0123456789876543210 :: Sing p_0123456789876543210)
@@ -326,8 +314,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
         forall (t1 :: S) (t2 :: S).
         Sing t1
         -> Sing t2
-           -> Sing (Apply (Apply (CompareSym0 :: TyFun S (TyFun S Ordering
-                                                          -> GHC.Types.Type)
+           -> Sing (Apply (Apply (CompareSym0 :: TyFun S ((~>) S Ordering)
                                                  -> GHC.Types.Type) t1) t2)
       sCompare SS1 SS1
         = (applySing
@@ -351,9 +338,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
         Sing t1
         -> Sing t2
            -> Sing t3
-              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat (TyFun S (TyFun Symbol Symbol
-                                                                                           -> GHC.Types.Type)
-                                                                                  -> GHC.Types.Type)
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat ((~>) S ((~>) Symbol Symbol))
                                                              -> GHC.Types.Type) t1) t2) t3)
       sShowsPrec
         _

--- a/tests/compile-and-dump/Singletons/Star.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Star.ghc84.template
@@ -30,7 +30,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
     instance SuppressUnusedWarnings VecSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) VecSym0KindInference) GHC.Tuple.())
-    data VecSym0 (l :: TyFun Type (TyFun Nat Type -> Type))
+    data VecSym0 (l :: TyFun Type ((~>) Nat Type))
       = forall arg. SameKind (Apply VecSym0 arg) (VecSym1 arg) =>
         VecSym0KindInference
     type instance Apply VecSym0 l = VecSym1 l
@@ -85,8 +85,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym0 (l :: TyFun Type (TyFun Type Ordering
-                                                           -> Type))
+    data Compare_0123456789876543210Sym0 (l :: TyFun Type ((~>) Type Ordering))
       = forall arg. SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
         Compare_0123456789876543210Sym0KindInference
     type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
@@ -114,8 +113,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun Type (TyFun Symbol Symbol
-                                                                                  -> Type))
+    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun Type ((~>) Symbol Symbol))
       = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
         ShowsPrec_0123456789876543210Sym1KindInference
     type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
@@ -124,9 +122,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat (TyFun Type (TyFun Symbol Symbol
-                                                                                  -> Type)
-                                                                      -> Type))
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) Type ((~>) Symbol Symbol)))
       = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
@@ -228,8 +224,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
         forall (t1 :: Type) (t2 :: Type).
         Sing t1
         -> Sing t2
-           -> Sing (Apply (Apply (CompareSym0 :: TyFun Type (TyFun Type Ordering
-                                                             -> Type)
+           -> Sing (Apply (Apply (CompareSym0 :: TyFun Type ((~>) Type Ordering)
                                                  -> Type) t1) t2)
       sCompare SNat SNat
         = (applySing
@@ -316,9 +311,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
         Sing t1
         -> Sing t2
            -> Sing t3
-              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat (TyFun Type (TyFun Symbol Symbol
-                                                                                              -> Type)
-                                                                                  -> Type)
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat ((~>) Type ((~>) Symbol Symbol))
                                                              -> Type) t1) t2) t3)
       sShowsPrec
         _

--- a/tests/compile-and-dump/Singletons/T145.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T145.ghc84.template
@@ -17,8 +17,7 @@ Singletons/T145.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ColSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ColSym0KindInference) GHC.Tuple.())
-    data ColSym0 (l :: TyFun (f0123456789876543210 a0123456789876543210) (TyFun a0123456789876543210 Bool
-                                                                          -> Type))
+    data ColSym0 (l :: TyFun (f0123456789876543210 a0123456789876543210) ((~>) a0123456789876543210 Bool))
       = forall arg. SameKind (Apply ColSym0 arg) (ColSym1 arg) =>
         ColSym0KindInference
     type instance Apply ColSym0 l = ColSym1 l

--- a/tests/compile-and-dump/Singletons/T159.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T159.ghc84.template
@@ -54,7 +54,7 @@ Singletons/T159.hs:0:0:: Splicing declarations
     instance SuppressUnusedWarnings C1Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) C1Sym0KindInference) GHC.Tuple.())
-    data C1Sym0 (l :: TyFun T0 (TyFun T1 T1 -> GHC.Types.Type))
+    data C1Sym0 (l :: TyFun T0 ((~>) T1 T1))
       = forall arg. SameKind (Apply C1Sym0 arg) (C1Sym1 arg) =>
         C1Sym0KindInference
     type instance Apply C1Sym0 l = C1Sym1 l
@@ -69,7 +69,7 @@ Singletons/T159.hs:0:0:: Splicing declarations
     instance SuppressUnusedWarnings (:&&@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::&&@#@$###)) GHC.Tuple.())
-    data (:&&@#@$) (l :: TyFun T0 (TyFun T1 T1 -> GHC.Types.Type))
+    data (:&&@#@$) (l :: TyFun T0 ((~>) T1 T1))
       = forall arg. SameKind (Apply (:&&@#@$) arg) ((:&&@#@$$) arg) =>
         (::&&@#@$###)
     type instance Apply (:&&@#@$) l = (:&&@#@$$) l
@@ -129,7 +129,7 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings C2Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) C2Sym0KindInference) GHC.Tuple.())
-    data C2Sym0 (l :: TyFun T0 (TyFun T2 T2 -> GHC.Types.Type))
+    data C2Sym0 (l :: TyFun T0 ((~>) T2 T2))
       = forall arg. SameKind (Apply C2Sym0 arg) (C2Sym1 arg) =>
         C2Sym0KindInference
     type instance Apply C2Sym0 l = C2Sym1 l
@@ -144,7 +144,7 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (:||@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::||@#@$###)) GHC.Tuple.())
-    data (:||@#@$) (l :: TyFun T0 (TyFun T2 T2 -> GHC.Types.Type))
+    data (:||@#@$) (l :: TyFun T0 ((~>) T2 T2))
       = forall arg. SameKind (Apply (:||@#@$) arg) ((:||@#@$$) arg) =>
         (::||@#@$###)
     type instance Apply (:||@#@$) l = (:||@#@$$) l

--- a/tests/compile-and-dump/Singletons/T167.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T167.ghc84.template
@@ -20,17 +20,14 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FoosPrecSym1 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FoosPrecSym1KindInference) GHC.Tuple.())
-    data FoosPrecSym1 (l :: Nat) (l :: TyFun a0123456789876543210 (TyFun [Bool] [Bool]
-                                                                   -> GHC.Types.Type))
+    data FoosPrecSym1 (l :: Nat) (l :: TyFun a0123456789876543210 ((~>) [Bool] [Bool]))
       = forall arg. SameKind (Apply (FoosPrecSym1 l) arg) (FoosPrecSym2 l arg) =>
         FoosPrecSym1KindInference
     type instance Apply (FoosPrecSym1 l) l = FoosPrecSym2 l l
     instance SuppressUnusedWarnings FoosPrecSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FoosPrecSym0KindInference) GHC.Tuple.())
-    data FoosPrecSym0 (l :: TyFun Nat (TyFun a0123456789876543210 (TyFun [Bool] [Bool]
-                                                                   -> GHC.Types.Type)
-                                       -> GHC.Types.Type))
+    data FoosPrecSym0 (l :: TyFun Nat ((~>) a0123456789876543210 ((~>) [Bool] [Bool])))
       = forall arg. SameKind (Apply FoosPrecSym0 arg) (FoosPrecSym1 arg) =>
         FoosPrecSym0KindInference
     type instance Apply FoosPrecSym0 l = FoosPrecSym1 l
@@ -46,8 +43,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FooListSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooListSym0KindInference) GHC.Tuple.())
-    data FooListSym0 (l :: TyFun a0123456789876543210 (TyFun [Bool] [Bool]
-                                                       -> GHC.Types.Type))
+    data FooListSym0 (l :: TyFun a0123456789876543210 ((~>) [Bool] [Bool]))
       = forall arg. SameKind (Apply FooListSym0 arg) (FooListSym1 arg) =>
         FooListSym0KindInference
     type instance Apply FooListSym0 l = FooListSym1 l
@@ -69,8 +65,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) FooList_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data FooList_0123456789876543210Sym0 (l :: TyFun a0123456789876543210 (TyFun [Bool] [Bool]
-                                                                           -> GHC.Types.Type))
+    data FooList_0123456789876543210Sym0 (l :: TyFun a0123456789876543210 ((~>) [Bool] [Bool]))
       = forall arg. SameKind (Apply FooList_0123456789876543210Sym0 arg) (FooList_0123456789876543210Sym1 arg) =>
         FooList_0123456789876543210Sym0KindInference
     type instance Apply FooList_0123456789876543210Sym0 l = FooList_0123456789876543210Sym1 l
@@ -96,8 +91,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) FoosPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data FoosPrec_0123456789876543210Sym1 (l :: Nat) (l :: TyFun [a0123456789876543210] (TyFun [Bool] [Bool]
-                                                                                         -> GHC.Types.Type))
+    data FoosPrec_0123456789876543210Sym1 (l :: Nat) (l :: TyFun [a0123456789876543210] ((~>) [Bool] [Bool]))
       = forall arg. SameKind (Apply (FoosPrec_0123456789876543210Sym1 l) arg) (FoosPrec_0123456789876543210Sym2 l arg) =>
         FoosPrec_0123456789876543210Sym1KindInference
     type instance Apply (FoosPrec_0123456789876543210Sym1 l) l = FoosPrec_0123456789876543210Sym2 l l
@@ -106,9 +100,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) FoosPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data FoosPrec_0123456789876543210Sym0 (l :: TyFun Nat (TyFun [a0123456789876543210] (TyFun [Bool] [Bool]
-                                                                                         -> GHC.Types.Type)
-                                                           -> GHC.Types.Type))
+    data FoosPrec_0123456789876543210Sym0 (l :: TyFun Nat ((~>) [a0123456789876543210] ((~>) [Bool] [Bool])))
       = forall arg. SameKind (Apply FoosPrec_0123456789876543210Sym0 arg) (FoosPrec_0123456789876543210Sym1 arg) =>
         FoosPrec_0123456789876543210Sym0KindInference
     type instance Apply FoosPrec_0123456789876543210Sym0 l = FoosPrec_0123456789876543210Sym1 l

--- a/tests/compile-and-dump/Singletons/T172.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T172.ghc84.template
@@ -14,7 +14,7 @@ Singletons/T172.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ($>@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:$>@#@$###)) GHC.Tuple.())
-    data ($>@#@$) (l :: TyFun Nat (TyFun Nat Nat -> GHC.Types.Type))
+    data ($>@#@$) (l :: TyFun Nat ((~>) Nat Nat))
       = forall arg. SameKind (Apply ($>@#@$) arg) (($>@#@$$) arg) =>
         (:$>@#@$###)
     type instance Apply ($>@#@$) l = ($>@#@$$) l

--- a/tests/compile-and-dump/Singletons/T176.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T176.ghc84.template
@@ -66,29 +66,25 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
       Quux2 x = Apply (Apply Bar2Sym0 x) Baz2Sym0
     type family Quux1 (a :: a) :: a where
       Quux1 x = Apply (Apply Bar1Sym0 x) (Apply Lambda_0123456789876543210Sym0 x)
-    type Bar1Sym2 (t :: a0123456789876543210) (t :: TyFun a0123456789876543210 b0123456789876543210
-                                                    -> Type) =
+    type Bar1Sym2 (t :: a0123456789876543210) (t :: (~>) a0123456789876543210 b0123456789876543210) =
         Bar1 t t
     instance SuppressUnusedWarnings Bar1Sym1 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Bar1Sym1KindInference) GHC.Tuple.())
-    data Bar1Sym1 (l :: a0123456789876543210) (l :: TyFun (TyFun a0123456789876543210 b0123456789876543210
-                                                           -> Type) b0123456789876543210)
+    data Bar1Sym1 (l :: a0123456789876543210) (l :: TyFun ((~>) a0123456789876543210 b0123456789876543210) b0123456789876543210)
       = forall arg. SameKind (Apply (Bar1Sym1 l) arg) (Bar1Sym2 l arg) =>
         Bar1Sym1KindInference
     type instance Apply (Bar1Sym1 l) l = Bar1 l l
     instance SuppressUnusedWarnings Bar1Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Bar1Sym0KindInference) GHC.Tuple.())
-    data Bar1Sym0 (l :: TyFun a0123456789876543210 (TyFun (TyFun a0123456789876543210 b0123456789876543210
-                                                           -> Type) b0123456789876543210
-                                                    -> Type))
+    data Bar1Sym0 (l :: TyFun a0123456789876543210 ((~>) ((~>) a0123456789876543210 b0123456789876543210) b0123456789876543210))
       = forall arg. SameKind (Apply Bar1Sym0 arg) (Bar1Sym1 arg) =>
         Bar1Sym0KindInference
     type instance Apply Bar1Sym0 l = Bar1Sym1 l
     type Baz1Sym0 = Baz1
     class PFoo1 (a :: Type) where
-      type Bar1 (arg :: a) (arg :: TyFun a b -> Type) :: b
+      type Bar1 (arg :: a) (arg :: (~>) a b) :: b
       type Baz1 :: a
     type Bar2Sym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
         Bar2 t t
@@ -102,8 +98,7 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Bar2Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Bar2Sym0KindInference) GHC.Tuple.())
-    data Bar2Sym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 b0123456789876543210
-                                                    -> Type))
+    data Bar2Sym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210))
       = forall arg. SameKind (Apply Bar2Sym0 arg) (Bar2Sym1 arg) =>
         Bar2Sym0KindInference
     type instance Apply Bar2Sym0 l = Bar2Sym1 l
@@ -127,7 +122,7 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
                             Sing (Case_0123456789876543210 x arg_0123456789876543210 arg_0123456789876543210) }))
     class SFoo1 a where
       sBar1 ::
-        forall (t :: a) (t :: TyFun a b -> Type).
+        forall (t :: a) (t :: (~>) a b).
         Sing t -> Sing t -> Sing (Apply (Apply Bar1Sym0 t) t :: b)
       sBaz1 :: Sing (Baz1Sym0 :: a)
     class SFoo2 a where

--- a/tests/compile-and-dump/Singletons/T178.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T178.ghc84.template
@@ -46,8 +46,7 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym0 (l :: TyFun Occ (TyFun Occ Ordering
-                                                          -> GHC.Types.Type))
+    data Compare_0123456789876543210Sym0 (l :: TyFun Occ ((~>) Occ Ordering))
       = forall arg. SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
         Compare_0123456789876543210Sym0KindInference
     type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
@@ -73,8 +72,7 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: Nat) (l :: TyFun Occ (TyFun Symbol Symbol
-                                                                       -> GHC.Types.Type))
+    data ShowsPrec_0123456789876543210Sym1 (l :: Nat) (l :: TyFun Occ ((~>) Symbol Symbol))
       = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
         ShowsPrec_0123456789876543210Sym1KindInference
     type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
@@ -83,9 +81,7 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun Nat (TyFun Occ (TyFun Symbol Symbol
-                                                                       -> GHC.Types.Type)
-                                                            -> GHC.Types.Type))
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun Nat ((~>) Occ ((~>) Symbol Symbol)))
       = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
@@ -119,8 +115,7 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
         forall (t1 :: Occ) (t2 :: Occ).
         Sing t1
         -> Sing t2
-           -> Sing (Apply (Apply (CompareSym0 :: TyFun Occ (TyFun Occ Ordering
-                                                            -> GHC.Types.Type)
+           -> Sing (Apply (Apply (CompareSym0 :: TyFun Occ ((~>) Occ Ordering)
                                                  -> GHC.Types.Type) t1) t2)
       sCompare SStr SStr
         = (applySing
@@ -155,9 +150,7 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
         Sing t1
         -> Sing t2
            -> Sing t3
-              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun Nat (TyFun Occ (TyFun Symbol Symbol
-                                                                                   -> GHC.Types.Type)
-                                                                        -> GHC.Types.Type)
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun Nat ((~>) Occ ((~>) Symbol Symbol))
                                                              -> GHC.Types.Type) t1) t2) t3)
       sShowsPrec
         _

--- a/tests/compile-and-dump/Singletons/T187.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T187.ghc84.template
@@ -26,8 +26,7 @@ Singletons/T187.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym0 (l :: TyFun Empty (TyFun Empty Ordering
-                                                            -> GHC.Types.Type))
+    data Compare_0123456789876543210Sym0 (l :: TyFun Empty ((~>) Empty Ordering))
       = forall arg. SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
         Compare_0123456789876543210Sym0KindInference
     type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
@@ -48,8 +47,7 @@ Singletons/T187.hs:(0,0)-(0,0): Splicing declarations
         forall (t1 :: Empty) (t2 :: Empty).
         Sing t1
         -> Sing t2
-           -> Sing (Apply (Apply (CompareSym0 :: TyFun Empty (TyFun Empty Ordering
-                                                              -> GHC.Types.Type)
+           -> Sing (Apply (Apply (CompareSym0 :: TyFun Empty ((~>) Empty Ordering)
                                                  -> GHC.Types.Type) t1) t2)
       sCompare _ _ = SEQ
     instance SEq Empty where

--- a/tests/compile-and-dump/Singletons/T190.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T190.ghc84.template
@@ -26,8 +26,7 @@ Singletons/T190.hs:0:0:: Splicing declarations
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym0 (l :: TyFun T (TyFun T Ordering
-                                                        -> GHC.Types.Type))
+    data Compare_0123456789876543210Sym0 (l :: TyFun T ((~>) T Ordering))
       = forall arg. SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
         Compare_0123456789876543210Sym0KindInference
     type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
@@ -94,8 +93,7 @@ Singletons/T190.hs:0:0:: Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun T (TyFun GHC.Types.Symbol GHC.Types.Symbol
-                                                                               -> GHC.Types.Type))
+    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun T ((~>) GHC.Types.Symbol GHC.Types.Symbol))
       = forall arg. SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
         ShowsPrec_0123456789876543210Sym1KindInference
     type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
@@ -104,9 +102,7 @@ Singletons/T190.hs:0:0:: Splicing declarations
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat (TyFun T (TyFun GHC.Types.Symbol GHC.Types.Symbol
-                                                                               -> GHC.Types.Type)
-                                                                      -> GHC.Types.Type))
+    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) T ((~>) GHC.Types.Symbol GHC.Types.Symbol)))
       = forall arg. SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
         ShowsPrec_0123456789876543210Sym0KindInference
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
@@ -128,8 +124,7 @@ Singletons/T190.hs:0:0:: Splicing declarations
         forall (t1 :: T) (t2 :: T).
         Sing t1
         -> Sing t2
-           -> Sing (Apply (Apply (CompareSym0 :: TyFun T (TyFun T Ordering
-                                                          -> GHC.Types.Type)
+           -> Sing (Apply (Apply (CompareSym0 :: TyFun T ((~>) T Ordering)
                                                  -> GHC.Types.Type) t1) t2)
       sCompare ST ST
         = (applySing
@@ -170,9 +165,7 @@ Singletons/T190.hs:0:0:: Splicing declarations
         Sing t1
         -> Sing t2
            -> Sing t3
-              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat (TyFun T (TyFun GHC.Types.Symbol GHC.Types.Symbol
-                                                                                           -> GHC.Types.Type)
-                                                                                  -> GHC.Types.Type)
+              -> Sing (Apply (Apply (Apply (ShowsPrecSym0 :: TyFun GHC.Types.Nat ((~>) T ((~>) GHC.Types.Symbol GHC.Types.Symbol))
                                                              -> GHC.Types.Type) t1) t2) t3)
       sShowsPrec
         _

--- a/tests/compile-and-dump/Singletons/T197.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T197.ghc84.template
@@ -19,8 +19,7 @@ Singletons/T197.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ($$:@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:$$:@#@$###)) GHC.Tuple.())
-    data ($$:@#@$) (l :: TyFun Bool (TyFun Bool Bool
-                                     -> GHC.Types.Type))
+    data ($$:@#@$) (l :: TyFun Bool ((~>) Bool Bool))
       = forall arg. SameKind (Apply ($$:@#@$) arg) (($$:@#@$$) arg) =>
         (:$$:@#@$###)
     type instance Apply ($$:@#@$) l = ($$:@#@$$) l

--- a/tests/compile-and-dump/Singletons/T197b.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T197b.ghc84.template
@@ -21,8 +21,7 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (:*:@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::*:@#@$###)) GHC.Tuple.())
-    data (:*:@#@$) (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 ((:*:) a0123456789876543210 b0123456789876543210)
-                                                     -> GHC.Types.Type))
+    data (:*:@#@$) (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 ((:*:) a0123456789876543210 b0123456789876543210)))
       = forall arg. SameKind (Apply (:*:@#@$) arg) ((:*:@#@$$) arg) =>
         (::*:@#@$###)
     type instance Apply (:*:@#@$) l = (:*:@#@$$) l
@@ -38,8 +37,7 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings MkPairSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MkPairSym0KindInference) GHC.Tuple.())
-    data MkPairSym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 (Pair a0123456789876543210 b0123456789876543210)
-                                                      -> GHC.Types.Type))
+    data MkPairSym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 (Pair a0123456789876543210 b0123456789876543210)))
       = forall arg. SameKind (Apply MkPairSym0 arg) (MkPairSym1 arg) =>
         MkPairSym0KindInference
     type instance Apply MkPairSym0 l = MkPairSym1 l

--- a/tests/compile-and-dump/Singletons/T200.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T200.ghc84.template
@@ -30,8 +30,7 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (:$$:@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::$$:@#@$###)) GHC.Tuple.())
-    data (:$$:@#@$) (l :: TyFun ErrorMessage (TyFun ErrorMessage ErrorMessage
-                                              -> GHC.Types.Type))
+    data (:$$:@#@$) (l :: TyFun ErrorMessage ((~>) ErrorMessage ErrorMessage))
       = forall arg. SameKind (Apply (:$$:@#@$) arg) ((:$$:@#@$$) arg) =>
         (::$$:@#@$###)
     type instance Apply (:$$:@#@$) l = (:$$:@#@$$) l
@@ -47,8 +46,7 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (:<>:@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::<>:@#@$###)) GHC.Tuple.())
-    data (:<>:@#@$) (l :: TyFun ErrorMessage (TyFun ErrorMessage ErrorMessage
-                                              -> GHC.Types.Type))
+    data (:<>:@#@$) (l :: TyFun ErrorMessage ((~>) ErrorMessage ErrorMessage))
       = forall arg. SameKind (Apply (:<>:@#@$) arg) ((:<>:@#@$$) arg) =>
         (::<>:@#@$###)
     type instance Apply (:<>:@#@$) l = (:<>:@#@$$) l
@@ -72,8 +70,7 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (<>:@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:<>:@#@$###)) GHC.Tuple.())
-    data (<>:@#@$) (l :: TyFun ErrorMessage (TyFun ErrorMessage ErrorMessage
-                                             -> GHC.Types.Type))
+    data (<>:@#@$) (l :: TyFun ErrorMessage ((~>) ErrorMessage ErrorMessage))
       = forall arg. SameKind (Apply (<>:@#@$) arg) ((<>:@#@$$) arg) =>
         (:<>:@#@$###)
     type instance Apply (<>:@#@$) l = (<>:@#@$$) l
@@ -89,8 +86,7 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ($$:@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:$$:@#@$###)) GHC.Tuple.())
-    data ($$:@#@$) (l :: TyFun ErrorMessage (TyFun ErrorMessage ErrorMessage
-                                             -> GHC.Types.Type))
+    data ($$:@#@$) (l :: TyFun ErrorMessage ((~>) ErrorMessage ErrorMessage))
       = forall arg. SameKind (Apply ($$:@#@$) arg) (($$:@#@$$) arg) =>
         (:$$:@#@$###)
     type instance Apply ($$:@#@$) l = ($$:@#@$$) l

--- a/tests/compile-and-dump/Singletons/T209.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T209.ghc84.template
@@ -30,17 +30,14 @@ Singletons/T209.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings MSym1 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MSym1KindInference) GHC.Tuple.())
-    data MSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 (TyFun Bool Bool
-                                                                             -> GHC.Types.Type))
+    data MSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 ((~>) Bool Bool))
       = forall arg. SameKind (Apply (MSym1 l) arg) (MSym2 l arg) =>
         MSym1KindInference
     type instance Apply (MSym1 l) l = MSym2 l l
     instance SuppressUnusedWarnings MSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MSym0KindInference) GHC.Tuple.())
-    data MSym0 (l :: TyFun a0123456789876543210 (TyFun b0123456789876543210 (TyFun Bool Bool
-                                                                             -> GHC.Types.Type)
-                                                 -> GHC.Types.Type))
+    data MSym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 ((~>) Bool Bool)))
       = forall arg. SameKind (Apply MSym0 arg) (MSym1 arg) =>
         MSym0KindInference
     type instance Apply MSym0 l = MSym1 l

--- a/tests/compile-and-dump/Singletons/T271.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T271.ghc84.template
@@ -47,8 +47,7 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym0 (l :: TyFun (Constant a0123456789876543210 b0123456789876543210) (TyFun (Constant a0123456789876543210 b0123456789876543210) Ordering
-                                                                                                           -> Type))
+    data Compare_0123456789876543210Sym0 (l :: TyFun (Constant a0123456789876543210 b0123456789876543210) ((~>) (Constant a0123456789876543210 b0123456789876543210) Ordering))
       = forall arg. SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
         Compare_0123456789876543210Sym0KindInference
     type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
@@ -72,8 +71,7 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym0 (l :: TyFun (Identity a0123456789876543210) (TyFun (Identity a0123456789876543210) Ordering
-                                                                                      -> Type))
+    data Compare_0123456789876543210Sym0 (l :: TyFun (Identity a0123456789876543210) ((~>) (Identity a0123456789876543210) Ordering))
       = forall arg. SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
         Compare_0123456789876543210Sym0KindInference
     type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
@@ -114,8 +112,7 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
         forall (t1 :: Constant a b) (t2 :: Constant a b).
         Sing t1
         -> Sing t2
-           -> Sing (Apply (Apply (CompareSym0 :: TyFun (Constant a b) (TyFun (Constant a b) Ordering
-                                                                       -> Type)
+           -> Sing (Apply (Apply (CompareSym0 :: TyFun (Constant a b) ((~>) (Constant a b) Ordering)
                                                  -> Type) t1) t2)
       sCompare
         (SConstant (sA_0123456789876543210 :: Sing a_0123456789876543210))
@@ -139,8 +136,7 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
         forall (t1 :: Identity a) (t2 :: Identity a).
         Sing t1
         -> Sing t2
-           -> Sing (Apply (Apply (CompareSym0 :: TyFun (Identity a) (TyFun (Identity a) Ordering
-                                                                     -> Type)
+           -> Sing (Apply (Apply (CompareSym0 :: TyFun (Identity a) ((~>) (Identity a) Ordering)
                                                  -> Type) t1) t2)
       sCompare
         (SIdentity (sA_0123456789876543210 :: Sing a_0123456789876543210))

--- a/tests/compile-and-dump/Singletons/T287.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T287.ghc84.template
@@ -1,0 +1,101 @@
+Singletons/T287.hs:(0,0)-(0,0): Splicing declarations
+    singletons
+      [d| class S a where
+            (<<>>) :: a -> a -> a
+          
+          instance S b => S (a -> b) where
+            f <<>> g = \ x -> f x <<>> g x |]
+  ======>
+    class S a where
+      (<<>>) :: a -> a -> a
+    instance S b => S (a -> b) where
+      (<<>>) f g = \ x -> ((f x) <<>> (g x))
+    type (<<>>@#@$$$) (t :: a0123456789876543210) (t :: a0123456789876543210) =
+        (<<>>) t t
+    instance SuppressUnusedWarnings (<<>>@#@$$) where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) (:<<>>@#@$$###)) GHC.Tuple.())
+    data (<<>>@#@$$) (l :: a0123456789876543210) (l :: TyFun a0123456789876543210 a0123456789876543210)
+      = forall arg. SameKind (Apply ((<<>>@#@$$) l) arg) ((<<>>@#@$$$) l arg) =>
+        (:<<>>@#@$$###)
+    type instance Apply ((<<>>@#@$$) l) l = (<<>>) l l
+    instance SuppressUnusedWarnings (<<>>@#@$) where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) (:<<>>@#@$###)) GHC.Tuple.())
+    data (<<>>@#@$) (l :: TyFun a0123456789876543210 ((~>) a0123456789876543210 a0123456789876543210))
+      = forall arg. SameKind (Apply (<<>>@#@$) arg) ((<<>>@#@$$) arg) =>
+        (:<<>>@#@$###)
+    type instance Apply (<<>>@#@$) l = (<<>>@#@$$) l
+    class PS (a :: GHC.Types.Type) where
+      type (<<>>) (arg :: a) (arg :: a) :: a
+    type family Lambda_0123456789876543210 f g t where
+      Lambda_0123456789876543210 f g x = Apply (Apply (<<>>@#@$) (Apply f x)) (Apply g x)
+    type Lambda_0123456789876543210Sym3 t t t =
+        Lambda_0123456789876543210 t t t
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym2 l l l
+      = forall arg. SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
+        Lambda_0123456789876543210Sym2KindInference
+    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym1 l l
+      = forall arg. SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
+        Lambda_0123456789876543210Sym1KindInference
+    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym0 l
+      = forall arg. SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
+        Lambda_0123456789876543210Sym0KindInference
+    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+    type family TFHelper_0123456789876543210 (a :: (~>) a b) (a :: (~>) a b) :: (~>) a b where
+      TFHelper_0123456789876543210 f g = Apply (Apply Lambda_0123456789876543210Sym0 f) g
+    type TFHelper_0123456789876543210Sym2 (t :: (~>) a0123456789876543210 b0123456789876543210) (t :: (~>) a0123456789876543210 b0123456789876543210) =
+        TFHelper_0123456789876543210 t t
+    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) TFHelper_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data TFHelper_0123456789876543210Sym1 (l :: (~>) a0123456789876543210 b0123456789876543210) (l :: TyFun ((~>) a0123456789876543210 b0123456789876543210) ((~>) a0123456789876543210 b0123456789876543210))
+      = forall arg. SameKind (Apply (TFHelper_0123456789876543210Sym1 l) arg) (TFHelper_0123456789876543210Sym2 l arg) =>
+        TFHelper_0123456789876543210Sym1KindInference
+    type instance Apply (TFHelper_0123456789876543210Sym1 l) l = TFHelper_0123456789876543210 l l
+    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) TFHelper_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data TFHelper_0123456789876543210Sym0 (l :: TyFun ((~>) a0123456789876543210 b0123456789876543210) ((~>) ((~>) a0123456789876543210 b0123456789876543210) ((~>) a0123456789876543210 b0123456789876543210)))
+      = forall arg. SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
+        TFHelper_0123456789876543210Sym0KindInference
+    type instance Apply TFHelper_0123456789876543210Sym0 l = TFHelper_0123456789876543210Sym1 l
+    instance PS ((~>) a b) where
+      type (<<>>) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
+    class SS a where
+      (%<<>>) ::
+        forall (t :: a) (t :: a).
+        Sing t -> Sing t -> Sing (Apply (Apply (<<>>@#@$) t) t :: a)
+    instance SS b => SS ((~>) a b) where
+      (%<<>>) ::
+        forall (t :: (~>) a b) (t :: (~>) a b).
+        Sing t -> Sing t -> Sing (Apply (Apply (<<>>@#@$) t) t :: (~>) a b)
+      (%<<>>) (sF :: Sing f) (sG :: Sing g)
+        = (singFun1 @(Apply (Apply Lambda_0123456789876543210Sym0 f) g))
+            (\ sX
+               -> case sX of {
+                    _ :: Sing x
+                      -> (applySing
+                            ((applySing ((singFun2 @(<<>>@#@$)) (%<<>>))) ((applySing sF) sX)))
+                           ((applySing sG) sX) })

--- a/tests/compile-and-dump/Singletons/T287.hs
+++ b/tests/compile-and-dump/Singletons/T287.hs
@@ -1,0 +1,11 @@
+module T287 where
+
+import Data.Singletons.TH
+
+$(singletons [d|
+  class S a where
+    (<<>>) :: a -> a -> a
+
+  instance S b => S (a -> b) where
+    f <<>> g = \x -> f x <<>> g x
+  |])

--- a/tests/compile-and-dump/Singletons/TopLevelPatterns.ghc84.template
+++ b/tests/compile-and-dump/Singletons/TopLevelPatterns.ghc84.template
@@ -20,7 +20,7 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = Data.Tuple.snd
             ((GHC.Tuple.(,) BarSym0KindInference) GHC.Tuple.())
-    data BarSym0 (l :: TyFun Bool (TyFun Bool Foo -> GHC.Types.Type))
+    data BarSym0 (l :: TyFun Bool ((~>) Bool Foo))
       = forall arg. SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
         BarSym0KindInference
     type instance Apply BarSym0 l = BarSym1 l


### PR DESCRIPTION
Currently, `singletons` always generated promoted function arrows as `TyFun a b -> Type`. However, this greatly confuses `defunctionalize`, as doesn't distinguish between an occurrence of `(->)` in `TyFun a b -> Type` from other occurrences of `(->)`. This leads to the shenanigans discovered in #287.

This patch avoids the issue entirely by generating `a ~> b` instead of `TyFun a b -> Type` wherever possible. I say "wherever possible" since there are some uses of `TyFun` that are currently unavoidable, such as when one generates a defunctionalization symbol of the form:

```haskell
type family Foo (a :: Bool) :: Bool

data IdSym0 (l :: TyFun Bool Bool) :: Type
```

Really, we ought to be generating `data IdSym0 :: Bool ~> Bool` there, but `th-desugar` currently lacks the ability to do this (see https://github.com/goldfirere/th-desugar/issues/68 for details). Luckily, the uses of `TyFun` that I _was_ able to remove were sufficient to fix #287, which is what counts in the end.