### PR TITLE
Fix #297 by explicitly binding kind variables in generated code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,9 +3,12 @@ Changelog for singletons project
 
 2.5
 ---
-* `singletons` now generates `a ~> b` instead of `TyFun a b -> Type` whenever
-  possible. This may require enabling `TypeInType` in code which did not
-  previously need it.
+* Template Haskell-generated code may require `TypeInType` in scenarios which
+  did not previously require it:
+  * `singletons` now explicitly quantifies all kind variables used in explicit
+    `forall`s.
+  * `singletons` now generates `a ~> b` instead of `TyFun a b -> Type` whenever
+    possible.
 
 * Rename `Data.Singletons.TypeRepStar` to `Data.Singletons.TypeRepTYPE`, and
   generalize the `Sing :: Type -> Type` instance to `Sing :: TYPE rep -> Type`,

--- a/src/Data/Singletons/Single/Data.hs
+++ b/src/Data/Singletons/Single/Data.hs
@@ -168,7 +168,7 @@ singCtor (DCon _tvbs cxt name fields _rty)
                 (Just (DConT singFamilyName `DAppT` foldType pCon indices))
   where buildArgType :: DType -> DType -> SgM DType
         buildArgType ty index = do
-          (ty', _, _, _) <- singType index ty
+          (ty', _, _, _, _) <- singType index ty
           return ty'
 
         isEqPred :: DPred -> Bool

--- a/src/Data/Singletons/Single/Monad.hs
+++ b/src/Data/Singletons/Single/Monad.hs
@@ -11,7 +11,8 @@ The SgM monad allows reading from a SgEnv environment and is wrapped around a Q.
 {-# LANGUAGE GeneralizedNewtypeDeriving, ParallelListComp, TemplateHaskell #-}
 
 module Data.Singletons.Single.Monad (
-  SgM, bindLets, lookupVarE, lookupConE,
+  SgM, bindLets, bindKindVars, allBoundKindVars,
+  lookupVarE, lookupConE,
   wrapSingFun, wrapUnSingFun,
   singM, singDecsM,
   emitDecs, emitDecsM
@@ -20,6 +21,8 @@ module Data.Singletons.Single.Monad (
 import Prelude hiding ( exp )
 import Data.Map ( Map )
 import qualified Data.Map as Map
+import Data.Set ( Set )
+import qualified Data.Set as Set
 import Data.Singletons.Promote.Monad ( emitDecs, emitDecsM )
 import Data.Singletons.Names
 import Data.Singletons.Util
@@ -33,13 +36,15 @@ import Control.Monad.Fail
 
 -- environment during singling
 data SgEnv =
-  SgEnv { sg_let_binds   :: Map Name DExp   -- from the *original* name
-        , sg_local_decls :: [Dec]
+  SgEnv { sg_let_binds       :: Map Name DExp   -- from the *original* name
+        , sg_bound_kind_vars :: Set Name -- See Note [Explicitly quantifying kinds variables]
+        , sg_local_decls     :: [Dec]
         }
 
 emptySgEnv :: SgEnv
-emptySgEnv = SgEnv { sg_let_binds   = Map.empty
-                   , sg_local_decls = []
+emptySgEnv = SgEnv { sg_let_binds       = Map.empty
+                   , sg_bound_kind_vars = Set.empty
+                   , sg_local_decls     = []
                    }
 
 -- the singling monad
@@ -90,6 +95,18 @@ bindLets :: [(Name, DExp)] -> SgM a -> SgM a
 bindLets lets1 =
   local (\env@(SgEnv { sg_let_binds = lets2 }) ->
                env { sg_let_binds = (Map.fromList lets1) `Map.union` lets2 })
+
+-- Add to the set of bound kind variables currently in scope.
+-- See Note [Explicitly binding kind variables]
+bindKindVars :: Set Name -> SgM a -> SgM a
+bindKindVars kvs1 =
+  local (\env@(SgEnv { sg_bound_kind_vars = kvs2 }) ->
+               env { sg_bound_kind_vars = kvs1 `Set.union` kvs2 })
+
+-- Look up the set of bound kind variables currently in scope.
+-- See Note [Explicitly binding kind variables]
+allBoundKindVars :: SgM (Set Name)
+allBoundKindVars = asks sg_bound_kind_vars
 
 lookupVarE :: Name -> SgM DExp
 lookupVarE = lookup_var_con singValName (DVarE . singValName)
@@ -154,3 +171,66 @@ singDecsM :: DsMonad q => [Dec] -> SgM [DDec] -> q [DDec]
 singDecsM locals thing = do
   (decs1, decs2) <- singM locals thing
   return $ decs1 ++ decs2
+
+{-
+Note [Explicitly binding kind variables]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+singletons is careful to generate code that explicitly quantifies every kind
+variable bound by a top-level forall. For example, if we were to single the
+identity function:
+
+  identity :: forall a. a -> a
+  identity x = x
+
+We would first promote the types to kinds and generate an explicit forall
+mapping fresh type variables to the promoted types (step 1):
+
+  sIdentity :: forall (x :: a). Sing x -> Sing (Identity x)
+  sIdentity sX = sX
+
+Now, because we want to explicitly bind the kind variable `a`, we traverse
+the promoted types, extract the set of all kind variables, and put
+them at the front of the forall, like so (step 2):
+
+  sIdentity :: forall a (x :: a). Sing x -> Sing (Identity x)
+  sIdentity sX = sX
+
+This approach works well enough for a simple function like identity. But
+consider this more complicated example:
+
+  f :: forall a. a -> a
+  f = g
+    where
+      g :: a -> a
+      g x = x
+
+When singling, we would eventually end up in this spot:
+
+  sF :: forall a (x :: a). Sing a -> Sing (F a)
+  sF = sG
+    where
+      sG :: _
+      sG x = x
+
+What should go in place of the _? After doing step 1, we would have
+sG :: forall (y :: a). Sing a -> Sing (G a), so naïvely charging forward with
+step 2 would extract the kind variable `a` and give:
+
+  sF :: forall a (x :: a). Sing a -> Sing (F a)
+  sF = sG
+    where
+      sG :: forall a (y :: a). Sing a -> Sing (G a)
+      sG x = x
+
+But this is incorrect! The `a` bound by sF /must/ be the same one used in sG,
+as per the scoping of the original `f` function. So it is not enough to extract
+the kind variables from the promoted types—we must extract the /free/ kind
+variables from the promoted types.
+
+That is the role that sg_bound_kind_vars in SgEnv serves. Whenever we single a
+type which binds kind variables, we add them to the sg_bound_kind_vars whenever
+singling code that those kind variables scope over. When we single a type
+signature that uses an explicit forall, we consult sg_bound_kind_vars to
+determine which kind variables have already been bound, and subtract them from
+the set of kind variables under consideration to obtain the free variables.
+-}

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -86,6 +86,7 @@ tests =
     , compileAndDumpStdTest "T271"
     , compileAndDumpStdTest "T287"
     , compileAndDumpStdTest "TypeRepTYPE"
+    , compileAndDumpStdTest "T297"
     ],
     testCompileAndDumpGroup "Promote"
     [ compileAndDumpStdTest "Constructors"

--- a/tests/compile-and-dump/Singletons/BoundedDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/BoundedDeriving.ghc84.template
@@ -144,7 +144,7 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
       toSing D = SomeSing SD
       toSing E = SomeSing SE
     data instance Sing (z :: Foo3 a)
-      where SFoo3 :: forall (n :: a). (Sing (n :: a)) -> Sing (Foo3 n)
+      where SFoo3 :: forall a (n :: a). (Sing (n :: a)) -> Sing (Foo3 n)
     type SFoo3 = (Sing :: Foo3 a -> Type)
     instance SingKind a => SingKind (Foo3 a) where
       type Demote (Foo3 a) = Foo3 (Demote a)

--- a/tests/compile-and-dump/Singletons/BoxUnBox.ghc84.template
+++ b/tests/compile-and-dump/Singletons/BoxUnBox.ghc84.template
@@ -27,7 +27,7 @@ Singletons/BoxUnBox.hs:(0,0)-(0,0): Splicing declarations
     type family UnBox (a :: Box a) :: a where
       UnBox (FBox a) = a
     sUnBox ::
-      forall (t :: Box a). Sing t -> Sing (Apply UnBoxSym0 t :: a)
+      forall a (t :: Box a). Sing t -> Sing (Apply UnBoxSym0 t :: a)
     sUnBox (SFBox (sA :: Sing a)) = sA
     data instance Sing (z :: Box a)
       where SFBox :: forall (n :: a). (Sing (n :: a)) -> Sing (FBox n)

--- a/tests/compile-and-dump/Singletons/BoxUnBox.ghc84.template
+++ b/tests/compile-and-dump/Singletons/BoxUnBox.ghc84.template
@@ -30,7 +30,7 @@ Singletons/BoxUnBox.hs:(0,0)-(0,0): Splicing declarations
       forall a (t :: Box a). Sing t -> Sing (Apply UnBoxSym0 t :: a)
     sUnBox (SFBox (sA :: Sing a)) = sA
     data instance Sing (z :: Box a)
-      where SFBox :: forall (n :: a). (Sing (n :: a)) -> Sing (FBox n)
+      where SFBox :: forall a (n :: a). (Sing (n :: a)) -> Sing (FBox n)
     type SBox = (Sing :: Box a -> GHC.Types.Type)
     instance SingKind a => SingKind (Box a) where
       type Demote (Box a) = Box (Demote a)

--- a/tests/compile-and-dump/Singletons/CaseExpressions.ghc84.template
+++ b/tests/compile-and-dump/Singletons/CaseExpressions.ghc84.template
@@ -214,16 +214,16 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
       Foo2 d _ = Case_0123456789876543210 d (Let0123456789876543210Scrutinee_0123456789876543210Sym1 d)
     type family Foo1 (a :: a) (a :: Maybe a) :: a where
       Foo1 d x = Case_0123456789876543210 d x x
-    sFoo5 :: forall (t :: a). Sing t -> Sing (Apply Foo5Sym0 t :: a)
-    sFoo4 :: forall (t :: a). Sing t -> Sing (Apply Foo4Sym0 t :: a)
+    sFoo5 :: forall a (t :: a). Sing t -> Sing (Apply Foo5Sym0 t :: a)
+    sFoo4 :: forall a (t :: a). Sing t -> Sing (Apply Foo4Sym0 t :: a)
     sFoo3 ::
-      forall (t :: a) (t :: b).
+      forall a b (t :: a) (t :: b).
       Sing t -> Sing t -> Sing (Apply (Apply Foo3Sym0 t) t :: a)
     sFoo2 ::
-      forall (t :: a) (t :: Maybe a).
+      forall a (t :: a) (t :: Maybe a).
       Sing t -> Sing t -> Sing (Apply (Apply Foo2Sym0 t) t :: a)
     sFoo1 ::
-      forall (t :: a) (t :: Maybe a).
+      forall a (t :: a) (t :: Maybe a).
       Sing t -> Sing t -> Sing (Apply (Apply Foo1Sym0 t) t :: a)
     sFoo5 (sX :: Sing x)
       = case sX of {

--- a/tests/compile-and-dump/Singletons/Classes.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Classes.ghc84.template
@@ -269,7 +269,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       Sing t
       -> Sing t -> Sing (Apply (Apply FooCompareSym0 t) t :: Ordering)
     sConst ::
-      forall (t :: a) (t :: b).
+      forall a b (t :: a) (t :: b).
       Sing t -> Sing t -> Sing (Apply (Apply ConstSym0 t) t :: a)
     sFooCompare SA SA = SEQ
     sFooCompare SA SB = SLT

--- a/tests/compile-and-dump/Singletons/Contains.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Contains.ghc84.template
@@ -27,7 +27,7 @@ Singletons/Contains.hs:(0,0)-(0,0): Splicing declarations
       Contains _ '[] = FalseSym0
       Contains elt ((:) h t) = Apply (Apply (||@#@$) (Apply (Apply (==@#@$) elt) h)) (Apply (Apply ContainsSym0 elt) t)
     sContains ::
-      forall (t :: a) (t :: [a]).
+      forall a (t :: a) (t :: [a]).
       SEq a =>
       Sing t -> Sing t -> Sing (Apply (Apply ContainsSym0 t) t :: Bool)
     sContains _ SNil = SFalse

--- a/tests/compile-and-dump/Singletons/DataValues.ghc84.template
+++ b/tests/compile-and-dump/Singletons/DataValues.ghc84.template
@@ -111,7 +111,7 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
           ((applySing ((applySing ((singFun2 @(:@#@$)) SCons)) SZero)) SNil)
     data instance Sing (z :: Pair a b)
       where
-        SPair :: forall (n :: a) (n :: b).
+        SPair :: forall a b (n :: a) (n :: b).
                  (Sing (n :: a)) -> (Sing (n :: b)) -> Sing (Pair n n)
     type SPair = (Sing :: Pair a b -> GHC.Types.Type)
     instance (SingKind a, SingKind b) => SingKind (Pair a b) where

--- a/tests/compile-and-dump/Singletons/Error.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Error.ghc84.template
@@ -18,7 +18,8 @@ Singletons/Error.hs:(0,0)-(0,0): Splicing declarations
     type family Head (a :: [a]) :: a where
       Head ((:) a _) = a
       Head '[] = Apply ErrorSym0 "Data.Singletons.List.head: empty list"
-    sHead :: forall (t :: [a]). Sing t -> Sing (Apply HeadSym0 t :: a)
+    sHead ::
+      forall a (t :: [a]). Sing t -> Sing (Apply HeadSym0 t :: a)
     sHead (SCons (sA :: Sing a) _) = sA
     sHead SNil
       = sError (sing :: Sing "Data.Singletons.List.head: empty list")

--- a/tests/compile-and-dump/Singletons/Fixity.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Fixity.ghc84.template
@@ -55,7 +55,7 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
     infix 4 %====
     infix 4 %<=>
     (%====) ::
-      forall (t :: a) (t :: a).
+      forall a (t :: a) (t :: a).
       Sing t -> Sing t -> Sing (Apply (Apply (====@#@$) t) t :: a)
     (%====) (sA :: Sing a) _ = sA
     class SMyOrd a where

--- a/tests/compile-and-dump/Singletons/HigherOrder.ghc84.template
+++ b/tests/compile-and-dump/Singletons/HigherOrder.ghc84.template
@@ -356,8 +356,8 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
           ((applySing ((applySing ((singFun2 @MapSym0) sMap)) sF)) sT)
     data instance Sing (z :: Either a b)
       where
-        SLeft :: forall (n :: a). (Sing (n :: a)) -> Sing (Left n)
-        SRight :: forall (n :: b). (Sing (n :: b)) -> Sing (Right n)
+        SLeft :: forall a (n :: a). (Sing (n :: a)) -> Sing (Left n)
+        SRight :: forall b (n :: b). (Sing (n :: b)) -> Sing (Right n)
     type SEither = (Sing :: Either a b -> GHC.Types.Type)
     instance (SingKind a, SingKind b) => SingKind (Either a b) where
       type Demote (Either a b) = Either (Demote a) (Demote b)

--- a/tests/compile-and-dump/Singletons/HigherOrder.ghc84.template
+++ b/tests/compile-and-dump/Singletons/HigherOrder.ghc84.template
@@ -269,12 +269,16 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
       Map _ '[] = '[]
       Map f ((:) h t) = Apply (Apply (:@#@$) (Apply f h)) (Apply (Apply MapSym0 f) t)
     sFoo ::
-      forall (t :: (~>) ((~>) a b) ((~>) a b)) (t :: (~>) a b) (t :: a).
+      forall a
+             b
+             (t :: (~>) ((~>) a b) ((~>) a b))
+             (t :: (~>) a b)
+             (t :: a).
       Sing t
       -> Sing t
          -> Sing t -> Sing (Apply (Apply (Apply FooSym0 t) t) t :: b)
     sZipWith ::
-      forall (t :: (~>) a ((~>) b c)) (t :: [a]) (t :: [b]).
+      forall a b c (t :: (~>) a ((~>) b c)) (t :: [a]) (t :: [b]).
       Sing t
       -> Sing t
          -> Sing t -> Sing (Apply (Apply (Apply ZipWithSym0 t) t) t :: [c])
@@ -285,11 +289,11 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
       forall (t :: [Nat]) (t :: [Bool]).
       Sing t -> Sing t -> Sing (Apply (Apply EtadSym0 t) t :: [Nat])
     sLiftMaybe ::
-      forall (t :: (~>) a b) (t :: Maybe a).
+      forall a b (t :: (~>) a b) (t :: Maybe a).
       Sing t
       -> Sing t -> Sing (Apply (Apply LiftMaybeSym0 t) t :: Maybe b)
     sMap ::
-      forall (t :: (~>) a b) (t :: [a]).
+      forall a b (t :: (~>) a b) (t :: [a]).
       Sing t -> Sing t -> Sing (Apply (Apply MapSym0 t) t :: [b])
     sFoo (sF :: Sing f) (sG :: Sing g) (sA :: Sing a)
       = (applySing ((applySing sF) sG)) sA

--- a/tests/compile-and-dump/Singletons/LambdaCase.ghc84.template
+++ b/tests/compile-and-dump/Singletons/LambdaCase.ghc84.template
@@ -176,13 +176,13 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
     type family Foo1 (a :: a) (a :: Maybe a) :: a where
       Foo1 d x = Apply (Apply (Apply Lambda_0123456789876543210Sym0 d) x) x
     sFoo3 ::
-      forall (t :: a) (t :: b).
+      forall a b (t :: a) (t :: b).
       Sing t -> Sing t -> Sing (Apply (Apply Foo3Sym0 t) t :: a)
     sFoo2 ::
-      forall (t :: a) (t :: Maybe a).
+      forall a (t :: a) (t :: Maybe a).
       Sing t -> Sing t -> Sing (Apply (Apply Foo2Sym0 t) t :: a)
     sFoo1 ::
-      forall (t :: a) (t :: Maybe a).
+      forall a (t :: a) (t :: Maybe a).
       Sing t -> Sing t -> Sing (Apply (Apply Foo1Sym0 t) t :: a)
     sFoo3 (sA :: Sing a) (sB :: Sing b)
       = (applySing

--- a/tests/compile-and-dump/Singletons/Lambdas.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Lambdas.ghc84.template
@@ -552,30 +552,30 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     type family Foo0 (a :: a) (a :: b) :: a where
       Foo0 a_0123456789876543210 a_0123456789876543210 = Apply (Apply (Apply (Apply Lambda_0123456789876543210Sym0 a_0123456789876543210) a_0123456789876543210) a_0123456789876543210) a_0123456789876543210
     sFoo8 ::
-      forall (t :: Foo a b). Sing t -> Sing (Apply Foo8Sym0 t :: a)
+      forall a b (t :: Foo a b). Sing t -> Sing (Apply Foo8Sym0 t :: a)
     sFoo7 ::
-      forall (t :: a) (t :: b).
+      forall a b (t :: a) (t :: b).
       Sing t -> Sing t -> Sing (Apply (Apply Foo7Sym0 t) t :: b)
     sFoo6 ::
-      forall (t :: a) (t :: b).
+      forall a b (t :: a) (t :: b).
       Sing t -> Sing t -> Sing (Apply (Apply Foo6Sym0 t) t :: a)
     sFoo5 ::
-      forall (t :: a) (t :: b).
+      forall a b (t :: a) (t :: b).
       Sing t -> Sing t -> Sing (Apply (Apply Foo5Sym0 t) t :: b)
     sFoo4 ::
-      forall (t :: a) (t :: b) (t :: c).
+      forall a b c (t :: a) (t :: b) (t :: c).
       Sing t
       -> Sing t
          -> Sing t -> Sing (Apply (Apply (Apply Foo4Sym0 t) t) t :: a)
-    sFoo3 :: forall (t :: a). Sing t -> Sing (Apply Foo3Sym0 t :: a)
+    sFoo3 :: forall a (t :: a). Sing t -> Sing (Apply Foo3Sym0 t :: a)
     sFoo2 ::
-      forall (t :: a) (t :: b).
+      forall a b (t :: a) (t :: b).
       Sing t -> Sing t -> Sing (Apply (Apply Foo2Sym0 t) t :: a)
     sFoo1 ::
-      forall (t :: a) (t :: b).
+      forall a b (t :: a) (t :: b).
       Sing t -> Sing t -> Sing (Apply (Apply Foo1Sym0 t) t :: a)
     sFoo0 ::
-      forall (t :: a) (t :: b).
+      forall a b (t :: a) (t :: b).
       Sing t -> Sing t -> Sing (Apply (Apply Foo0Sym0 t) t :: a)
     sFoo8 (sX :: Sing x)
       = (applySing

--- a/tests/compile-and-dump/Singletons/Lambdas.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Lambdas.ghc84.template
@@ -679,7 +679,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
           sA_0123456789876543210
     data instance Sing (z :: Foo a b)
       where
-        SFoo :: forall (n :: a) (n :: b).
+        SFoo :: forall a b (n :: a) (n :: b).
                 (Sing (n :: a)) -> (Sing (n :: b)) -> Sing (Foo n n)
     type SFoo = (Sing :: Foo a b -> GHC.Types.Type)
     instance (SingKind a, SingKind b) => SingKind (Foo a b) where

--- a/tests/compile-and-dump/Singletons/LetStatements.ghc84.template
+++ b/tests/compile-and-dump/Singletons/LetStatements.ghc84.template
@@ -718,8 +718,9 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     sFoo14 ::
       forall (t :: Nat). Sing t -> Sing (Apply Foo14Sym0 t :: (Nat, Nat))
     sFoo13_ ::
-      forall (t :: a). Sing t -> Sing (Apply Foo13_Sym0 t :: a)
-    sFoo13 :: forall (t :: a). Sing t -> Sing (Apply Foo13Sym0 t :: a)
+      forall a (t :: a). Sing t -> Sing (Apply Foo13_Sym0 t :: a)
+    sFoo13 ::
+      forall a (t :: a). Sing t -> Sing (Apply Foo13Sym0 t :: a)
     sFoo12 ::
       forall (t :: Nat). Sing t -> Sing (Apply Foo12Sym0 t :: Nat)
     sFoo11 ::

--- a/tests/compile-and-dump/Singletons/Maybe.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Maybe.ghc84.template
@@ -59,7 +59,7 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
     data instance Sing (z :: Maybe a)
       where
         SNothing :: Sing Nothing
-        SJust :: forall (n :: a). (Sing (n :: a)) -> Sing (Just n)
+        SJust :: forall a (n :: a). (Sing (n :: a)) -> Sing (Just n)
     type SMaybe = (Sing :: Maybe a -> GHC.Types.Type)
     instance SingKind a => SingKind (Maybe a) where
       type Demote (Maybe a) = Maybe (Demote a)

--- a/tests/compile-and-dump/Singletons/OrdDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/OrdDeriving.ghc84.template
@@ -329,27 +329,27 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
             SomeSing c -> SomeSing (SSucc c) }
     data instance Sing (z :: Foo a b c d)
       where
-        SA :: forall (n :: a) (n :: b) (n :: c) (n :: d).
+        SA :: forall a b c d (n :: a) (n :: b) (n :: c) (n :: d).
               (Sing (n :: a))
               -> (Sing (n :: b))
                  -> (Sing (n :: c)) -> (Sing (n :: d)) -> Sing (A n n n n)
-        SB :: forall (n :: a) (n :: b) (n :: c) (n :: d).
+        SB :: forall a b c d (n :: a) (n :: b) (n :: c) (n :: d).
               (Sing (n :: a))
               -> (Sing (n :: b))
                  -> (Sing (n :: c)) -> (Sing (n :: d)) -> Sing (B n n n n)
-        SC :: forall (n :: a) (n :: b) (n :: c) (n :: d).
+        SC :: forall a b c d (n :: a) (n :: b) (n :: c) (n :: d).
               (Sing (n :: a))
               -> (Sing (n :: b))
                  -> (Sing (n :: c)) -> (Sing (n :: d)) -> Sing (C n n n n)
-        SD :: forall (n :: a) (n :: b) (n :: c) (n :: d).
+        SD :: forall a b c d (n :: a) (n :: b) (n :: c) (n :: d).
               (Sing (n :: a))
               -> (Sing (n :: b))
                  -> (Sing (n :: c)) -> (Sing (n :: d)) -> Sing (D n n n n)
-        SE :: forall (n :: a) (n :: b) (n :: c) (n :: d).
+        SE :: forall a b c d (n :: a) (n :: b) (n :: c) (n :: d).
               (Sing (n :: a))
               -> (Sing (n :: b))
                  -> (Sing (n :: c)) -> (Sing (n :: d)) -> Sing (E n n n n)
-        SF :: forall (n :: a) (n :: b) (n :: c) (n :: d).
+        SF :: forall a b c d (n :: a) (n :: b) (n :: c) (n :: d).
               (Sing (n :: a))
               -> (Sing (n :: b))
                  -> (Sing (n :: c)) -> (Sing (n :: d)) -> Sing (F n n n n)

--- a/tests/compile-and-dump/Singletons/PatternMatching.ghc84.template
+++ b/tests/compile-and-dump/Singletons/PatternMatching.ghc84.template
@@ -111,7 +111,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
           ((applySing ((applySing ((singFun2 @(:@#@$)) SCons)) SZero)) SNil)
     data instance Sing (z :: Pair a b)
       where
-        SPair :: forall (n :: a) (n :: b).
+        SPair :: forall a b (n :: a) (n :: b).
                  (Sing (n :: a)) -> (Sing (n :: b)) -> Sing (Pair n n)
     type SPair = (Sing :: Pair a b -> GHC.Types.Type)
     instance (SingKind a, SingKind b) => SingKind (Pair a b) where

--- a/tests/compile-and-dump/Singletons/PatternMatching.ghc84.template
+++ b/tests/compile-and-dump/Singletons/PatternMatching.ghc84.template
@@ -424,11 +424,12 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
       X_0123456789876543210 = TupleSym0
     type family X_0123456789876543210 where
       X_0123456789876543210 = AListSym0
-    sSilly :: forall (t :: a). Sing t -> Sing (Apply SillySym0 t :: ())
+    sSilly ::
+      forall a (t :: a). Sing t -> Sing (Apply SillySym0 t :: ())
     sFoo2 ::
-      forall (t :: (a, b)). Sing t -> Sing (Apply Foo2Sym0 t :: a)
+      forall a b (t :: (a, b)). Sing t -> Sing (Apply Foo2Sym0 t :: a)
     sFoo1 ::
-      forall (t :: (a, b)). Sing t -> Sing (Apply Foo1Sym0 t :: a)
+      forall a b (t :: (a, b)). Sing t -> Sing (Apply Foo1Sym0 t :: a)
     sLsz :: Sing (LszSym0 :: Nat)
     sBlimy :: Sing BlimySym0
     sTf :: Sing TfSym0

--- a/tests/compile-and-dump/Singletons/PolyKindsApp.ghc84.template
+++ b/tests/compile-and-dump/Singletons/PolyKindsApp.ghc84.template
@@ -9,4 +9,4 @@ Singletons/PolyKindsApp.hs:(0,0)-(0,0): Splicing declarations
     class PCls (a :: k -> Type) where
       type Fff :: (a :: k -> Type) (b :: k)
     class SCls (a :: k -> Type) where
-      sFff :: Sing (FffSym0 :: (a :: k -> Type) (b :: k))
+      sFff :: forall b. Sing (FffSym0 :: (a :: k -> Type) (b :: k))

--- a/tests/compile-and-dump/Singletons/Records.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Records.ghc84.template
@@ -41,7 +41,7 @@ Singletons/Records.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply MkRecordSym0 l = MkRecordSym1 l
     data instance Sing (z :: Record a)
       where
-        SMkRecord :: forall (n :: a) (n :: Bool).
+        SMkRecord :: forall a (n :: a) (n :: Bool).
                      {sField1 :: (Sing (n :: a)), sField2 :: (Sing (n :: Bool))}
                      -> Sing (MkRecord n n)
     type SRecord = (Sing :: Record a -> GHC.Types.Type)

--- a/tests/compile-and-dump/Singletons/ReturnFunc.ghc84.template
+++ b/tests/compile-and-dump/Singletons/ReturnFunc.ghc84.template
@@ -58,9 +58,9 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
       IdFoo _ a_0123456789876543210 = Apply IdSym0 a_0123456789876543210
     type family ReturnFunc (a :: Nat) (a :: Nat) :: Nat where
       ReturnFunc _ a_0123456789876543210 = Apply SuccSym0 a_0123456789876543210
-    sId :: forall (t :: a). Sing t -> Sing (Apply IdSym0 t :: a)
+    sId :: forall a (t :: a). Sing t -> Sing (Apply IdSym0 t :: a)
     sIdFoo ::
-      forall (t :: c) (t :: a).
+      forall c a (t :: c) (t :: a).
       Sing t -> Sing t -> Sing (Apply (Apply IdFooSym0 t) t :: a)
     sReturnFunc ::
       forall (t :: Nat) (t :: Nat).

--- a/tests/compile-and-dump/Singletons/ShowDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/ShowDeriving.ghc84.template
@@ -237,13 +237,13 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
       toSing MkFoo1 = SomeSing SMkFoo1
     data instance Sing (z :: Foo2 a)
       where
-        SMkFoo2a :: forall (n :: a) (n :: a).
+        SMkFoo2a :: forall a (n :: a) (n :: a).
                     (Sing (n :: a)) -> (Sing (n :: a)) -> Sing (MkFoo2a n n)
-        SMkFoo2b :: forall (n :: a) (n :: a).
+        SMkFoo2b :: forall a (n :: a) (n :: a).
                     (Sing (n :: a)) -> (Sing (n :: a)) -> Sing (MkFoo2b n n)
-        (:%*:) :: forall (n :: a) (n :: a).
+        (:%*:) :: forall a (n :: a) (n :: a).
                   (Sing (n :: a)) -> (Sing (n :: a)) -> Sing ((:*:) n n)
-        (:%&:) :: forall (n :: a) (n :: a).
+        (:%&:) :: forall a (n :: a) (n :: a).
                   (Sing (n :: a)) -> (Sing (n :: a)) -> Sing ((:&:) n n)
     type SFoo2 = (Sing :: Foo2 a -> GHC.Types.Type)
     instance SingKind a => SingKind (Foo2 a) where

--- a/tests/compile-and-dump/Singletons/StandaloneDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/StandaloneDeriving.ghc84.template
@@ -222,7 +222,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
     infixl 6 :%*:
     data instance Sing (z :: T a b)
       where
-        (:%*:) :: forall (n :: a) (n :: b).
+        (:%*:) :: forall a b (n :: a) (n :: b).
                   (Sing (n :: a)) -> (Sing (n :: b)) -> Sing ((:*:) n n)
     type ST = (Sing :: T a b -> GHC.Types.Type)
     instance (SingKind a, SingKind b) => SingKind (T a b) where

--- a/tests/compile-and-dump/Singletons/T145.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T145.ghc84.template
@@ -25,5 +25,5 @@ Singletons/T145.hs:(0,0)-(0,0): Splicing declarations
       type Col (arg :: f a) (arg :: a) :: Bool
     class SColumn (f :: Type -> Type) where
       sCol ::
-        forall (t :: f a) (t :: a).
+        forall a (t :: f a) (t :: a).
         Sing t -> Sing t -> Sing (Apply (Apply ColSym0 t) t :: Bool)

--- a/tests/compile-and-dump/Singletons/T163.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T163.ghc84.template
@@ -20,8 +20,8 @@ Singletons/T163.hs:0:0:: Splicing declarations
     type instance Apply RSym0 l = R l
     data instance Sing (z :: (+) a b)
       where
-        SL :: forall (n :: a). (Sing (n :: a)) -> Sing (L n)
-        SR :: forall (n :: b). (Sing (n :: b)) -> Sing (R n)
+        SL :: forall a (n :: a). (Sing (n :: a)) -> Sing (L n)
+        SR :: forall b (n :: b). (Sing (n :: b)) -> Sing (R n)
     type %+ = (Sing :: (+) a b -> GHC.Types.Type)
     instance (SingKind a, SingKind b) => SingKind ((+) a b) where
       type Demote ((+) a b) = (+) (Demote a) (Demote b)

--- a/tests/compile-and-dump/Singletons/T175.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T175.ghc84.template
@@ -32,7 +32,7 @@ Singletons/T175.hs:(0,0)-(0,0): Splicing declarations
       type Quux1 :: a
       type Quux1 = Quux1_0123456789876543210Sym0
     class PFoo a => PBar2 (a :: GHC.Types.Type)
-    sQuux2 :: SBar2 a => Sing (Quux2Sym0 :: a)
+    sQuux2 :: forall a. SBar2 a => Sing (Quux2Sym0 :: a)
     sQuux2 = sBaz
     class SFoo a where
       sBaz :: Sing (BazSym0 :: a)

--- a/tests/compile-and-dump/Singletons/T176.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T176.ghc84.template
@@ -107,9 +107,11 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
       type Bar2 (arg :: a) (arg :: b) :: b
       type Baz2 :: a
     sQuux2 ::
-      forall (t :: a). SFoo2 a => Sing t -> Sing (Apply Quux2Sym0 t :: a)
+      forall a (t :: a).
+      SFoo2 a => Sing t -> Sing (Apply Quux2Sym0 t :: a)
     sQuux1 ::
-      forall (t :: a). SFoo1 a => Sing t -> Sing (Apply Quux1Sym0 t :: a)
+      forall a (t :: a).
+      SFoo1 a => Sing t -> Sing (Apply Quux1Sym0 t :: a)
     sQuux2 (sX :: Sing x)
       = (applySing ((applySing ((singFun2 @Bar2Sym0) sBar2)) sX)) sBaz2
     sQuux1 (sX :: Sing x)
@@ -122,11 +124,11 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
                             Sing (Case_0123456789876543210 x arg_0123456789876543210 arg_0123456789876543210) }))
     class SFoo1 a where
       sBar1 ::
-        forall (t :: a) (t :: (~>) a b).
+        forall b (t :: a) (t :: (~>) a b).
         Sing t -> Sing t -> Sing (Apply (Apply Bar1Sym0 t) t :: b)
       sBaz1 :: Sing (Baz1Sym0 :: a)
     class SFoo2 a where
       sBar2 ::
-        forall (t :: a) (t :: b).
+        forall b (t :: a) (t :: b).
         Sing t -> Sing t -> Sing (Apply (Apply Bar2Sym0 t) t :: b)
       sBaz2 :: Sing (Baz2Sym0 :: a)

--- a/tests/compile-and-dump/Singletons/T197b.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T197b.ghc84.template
@@ -45,7 +45,7 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
     infixr 9 `SPair`
     data instance Sing (z :: (:*:) a b)
       where
-        (:%*:) :: forall (n :: a) (n :: b).
+        (:%*:) :: forall a b (n :: a) (n :: b).
                   (Sing (n :: a)) -> (Sing (n :: b)) -> Sing ((:*:) n n)
     type %:*: = (Sing :: (:*:) a b -> GHC.Types.Type)
     instance (SingKind a, SingKind b) => SingKind ((:*:) a b) where
@@ -59,7 +59,7 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
               -> SomeSing (((:%*:) c) c) }
     data instance Sing (z :: Pair a b)
       where
-        SMkPair :: forall (n :: a) (n :: b).
+        SMkPair :: forall a b (n :: a) (n :: b).
                    (Sing (n :: a)) -> (Sing (n :: b)) -> Sing (MkPair n n)
     type SPair = (Sing :: Pair a b -> GHC.Types.Type)
     instance (SingKind a, SingKind b) => SingKind (Pair a b) where

--- a/tests/compile-and-dump/Singletons/T209.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T209.ghc84.template
@@ -47,7 +47,7 @@ Singletons/T209.hs:(0,0)-(0,0): Splicing declarations
     instance PC Bool Hm
     instance PC a (Maybe a)
     sM ::
-      forall (t :: a) (t :: b) (t :: Bool).
+      forall a b (t :: a) (t :: b) (t :: Bool).
       Sing t
       -> Sing t
          -> Sing t -> Sing (Apply (Apply (Apply MSym0 t) t) t :: Bool)

--- a/tests/compile-and-dump/Singletons/T249.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T249.ghc84.template
@@ -33,7 +33,7 @@ Singletons/T249.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply MkFoo3Sym0 l = MkFoo3 l
     data instance Sing (z :: Foo1 a)
       where
-        SMkFoo1 :: forall (n :: a). (Sing (n :: a)) -> Sing (MkFoo1 n)
+        SMkFoo1 :: forall a (n :: a). (Sing (n :: a)) -> Sing (MkFoo1 n)
     type SFoo1 = (Sing :: Foo1 a -> Type)
     instance SingKind a => SingKind (Foo1 a) where
       type Demote (Foo1 a) = Foo1 (Demote a)
@@ -43,7 +43,7 @@ Singletons/T249.hs:(0,0)-(0,0): Splicing declarations
             SomeSing c -> SomeSing (SMkFoo1 c) }
     data instance Sing (z :: Foo2 a)
       where
-        SMkFoo2 :: forall (n :: x). (Sing (n :: x)) -> Sing (MkFoo2 n)
+        SMkFoo2 :: forall x (n :: x). (Sing (n :: x)) -> Sing (MkFoo2 n)
     type SFoo2 = (Sing :: Foo2 a -> Type)
     instance SingKind a => SingKind (Foo2 a) where
       type Demote (Foo2 a) = Foo2 (Demote a)
@@ -53,7 +53,7 @@ Singletons/T249.hs:(0,0)-(0,0): Splicing declarations
             SomeSing c -> SomeSing (SMkFoo2 c) }
     data instance Sing (z :: Foo3 a)
       where
-        SMkFoo3 :: forall (n :: x). (Sing (n :: x)) -> Sing (MkFoo3 n)
+        SMkFoo3 :: forall x (n :: x). (Sing (n :: x)) -> Sing (MkFoo3 n)
     type SFoo3 = (Sing :: Foo3 a -> Type)
     instance SingKind a => SingKind (Foo3 a) where
       type Demote (Foo3 a) = Foo3 (Demote a)

--- a/tests/compile-and-dump/Singletons/T271.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T271.ghc84.template
@@ -89,7 +89,8 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
       type (==) a b = Equals_0123456789876543210 a b
     data instance Sing (z :: Constant a b)
       where
-        SConstant :: forall (n :: a). (Sing (n :: a)) -> Sing (Constant n)
+        SConstant :: forall a (n :: a).
+                     (Sing (n :: a)) -> Sing (Constant n)
     type SConstant = (Sing :: Constant a b -> Type)
     instance (SingKind a, SingKind b) => SingKind (Constant a b) where
       type Demote (Constant a b) = Constant (Demote a) (Demote b)
@@ -99,7 +100,8 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
             SomeSing c -> SomeSing (SConstant c) }
     data instance Sing (z :: Identity a)
       where
-        SIdentity :: forall (n :: a). (Sing (n :: a)) -> Sing (Identity n)
+        SIdentity :: forall a (n :: a).
+                     (Sing (n :: a)) -> Sing (Identity n)
     type SIdentity = (Sing :: Identity a -> Type)
     instance SingKind a => SingKind (Identity a) where
       type Demote (Identity a) = Identity (Demote a)

--- a/tests/compile-and-dump/Singletons/T297.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T297.ghc84.template
@@ -1,0 +1,55 @@
+Singletons/T297.hs:(0,0)-(0,0): Splicing declarations
+    singletons
+      [d| f MyProxy
+            = let
+                x = let
+                      z :: MyProxy a
+                      z = MyProxy
+                    in z
+              in x
+          
+          data MyProxy (a :: Type) = MyProxy |]
+  ======>
+    data MyProxy (a :: Type) = MyProxy
+    f MyProxy
+      = let
+          x = let
+                z :: MyProxy a
+                z = MyProxy
+              in z
+        in x
+    type MyProxySym0 = MyProxy
+    type Let0123456789876543210ZSym0 = Let0123456789876543210Z
+    type family Let0123456789876543210Z :: MyProxy a where
+      Let0123456789876543210Z = MyProxySym0
+    type Let0123456789876543210XSym0 = Let0123456789876543210X
+    type family Let0123456789876543210X where
+      Let0123456789876543210X = Let0123456789876543210ZSym0
+    type FSym1 t = F t
+    instance SuppressUnusedWarnings FSym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) FSym0KindInference) GHC.Tuple.())
+    data FSym0 l
+      = forall arg. SameKind (Apply FSym0 arg) (FSym1 arg) =>
+        FSym0KindInference
+    type instance Apply FSym0 l = F l
+    type family F a where
+      F MyProxy = Let0123456789876543210XSym0
+    sF :: forall arg. Sing arg -> Sing (Apply FSym0 arg)
+    sF SMyProxy
+      = let
+          sX :: Sing Let0123456789876543210XSym0
+          sX
+            = let
+                sZ :: forall a. Sing (Let0123456789876543210ZSym0 :: MyProxy a)
+                sZ = SMyProxy
+              in sZ
+        in sX
+    data instance Sing (z :: MyProxy a) where SMyProxy :: Sing MyProxy
+    type SMyProxy = (Sing :: MyProxy a -> Type)
+    instance SingKind a => SingKind (MyProxy a) where
+      type Demote (MyProxy a) = MyProxy (Demote a)
+      fromSing SMyProxy = MyProxy
+      toSing MyProxy = SomeSing SMyProxy
+    instance SingI MyProxy where
+      sing = SMyProxy

--- a/tests/compile-and-dump/Singletons/T297.hs
+++ b/tests/compile-and-dump/Singletons/T297.hs
@@ -1,0 +1,13 @@
+module T297 where
+
+import Data.Kind
+import Data.Singletons.TH
+
+$(singletons [d|
+  data MyProxy (a :: Type) = MyProxy
+
+  f MyProxy =
+    let x = let z :: MyProxy a -- When singled, this `a` should be explicitly quantified
+                z = MyProxy in z
+    in x
+  |])

--- a/tests/compile-and-dump/Singletons/TopLevelPatterns.ghc84.template
+++ b/tests/compile-and-dump/Singletons/TopLevelPatterns.ghc84.template
@@ -212,7 +212,7 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
     sFalse_ :: Sing False_Sym0
     sNot ::
       forall (t :: Bool). Sing t -> Sing (Apply NotSym0 t :: Bool)
-    sId :: forall (t :: a). Sing t -> Sing (Apply IdSym0 t :: a)
+    sId :: forall a (t :: a). Sing t -> Sing (Apply IdSym0 t :: a)
     sF :: forall (t :: Bool). Sing t -> Sing (Apply FSym0 t :: Bool)
     sG :: forall (t :: Bool). Sing t -> Sing (Apply GSym0 t :: Bool)
     sH :: forall (t :: Bool). Sing t -> Sing (Apply HSym0 t :: Bool)


### PR DESCRIPTION
See `Note [Explicitly binding kind variables]`. In summary, we now track bound kind variables in `SgEnv`, and consult this to determine which kind variables to put an explicit `forall` in a singled type signature.

(Note that if this were to be merged, #295 would need to be updated slightly, as pattern signatures also have the ability to bind kind variables in singled definitions.)