### PR TITLE
Add promoted/singled versions of Semigroup/Monoid

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,14 @@ next
 * Add `(%<=?)`, a singled version of `(<=?)` from `GHC.TypeNats`, as well as
   defunctionalization symbols for `(<=?)`, to `Data.Singletons.TypeLits`.
 
+* Add `Data.{Promotion,Singletons}.Prelude.{Semigroup,Monoid}`, which define
+  promoted and singled versions of the `Semigroup` and `Monoid` type classes.
+
+  `Symbol` is now has promoted `Semigroup` and `Monoid` instances as well.
+  As a consequence, `Data.Singletons.TypeLits` no longer exports `(<>)` or
+  `(%<>)`, as they are superseded by the corresponding methods from
+  `PSemigroup` and `SSemigroup`.
+
 2.4.1
 -----
 * Restore the `TyCon1`, `TyCon2`, etc. types. It turns out that the new

--- a/singletons.cabal
+++ b/singletons.cabal
@@ -72,7 +72,9 @@ library
                       Data.Singletons.Prelude.List
                       Data.Singletons.Prelude.List.NonEmpty
                       Data.Singletons.Prelude.Maybe
+                      Data.Singletons.Prelude.Monoid
                       Data.Singletons.Prelude.Num
+                      Data.Singletons.Prelude.Semigroup
                       Data.Singletons.Prelude.Show
                       Data.Singletons.Prelude.Tuple
                       Data.Singletons.Prelude.Void
@@ -89,7 +91,9 @@ library
                       Data.Promotion.Prelude.List
                       Data.Promotion.Prelude.List.NonEmpty
                       Data.Promotion.Prelude.Maybe
+                      Data.Promotion.Prelude.Monoid
                       Data.Promotion.Prelude.Num
+                      Data.Promotion.Prelude.Semigroup
                       Data.Promotion.Prelude.Show
                       Data.Promotion.Prelude.Tuple
                       Data.Promotion.Prelude.Void

--- a/src/Data/Promotion/Prelude.hs
+++ b/src/Data/Promotion/Prelude.hs
@@ -44,7 +44,10 @@ module Data.Promotion.Prelude (
   type (^),
 
   -- * Promoted 'Show'
-  PShow(..), ShowS, SChar, show_, type (<>), Shows, ShowChar, ShowString, ShowParen,
+  PShow(..), ShowS, SChar, show_, Shows, ShowChar, ShowString, ShowParen,
+
+  -- * Promoted 'Semigroup' and 'Monoid'
+  PSemigroup(..), PMonoid(..),
 
   -- ** Miscellaneous functions
   Id, Const, (:.), type ($), type ($!), Flip, AsTypeOf, Until, Seq,
@@ -107,11 +110,16 @@ module Data.Promotion.Prelude (
   ShowsPrecSym0, ShowsPrecSym1, ShowsPrecSym2, ShowsPrecSym3,
   Show_Sym0, Show_Sym1,
   ShowListSym0, ShowListSym1, ShowListSym2,
-  type (<>@#@$), type (<>@#@$$), type (<>@#@$$$),
   ShowsSym0, ShowsSym1, ShowsSym2,
   ShowCharSym0, ShowCharSym1, ShowCharSym2,
   ShowStringSym0, ShowStringSym1, ShowStringSym2,
   ShowParenSym0, ShowParenSym1, ShowParenSym2,
+
+  type (<>@#@$), type (<>@#@$$), type (<>@#@$$$),
+  SconcatSym0, SconcatSym1,
+  MemptySym0,
+  MappendSym0, MappendSym1, MappendSym2,
+  MconcatSym0, MconcatSym1,
 
   IdSym0, IdSym1, ConstSym0, ConstSym1, ConstSym2,
   type (.@#@$), type (.@#@$$), type (.@#@$$$),
@@ -181,6 +189,8 @@ import Data.Promotion.Prelude.Eq
 import Data.Promotion.Prelude.Ord
 import Data.Promotion.Prelude.Enum
   hiding (Succ, Pred, SuccSym0, SuccSym1, PredSym0, PredSym1)
+import Data.Promotion.Prelude.Monoid
 import Data.Promotion.Prelude.Num
+import Data.Promotion.Prelude.Semigroup
 import Data.Promotion.Prelude.Show
 import Data.Singletons.TypeLits

--- a/src/Data/Promotion/Prelude/Monoid.hs
+++ b/src/Data/Promotion/Prelude/Monoid.hs
@@ -1,0 +1,23 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Promotion.Prelude.Monoid
+-- Copyright   :  (C) 2018 Ryan Scott
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Exports a promoted version of 'Monoid'.
+--
+----------------------------------------------------------------------------
+
+module Data.Promotion.Prelude.Monoid (
+  PMonoid(..),
+
+  -- ** Defunctionalization symbols
+  MemptySym0,
+  MappendSym0, MappendSym1, MappendSym2,
+  MconcatSym0, MconcatSym1
+  ) where
+
+import Data.Singletons.Prelude.Monoid

--- a/src/Data/Promotion/Prelude/Semigroup.hs
+++ b/src/Data/Promotion/Prelude/Semigroup.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE ExplicitNamespaces #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Promotion.Prelude.Semigroup
+-- Copyright   :  (C) 2018 Ryan Scott
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Exports a promoted version of 'Semigroup'.
+--
+----------------------------------------------------------------------------
+
+module Data.Promotion.Prelude.Semigroup (
+  PSemigroup(..),
+
+  -- ** Defunctionalization symbols
+  type (<>@#@$), type (<>@#@$$), type (<>@#@$$$),
+  SconcatSym0, SconcatSym1
+  ) where
+
+import Data.Singletons.Prelude.Semigroup

--- a/src/Data/Promotion/Prelude/Show.hs
+++ b/src/Data/Promotion/Prelude/Show.hs
@@ -14,7 +14,7 @@
 -----------------------------------------------------------------------------
 
 module Data.Promotion.Prelude.Show (
-  PShow(..), SymbolS, SChar, show_, type (<>),
+  PShow(..), SymbolS, SChar, show_,
   Shows, ShowListWith, ShowChar, ShowString, ShowParen,
   ShowSpace, ShowCommaSpace, AppPrec, AppPrec1,
 
@@ -22,7 +22,6 @@ module Data.Promotion.Prelude.Show (
   ShowsPrecSym0, ShowsPrecSym1, ShowsPrecSym2, ShowsPrecSym3,
   Show_Sym0, Show_Sym1,
   ShowListSym0, ShowListSym1, ShowListSym2,
-  type (<>@#@$), type (<>@#@$$), type (<>@#@$$$),
   ShowsSym0, ShowsSym1, ShowsSym2,
   ShowListWithSym0, ShowListWithSym1, ShowListWithSym2, ShowListWithSym3,
   ShowCharSym0, ShowCharSym1, ShowCharSym2,

--- a/src/Data/Singletons/Prelude.hs
+++ b/src/Data/Singletons/Prelude.hs
@@ -57,8 +57,12 @@ module Data.Singletons.Prelude (
   type (^), (%^),
 
   -- * Singleton 'Show'
-  PShow(..), SShow(..), ShowS, SChar, type (<>), (%<>),
+  PShow(..), SShow(..), ShowS, SChar,
   Shows, sShows, ShowChar, sShowChar, ShowString, sShowString, ShowParen, sShowParen,
+
+  -- * Singleton 'Semigroup' and 'Monoid'
+  PSemigroup(..), SSemigroup(..),
+  PMonoid(..), SMonoid(..),
 
   -- ** Miscellaneous functions
   Id, sId, Const, sConst, (:.), (%.), type ($), (%$), type ($!), (%$!),
@@ -131,11 +135,16 @@ module Data.Singletons.Prelude (
   ShowsPrecSym0, ShowsPrecSym1, ShowsPrecSym2, ShowsPrecSym3,
   Show_Sym0, Show_Sym1,
   ShowListSym0, ShowListSym1, ShowListSym2,
-  type (<>@#@$), type (<>@#@$$), type (<>@#@$$$),
   ShowsSym0, ShowsSym1, ShowsSym2,
   ShowCharSym0, ShowCharSym1, ShowCharSym2,
   ShowStringSym0, ShowStringSym1, ShowStringSym2,
   ShowParenSym0, ShowParenSym1, ShowParenSym2,
+
+  type (<>@#@$), type (<>@#@$$), type (<>@#@$$$),
+  SconcatSym0, SconcatSym1,
+  MemptySym0,
+  MappendSym0, MappendSym1, MappendSym2,
+  MconcatSym0, MconcatSym1,
 
   IdSym0, IdSym1, ConstSym0, ConstSym1, ConstSym2,
   type (.@#@$),  type (.@#@$$),  type (.@#@$$$),
@@ -200,6 +209,8 @@ import Data.Singletons.Prelude.Ord
 import Data.Singletons.Prelude.Instances
 import Data.Singletons.Prelude.Enum
   hiding (Succ, Pred, SuccSym0, SuccSym1, PredSym0, PredSym1, sSucc, sPred)
+import Data.Singletons.Prelude.Monoid
 import Data.Singletons.Prelude.Num
+import Data.Singletons.Prelude.Semigroup
 import Data.Singletons.Prelude.Show
 import Data.Singletons.TypeLits

--- a/src/Data/Singletons/Prelude/List.hs
+++ b/src/Data/Singletons/Prelude/List.hs
@@ -251,6 +251,7 @@ import Data.Singletons.Prelude.Base
 import Data.Singletons.Prelude.Bool
 import Data.Singletons.Prelude.Eq
 import Data.Singletons.Prelude.Maybe
+import Data.Singletons.Prelude.Semigroup
 import Data.Singletons.Prelude.Tuple
 import Data.Singletons.Prelude.Num
 import Data.Singletons.Prelude.Ord

--- a/src/Data/Singletons/Prelude/Monoid.hs
+++ b/src/Data/Singletons/Prelude/Monoid.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeInType #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Singletons.Prelude.Monoid
+-- Copyright   :  (C) 2018 Ryan Scott
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Defines the promoted version of 'Monoid', 'PMonoid', and the
+-- singleton version, 'SMonoid'.
+--
+----------------------------------------------------------------------------
+
+module Data.Singletons.Prelude.Monoid (
+  PMonoid(..), SMonoid(..),
+
+  -- ** Defunctionalization symbols
+  MemptySym0,
+  MappendSym0, MappendSym1, MappendSym2,
+  MconcatSym0, MconcatSym1
+  ) where
+
+import Data.Semigroup (Semigroup(..))
+import Data.Singletons.Prelude.Base
+import Data.Singletons.Prelude.Instances
+import Data.Singletons.Prelude.Semigroup
+import Data.Singletons.Single
+
+$(singletonsOnly [d|
+  -- -| The class of monoids (types with an associative binary operation that
+  -- has an identity).  Instances should satisfy the following laws:
+  --
+  --  * @x '<>' 'mempty' = x@
+  --
+  --  * @'mempty' '<>' x = x@
+  --
+  --  * @x '<>' (y '<>' z) = (x '<>' y) '<>' z@ ('Semigroup' law)
+  --
+  --  * @'mconcat' = 'foldr' '(<>)' 'mempty'@
+  --
+  -- The method names refer to the monoid of lists under concatenation,
+  -- but there are many other instances.
+  --
+  -- Some types can be viewed as a monoid in more than one way,
+  -- e.g. both addition and multiplication on numbers.
+  -- In such cases we often define @newtype@s and make those instances
+  -- of 'Monoid', e.g. 'Sum' and 'Product'.
+  class Semigroup a => Monoid a where
+        -- -| Identity of 'mappend'
+        mempty  :: a
+
+        -- -| An associative operation
+        --
+        -- __NOTE__: This method is redundant and has the default
+        -- implementation @'mappend' = '(<>)'@.
+        mappend :: a -> a -> a
+        mappend = (<>)
+
+        -- -| Fold a list using the monoid.
+        --
+        -- For most types, the default definition for 'mconcat' will be
+        -- used, but the function is included in the class definition so
+        -- that an optimized version can be provided for specific types.
+        mconcat :: [a] -> a
+        mconcat = foldr mappend mempty
+
+  instance Monoid [a] where
+        mempty  = []
+        -- mconcat xss = [x | xs <- xss, x <- xs]
+
+  instance Monoid b => Monoid (a -> b) where
+        mempty = \_ -> mempty
+
+  instance Monoid () where
+        -- Should it be strict?
+        mempty        = ()
+        mconcat _     = ()
+
+  instance (Monoid a, Monoid b) => Monoid (a,b) where
+        mempty = (mempty, mempty)
+
+  instance (Monoid a, Monoid b, Monoid c) => Monoid (a,b,c) where
+        mempty = (mempty, mempty, mempty)
+
+  instance (Monoid a, Monoid b, Monoid c, Monoid d) => Monoid (a,b,c,d) where
+        mempty = (mempty, mempty, mempty, mempty)
+
+  instance (Monoid a, Monoid b, Monoid c, Monoid d, Monoid e) =>
+                Monoid (a,b,c,d,e) where
+        mempty = (mempty, mempty, mempty, mempty, mempty)
+
+  -- lexicographical ordering
+  instance Monoid Ordering where
+    mempty             = EQ
+
+  -- -| Lift a semigroup into 'Maybe' forming a 'Monoid' according to
+  -- <http://en.wikipedia.org/wiki/Monoid>: \"Any semigroup @S@ may be
+  -- turned into a monoid simply by adjoining an element @e@ not in @S@
+  -- and defining @e*e = e@ and @e*s = s = s*e@ for all @s âˆˆ S@.\"
+  instance Semigroup a => Monoid (Maybe a) where
+    mempty = Nothing
+  |])

--- a/src/Data/Singletons/Prelude/Semigroup.hs
+++ b/src/Data/Singletons/Prelude/Semigroup.hs
@@ -1,0 +1,123 @@
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeInType #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Singletons.Prelude.Semigroup
+-- Copyright   :  (C) 2018 Ryan Scott
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Defines the promoted version of 'Semigroup', 'PSemigroup', and the
+-- singleton version, 'SSemigroup'.
+--
+----------------------------------------------------------------------------
+
+module Data.Singletons.Prelude.Semigroup (
+  PSemigroup(..), SSemigroup(..),
+
+  -- ** Defunctionalization symbols
+  type (<>@#@$), type (<>@#@$$), type (<>@#@$$$),
+  SconcatSym0, SconcatSym1
+  ) where
+
+import Data.List.NonEmpty (NonEmpty(..))
+import Data.Singletons.Prelude.Base
+import Data.Singletons.Prelude.Instances
+import Data.Singletons.Single
+import Data.Void (Void)
+
+$(singletonsOnly [d|
+  -- -| The class of semigroups (types with an associative binary operation).
+  --
+  -- Instances should satisfy the associativity law:
+  --
+  --  * @x '<>' (y '<>' z) = (x '<>' y) '<>' z@
+  class Semigroup a where
+        -- -| An associative operation.
+        (<>) :: a -> a -> a
+        infixr 6 <>
+
+        -- -| Reduce a non-empty list with @\<\>@
+        --
+        -- The default definition should be sufficient, but this can be
+        -- overridden for efficiency.
+        --
+        sconcat :: NonEmpty a -> a
+        sconcat (a :| as) = go a as where
+          go b (c:cs) = b <> go c cs
+          go b []     = b
+
+        {-
+        Can't single 'stimes', since there's no singled 'Integral' class.
+
+        -- -| Repeat a value @n@ times.
+        --
+        -- Given that this works on a 'Semigroup' it is allowed to fail if
+        -- you request 0 or fewer repetitions, and the default definition
+        -- will do so.
+        --
+        -- By making this a member of the class, idempotent semigroups
+        -- and monoids can upgrade this to execute in /O(1)/ by
+        -- picking @stimes = 'stimesIdempotent'@ or @stimes =
+        -- 'stimesIdempotentMonoid'@ respectively.
+        stimes :: Integral b => b -> a -> a
+        stimes = stimesDefault
+        -}
+
+
+  instance Semigroup [a] where
+        (<>) = (++)
+
+  instance Semigroup (NonEmpty a) where
+        (a :| as) <> (b :| bs) = a :| (as ++ b : bs)
+
+  instance Semigroup b => Semigroup (a -> b) where
+        f <> g = \x -> f x <> g x
+
+  instance Semigroup () where
+        _ <> _      = ()
+        sconcat _   = ()
+
+  instance (Semigroup a, Semigroup b) => Semigroup (a, b) where
+        (a,b) <> (a',b') = (a<>a',b<>b')
+
+  instance (Semigroup a, Semigroup b, Semigroup c) => Semigroup (a, b, c) where
+        (a,b,c) <> (a',b',c') = (a<>a',b<>b',c<>c')
+
+  instance (Semigroup a, Semigroup b, Semigroup c, Semigroup d)
+         => Semigroup (a, b, c, d) where
+        (a,b,c,d) <> (a',b',c',d') = (a<>a',b<>b',c<>c',d<>d')
+
+  instance (Semigroup a, Semigroup b, Semigroup c, Semigroup d, Semigroup e)
+         => Semigroup (a, b, c, d, e) where
+        (a,b,c,d,e) <> (a',b',c',d',e') = (a<>a',b<>b',c<>c',d<>d',e<>e')
+
+  instance Semigroup Ordering where
+    LT <> _ = LT
+    EQ <> y = y
+    GT <> _ = GT
+
+  instance Semigroup a => Semigroup (Maybe a) where
+    Nothing <> b       = b
+    a       <> Nothing = a
+    Just a  <> Just b  = Just (a <> b)
+
+  instance Semigroup (Either a b) where
+    Left _    <> b = b
+    -- a      <> _ = a
+    a@Right{} <> _ = a
+
+  instance Semigroup Void where
+    a <> _ = a
+  |])

--- a/src/Data/Singletons/Prelude/Show.hs
+++ b/src/Data/Singletons/Prelude/Show.hs
@@ -26,7 +26,6 @@
 
 module Data.Singletons.Prelude.Show (
   PShow(..), SShow(..), SymbolS, SChar, show_,
-  type (<>), (%<>),
   Shows, sShows,
   ShowListWith, sShowListWith,
   ShowChar, sShowChar,
@@ -41,7 +40,6 @@ module Data.Singletons.Prelude.Show (
   ShowsPrecSym0, ShowsPrecSym1, ShowsPrecSym2, ShowsPrecSym3,
   Show_Sym0, Show_Sym1,
   ShowListSym0, ShowListSym1, ShowListSym2,
-  type (<>@#@$), type (<>@#@$$), type (<>@#@$$$),
   ShowsSym0, ShowsSym1, ShowsSym2,
   ShowListWithSym0, ShowListWithSym1, ShowListWithSym2, ShowListWithSym3,
   ShowCharSym0, ShowCharSym1, ShowCharSym2,
@@ -59,6 +57,7 @@ import           Data.Singletons.Prelude.Base
 import           Data.Singletons.Prelude.Instances
 import           Data.Singletons.Prelude.List
 import           Data.Singletons.Prelude.Ord
+import           Data.Singletons.Prelude.Semigroup
 import           Data.Singletons.Promote
 import           Data.Singletons.Single
 import           Data.Singletons.TypeLits

--- a/src/Data/Singletons/TypeLits.hs
+++ b/src/Data/Singletons/TypeLits.hs
@@ -27,7 +27,6 @@ module Data.Singletons.TypeLits (
 
   type (^), (%^),
   type (<=?), (%<=?),
-  type (<>), (%<>),
 
   TN.Log2, sLog2,
   Div, sDiv, Mod, sMod, DivMod, sDivMod,
@@ -39,7 +38,6 @@ module Data.Singletons.TypeLits (
   KnownSymbolSym0, KnownSymbolSym1,
   type (^@#@$), type (^@#@$$), type (^@#@$$$),
   type (<=?@#@$), type (<=?@#@$$), type (<=?@#@$$$),
-  type (<>@#@$), type (<>@#@$$), type (<>@#@$$$),
   Log2Sym0, Log2Sym1,
   DivSym0, DivSym1, DivSym2,
   ModSym0, ModSym1, ModSym2,
@@ -91,6 +89,12 @@ instance Ord Symbol where
 
 instance IsString Symbol where
   fromString  = no_term_level_syms
+
+instance Semigroup Symbol where
+  (<>) = no_term_level_syms
+
+instance Monoid Symbol where
+  mempty = no_term_level_syms
 
 no_term_level_nats :: a
 no_term_level_nats = error "The kind `Nat` may not be used at the term level."


### PR DESCRIPTION
Addresses one part of #184 (specifically, https://github.com/goldfirere/singletons/issues/184#issuecomment-355857980) by introducing promoted/singled versions of `Semigroup` and `Monoid`, as well as exporting them from the `Prelude` to match `base-4.11`. This also adds a `Semigroup`/`Monoid` instance for `Symbol` using `AppendSymbol`.

Unresolved question: do we want to single all of the newtype modifiers from `Data.Monoid` and `Data.Semigroup`? They're perhaps of dubious value (although one possible use case would be to add an indirect `Monoid` instance for `Nat` using [`Sum`](https://hackage.haskell.org/package/base-4.10.1.0/docs/Data-Monoid.html#t:Sum) and [`Product`](https://hackage.haskell.org/package/base-4.10.1.0/docs/Data-Monoid.html#t:Product)).