### PR TITLE
Use Cabal API for more robust tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,13 +106,7 @@ script:
 
   # build & run tests, build benchmarks
   - cabal new-build ${TARGETS}
-  - |
-    if [ "x$TEST" = "x--enable-tests" ]; then
-      # Why not use `cabal new-test` here? Sadly, it's because `new-test` does
-      # not yet support passing arguments to test suite executables.
-      # See https://github.com/haskell/cabal/issues/4643.
-      CMD="$(find dist-newstyle -type f -iname "singletons-test-suite" -print -quit)" && ${CMD} --rootdir singletons-2.5
-    fi
+  - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${TEST} ${BENCH} all; fi
 
   # cabal check
   - (cd singletons-* && cabal check)

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,8 +86,7 @@ install:
       (cd "./th-desugar" && autoreconf -i);
     fi
   - rm -f cabal.project.freeze
-  - cabal new-configure -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project"
-  - cabal new-build --dep -j2 ${TARGETS}
+  - cabal new-build -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project" --dep -j2 ${TARGETS}
   - rm -rf "."/.ghc.environment.* "./th-desugar"/.ghc.environment.* "."/dist "./th-desugar"/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
 
@@ -105,8 +104,8 @@ script:
 
 
   # build & run tests, build benchmarks
-  - cabal new-build ${TARGETS}
-  - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${TEST} ${BENCH} all; fi
+  - cabal new-build -w ${HC} ${TEST} ${BENCH} ${TARGETS}
+  - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${TEST} ${BENCH} ${TARGETS}; fi
 
   # cabal check
   - (cd singletons-* && cabal check)
@@ -114,7 +113,7 @@ script:
 
   # haddock
   - rm -rf ./dist-newstyle
-  - if $HADDOCK; then cabal new-haddock ${TARGETS}; else echo "Skipping haddock generation";fi
+  - if $HADDOCK; then cabal new-haddock -w ${HC} ${TEST} ${BENCH} ${TARGETS}; else echo "Skipping haddock generation";fi
 
 # REGENDATA ["-o",".travis.yml","--no-no-tests-no-bench","--no-installed","cabal.project"]
 # EOF

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,2 +1,138 @@
+{-# OPTIONS_GHC -Wall #-}
+module Main (main) where
+
+import Control.Monad
+
+import Data.List
+import Data.String
+
+import Distribution.PackageDescription
 import Distribution.Simple
-main = defaultMain
+import Distribution.Simple.BuildPaths
+import Distribution.Simple.LocalBuildInfo
+import Distribution.Simple.PackageIndex
+import Distribution.Simple.Program
+import Distribution.Simple.Setup
+import Distribution.Simple.Utils
+import Distribution.Text
+
+import System.Directory
+import System.FilePath
+
+main :: IO ()
+main = defaultMainWithHooks simpleUserHooks
+  { buildHook = \pkg lbi hooks flags -> do
+      generateBuildModule flags pkg lbi
+      buildHook simpleUserHooks pkg lbi hooks flags
+  , confHook = \(gpd, hbi) flags ->
+      confHook simpleUserHooks (amendGPD gpd, hbi) flags
+  , haddockHook = \pkg lbi hooks flags -> do
+      generateBuildModule (haddockToBuildFlags flags) pkg lbi
+      haddockHook simpleUserHooks pkg lbi hooks flags
+  }
+
+-- | Convert only flags used by 'generateBuildModule'.
+haddockToBuildFlags :: HaddockFlags -> BuildFlags
+haddockToBuildFlags f = emptyBuildFlags
+    { buildVerbosity = haddockVerbosity f
+    , buildDistPref  = haddockDistPref f
+    }
+
+generateBuildModule :: BuildFlags -> PackageDescription -> LocalBuildInfo -> IO ()
+generateBuildModule flags pkg lbi = do
+  rootDir <- getCurrentDirectory
+  let verbosity = fromFlag (buildVerbosity flags)
+      distPref  = fromFlag (buildDistPref flags)
+      distPref' | isRelative distPref = rootDir </> distPref
+                | otherwise           = distPref
+      -- Package DBs
+      dbStack = withPackageDB lbi ++ [ SpecificPackageDB $ distPref' </> "package.conf.inplace" ]
+      dbFlags = "-hide-all-packages" : packageDbArgsDb dbStack
+
+      ghc = case lookupProgram ghcProgram (withPrograms lbi) of
+              Just fp -> locationPath $ programLocation fp
+              Nothing -> error "Can't find GHC path"
+  withTestLBI pkg lbi $ \suite suitecfg -> when (testName suite == fromString testSuiteName) $ do
+    let testAutogenDir = autogenComponentModulesDir lbi suitecfg
+    createDirectoryIfMissingVerbose verbosity True testAutogenDir
+    let buildSingletonsFile = testAutogenDir </> buildSingletonsModule <.> "hs"
+    withLibLBI pkg lbi $ \_ libCLBI -> do
+      let libDeps = map fst $ componentPackageDeps libCLBI
+          pidx = case dependencyClosure (installedPkgs lbi) libDeps of
+                   Left p  -> p
+                   Right _ -> error "Broken dependency closure"
+          libTransDeps = map installedUnitId $ allPackages pidx
+          singletonsUnitId = componentUnitId libCLBI
+          deps = formatDeps (singletonsUnitId:libTransDeps)
+          allFlags = dbFlags ++ deps
+      writeFile buildSingletonsFile $ unlines
+        [ "module Build_singletons where"
+        , ""
+        , "ghcPath :: FilePath"
+        , "ghcPath = " ++ show ghc
+        , ""
+        , "ghcFlags :: [String]"
+        , "ghcFlags = " ++ show allFlags
+        , ""
+        , "rootDir :: FilePath"
+        , "rootDir = " ++ show rootDir
+        ]
+  where
+    formatDeps = map formatOne
+    formatOne installedPkgId = "-package-id=" ++ display installedPkgId
+
+    -- GHC >= 7.6 uses the '-package-db' flag. See
+    -- https://ghc.haskell.org/trac/ghc/ticket/5977.
+    packageDbArgsDb :: [PackageDB] -> [String]
+    -- special cases to make arguments prettier in common scenarios
+    packageDbArgsDb dbstack = case dbstack of
+      (GlobalPackageDB:UserPackageDB:dbs)
+        | all isSpecific dbs              -> concatMap single dbs
+      (GlobalPackageDB:dbs)
+        | all isSpecific dbs              -> "-no-user-package-db"
+                                           : concatMap single dbs
+      dbs                                 -> "-clear-package-db"
+                                           : concatMap single dbs
+     where
+       single (SpecificPackageDB db) = [ "-package-db=" ++ db ]
+       single GlobalPackageDB        = [ "-global-package-db" ]
+       single UserPackageDB          = [ "-user-package-db" ]
+       isSpecific (SpecificPackageDB _) = True
+       isSpecific _                     = False
+
+buildSingletonsModule :: FilePath
+buildSingletonsModule = "Build_singletons"
+
+testSuiteName :: String
+testSuiteName = "singletons-test-suite"
+
+amendGPD :: GenericPackageDescription -> GenericPackageDescription
+amendGPD gpd = gpd
+    { condTestSuites = map f (condTestSuites gpd)
+    }
+  where
+    f (name, condTree)
+        | name == fromString testSuiteName = (name, condTree')
+        | otherwise                        = (name, condTree)
+      where
+        -- I miss 'lens'
+        testSuite = condTreeData condTree
+        bi = testBuildInfo testSuite
+        om = otherModules bi
+        am = autogenModules bi
+
+        -- Cons the module to both other-modules and autogen-modules.
+        -- At the moment, cabal-spec-2.0 and cabal-spec-2.2 don't have
+        -- "all autogen-modules are other-modules if they aren't exposed-modules"
+        -- rule. Hopefully cabal-spec-3.0 will have.
+        --
+        -- Note: we `nub`, because it's unclear if that's ok to have duplicate
+        -- modules in the lists.
+        om' = nub $ mn : om
+        am' = nub $ mn : am
+
+        mn = fromString buildSingletonsModule
+
+        bi' = bi { otherModules = om', autogenModules = am' }
+        testSuite' = testSuite { testBuildInfo = bi' }
+        condTree' = condTree { condTreeData = testSuite' }

--- a/singletons.cabal
+++ b/singletons.cabal
@@ -22,7 +22,7 @@ extra-source-files: README.md, CHANGES.md,
                     tests/compile-and-dump/Singletons/*.ghc84.template
 license:        BSD3
 license-file:   LICENSE
-build-type:     Simple
+build-type:     Custom
 description:
     This library generates singleton types, promoted functions, and singleton
     functions using Template Haskell. It is useful for programmers who wish
@@ -39,6 +39,13 @@ source-repository this
   type:     git
   location: https://github.com/goldfirere/singletons.git
   tag:      v2.5
+
+custom-setup
+  setup-depends:
+    base      >= 4.11 && < 4.12,
+    Cabal     >= 2.1 && < 2.3,
+    directory >= 1,
+    filepath  >= 1.3
 
 library
   hs-source-dirs:     src
@@ -146,5 +153,4 @@ test-suite singletons-test-suite
                       process >= 1.1,
                       singletons,
                       tasty >= 0.6,
-                      tasty-golden >= 2.2,
-                      directory >= 1
+                      tasty-golden >= 2.2

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,15 +30,10 @@ tests:
       make clean-tests
       ```
 
- * Running the testsuite currently requires `cabal-install-2.1` later, as it
-   makes extensive use of the `new-exec` feature to invoke `ghc` using the
-   in-tree `singletons` library. Make sure this version of `cabal` is on your
-   `PATH` before invoking the tests.
-
-   Running the testsuite also requires `awk`, `sed` and `diff`. `awk` is used
-   to generate golden files from templates (see below). `sed` is used to
-   normalize output from GHC (see Note [Normalization with sed]).`diff` is used
-   to compare golden and actual files.
+ * Running the testsuite requires `awk`, `sed` and `diff`. `awk` is used to
+   generate golden files from templates (see below). `sed` is used to normalize
+   output from GHC (see Note [Normalization with sed]).`diff` is used to compare
+   golden and actual files.
 
  * Each compile-and-dump test requires a set of GHC options to be used for
    compilation. Testsuite defines a default set of options that enable on the

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -1,115 +1,105 @@
-{-# LANGUAGE TypeApplications #-}
 module Main (
     main
  ) where
 
-import Data.Proxy               ( Proxy(..)                                 )
+import Test.Tasty               ( TestTree, defaultMain, testGroup          )
 import SingletonsTestSuiteUtils ( compileAndDumpStdTest, compileAndDumpTest
-                                , testCompileAndDumpGroup, cabalArgs
-                                , RootDir(..)
+                                , testCompileAndDumpGroup, ghcOpts
                              --   , cleanFiles
                                 )
-import Test.Tasty               ( TestTree, askOption, defaultIngredients
-                                , defaultMainWithIngredients
-                                , includingOptions, testGroup               )
-import Test.Tasty.Options       ( OptionDescription(..)                     )
 
 main :: IO ()
 main = do
---    cleanFiles    We really need to parallelize the testsuite.
-    defaultMainWithIngredients ings $ askOption $ \(RootDir rootDir) -> tests rootDir
-  where
-    ings = includingOptions [Option (Proxy @RootDir)] : defaultIngredients
+--  cleanFiles    We really need to parallelize the testsuite.
+  defaultMain tests
 
-tests :: FilePath -> TestTree
-tests rootDir =
- let stdTest   = compileAndDumpStdTest rootDir
-     test name = compileAndDumpTest rootDir name $ cabalArgs rootDir
- in testGroup "Testsuite" $ [
+tests :: TestTree
+tests =
+    testGroup "Testsuite" $ [
     testCompileAndDumpGroup "Singletons"
-    [ stdTest "Nat"
-    , stdTest "Empty"
-    , stdTest "Maybe"
-    , stdTest "BoxUnBox"
-    , stdTest "Operators"
-    , stdTest "HigherOrder"
-    , stdTest "Contains"
-    , stdTest "AsPattern"
-    , stdTest "DataValues"
-    , stdTest "EqInstances"
-    , stdTest "CaseExpressions"
-    , stdTest "Star"
-    , stdTest "ReturnFunc"
-    , stdTest "Lambdas"
-    , stdTest "LambdasComprehensive"
-    , stdTest "Error"
-    , stdTest "TopLevelPatterns"
-    , stdTest "LetStatements"
-    , stdTest "LambdaCase"
-    , stdTest "Sections"
-    , stdTest "PatternMatching"
-    , stdTest "Records"
-    , stdTest "T29"
-    , stdTest "T33"
-    , stdTest "T54"
-    , stdTest "Classes"
-    , stdTest "Classes2"
-    , stdTest "FunDeps"
-    , stdTest "T78"
-    , stdTest "OrdDeriving"
-    , stdTest "BoundedDeriving"
-    , stdTest "BadBoundedDeriving"
-    , stdTest "EnumDeriving"
-    , stdTest "BadEnumDeriving"
-    , stdTest "Fixity"
-    , stdTest "Undef"
-    , stdTest "T124"
-    , stdTest "T136"
-    , stdTest "T136b"
-    , stdTest "T153"
-    , stdTest "T157"
-    , stdTest "T159"
-    , stdTest "T167"
-    , stdTest "T145"
-    , stdTest "PolyKinds"
-    , stdTest "PolyKindsApp"
-    , stdTest "T163"
-    , stdTest "T166"
-    , stdTest "T172"
-    , stdTest "T175"
-    , stdTest "T176"
-    , stdTest "T178"
-    , stdTest "T187"
-    , stdTest "T190"
-    , stdTest "ShowDeriving"
-    , stdTest "EmptyShowDeriving"
-    , stdTest "StandaloneDeriving"
-    , stdTest "T197"
-    , stdTest "T197b"
-    , stdTest "T200"
-    , stdTest "T206"
-    , stdTest "T209"
-    , stdTest "T226"
-    , stdTest "T229"
-    , stdTest "T249"
-    , stdTest "OverloadedStrings"
-    , stdTest "T271"
-    , stdTest "T287"
-    , stdTest "TypeRepTYPE"
+    [ compileAndDumpStdTest "Nat"
+    , compileAndDumpStdTest "Empty"
+    , compileAndDumpStdTest "Maybe"
+    , compileAndDumpStdTest "BoxUnBox"
+    , compileAndDumpStdTest "Operators"
+    , compileAndDumpStdTest "HigherOrder"
+    , compileAndDumpStdTest "Contains"
+    , compileAndDumpStdTest "AsPattern"
+    , compileAndDumpStdTest "DataValues"
+    , compileAndDumpStdTest "EqInstances"
+    , compileAndDumpStdTest "CaseExpressions"
+    , compileAndDumpStdTest "Star"
+    , compileAndDumpStdTest "ReturnFunc"
+    , compileAndDumpStdTest "Lambdas"
+    , compileAndDumpStdTest "LambdasComprehensive"
+    , compileAndDumpStdTest "Error"
+    , compileAndDumpStdTest "TopLevelPatterns"
+    , compileAndDumpStdTest "LetStatements"
+    , compileAndDumpStdTest "LambdaCase"
+    , compileAndDumpStdTest "Sections"
+    , compileAndDumpStdTest "PatternMatching"
+    , compileAndDumpStdTest "Records"
+    , compileAndDumpStdTest "T29"
+    , compileAndDumpStdTest "T33"
+    , compileAndDumpStdTest "T54"
+    , compileAndDumpStdTest "Classes"
+    , compileAndDumpStdTest "Classes2"
+    , compileAndDumpStdTest "FunDeps"
+    , compileAndDumpStdTest "T78"
+    , compileAndDumpStdTest "OrdDeriving"
+    , compileAndDumpStdTest "BoundedDeriving"
+    , compileAndDumpStdTest "BadBoundedDeriving"
+    , compileAndDumpStdTest "EnumDeriving"
+    , compileAndDumpStdTest "BadEnumDeriving"
+    , compileAndDumpStdTest "Fixity"
+    , compileAndDumpStdTest "Undef"
+    , compileAndDumpStdTest "T124"
+    , compileAndDumpStdTest "T136"
+    , compileAndDumpStdTest "T136b"
+    , compileAndDumpStdTest "T153"
+    , compileAndDumpStdTest "T157"
+    , compileAndDumpStdTest "T159"
+    , compileAndDumpStdTest "T167"
+    , compileAndDumpStdTest "T145"
+    , compileAndDumpStdTest "PolyKinds"
+    , compileAndDumpStdTest "PolyKindsApp"
+    , compileAndDumpStdTest "T163"
+    , compileAndDumpStdTest "T166"
+    , compileAndDumpStdTest "T172"
+    , compileAndDumpStdTest "T175"
+    , compileAndDumpStdTest "T176"
+    , compileAndDumpStdTest "T178"
+    , compileAndDumpStdTest "T187"
+    , compileAndDumpStdTest "T190"
+    , compileAndDumpStdTest "ShowDeriving"
+    , compileAndDumpStdTest "EmptyShowDeriving"
+    , compileAndDumpStdTest "StandaloneDeriving"
+    , compileAndDumpStdTest "T197"
+    , compileAndDumpStdTest "T197b"
+    , compileAndDumpStdTest "T200"
+    , compileAndDumpStdTest "T206"
+    , compileAndDumpStdTest "T209"
+    , compileAndDumpStdTest "T226"
+    , compileAndDumpStdTest "T229"
+    , compileAndDumpStdTest "T249"
+    , compileAndDumpStdTest "OverloadedStrings"
+    , compileAndDumpStdTest "T271"
+    , compileAndDumpStdTest "T287"
+    , compileAndDumpStdTest "TypeRepTYPE"
     ],
     testCompileAndDumpGroup "Promote"
-    [ stdTest "Constructors"
-    , stdTest "GenDefunSymbols"
-    , stdTest "Newtypes"
-    , stdTest "Pragmas"
-    , stdTest "Prelude"
-    , stdTest "T180"
+    [ compileAndDumpStdTest "Constructors"
+    , compileAndDumpStdTest "GenDefunSymbols"
+    , compileAndDumpStdTest "Newtypes"
+    , compileAndDumpStdTest "Pragmas"
+    , compileAndDumpStdTest "Prelude"
+    , compileAndDumpStdTest "T180"
     ],
     testGroup "Database client"
-    [ test "GradingClient/Database"
-    , test "GradingClient/Main"
+    [ compileAndDumpTest "GradingClient/Database" ghcOpts
+    , compileAndDumpTest "GradingClient/Main"     ghcOpts
     ],
     testCompileAndDumpGroup "InsertionSort"
-    [ stdTest "InsertionSortImp"
+    [ compileAndDumpStdTest "InsertionSortImp"
     ]
   ]


### PR DESCRIPTION
In #290, I revamped the test suite to be compatible with `cabal new-build`. Well, to be more accurate, I forced everyone to use `cabal new-build`, and with an extremely recent version of `cabal-install` to boot. This "solution" left a sour taste in my mouth, so I sought a more principled approach, which I believe I've found.

We now use a custom `Setup.hs` script to detect all of the relevant information we'll need to invoke GHC, such as:

* GHC's path
* The database flags to pass it
* The directory in which `singletons.cabal` is located (previously, we had to pass this manually to the test suite, in one of the more disgusting hacks I've ever put into production)

All of this information is put into an autogenerated module `Build_singletons` that the test suite uses in turn. This approach was inspired by the widely used [`cabal-doctest`](http://hackage.haskell.org/package/cabal-doctest) library, which performs similar tricks to figure out the right flags to pass to `doctest` (which is essentially a wrapper around GHC). Not unrelatedly, much of the code in `Setup.hs` is cargo-culted from `cabal-doctest` itself.

The big win from this patch is that we are no longer tied to a particular build tool—the tests now pass with `cabal` old-`build`, `cabal new-build`, and `stack`! This should hopefully make life easier when testing locally, testing on Travis, and for others who want to try the tests out.