### PR TITLE
Add newtype modifiers to Data.Ord, Data.Semigroup, and Data.Monoid

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,17 +11,24 @@ Changelog for singletons project
   generalize the `Sing :: Type -> Type` instance to `Sing :: TYPE rep -> Type`,
   allowing it to work over more open kinds. Also rename `SomeTypeRepStar` to
   `SomeTypeRepTYPE`, and change its definition accordingly.
-  
+
 * Add `(%<=?)`, a singled version of `(<=?)` from `GHC.TypeNats`, as well as
   defunctionalization symbols for `(<=?)`, to `Data.Singletons.TypeLits`.
 
 * Add `Data.{Promotion,Singletons}.Prelude.{Semigroup,Monoid}`, which define
-  promoted and singled versions of the `Semigroup` and `Monoid` type classes.
+  promoted and singled versions of the `Semigroup` and `Monoid` type classes,
+  as well as various newtype modifiers.
 
   `Symbol` is now has promoted `Semigroup` and `Monoid` instances as well.
   As a consequence, `Data.Singletons.TypeLits` no longer exports `(<>)` or
   `(%<>)`, as they are superseded by the corresponding methods from
   `PSemigroup` and `SSemigroup`.
+
+* Promote and single the `Down` newtype in `Data.Singletons.Prelude.Ord`.
+
+* To match the `base` library, the promoted/singled versions of `comparing`
+  and `thenCmp` are no longer exported from `Data.Singletons.Prelude`. (They
+  continue to live in `Data.Singletons.Prelude.Ord`.)
 
 2.4.1
 -----

--- a/singletons.cabal
+++ b/singletons.cabal
@@ -110,6 +110,7 @@ library
                       Data.Singletons.Deriving.Show
                       Data.Singletons.Internal
                       Data.Singletons.Prelude.List.NonEmpty.Internal
+                      Data.Singletons.Prelude.Semigroup.Internal
                       Data.Singletons.Promote
                       Data.Singletons.Promote.Monad
                       Data.Singletons.Promote.Eq

--- a/src/Data/Promotion/Prelude.hs
+++ b/src/Data/Promotion/Prelude.hs
@@ -30,7 +30,7 @@ module Data.Promotion.Prelude (
   module Data.Promotion.Prelude.Eq,
 
   -- * Promoted comparisons
-  module Data.Promotion.Prelude.Ord,
+  POrd(..),
 
   -- * Promoted enumerations
   -- | As a matter of convenience, the promoted Prelude does /not/ export
@@ -104,6 +104,15 @@ module Data.Promotion.Prelude (
   UncurrySym0, UncurrySym1, UncurrySym2,
 
   ErrorSym0, ErrorSym1, UndefinedSym0,
+
+  LTSym0, EQSym0, GTSym0,
+  CompareSym0, CompareSym1, CompareSym2,
+  type (<@#@$),  type (<@#@$$),  type (<@#@$$$),
+  type (<=@#@$), type (<=@#@$$), type (<=@#@$$$),
+  type (>@#@$),  type (>@#@$$),  type (>@#@$$$),
+  type (>=@#@$), type (>=@#@$$), type (>=@#@$$$),
+  MaxSym0, MaxSym1, MaxSym2,
+  MinSym0, MinSym1, MinSym2,
 
   type (^@#@$), type (^@#@$$), type (^@#@$$$),
 
@@ -190,7 +199,11 @@ import Data.Promotion.Prelude.Ord
 import Data.Promotion.Prelude.Enum
   hiding (Succ, Pred, SuccSym0, SuccSym1, PredSym0, PredSym1)
 import Data.Promotion.Prelude.Monoid
+       ( PMonoid(..), MemptySym0, MappendSym0
+       , MappendSym1, MappendSym2, MconcatSym0, MconcatSym1)
 import Data.Promotion.Prelude.Num
 import Data.Promotion.Prelude.Semigroup
+       ( PSemigroup(..), type (<>@#@$), type (<>@#@$$), type (<>@#@$$$)
+       , SconcatSym0, SconcatSym1)
 import Data.Promotion.Prelude.Show
 import Data.Singletons.TypeLits

--- a/src/Data/Promotion/Prelude/Monoid.hs
+++ b/src/Data/Promotion/Prelude/Monoid.hs
@@ -14,10 +14,19 @@
 module Data.Promotion.Prelude.Monoid (
   PMonoid(..),
 
+  GetDual, GetAll, GetAny, GetSum, GetProduct, GetFirst, GetLast,
+
   -- ** Defunctionalization symbols
   MemptySym0,
   MappendSym0, MappendSym1, MappendSym2,
-  MconcatSym0, MconcatSym1
+  MconcatSym0, MconcatSym1,
+  DualSym0, DualSym1, GetDualSym0, GetDualSym1,
+  AllSym0, AllSym1, GetAllSym0, GetAllSym1,
+  AnySym0, AnySym1, GetAnySym0, GetAnySym1,
+  SumSym0, SumSym1, GetSumSym0, GetSumSym1,
+  ProductSym0, ProductSym1, GetProductSym0, GetProductSym1,
+  FirstSym0, FirstSym1, GetFirstSym0, GetFirstSym1,
+  LastSym0, LastSym1, GetLastSym0, GetLastSym1
   ) where
 
 import Data.Singletons.Prelude.Monoid

--- a/src/Data/Promotion/Prelude/Ord.hs
+++ b/src/Data/Promotion/Prelude/Ord.hs
@@ -29,7 +29,8 @@ module Data.Promotion.Prelude.Ord (
   type (>=@#@$), type (>=@#@$$), type (>=@#@$$$),
   MaxSym0, MaxSym1, MaxSym2,
   MinSym0, MinSym1, MinSym2,
-  ComparingSym0, ComparingSym1, ComparingSym2, ComparingSym3
+  ComparingSym0, ComparingSym1, ComparingSym2, ComparingSym3,
+  DownSym0, DownSym1
   ) where
 
 import Data.Singletons.Prelude.Ord

--- a/src/Data/Promotion/Prelude/Semigroup.hs
+++ b/src/Data/Promotion/Prelude/Semigroup.hs
@@ -16,9 +16,26 @@
 module Data.Promotion.Prelude.Semigroup (
   PSemigroup(..),
 
+  GetMin, GetMax, GetFirst, GetLast, GetDual,
+  GetAll, GetAny, GetSum, GetProduct, GetOption,
+
+  Option_,
+
   -- ** Defunctionalization symbols
   type (<>@#@$), type (<>@#@$$), type (<>@#@$$$),
-  SconcatSym0, SconcatSym1
+  SconcatSym0, SconcatSym1,
+  MinSym0, MinSym1, GetMinSym0, GetMinSym1,
+  MaxSym0, MaxSym1, GetMaxSym0, GetMaxSym1,
+  FirstSym0, FirstSym1, GetFirstSym0, GetFirstSym1,
+  LastSym0, LastSym1, GetLastSym0, GetLastSym1,
+  WrapMonoidSym0, WrapMonoidSym1, UnwrapMonoidSym0, UnwrapMonoidSym1,
+  DualSym0, DualSym1, GetDualSym0, GetDualSym1,
+  AllSym0, AllSym1, GetAllSym0, GetAllSym1,
+  AnySym0, AnySym1, GetAnySym0, GetAnySym1,
+  SumSym0, SumSym1, GetSumSym0, GetSumSym1,
+  ProductSym0, ProductSym1, GetProductSym0, GetProductSym1,
+  OptionSym0, OptionSym1, GetOptionSym0, GetOptionSym1,
+  ArgSym0, ArgSym1, ArgSym2
   ) where
 
 import Data.Singletons.Prelude.Semigroup

--- a/src/Data/Singletons/Prelude.hs
+++ b/src/Data/Singletons/Prelude.hs
@@ -43,7 +43,7 @@ module Data.Singletons.Prelude (
   module Data.Singletons.Prelude.Eq,
 
   -- * Singleton comparisons
-  module Data.Singletons.Prelude.Ord,
+  POrd(..), SOrd(..),
 
   -- * Singleton Enum and Bounded
   -- | As a matter of convenience, the singletons Prelude does /not/ export
@@ -130,6 +130,15 @@ module Data.Singletons.Prelude (
 
   ErrorSym0, ErrorSym1, UndefinedSym0,
 
+  LTSym0, EQSym0, GTSym0,
+  CompareSym0, CompareSym1, CompareSym2,
+  type (<@#@$),  type (<@#@$$),  type (<@#@$$$),
+  type (<=@#@$), type (<=@#@$$), type (<=@#@$$$),
+  type (>@#@$),  type (>@#@$$),  type (>@#@$$$),
+  type (>=@#@$), type (>=@#@$$), type (>=@#@$$$),
+  MaxSym0, MaxSym1, MaxSym2,
+  MinSym0, MinSym1, MinSym2,
+
   type (^@#@$), type (^@#@$$), type (^@#@$$$),
 
   ShowsPrecSym0, ShowsPrecSym1, ShowsPrecSym2, ShowsPrecSym3,
@@ -206,11 +215,15 @@ import Data.Singletons.Prelude.Maybe
 import Data.Singletons.Prelude.Tuple
 import Data.Singletons.Prelude.Eq
 import Data.Singletons.Prelude.Ord
-import Data.Singletons.Prelude.Instances
 import Data.Singletons.Prelude.Enum
   hiding (Succ, Pred, SuccSym0, SuccSym1, PredSym0, PredSym1, sSucc, sPred)
 import Data.Singletons.Prelude.Monoid
+       ( PMonoid(..), SMonoid(..), MemptySym0, MappendSym0
+       , MappendSym1, MappendSym2, MconcatSym0, MconcatSym1)
 import Data.Singletons.Prelude.Num
 import Data.Singletons.Prelude.Semigroup
+       ( PSemigroup(..), SSemigroup(..)
+       , type (<>@#@$), type (<>@#@$$), type (<>@#@$$$)
+       , SconcatSym0, SconcatSym1)
 import Data.Singletons.Prelude.Show
 import Data.Singletons.TypeLits

--- a/src/Data/Singletons/Prelude/List.hs
+++ b/src/Data/Singletons/Prelude/List.hs
@@ -251,7 +251,7 @@ import Data.Singletons.Prelude.Base
 import Data.Singletons.Prelude.Bool
 import Data.Singletons.Prelude.Eq
 import Data.Singletons.Prelude.Maybe
-import Data.Singletons.Prelude.Semigroup
+import Data.Singletons.Prelude.Semigroup.Internal (SSemigroup(..), type (<>@#@$))
 import Data.Singletons.Prelude.Tuple
 import Data.Singletons.Prelude.Num
 import Data.Singletons.Prelude.Ord

--- a/src/Data/Singletons/Prelude/Monoid.hs
+++ b/src/Data/Singletons/Prelude/Monoid.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE TypeInType #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -26,17 +27,44 @@
 module Data.Singletons.Prelude.Monoid (
   PMonoid(..), SMonoid(..),
 
+  Sing(SDual, sGetDual, SAll, sGetAll, SAny, sGetAny, SSum, sGetSum,
+       SProduct, sGetProduct, SFirst, sGetFirst, SLast, sGetLast),
+  GetDual, GetAll, GetAny, GetSum, GetProduct, GetFirst, GetLast,
+
+  SDual, SAll, SAny, SSum, SProduct, SFirst, SLast,
+
   -- ** Defunctionalization symbols
   MemptySym0,
   MappendSym0, MappendSym1, MappendSym2,
-  MconcatSym0, MconcatSym1
+  MconcatSym0, MconcatSym1,
+  DualSym0, DualSym1, GetDualSym0, GetDualSym1,
+  AllSym0, AllSym1, GetAllSym0, GetAllSym1,
+  AnySym0, AnySym1, GetAnySym0, GetAnySym1,
+  SumSym0, SumSym1, GetSumSym0, GetSumSym1,
+  ProductSym0, ProductSym1, GetProductSym0, GetProductSym1,
+  FirstSym0, FirstSym1, GetFirstSym0, GetFirstSym1,
+  LastSym0, LastSym1, GetLastSym0, GetLastSym1
   ) where
 
-import Data.Semigroup (Semigroup(..))
+import Data.Monoid (First(..), Last(..))
+import Data.Ord (Down(..))
+import Data.Semigroup hiding (First(..), Last(..))
 import Data.Singletons.Prelude.Base
+import Data.Singletons.Prelude.Eq
 import Data.Singletons.Prelude.Instances
-import Data.Singletons.Prelude.Semigroup
+import Data.Singletons.Prelude.Num
+import Data.Singletons.Prelude.Ord
+import Data.Singletons.Prelude.Semigroup.Internal hiding
+       (Sing(SFirst, SLast), SFirst, SLast,
+        FirstSym0, FirstSym1, FirstSym0KindInference,
+        LastSym0,  LastSym1,  LastSym0KindInference,
+        GetFirst,  GetFirstSym0, GetFirstSym1, GetFirstSym0KindInference,
+        GetLast,   GetLastSym0,  GetLastSym1, GetLastSym0KindInference)
+import Data.Singletons.Prelude.Show
 import Data.Singletons.Single
+import Data.Singletons.Util
+
+import GHC.TypeLits (Symbol)
 
 $(singletonsOnly [d|
   -- -| The class of monoids (types with an associative binary operation that
@@ -111,4 +139,50 @@ $(singletonsOnly [d|
   -- and defining @e*e = e@ and @e*s = s = s*e@ for all @s âˆˆ S@.\"
   instance Semigroup a => Monoid (Maybe a) where
     mempty = Nothing
+
+  instance Monoid Symbol where
+    mempty = ""
+  |])
+
+$(genSingletons        monoidBasicTypes)
+$(showSingInstances    monoidBasicTypes)
+$(singEqInstances      monoidBasicTypes)
+$(singDecideInstances  monoidBasicTypes)
+$(singOrdInstances     monoidBasicTypes)
+$(singShowInstances    monoidBasicTypes)
+
+$(singletonsOnly [d|
+  instance Monoid a => Monoid (Dual a) where
+          mempty = Dual mempty
+
+  instance Monoid All where
+          mempty = All True
+
+  instance Monoid Any where
+          mempty = Any False
+
+  instance Num a => Monoid (Sum a) where
+          mempty = Sum 0
+
+  instance Num a => Monoid (Product a) where
+          mempty = Product 1
+
+  -- deriving newtype instance Monoid a => Monoid (Down a)
+  instance Monoid a => Monoid (Down a) where
+      mempty = Down mempty
+      Down a `mappend` Down b = Down (a `mappend` b)
+
+  instance Semigroup (First a) where
+          First Nothing    <> b = b
+          a@(First Just{}) <> _ = a
+
+  instance Monoid (First a) where
+          mempty = First Nothing
+
+  instance Semigroup (Last a) where
+          a <> Last Nothing     = a
+          _ <> b@(Last Just {}) = b
+
+  instance Monoid (Last a) where
+          mempty = Last Nothing
   |])

--- a/src/Data/Singletons/Prelude/Num.hs
+++ b/src/Data/Singletons/Prelude/Num.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TemplateHaskell, PolyKinds, DataKinds, TypeFamilies, TypeInType,
              TypeOperators, GADTs, ScopedTypeVariables, UndecidableInstances,
-             DefaultSignatures, FlexibleContexts
+             DefaultSignatures, FlexibleContexts, InstanceSigs
   #-}
 
 -----------------------------------------------------------------------------
@@ -34,8 +34,10 @@ module Data.Singletons.Prelude.Num (
   SubtractSym0, SubtractSym1, SubtractSym2
   ) where
 
+import Data.Ord (Down(..))
 import Data.Singletons.Single
 import Data.Singletons.Internal
+import Data.Singletons.Prelude.Ord
 import Data.Singletons.TypeLits.Internal
 import Data.Singletons.Decide
 import qualified GHC.TypeNats as TN
@@ -69,6 +71,16 @@ $(singletonsOnly [d|
       x - y               = x + negate y
 
       negate x            = 0 - x
+
+  -- deriving newtype instance Num a => Num (Down a)
+  instance Num a => Num (Down a) where
+      Down a + Down b = Down (a + b)
+      Down a - Down b = Down (a - b)
+      Down a * Down b = Down (a * b)
+      negate (Down a) = Down (negate a)
+      abs    (Down a) = Down (abs a)
+      signum (Down a) = Down (signum a)
+      fromInteger n   = Down (fromInteger n)
   |])
 
 -- PNum instance

--- a/src/Data/Singletons/Prelude/Ord.hs
+++ b/src/Data/Singletons/Prelude/Ord.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE TemplateHaskell, DataKinds, PolyKinds, ScopedTypeVariables,
              TypeFamilies, TypeOperators, GADTs, UndecidableInstances,
-             FlexibleContexts, DefaultSignatures, InstanceSigs, TypeInType #-}
+             FlexibleContexts, DefaultSignatures, InstanceSigs, TypeInType,
+             StandaloneDeriving #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -25,7 +27,9 @@ module Data.Singletons.Prelude.Ord (
   -- it returns its first argument.
   thenCmp, ThenCmp, sThenCmp,
 
-  Sing(SLT, SEQ, SGT),
+  Sing(SLT, SEQ, SGT, SDown),
+
+  SOrdering, SDown,
 
   -- ** Defunctionalization symbols
   ThenCmpSym0, ThenCmpSym1, ThenCmpSym2,
@@ -37,9 +41,11 @@ module Data.Singletons.Prelude.Ord (
   type (>=@#@$), type (>=@#@$$), type (>=@#@$$$),
   MaxSym0, MaxSym1, MaxSym2,
   MinSym0, MinSym1, MinSym2,
-  ComparingSym0, ComparingSym1, ComparingSym2, ComparingSym3
+  ComparingSym0, ComparingSym1, ComparingSym2, ComparingSym3,
+  DownSym0, DownSym1
   ) where
 
+import Data.Ord (Down(..))
 import Data.Singletons.Single
 import Data.Singletons.Prelude.Eq
 import Data.Singletons.Prelude.Instances
@@ -82,6 +88,15 @@ $(singletonsOnly [d|
   -- >   ... sortBy (comparing fst) ...
   comparing :: (Ord a) => (b -> a) -> b -> b -> Ordering
   comparing p x y = compare (p x) (p y)
+  |])
+
+$(genSingletons [''Down])
+
+$(singletonsOnly [d|
+  deriving instance Eq a => Eq (Down a)
+
+  instance Ord a => Ord (Down a) where
+      compare (Down x) (Down y) = y `compare` x
   |])
 
 $(singletons [d|

--- a/src/Data/Singletons/Prelude/Semigroup/Internal.hs
+++ b/src/Data/Singletons/Prelude/Semigroup/Internal.hs
@@ -1,0 +1,216 @@
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeInType #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Singletons.Prelude.Semigroup.Internal
+-- Copyright   :  (C) 2018 Ryan Scott
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Defines the promoted version of 'Semigroup', 'PSemigroup'; the
+-- singleton version, 'SSemigroup'; and some @newtype@ wrappers, all
+-- of which are reexported from the "Data.Semigroup" module or
+-- imported directly by some other modules.
+--
+-- This module exists to avoid import cycles with
+-- "Data.Singletons.Prelude.Monoid".
+--
+----------------------------------------------------------------------------
+
+module Data.Singletons.Prelude.Semigroup.Internal where
+
+import Data.List.NonEmpty (NonEmpty(..))
+import Data.Ord (Down(..))
+import Data.Proxy
+import Data.Semigroup (Dual(..), All(..), Any(..), Sum(..), Product(..), Option(..))
+import Data.Singletons.Internal
+import Data.Singletons.Prelude.Base
+import Data.Singletons.Prelude.Bool
+import Data.Singletons.Prelude.Enum
+import Data.Singletons.Prelude.Eq
+import Data.Singletons.Prelude.Instances
+import Data.Singletons.Prelude.Num
+import Data.Singletons.Prelude.Ord hiding (MinSym0, MinSym1, MaxSym0, MaxSym1)
+import Data.Singletons.Promote
+import Data.Singletons.Single
+import Data.Singletons.TypeLits.Internal
+import Data.Singletons.Util
+import qualified Data.Text as T
+import Data.Void (Void)
+
+import GHC.TypeLits (AppendSymbol, SomeSymbol(..), someSymbolVal, Symbol)
+
+import Unsafe.Coerce
+
+$(singletonsOnly [d|
+  -- -| The class of semigroups (types with an associative binary operation).
+  --
+  -- Instances should satisfy the associativity law:
+  --
+  --  * @x '<>' (y '<>' z) = (x '<>' y) '<>' z@
+  class Semigroup a where
+        -- -| An associative operation.
+        (<>) :: a -> a -> a
+        infixr 6 <>
+
+        -- -| Reduce a non-empty list with @\<\>@
+        --
+        -- The default definition should be sufficient, but this can be
+        -- overridden for efficiency.
+        --
+        sconcat :: NonEmpty a -> a
+        sconcat (a :| as) = go a as where
+          go b (c:cs) = b <> go c cs
+          go b []     = b
+
+        {-
+        Can't single 'stimes', since there's no singled 'Integral' class.
+
+        -- -| Repeat a value @n@ times.
+        --
+        -- Given that this works on a 'Semigroup' it is allowed to fail if
+        -- you request 0 or fewer repetitions, and the default definition
+        -- will do so.
+        --
+        -- By making this a member of the class, idempotent semigroups
+        -- and monoids can upgrade this to execute in /O(1)/ by
+        -- picking @stimes = 'stimesIdempotent'@ or @stimes =
+        -- 'stimesIdempotentMonoid'@ respectively.
+        stimes :: Integral b => b -> a -> a
+        stimes = stimesDefault
+        -}
+
+
+  instance Semigroup [a] where
+        (<>) = (++)
+
+  instance Semigroup (NonEmpty a) where
+        (a :| as) <> (b :| bs) = a :| (as ++ b : bs)
+
+  instance Semigroup b => Semigroup (a -> b) where
+        f <> g = \x -> f x <> g x
+
+  instance Semigroup () where
+        _ <> _      = ()
+        sconcat _   = ()
+
+  instance (Semigroup a, Semigroup b) => Semigroup (a, b) where
+        (a,b) <> (a',b') = (a<>a',b<>b')
+
+  instance (Semigroup a, Semigroup b, Semigroup c) => Semigroup (a, b, c) where
+        (a,b,c) <> (a',b',c') = (a<>a',b<>b',c<>c')
+
+  instance (Semigroup a, Semigroup b, Semigroup c, Semigroup d)
+         => Semigroup (a, b, c, d) where
+        (a,b,c,d) <> (a',b',c',d') = (a<>a',b<>b',c<>c',d<>d')
+
+  instance (Semigroup a, Semigroup b, Semigroup c, Semigroup d, Semigroup e)
+         => Semigroup (a, b, c, d, e) where
+        (a,b,c,d,e) <> (a',b',c',d',e') = (a<>a',b<>b',c<>c',d<>d',e<>e')
+
+  instance Semigroup Ordering where
+    LT <> _ = LT
+    EQ <> y = y
+    GT <> _ = GT
+
+  instance Semigroup a => Semigroup (Maybe a) where
+    Nothing <> b       = b
+    a       <> Nothing = a
+    Just a  <> Just b  = Just (a <> b)
+
+  instance Semigroup (Either a b) where
+    Left _    <> b = b
+    -- a      <> _ = a
+    a@Right{} <> _ = a
+
+  instance Semigroup Void where
+    a <> _ = a
+
+  -- deriving newtype instance Semigroup a => Semigroup (Down a)
+  instance Semigroup a => Semigroup (Down a) where
+    Down a <> Down b = Down (a <> b)
+  |])
+
+$(genSingletons       $ ''Option : semigroupBasicTypes)
+$(singBoundedInstances             semigroupBasicTypes)
+$(singEqInstances     $ ''Option : semigroupBasicTypes)
+$(singDecideInstances $ ''Option : semigroupBasicTypes)
+$(singOrdInstances    $ ''Option : semigroupBasicTypes)
+
+$(singletonsOnly [d|
+  instance Semigroup a => Semigroup (Dual a) where
+          Dual a <> Dual b = Dual (b <> a)
+
+  instance Semigroup All where
+          All a <> All b = All (a && b)
+
+  instance Semigroup Any where
+          Any a <> Any b = Any (a || b)
+
+  instance Num a => Semigroup (Sum a) where
+          Sum a <> Sum b = Sum (a + b)
+
+  -- deriving newtype instance Num a => Num (Sum a)
+  instance Num a => Num (Sum a) where
+      Sum a + Sum b = Sum (a + b)
+      Sum a - Sum b = Sum (a - b)
+      Sum a * Sum b = Sum (a * b)
+      negate (Sum a) = Sum (negate a)
+      abs    (Sum a) = Sum (abs a)
+      signum (Sum a) = Sum (signum a)
+      fromInteger n  = Sum (fromInteger n)
+
+  instance Num a => Semigroup (Product a) where
+          Product a <> Product b = Product (a * b)
+
+  -- deriving newtype instance Num a => Num (Product a)
+  instance Num a => Num (Product a) where
+      Product a + Product b = Product (a + b)
+      Product a - Product b = Product (a - b)
+      Product a * Product b = Product (a * b)
+      negate (Product a) = Product (negate a)
+      abs    (Product a) = Product (abs a)
+      signum (Product a) = Product (signum a)
+      fromInteger n      = Product (fromInteger n)
+  |])
+
+instance PSemigroup Symbol where
+  type a <> b = AppendSymbol a b
+
+instance SSemigroup Symbol where
+  sa %<> sb =
+    let a  = fromSing sa
+        b  = fromSing sb
+        ex = someSymbolVal $ T.unpack $ a <> b
+    in case ex of
+         SomeSymbol (_ :: Proxy ab) -> unsafeCoerce (SSym :: Sing ab)
+
+-- We need these in Data.Singletons.Prelude.Semigroup, as we need to promote
+-- code that simultaneously uses the Min/Max constructors and the min/max
+-- functions, which have clashing defunctionalization symbol names. Our
+-- workaround is to simply define synonyms for min/max and use those instead.
+min_, max_ :: Ord a => a -> a -> a
+min_ = min
+max_ = max
+
+type Min_ x y = Min x y
+type Max_ x y = Max x y
+$(genDefunSymbols [''Min_, ''Max_])
+
+sMin_ :: forall a (x :: a) (y :: a). SOrd a => Sing x -> Sing y -> Sing (x `Min` y)
+sMin_ = sMin
+
+sMax_ :: forall a (x :: a) (y :: a). SOrd a => Sing x -> Sing y -> Sing (x `Max` y)
+sMax_ = sMax

--- a/src/Data/Singletons/Prelude/Show.hs
+++ b/src/Data/Singletons/Prelude/Show.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeInType #-}
@@ -51,13 +52,14 @@ module Data.Singletons.Prelude.Show (
   ) where
 
 import           Data.List.NonEmpty (NonEmpty)
+import           Data.Ord (Down)
 import           Data.Proxy
 import           Data.Singletons.Internal
 import           Data.Singletons.Prelude.Base
 import           Data.Singletons.Prelude.Instances
 import           Data.Singletons.Prelude.List
 import           Data.Singletons.Prelude.Ord
-import           Data.Singletons.Prelude.Semigroup
+import           Data.Singletons.Prelude.Semigroup.Internal
 import           Data.Singletons.Promote
 import           Data.Singletons.Single
 import           Data.Singletons.TypeLits
@@ -153,6 +155,8 @@ $(singletonsOnly [d|
           => Show (a,b,c,d,e,f,g) where
     showsPrec _ (a,b,c,d,e,f,g) s
           = show_tuple [shows a, shows b, shows c, shows d, shows e, shows f, shows g] s
+
+  deriving instance Show a => Show (Down a)
   |])
 
 $(promoteOnly [d|
@@ -170,8 +174,6 @@ $(promoteOnly [d|
   showsNat n = showsNat (n `div` 10) . showsNat (n `mod` 10)
   |])
 
--- | Note that this instance is really, really slow, since it uses an inefficient,
--- inductive definition of division behind the hood.
 instance PShow Nat where
   type ShowsPrec _ n x = ShowsNat n x
 

--- a/src/Data/Singletons/TypeLits/Internal.hs
+++ b/src/Data/Singletons/TypeLits/Internal.hs
@@ -41,13 +41,10 @@ import Data.Singletons.Promote
 import Data.Singletons.Internal
 import Data.Singletons.Prelude.Eq
 import Data.Singletons.Prelude.Ord as O
-import Data.Singletons.Prelude.Monoid
-import Data.Singletons.Prelude.Semigroup
 import Data.Singletons.Decide
 import Data.Singletons.Prelude.Bool
 import GHC.TypeLits as TL
 import qualified GHC.TypeNats as TN
-import Data.Monoid ((<>))
 import qualified Data.Type.Equality as DTE
 import Data.Type.Equality ((:~:)(..))
 import Data.Proxy ( Proxy(..) )
@@ -142,27 +139,6 @@ instance SOrd Symbol where
                      LT -> unsafeCoerce SLT
                      EQ -> unsafeCoerce SEQ
                      GT -> unsafeCoerce SGT
-
--- PSemigroup Symbol instance
-instance PSemigroup Symbol where
-  type a <> b = TL.AppendSymbol a b
-
--- SSemigroup Symbol instance
-instance SSemigroup Symbol where
-  sa %<> sb =
-    let a  = fromSing sa
-        b  = fromSing sb
-        ex = someSymbolVal $ T.unpack $ a <> b
-    in case ex of
-         SomeSymbol (_ :: Proxy ab) -> unsafeCoerce (SSym :: Sing ab)
-
--- PMonoid Symbol instance
-instance PMonoid Symbol where
-  type Mempty = ""
-
--- SMonoid Symbol instance
-instance SMonoid Symbol where
-  sMempty = SSym @""
 
 -- Convenience functions
 

--- a/src/Data/Singletons/Util.hs
+++ b/src/Data/Singletons/Util.hs
@@ -25,6 +25,8 @@ import Control.Monad.Reader hiding ( mapM )
 import qualified Data.Map as Map
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Map ( Map )
+import qualified Data.Monoid as Monoid
+import Data.Semigroup as Semigroup
 import Data.Foldable
 import Data.Traversable
 import Data.Generics
@@ -42,7 +44,7 @@ basicTypes = [ ''Maybe
 
 boundedBasicTypes :: [Name]
 boundedBasicTypes =
-            [  ''(,)
+            [ ''(,)
             , ''(,,)
             , ''(,,,)
             , ''(,,,,)
@@ -52,6 +54,31 @@ boundedBasicTypes =
 
 enumBasicTypes :: [Name]
 enumBasicTypes = [ ''Bool, ''Ordering, ''() ]
+
+semigroupBasicTypes :: [Name]
+semigroupBasicTypes
+  = [ ''Dual
+    , ''All
+    , ''Any
+    , ''Sum
+    , ''Product
+    -- , ''Endo      see https://github.com/goldfirere/singletons/issues/82
+    {- , ''Alt       singletons doesn't support higher kinds :(
+                     see https://github.com/goldfirere/singletons/issues/150
+    -}
+
+    , ''Min
+    , ''Max
+    , ''Semigroup.First
+    , ''Semigroup.Last
+    , ''WrappedMonoid
+    ]
+
+monoidBasicTypes :: [Name]
+monoidBasicTypes
+  = [ ''Monoid.First
+    , ''Monoid.Last
+    ]
 
 -- like reportWarning, but generalized to any Quasi
 qReportWarning :: Quasi q => String -> q ()


### PR DESCRIPTION
Addresses https://github.com/goldfirere/singletons/pull/291#issuecomment-360885936.

This patch looks larger than it actually is due to the need to reorganize the module hierarchy a bit to avoid import cycles.