### PR TITLE
singleton analogue and defunctionalization symbols for <=?

### DIFF
--- a/src/Data/Singletons/TypeLits.hs
+++ b/src/Data/Singletons/TypeLits.hs
@@ -26,6 +26,7 @@ module Data.Singletons.TypeLits (
   KnownSymbol, symbolVal,
 
   type (^), (%^),
+  type (<=?), (%<=?),
   type (<>), (%<>),
 
   TN.Log2, sLog2,
@@ -37,6 +38,7 @@ module Data.Singletons.TypeLits (
   KnownNatSym0, KnownNatSym1,
   KnownSymbolSym0, KnownSymbolSym1,
   type (^@#@$), type (^@#@$$), type (^@#@$$$),
+  type (<=?@#@$), type (<=?@#@$$), type (<=?@#@$$$),
   type (<>@#@$), type (<>@#@$$), type (<>@#@$$$),
   Log2Sym0, Log2Sym1,
   DivSym0, DivSym1, DivSym2,

--- a/src/Data/Singletons/TypeLits/Internal.hs
+++ b/src/Data/Singletons/TypeLits/Internal.hs
@@ -28,11 +28,13 @@ module Data.Singletons.TypeLits.Internal (
   Undefined, sUndefined,
   KnownNat, TN.natVal, KnownSymbol, symbolVal,
   type (^), (%^),
+  type (<=?), (%<=?),
   type (<>), (%<>),
 
   -- * Defunctionalization symbols
   ErrorSym0, ErrorSym1, UndefinedSym0,
   type (^@#@$),  type (^@#@$$),  type (^@#@$$$),
+  type (<=?@#@$),  type (<=?@#@$$),  type (<=?@#@$$$),
   type (<>@#@$), type (<>@#@$$), type (<>@#@$$$)
   ) where
 
@@ -169,7 +171,7 @@ $(genDefunSymbols [''Undefined])
 sUndefined :: a
 sUndefined = undefined
 
--- | The singleton analogue of '(TL.^)' for 'Nat's.
+-- | The singleton analogue of '(TN.^)' for 'Nat's.
 (%^) :: Sing a -> Sing b -> Sing (a ^ b)
 sa %^ sb =
   let a = fromSing sa
@@ -182,6 +184,14 @@ infixr 8 %^
 
 -- Defunctionalization symbols for type-level (^)
 $(genDefunSymbols [''(^)])
+
+-- | The singleton analogue of 'TN.<=?' 
+(%<=?) :: Sing a -> Sing b -> Sing (a <=? b)
+sa %<=? sb = unsafeCoerce (sa %<= sb)
+infix 4 %<=?
+
+-- Defunctionalization symbols for (<=?)
+$(genDefunSymbols [''(<=?)])
 
 -- | The promoted analogue of '(<>)' for 'Symbol's. This uses the special
 -- 'TL.AppendSymbol' type family from "GHC.TypeLits".

--- a/src/Data/Singletons/TypeLits/Internal.hs
+++ b/src/Data/Singletons/TypeLits/Internal.hs
@@ -41,7 +41,7 @@ module Data.Singletons.TypeLits.Internal (
 import Data.Singletons.Promote
 import Data.Singletons.Internal
 import Data.Singletons.Prelude.Eq
-import Data.Singletons.Prelude.Ord
+import Data.Singletons.Prelude.Ord as O
 import Data.Singletons.Decide
 import Data.Singletons.Prelude.Bool
 import GHC.TypeLits as TL
@@ -188,12 +188,18 @@ $(genDefunSymbols [''(^)])
 -- | The singleton analogue of 'TN.<=?' 
 --
 -- Note that, because of historical reasons in GHC's 'TN.Nat' API, 'TN.<=?'
--- is incompatible (unification-wise) with '<=' and the 'PEq', 'SEq',
+-- is incompatible (unification-wise) with 'O.<=' and the 'PEq', 'SEq',
 -- 'POrd', and 'SOrd' instances for 'Nat'.  @(a '<=?' b) ~ 'True@ does not
--- imply anything about @a '<=' b@ or any other 'PEq'/'POrd' relationships.
+-- imply anything about @a 'O.<=' b@ or any other 'PEq' / 'POrd'
+-- relationships.
 --
--- This is provided for the sake of completeness and for compatibility with
--- libraries with APIs built around '<=?'.  Newer codebases should use
+-- (Be aware that 'O.<=' in the paragraph above refers to 'O.<=' from the
+-- 'POrd' typeclass, exported from "Data.Singletons.Prelude.Ord", and /not/
+-- the 'TN.<=' from "GHC.TypeNats".  The latter is simply a type alias for
+-- @(a 'TN.<=?' b) ~ 'True@.)
+--
+-- This is provided here for the sake of completeness and for compatibility
+-- with libraries with APIs built around '<=?'.  New code should use
 -- 'CmpNat', exposed through this library through the 'POrd' and 'SOrd'
 -- instances for 'Nat'.
 (%<=?) :: Sing a -> Sing b -> Sing (a <=? b)

--- a/src/Data/Singletons/TypeLits/Internal.hs
+++ b/src/Data/Singletons/TypeLits/Internal.hs
@@ -186,6 +186,16 @@ infixr 8 %^
 $(genDefunSymbols [''(^)])
 
 -- | The singleton analogue of 'TN.<=?' 
+--
+-- Note that, because of historical reasons in GHC's 'TN.Nat' API, 'TN.<=?'
+-- is incompatible (unification-wise) with '<=' and the 'PEq', 'SEq',
+-- 'POrd', and 'SOrd' instances for 'Nat'.  @(a '<=?' b) ~ 'True@ does not
+-- imply anything about @a '<=' b@ or any other 'PEq'/'POrd' relationships.
+--
+-- This is provided for the sake of completeness and for compatibility with
+-- libraries with APIs built around '<=?'.  Newer codebases should use
+-- 'CmpNat', exposed through this library through the 'POrd' and 'SOrd'
+-- instances for 'Nat'.
 (%<=?) :: Sing a -> Sing b -> Sing (a <=? b)
 sa %<=? sb = unsafeCoerce (sa %<= sb)
 infix 4 %<=?


### PR DESCRIPTION
This PR adds the singleton analogue (`%<=`) and defunctionalization symbols to fully cover the *GHC.TypeNats* API, partially just for the sake of completeness.

On a more practical note, though, a bunch of libraries built on native GHC.TypeLits/GHC.TypeNats still build their API's around `<=?`, instead of `CmpNat`, so they're incompatible with *singleton*'s `POrd`/`SOrd` typeclasses.  Having `%<=?` makes these libraries significantly easier to use.