### PR TITLE
Explicitly bind kinds during promotion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,9 +3,12 @@ Changelog for singletons project
 
 2.5
 ---
-* `singletons` now generates `a ~> b` instead of `TyFun a b -> Type` whenever
-  possible. This may require enabling `TypeInType` in code which did not
-  previously need it.
+* Template Haskell-generated code may require `TypeInType` in scenarios which
+  did not previously require it:
+  * `singletons` now explicitly quantifies all kind variables used in explicit
+    `forall`s.
+  * `singletons` now generates `a ~> b` instead of `TyFun a b -> Type` whenever
+    possible.
 
 * Rename `Data.Singletons.TypeRepStar` to `Data.Singletons.TypeRepTYPE`, and
   generalize the `Sing :: Type -> Type` instance to `Sing :: TYPE rep -> Type`,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,8 @@ Changelog for singletons project
   and `thenCmp` are no longer exported from `Data.Singletons.Prelude`. (They
   continue to live in `Data.Singletons.Prelude.Ord`.)
 
+* Permit singling of expression and pattern signatures.
+
 2.4.1
 -----
 * Restore the `TyCon1`, `TyCon2`, etc. types. It turns out that the new

--- a/README.md
+++ b/README.md
@@ -555,6 +555,8 @@ The following constructs are fully supported:
 * lambda expressions
 * `!` and `~` patterns (silently but successfully ignored during promotion)
 * class and instance declarations
+* scoped type variables
+* signatures (e.g., `(x :: Maybe a)`) in expressions and patterns
 * higher-kinded type variables (see below)
 * functional dependencies (with limitations -- see below)
 
@@ -579,7 +581,6 @@ using the `DerivingStrategies` extension.
 
 The following constructs are supported for promotion but not singleton generation:
 
-* scoped type variables
 * overlapping patterns. Note that overlapping patterns are
   sometimes not obvious. For example, the `filter` function does not
   singletonize due

--- a/src/Data/Singletons/Partition.hs
+++ b/src/Data/Singletons/Partition.hs
@@ -73,18 +73,19 @@ partitionDec (DDataD nd _cxt name tvbs cons derivings) = do
 
 partitionDec (DClassD cxt name tvbs fds decs) = do
   env <- concatMapM partitionClassDec decs
-  return $ mempty { pd_class_decs = [ClassDecl { cd_cxt  = cxt
-                                               , cd_name = name
-                                               , cd_tvbs = tvbs
-                                               , cd_fds  = fds
-                                               , cd_lde  = env }] }
+  return $ mempty { pd_class_decs = [ClassDecl { cd_cxt       = cxt
+                                               , cd_name      = name
+                                               , cd_tvbs      = tvbs
+                                               , cd_fds       = fds
+                                               , cd_lde       = env
+                                               , cd_bound_kvs = () }] }
 partitionDec (DInstanceD _ cxt ty decs) = do
   defns <- liftM catMaybes $ mapM partitionInstanceDec decs
   (name, tys) <- split_app_tys [] ty
-  return $ mempty { pd_instance_decs = [InstDecl { id_cxt = cxt
-                                                 , id_name = name
-                                                 , id_arg_tys = tys
-                                                 , id_meths = defns }] }
+  return $ mempty { pd_instance_decs = [InstDecl { id_cxt       = cxt
+                                                 , id_name      = name
+                                                 , id_arg_tys   = tys
+                                                 , id_meths     = defns }] }
   where
     split_app_tys acc (DAppT t1 t2) = split_app_tys (t2:acc) t1
     split_app_tys acc (DConT name)  = return (name, acc)
@@ -158,9 +159,9 @@ partitionDeriving mb_strat deriv_pred mb_ctxt ty cons =
                       -- (Of course, if a user specifies a context with
                       -- StandaloneDeriving, use that.)
 
-                    , id_name    = deriv_name
-                    , id_arg_tys = arg_tys ++ [ty]
-                    , id_meths   = [] }
+                    , id_name      = deriv_name
+                    , id_arg_tys   = arg_tys ++ [ty]
+                    , id_meths     = [] }
 
        | Just NewtypeStrategy <- mb_strat
       -> do qReportWarning "GeneralizedNewtypeDeriving is ignored by `singletons`."

--- a/src/Data/Singletons/Promote.hs
+++ b/src/Data/Singletons/Promote.hs
@@ -32,8 +32,11 @@ import Control.Arrow (second)
 import Control.Monad
 import Control.Monad.Trans.Class (MonadTrans(..))
 import Control.Monad.Trans.Maybe
+import Control.Monad.Writer
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict ( Map )
+import qualified Data.Set as Set
+import Data.Set ( Set )
 import Data.Maybe
 import qualified GHC.LanguageExtensions.Type as LangExt
 
@@ -274,33 +277,46 @@ promoteClassDec decl@(ClassDecl { cd_cxt  = cxt
     tvbs = map cuskify tvbs'
   let pClsName = promoteClassName cls_name
   pCxt <- mapM promote_superclass_pred cxt
-  sig_decs <- mapM (uncurry promote_sig) (Map.toList meth_sigs)
-  let defaults_list  = Map.toList defaults
-      defaults_names = map fst defaults_list
-  (default_decs, ann_rhss, prom_rhss)
-    <- mapAndUnzip3M (promoteMethod Nothing meth_sigs) defaults_list
+  forallBind cls_kvs_to_bind $ do
+    (sig_decs, meth_kvs_to_bind)
+      <- mapAndUnzipM (uncurry promote_sig) (Map.toList meth_sigs)
+    let defaults_list  = Map.toList defaults
+        defaults_names = map fst defaults_list
+    (default_decs, ann_rhss, prom_rhss)
+      <- mapAndUnzip3M (promoteMethod Nothing meth_sigs) defaults_list
 
-  let infix_decls' = catMaybes $ map (uncurry promoteInfixDecl) infix_decls
+    let infix_decls' = catMaybes $ map (uncurry promoteInfixDecl) infix_decls
 
-  -- no need to do anything to the fundeps. They work as is!
-  emitDecs [DClassD pCxt pClsName tvbs fundeps
-                    (sig_decs ++ default_decs ++ infix_decls')]
-  let defaults_list' = zip defaults_names ann_rhss
-      proms          = zip defaults_names prom_rhss
-  return (decl { cd_lde = lde { lde_defns = Map.fromList defaults_list'
-                              , lde_proms = Map.fromList proms } })
+    -- no need to do anything to the fundeps. They work as is!
+    emitDecs [DClassD pCxt pClsName tvbs fundeps
+                      (sig_decs ++ default_decs ++ infix_decls')]
+    let defaults_list'    = zip defaults_names       ann_rhss
+        proms             = zip defaults_names       prom_rhss
+        meth_kvs_to_bind' = zip (Map.keys meth_sigs) meth_kvs_to_bind
+    return (decl { cd_lde = lde { lde_defns     = Map.fromList defaults_list'
+                                , lde_proms     = Map.fromList proms
+                                , lde_bound_kvs = Map.fromList meth_kvs_to_bind' }
+                 , cd_bound_kvs = cls_kvs_to_bind
+                 })
   where
-    promote_sig :: Name -> DType -> PrM DDec
+    cls_kvb_names, cls_tvb_names, cls_kvs_to_bind :: Set Name
+    cls_kvb_names   = foldMap (foldMap fvDType . extractTvbKind) tvbs'
+    cls_tvb_names   = Set.fromList $ map extractTvbName tvbs'
+    cls_kvs_to_bind = cls_kvb_names `Set.union` cls_tvb_names
+
+    promote_sig :: Name -> DType -> PrM (DDec, Set Name)
     promote_sig name ty = do
       let proName = promoteValNameLhs name
       (argKs, resK) <- promoteUnraveled ty
       args <- mapM (const $ qNewName "arg") argKs
       emitDecsM $ defunctionalize proName (map Just argKs) (Just resK)
 
-      return $ DOpenTypeFamilyD (DTypeFamilyHead proName
+      return ( DOpenTypeFamilyD (DTypeFamilyHead proName
                                                  (zipWith DKindedTV args argKs)
                                                  (DKindSig resK)
                                                  Nothing)
+             , cls_kvs_to_bind `Set.union` foldMap fvDType argKs
+                               `Set.union` fvDType resK )
 
     promote_superclass_pred :: DPred -> PrM DPred
     promote_superclass_pred = go
@@ -320,11 +336,13 @@ promoteInstanceDec meth_sigs
                                   , id_meths    = meths }) = do
   cls_tvb_names <- lookup_cls_tvb_names
   inst_kis <- mapM promoteType inst_tys
-  let subst = Map.fromList $ zip cls_tvb_names inst_kis
-  (meths', ann_rhss, _) <- mapAndUnzip3M (promoteMethod (Just subst) meth_sigs) meths
-  emitDecs [DInstanceD Nothing [] (foldType (DConT pClsName)
-                                    inst_kis) meths']
-  return (decl { id_meths = zip (map fst meths) ann_rhss })
+  let kvs_to_bind = foldMap fvDType inst_kis
+  forallBind kvs_to_bind $ do
+    let subst = Map.fromList $ zip cls_tvb_names inst_kis
+    (meths', ann_rhss, _) <- mapAndUnzip3M (promoteMethod (Just subst) meth_sigs) meths
+    emitDecs [DInstanceD Nothing [] (foldType (DConT pClsName)
+                                      inst_kis) meths']
+    return (decl { id_meths = zip (map fst meths) ann_rhss })
   where
     pClsName = promoteClassName cls_name
 
@@ -494,13 +512,15 @@ promoteLetDecEnv prefixes (LetDecEnv { lde_defns = value_env
     <- fmap unzip3 $ zipWithM (promoteLetDecRHS Nothing type_env prefixes) names rhss
 
   emitDecs $ concat defun_decss
+  bound_kvs <- allBoundKindVars
   let decs = map payload_to_dec payloads ++ infix_decls'
 
     -- build the ALetDecEnv
-  let let_dec_env' = LetDecEnv { lde_defns = Map.fromList $ zip names ann_rhss
-                               , lde_types = type_env
-                               , lde_infix = infix_decls
-                               , lde_proms = Map.empty }  -- filled in promoteLetDecs
+  let let_dec_env' = LetDecEnv { lde_defns     = Map.fromList $ zip names ann_rhss
+                               , lde_types     = type_env
+                               , lde_infix     = infix_decls
+                               , lde_proms     = Map.empty   -- filled in promoteLetDecs
+                               , lde_bound_kvs = Map.fromList $ map (, bound_kvs) names }
 
   return (decs, let_dec_env')
   where
@@ -544,7 +564,8 @@ promoteLetDecRHS m_rhs_ki type_env prefixes name (UValue exp) = do
   case num_arrows of
     0 -> do
       all_locals <- allLocals
-      (exp', ann_exp) <- promoteExp exp
+      let lde_kvs_to_bind = foldMap fvDType res_kind
+      (exp', ann_exp) <- forallBind lde_kvs_to_bind $ promoteExp exp
       let proName = promoteValNameLhsPrefix prefixes name
       defuns <- defunctionalize proName (map (const Nothing) all_locals) res_kind
       return ( ( proName, map DPlainTV all_locals, res_kind
@@ -581,7 +602,9 @@ promoteLetDecRHS m_rhs_ki type_env prefixes name (UFunction clauses) = do
   let local_tvbs = map DPlainTV all_locals
   tyvarNames <- mapM (const $ qNewName "a") m_argKs
   expClauses <- mapM (etaContractOrExpand ty_num_args numArgs) clauses
-  (eqns, ann_clauses) <- mapAndUnzipM promoteClause expClauses
+  let lde_kvs_to_bind = foldMap (foldMap fvDType) m_argKs <> foldMap fvDType m_resK
+  (eqns, ann_clauses) <- forallBind lde_kvs_to_bind $
+                         mapAndUnzipM promoteClause expClauses
   prom_fun <- lookupVarE name
   let args     = zipWith inferMaybeKindTV tyvarNames m_argKs
       all_args = local_tvbs ++ args
@@ -611,8 +634,12 @@ promoteClause :: DClause -> PrM (DTySynEqn, ADClause)
 promoteClause (DClause pats exp) = do
   -- promoting the patterns creates variable bindings. These are passed
   -- to the function promoted the RHS
-  ((types, pats'), new_vars) <- evalForPair $ mapAndUnzipM promotePat pats
-  (ty, ann_exp) <- lambdaBind new_vars $ promoteExp exp
+  ((types, pats'), prom_pat_infos) <- evalForPair $ mapAndUnzipM promotePat pats
+  let PromDPatInfos { prom_dpat_vars    = new_vars
+                    , prom_dpat_sig_kvs = sig_kvs } = prom_pat_infos
+  (ty, ann_exp) <- forallBind sig_kvs $
+                   lambdaBind new_vars $
+                   promoteExp exp
   all_locals <- allLocals   -- these are bound *outside* of this clause
   return ( DTySynEqn (map DVarT all_locals ++ types) ty
          , ADClause new_vars pats' ann_exp )
@@ -621,19 +648,23 @@ promoteMatch :: DMatch -> PrM (DTySynEqn, ADMatch)
 promoteMatch (DMatch pat exp) = do
   -- promoting the patterns creates variable bindings. These are passed
   -- to the function promoted the RHS
-  ((ty, pat'), new_vars) <- evalForPair $ promotePat pat
-  (rhs, ann_exp) <- lambdaBind new_vars $ promoteExp exp
+  ((ty, pat'), prom_pat_infos) <- evalForPair $ promotePat pat
+  let PromDPatInfos { prom_dpat_vars    = new_vars
+                    , prom_dpat_sig_kvs = sig_kvs } = prom_pat_infos
+  (rhs, ann_exp) <- forallBind sig_kvs $
+                    lambdaBind new_vars $
+                    promoteExp exp
   all_locals <- allLocals
   return $ ( DTySynEqn (map DVarT all_locals ++ [ty]) rhs
            , ADMatch new_vars pat' ann_exp)
 
 -- promotes a term pattern into a type pattern, accumulating bound variable names
-promotePat :: DPat -> QWithAux VarPromotions PrM (DType, ADPat)
+promotePat :: DPat -> QWithAux PromDPatInfos PrM (DType, ADPat)
 promotePat (DLitPa lit) = (, ADLitPa lit) <$> promoteLitPat lit
 promotePat (DVarPa name) = do
       -- term vars can be symbols... type vars can't!
   tyName <- mkTyName name
-  addElement (name, tyName)
+  tell $ PromDPatInfos [(name, tyName)] Set.empty
   return (DVarT tyName, ADVarPa name)
 promotePat (DConPa name pats) = do
   (types, pats') <- mapAndUnzipM promotePat pats
@@ -656,6 +687,7 @@ promotePat (DSigPa pat ty) = do
   wildless_pat <- removeWilds pat
   (promoted, pat') <- promotePat wildless_pat
   ki <- promoteType ty
+  tell $ PromDPatInfos [] (fvDType ki)
   return (DSigT promoted ki, ADSigPa promoted pat' ki)
 promotePat DWildPa = return (DWildCardT, ADWildPa)
 

--- a/src/Data/Singletons/Promote.hs
+++ b/src/Data/Singletons/Promote.hs
@@ -28,6 +28,7 @@ import Data.Singletons.Util
 import Data.Singletons.Syntax
 import Prelude hiding (exp)
 import Control.Applicative (Alternative(..))
+import Control.Arrow (second)
 import Control.Monad
 import Control.Monad.Trans.Class (MonadTrans(..))
 import Control.Monad.Trans.Maybe
@@ -644,10 +645,10 @@ promotePat (DConPa name pats) = do
       | otherwise                                  = n
 promotePat (DTildePa pat) = do
   qReportWarning "Lazy pattern converted into regular pattern in promotion"
-  fmap ADTildePa <$> promotePat pat
+  second ADTildePa <$> promotePat pat
 promotePat (DBangPa pat) = do
   qReportWarning "Strict pattern converted into regular pattern in promotion"
-  fmap ADBangPa <$> promotePat pat
+  second ADBangPa <$> promotePat pat
 promotePat (DSigPa pat ty) = do
   -- We must maintain the invariant that any promoted pattern signature must
   -- not have any wildcards in the underlying pattern.

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -87,6 +87,7 @@ tests =
     , compileAndDumpStdTest "T271"
     , compileAndDumpStdTest "T287"
     , compileAndDumpStdTest "TypeRepTYPE"
+    , compileAndDumpStdTest "T297"
     ],
     testCompileAndDumpGroup "Promote"
     [ compileAndDumpStdTest "Constructors"

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -69,6 +69,7 @@ tests =
     , compileAndDumpStdTest "T175"
     , compileAndDumpStdTest "T176"
     , compileAndDumpStdTest "T178"
+    , compileAndDumpStdTest "T183"
     , compileAndDumpStdTest "T187"
     , compileAndDumpStdTest "T190"
     , compileAndDumpStdTest "ShowDeriving"

--- a/tests/compile-and-dump/Singletons/BoundedDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/BoundedDeriving.ghc84.template
@@ -144,7 +144,7 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
       toSing D = SomeSing SD
       toSing E = SomeSing SE
     data instance Sing (z :: Foo3 a)
-      where SFoo3 :: forall (n :: a). (Sing (n :: a)) -> Sing (Foo3 n)
+      where SFoo3 :: forall a (n :: a). (Sing (n :: a)) -> Sing (Foo3 n)
     type SFoo3 = (Sing :: Foo3 a -> Type)
     instance SingKind a => SingKind (Foo3 a) where
       type Demote (Foo3 a) = Foo3 (Demote a)

--- a/tests/compile-and-dump/Singletons/BoxUnBox.ghc84.template
+++ b/tests/compile-and-dump/Singletons/BoxUnBox.ghc84.template
@@ -27,10 +27,10 @@ Singletons/BoxUnBox.hs:(0,0)-(0,0): Splicing declarations
     type family UnBox (a :: Box a) :: a where
       UnBox (FBox a) = a
     sUnBox ::
-      forall (t :: Box a). Sing t -> Sing (Apply UnBoxSym0 t :: a)
+      forall a (t :: Box a). Sing t -> Sing (Apply UnBoxSym0 t :: a)
     sUnBox (SFBox (sA :: Sing a)) = sA
     data instance Sing (z :: Box a)
-      where SFBox :: forall (n :: a). (Sing (n :: a)) -> Sing (FBox n)
+      where SFBox :: forall a (n :: a). (Sing (n :: a)) -> Sing (FBox n)
     type SBox = (Sing :: Box a -> GHC.Types.Type)
     instance SingKind a => SingKind (Box a) where
       type Demote (Box a) = Box (Demote a)

--- a/tests/compile-and-dump/Singletons/CaseExpressions.ghc84.template
+++ b/tests/compile-and-dump/Singletons/CaseExpressions.ghc84.template
@@ -214,16 +214,16 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
       Foo2 d _ = Case_0123456789876543210 d (Let0123456789876543210Scrutinee_0123456789876543210Sym1 d)
     type family Foo1 (a :: a) (a :: Maybe a) :: a where
       Foo1 d x = Case_0123456789876543210 d x x
-    sFoo5 :: forall (t :: a). Sing t -> Sing (Apply Foo5Sym0 t :: a)
-    sFoo4 :: forall (t :: a). Sing t -> Sing (Apply Foo4Sym0 t :: a)
+    sFoo5 :: forall a (t :: a). Sing t -> Sing (Apply Foo5Sym0 t :: a)
+    sFoo4 :: forall a (t :: a). Sing t -> Sing (Apply Foo4Sym0 t :: a)
     sFoo3 ::
-      forall (t :: a) (t :: b).
+      forall a b (t :: a) (t :: b).
       Sing t -> Sing t -> Sing (Apply (Apply Foo3Sym0 t) t :: a)
     sFoo2 ::
-      forall (t :: a) (t :: Maybe a).
+      forall a (t :: a) (t :: Maybe a).
       Sing t -> Sing t -> Sing (Apply (Apply Foo2Sym0 t) t :: a)
     sFoo1 ::
-      forall (t :: a) (t :: Maybe a).
+      forall a (t :: a) (t :: Maybe a).
       Sing t -> Sing t -> Sing (Apply (Apply Foo1Sym0 t) t :: a)
     sFoo5 (sX :: Sing x)
       = case sX of {

--- a/tests/compile-and-dump/Singletons/Classes.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Classes.ghc84.template
@@ -269,7 +269,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       Sing t
       -> Sing t -> Sing (Apply (Apply FooCompareSym0 t) t :: Ordering)
     sConst ::
-      forall (t :: a) (t :: b).
+      forall a b (t :: a) (t :: b).
       Sing t -> Sing t -> Sing (Apply (Apply ConstSym0 t) t :: a)
     sFooCompare SA SA = SEQ
     sFooCompare SA SB = SLT

--- a/tests/compile-and-dump/Singletons/Contains.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Contains.ghc84.template
@@ -27,7 +27,7 @@ Singletons/Contains.hs:(0,0)-(0,0): Splicing declarations
       Contains _ '[] = FalseSym0
       Contains elt ((:) h t) = Apply (Apply (||@#@$) (Apply (Apply (==@#@$) elt) h)) (Apply (Apply ContainsSym0 elt) t)
     sContains ::
-      forall (t :: a) (t :: [a]).
+      forall a (t :: a) (t :: [a]).
       SEq a =>
       Sing t -> Sing t -> Sing (Apply (Apply ContainsSym0 t) t :: Bool)
     sContains _ SNil = SFalse

--- a/tests/compile-and-dump/Singletons/DataValues.ghc84.template
+++ b/tests/compile-and-dump/Singletons/DataValues.ghc84.template
@@ -111,7 +111,7 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
           ((applySing ((applySing ((singFun2 @(:@#@$)) SCons)) SZero)) SNil)
     data instance Sing (z :: Pair a b)
       where
-        SPair :: forall (n :: a) (n :: b).
+        SPair :: forall a b (n :: a) (n :: b).
                  (Sing (n :: a)) -> (Sing (n :: b)) -> Sing (Pair n n)
     type SPair = (Sing :: Pair a b -> GHC.Types.Type)
     instance (SingKind a, SingKind b) => SingKind (Pair a b) where

--- a/tests/compile-and-dump/Singletons/Error.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Error.ghc84.template
@@ -18,7 +18,8 @@ Singletons/Error.hs:(0,0)-(0,0): Splicing declarations
     type family Head (a :: [a]) :: a where
       Head ((:) a _) = a
       Head '[] = Apply ErrorSym0 "Data.Singletons.List.head: empty list"
-    sHead :: forall (t :: [a]). Sing t -> Sing (Apply HeadSym0 t :: a)
+    sHead ::
+      forall a (t :: [a]). Sing t -> Sing (Apply HeadSym0 t :: a)
     sHead (SCons (sA :: Sing a) _) = sA
     sHead SNil
       = sError (sing :: Sing "Data.Singletons.List.head: empty list")

--- a/tests/compile-and-dump/Singletons/Fixity.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Fixity.ghc84.template
@@ -55,7 +55,7 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
     infix 4 %====
     infix 4 %<=>
     (%====) ::
-      forall (t :: a) (t :: a).
+      forall a (t :: a) (t :: a).
       Sing t -> Sing t -> Sing (Apply (Apply (====@#@$) t) t :: a)
     (%====) (sA :: Sing a) _ = sA
     class SMyOrd a where

--- a/tests/compile-and-dump/Singletons/HigherOrder.ghc84.template
+++ b/tests/compile-and-dump/Singletons/HigherOrder.ghc84.template
@@ -269,12 +269,16 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
       Map _ '[] = '[]
       Map f ((:) h t) = Apply (Apply (:@#@$) (Apply f h)) (Apply (Apply MapSym0 f) t)
     sFoo ::
-      forall (t :: (~>) ((~>) a b) ((~>) a b)) (t :: (~>) a b) (t :: a).
+      forall a
+             b
+             (t :: (~>) ((~>) a b) ((~>) a b))
+             (t :: (~>) a b)
+             (t :: a).
       Sing t
       -> Sing t
          -> Sing t -> Sing (Apply (Apply (Apply FooSym0 t) t) t :: b)
     sZipWith ::
-      forall (t :: (~>) a ((~>) b c)) (t :: [a]) (t :: [b]).
+      forall a b c (t :: (~>) a ((~>) b c)) (t :: [a]) (t :: [b]).
       Sing t
       -> Sing t
          -> Sing t -> Sing (Apply (Apply (Apply ZipWithSym0 t) t) t :: [c])
@@ -285,11 +289,11 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
       forall (t :: [Nat]) (t :: [Bool]).
       Sing t -> Sing t -> Sing (Apply (Apply EtadSym0 t) t :: [Nat])
     sLiftMaybe ::
-      forall (t :: (~>) a b) (t :: Maybe a).
+      forall a b (t :: (~>) a b) (t :: Maybe a).
       Sing t
       -> Sing t -> Sing (Apply (Apply LiftMaybeSym0 t) t :: Maybe b)
     sMap ::
-      forall (t :: (~>) a b) (t :: [a]).
+      forall a b (t :: (~>) a b) (t :: [a]).
       Sing t -> Sing t -> Sing (Apply (Apply MapSym0 t) t :: [b])
     sFoo (sF :: Sing f) (sG :: Sing g) (sA :: Sing a)
       = (applySing ((applySing sF) sG)) sA
@@ -352,8 +356,8 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
           ((applySing ((applySing ((singFun2 @MapSym0) sMap)) sF)) sT)
     data instance Sing (z :: Either a b)
       where
-        SLeft :: forall (n :: a). (Sing (n :: a)) -> Sing (Left n)
-        SRight :: forall (n :: b). (Sing (n :: b)) -> Sing (Right n)
+        SLeft :: forall a (n :: a). (Sing (n :: a)) -> Sing (Left n)
+        SRight :: forall b (n :: b). (Sing (n :: b)) -> Sing (Right n)
     type SEither = (Sing :: Either a b -> GHC.Types.Type)
     instance (SingKind a, SingKind b) => SingKind (Either a b) where
       type Demote (Either a b) = Either (Demote a) (Demote b)

--- a/tests/compile-and-dump/Singletons/LambdaCase.ghc84.template
+++ b/tests/compile-and-dump/Singletons/LambdaCase.ghc84.template
@@ -176,13 +176,13 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
     type family Foo1 (a :: a) (a :: Maybe a) :: a where
       Foo1 d x = Apply (Apply (Apply Lambda_0123456789876543210Sym0 d) x) x
     sFoo3 ::
-      forall (t :: a) (t :: b).
+      forall a b (t :: a) (t :: b).
       Sing t -> Sing t -> Sing (Apply (Apply Foo3Sym0 t) t :: a)
     sFoo2 ::
-      forall (t :: a) (t :: Maybe a).
+      forall a (t :: a) (t :: Maybe a).
       Sing t -> Sing t -> Sing (Apply (Apply Foo2Sym0 t) t :: a)
     sFoo1 ::
-      forall (t :: a) (t :: Maybe a).
+      forall a (t :: a) (t :: Maybe a).
       Sing t -> Sing t -> Sing (Apply (Apply Foo1Sym0 t) t :: a)
     sFoo3 (sA :: Sing a) (sB :: Sing b)
       = (applySing

--- a/tests/compile-and-dump/Singletons/Lambdas.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Lambdas.ghc84.template
@@ -552,30 +552,30 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     type family Foo0 (a :: a) (a :: b) :: a where
       Foo0 a_0123456789876543210 a_0123456789876543210 = Apply (Apply (Apply (Apply Lambda_0123456789876543210Sym0 a_0123456789876543210) a_0123456789876543210) a_0123456789876543210) a_0123456789876543210
     sFoo8 ::
-      forall (t :: Foo a b). Sing t -> Sing (Apply Foo8Sym0 t :: a)
+      forall a b (t :: Foo a b). Sing t -> Sing (Apply Foo8Sym0 t :: a)
     sFoo7 ::
-      forall (t :: a) (t :: b).
+      forall a b (t :: a) (t :: b).
       Sing t -> Sing t -> Sing (Apply (Apply Foo7Sym0 t) t :: b)
     sFoo6 ::
-      forall (t :: a) (t :: b).
+      forall a b (t :: a) (t :: b).
       Sing t -> Sing t -> Sing (Apply (Apply Foo6Sym0 t) t :: a)
     sFoo5 ::
-      forall (t :: a) (t :: b).
+      forall a b (t :: a) (t :: b).
       Sing t -> Sing t -> Sing (Apply (Apply Foo5Sym0 t) t :: b)
     sFoo4 ::
-      forall (t :: a) (t :: b) (t :: c).
+      forall a b c (t :: a) (t :: b) (t :: c).
       Sing t
       -> Sing t
          -> Sing t -> Sing (Apply (Apply (Apply Foo4Sym0 t) t) t :: a)
-    sFoo3 :: forall (t :: a). Sing t -> Sing (Apply Foo3Sym0 t :: a)
+    sFoo3 :: forall a (t :: a). Sing t -> Sing (Apply Foo3Sym0 t :: a)
     sFoo2 ::
-      forall (t :: a) (t :: b).
+      forall a b (t :: a) (t :: b).
       Sing t -> Sing t -> Sing (Apply (Apply Foo2Sym0 t) t :: a)
     sFoo1 ::
-      forall (t :: a) (t :: b).
+      forall a b (t :: a) (t :: b).
       Sing t -> Sing t -> Sing (Apply (Apply Foo1Sym0 t) t :: a)
     sFoo0 ::
-      forall (t :: a) (t :: b).
+      forall a b (t :: a) (t :: b).
       Sing t -> Sing t -> Sing (Apply (Apply Foo0Sym0 t) t :: a)
     sFoo8 (sX :: Sing x)
       = (applySing
@@ -679,7 +679,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
           sA_0123456789876543210
     data instance Sing (z :: Foo a b)
       where
-        SFoo :: forall (n :: a) (n :: b).
+        SFoo :: forall a b (n :: a) (n :: b).
                 (Sing (n :: a)) -> (Sing (n :: b)) -> Sing (Foo n n)
     type SFoo = (Sing :: Foo a b -> GHC.Types.Type)
     instance (SingKind a, SingKind b) => SingKind (Foo a b) where

--- a/tests/compile-and-dump/Singletons/LetStatements.ghc84.template
+++ b/tests/compile-and-dump/Singletons/LetStatements.ghc84.template
@@ -718,8 +718,9 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     sFoo14 ::
       forall (t :: Nat). Sing t -> Sing (Apply Foo14Sym0 t :: (Nat, Nat))
     sFoo13_ ::
-      forall (t :: a). Sing t -> Sing (Apply Foo13_Sym0 t :: a)
-    sFoo13 :: forall (t :: a). Sing t -> Sing (Apply Foo13Sym0 t :: a)
+      forall a (t :: a). Sing t -> Sing (Apply Foo13_Sym0 t :: a)
+    sFoo13 ::
+      forall a (t :: a). Sing t -> Sing (Apply Foo13Sym0 t :: a)
     sFoo12 ::
       forall (t :: Nat). Sing t -> Sing (Apply Foo12Sym0 t :: Nat)
     sFoo11 ::

--- a/tests/compile-and-dump/Singletons/Maybe.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Maybe.ghc84.template
@@ -59,7 +59,7 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
     data instance Sing (z :: Maybe a)
       where
         SNothing :: Sing Nothing
-        SJust :: forall (n :: a). (Sing (n :: a)) -> Sing (Just n)
+        SJust :: forall a (n :: a). (Sing (n :: a)) -> Sing (Just n)
     type SMaybe = (Sing :: Maybe a -> GHC.Types.Type)
     instance SingKind a => SingKind (Maybe a) where
       type Demote (Maybe a) = Maybe (Demote a)

--- a/tests/compile-and-dump/Singletons/OrdDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/OrdDeriving.ghc84.template
@@ -329,27 +329,27 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
             SomeSing c -> SomeSing (SSucc c) }
     data instance Sing (z :: Foo a b c d)
       where
-        SA :: forall (n :: a) (n :: b) (n :: c) (n :: d).
+        SA :: forall a b c d (n :: a) (n :: b) (n :: c) (n :: d).
               (Sing (n :: a))
               -> (Sing (n :: b))
                  -> (Sing (n :: c)) -> (Sing (n :: d)) -> Sing (A n n n n)
-        SB :: forall (n :: a) (n :: b) (n :: c) (n :: d).
+        SB :: forall a b c d (n :: a) (n :: b) (n :: c) (n :: d).
               (Sing (n :: a))
               -> (Sing (n :: b))
                  -> (Sing (n :: c)) -> (Sing (n :: d)) -> Sing (B n n n n)
-        SC :: forall (n :: a) (n :: b) (n :: c) (n :: d).
+        SC :: forall a b c d (n :: a) (n :: b) (n :: c) (n :: d).
               (Sing (n :: a))
               -> (Sing (n :: b))
                  -> (Sing (n :: c)) -> (Sing (n :: d)) -> Sing (C n n n n)
-        SD :: forall (n :: a) (n :: b) (n :: c) (n :: d).
+        SD :: forall a b c d (n :: a) (n :: b) (n :: c) (n :: d).
               (Sing (n :: a))
               -> (Sing (n :: b))
                  -> (Sing (n :: c)) -> (Sing (n :: d)) -> Sing (D n n n n)
-        SE :: forall (n :: a) (n :: b) (n :: c) (n :: d).
+        SE :: forall a b c d (n :: a) (n :: b) (n :: c) (n :: d).
               (Sing (n :: a))
               -> (Sing (n :: b))
                  -> (Sing (n :: c)) -> (Sing (n :: d)) -> Sing (E n n n n)
-        SF :: forall (n :: a) (n :: b) (n :: c) (n :: d).
+        SF :: forall a b c d (n :: a) (n :: b) (n :: c) (n :: d).
               (Sing (n :: a))
               -> (Sing (n :: b))
                  -> (Sing (n :: c)) -> (Sing (n :: d)) -> Sing (F n n n n)

--- a/tests/compile-and-dump/Singletons/PatternMatching.ghc84.template
+++ b/tests/compile-and-dump/Singletons/PatternMatching.ghc84.template
@@ -111,7 +111,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
           ((applySing ((applySing ((singFun2 @(:@#@$)) SCons)) SZero)) SNil)
     data instance Sing (z :: Pair a b)
       where
-        SPair :: forall (n :: a) (n :: b).
+        SPair :: forall a b (n :: a) (n :: b).
                  (Sing (n :: a)) -> (Sing (n :: b)) -> Sing (Pair n n)
     type SPair = (Sing :: Pair a b -> GHC.Types.Type)
     instance (SingKind a, SingKind b) => SingKind (Pair a b) where
@@ -424,11 +424,12 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
       X_0123456789876543210 = TupleSym0
     type family X_0123456789876543210 where
       X_0123456789876543210 = AListSym0
-    sSilly :: forall (t :: a). Sing t -> Sing (Apply SillySym0 t :: ())
+    sSilly ::
+      forall a (t :: a). Sing t -> Sing (Apply SillySym0 t :: ())
     sFoo2 ::
-      forall (t :: (a, b)). Sing t -> Sing (Apply Foo2Sym0 t :: a)
+      forall a b (t :: (a, b)). Sing t -> Sing (Apply Foo2Sym0 t :: a)
     sFoo1 ::
-      forall (t :: (a, b)). Sing t -> Sing (Apply Foo1Sym0 t :: a)
+      forall a b (t :: (a, b)). Sing t -> Sing (Apply Foo1Sym0 t :: a)
     sLsz :: Sing (LszSym0 :: Nat)
     sBlimy :: Sing BlimySym0
     sTf :: Sing TfSym0

--- a/tests/compile-and-dump/Singletons/Records.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Records.ghc84.template
@@ -41,7 +41,7 @@ Singletons/Records.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply MkRecordSym0 l = MkRecordSym1 l
     data instance Sing (z :: Record a)
       where
-        SMkRecord :: forall (n :: a) (n :: Bool).
+        SMkRecord :: forall a (n :: a) (n :: Bool).
                      {sField1 :: (Sing (n :: a)), sField2 :: (Sing (n :: Bool))}
                      -> Sing (MkRecord n n)
     type SRecord = (Sing :: Record a -> GHC.Types.Type)

--- a/tests/compile-and-dump/Singletons/ReturnFunc.ghc84.template
+++ b/tests/compile-and-dump/Singletons/ReturnFunc.ghc84.template
@@ -58,9 +58,9 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
       IdFoo _ a_0123456789876543210 = Apply IdSym0 a_0123456789876543210
     type family ReturnFunc (a :: Nat) (a :: Nat) :: Nat where
       ReturnFunc _ a_0123456789876543210 = Apply SuccSym0 a_0123456789876543210
-    sId :: forall (t :: a). Sing t -> Sing (Apply IdSym0 t :: a)
+    sId :: forall a (t :: a). Sing t -> Sing (Apply IdSym0 t :: a)
     sIdFoo ::
-      forall (t :: c) (t :: a).
+      forall c a (t :: c) (t :: a).
       Sing t -> Sing t -> Sing (Apply (Apply IdFooSym0 t) t :: a)
     sReturnFunc ::
       forall (t :: Nat) (t :: Nat).

--- a/tests/compile-and-dump/Singletons/ShowDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/ShowDeriving.ghc84.template
@@ -237,13 +237,13 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
       toSing MkFoo1 = SomeSing SMkFoo1
     data instance Sing (z :: Foo2 a)
       where
-        SMkFoo2a :: forall (n :: a) (n :: a).
+        SMkFoo2a :: forall a (n :: a) (n :: a).
                     (Sing (n :: a)) -> (Sing (n :: a)) -> Sing (MkFoo2a n n)
-        SMkFoo2b :: forall (n :: a) (n :: a).
+        SMkFoo2b :: forall a (n :: a) (n :: a).
                     (Sing (n :: a)) -> (Sing (n :: a)) -> Sing (MkFoo2b n n)
-        (:%*:) :: forall (n :: a) (n :: a).
+        (:%*:) :: forall a (n :: a) (n :: a).
                   (Sing (n :: a)) -> (Sing (n :: a)) -> Sing ((:*:) n n)
-        (:%&:) :: forall (n :: a) (n :: a).
+        (:%&:) :: forall a (n :: a) (n :: a).
                   (Sing (n :: a)) -> (Sing (n :: a)) -> Sing ((:&:) n n)
     type SFoo2 = (Sing :: Foo2 a -> GHC.Types.Type)
     instance SingKind a => SingKind (Foo2 a) where

--- a/tests/compile-and-dump/Singletons/StandaloneDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/StandaloneDeriving.ghc84.template
@@ -222,7 +222,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
     infixl 6 :%*:
     data instance Sing (z :: T a b)
       where
-        (:%*:) :: forall (n :: a) (n :: b).
+        (:%*:) :: forall a b (n :: a) (n :: b).
                   (Sing (n :: a)) -> (Sing (n :: b)) -> Sing ((:*:) n n)
     type ST = (Sing :: T a b -> GHC.Types.Type)
     instance (SingKind a, SingKind b) => SingKind (T a b) where

--- a/tests/compile-and-dump/Singletons/T163.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T163.ghc84.template
@@ -20,8 +20,8 @@ Singletons/T163.hs:0:0:: Splicing declarations
     type instance Apply RSym0 l = R l
     data instance Sing (z :: (+) a b)
       where
-        SL :: forall (n :: a). (Sing (n :: a)) -> Sing (L n)
-        SR :: forall (n :: b). (Sing (n :: b)) -> Sing (R n)
+        SL :: forall a (n :: a). (Sing (n :: a)) -> Sing (L n)
+        SR :: forall b (n :: b). (Sing (n :: b)) -> Sing (R n)
     type %+ = (Sing :: (+) a b -> GHC.Types.Type)
     instance (SingKind a, SingKind b) => SingKind ((+) a b) where
       type Demote ((+) a b) = (+) (Demote a) (Demote b)

--- a/tests/compile-and-dump/Singletons/T175.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T175.ghc84.template
@@ -32,7 +32,7 @@ Singletons/T175.hs:(0,0)-(0,0): Splicing declarations
       type Quux1 :: a
       type Quux1 = Quux1_0123456789876543210Sym0
     class PFoo a => PBar2 (a :: GHC.Types.Type)
-    sQuux2 :: SBar2 a => Sing (Quux2Sym0 :: a)
+    sQuux2 :: forall a. SBar2 a => Sing (Quux2Sym0 :: a)
     sQuux2 = sBaz
     class SFoo a where
       sBaz :: Sing (BazSym0 :: a)

--- a/tests/compile-and-dump/Singletons/T176.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T176.ghc84.template
@@ -107,9 +107,11 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
       type Bar2 (arg :: a) (arg :: b) :: b
       type Baz2 :: a
     sQuux2 ::
-      forall (t :: a). SFoo2 a => Sing t -> Sing (Apply Quux2Sym0 t :: a)
+      forall a (t :: a).
+      SFoo2 a => Sing t -> Sing (Apply Quux2Sym0 t :: a)
     sQuux1 ::
-      forall (t :: a). SFoo1 a => Sing t -> Sing (Apply Quux1Sym0 t :: a)
+      forall a (t :: a).
+      SFoo1 a => Sing t -> Sing (Apply Quux1Sym0 t :: a)
     sQuux2 (sX :: Sing x)
       = (applySing ((applySing ((singFun2 @Bar2Sym0) sBar2)) sX)) sBaz2
     sQuux1 (sX :: Sing x)

--- a/tests/compile-and-dump/Singletons/T183.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T183.ghc84.template
@@ -20,7 +20,13 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
           foo7 :: a -> b -> a
           foo7 (x :: a) (_ :: b) = (x :: a)
           foo8 :: forall a. Maybe a -> Maybe a
-          foo8 x@(Just (_ :: a) :: Maybe a) = x |]
+          foo8 x@(Just (_ :: a) :: Maybe a) = x
+          foo9 :: a -> a
+          foo9 (x :: a)
+            = let
+                g :: a -> b -> a
+                g y _ = y
+              in g x () |]
   ======>
     f1 (x :: Maybe Bool) = x :: Maybe Bool
     f2 (x :: Maybe a) = x :: Maybe a
@@ -45,6 +51,43 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
     foo7 (x :: a) (_ :: b) = x :: a
     foo8 :: forall a. Maybe a -> Maybe a
     foo8 x@(Just (_ :: a) :: Maybe a) = x
+    foo9 :: a -> a
+    foo9 (x :: a)
+      = let
+          g :: a -> b -> a
+          g y _ = y
+        in (g x) GHC.Tuple.()
+    type Let0123456789876543210GSym3 t (t :: a) (t :: b0123456789876543210) =
+        Let0123456789876543210G t t t
+    instance SuppressUnusedWarnings Let0123456789876543210GSym2 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Let0123456789876543210GSym2KindInference)
+               GHC.Tuple.())
+    data Let0123456789876543210GSym2 l (l :: a) (l :: TyFun b0123456789876543210 a)
+      = forall arg. SameKind (Apply (Let0123456789876543210GSym2 l l) arg) (Let0123456789876543210GSym3 l l arg) =>
+        Let0123456789876543210GSym2KindInference
+    type instance Apply (Let0123456789876543210GSym2 l l) l = Let0123456789876543210G l l l
+    instance SuppressUnusedWarnings Let0123456789876543210GSym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Let0123456789876543210GSym1KindInference)
+               GHC.Tuple.())
+    data Let0123456789876543210GSym1 l (l :: TyFun a ((~>) b0123456789876543210 a))
+      = forall arg. SameKind (Apply (Let0123456789876543210GSym1 l) arg) (Let0123456789876543210GSym2 l arg) =>
+        Let0123456789876543210GSym1KindInference
+    type instance Apply (Let0123456789876543210GSym1 l) l = Let0123456789876543210GSym2 l l
+    instance SuppressUnusedWarnings Let0123456789876543210GSym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Let0123456789876543210GSym0KindInference)
+               GHC.Tuple.())
+    data Let0123456789876543210GSym0 l
+      = forall arg. SameKind (Apply Let0123456789876543210GSym0 arg) (Let0123456789876543210GSym1 arg) =>
+        Let0123456789876543210GSym0KindInference
+    type instance Apply Let0123456789876543210GSym0 l = Let0123456789876543210GSym1 l
+    type family Let0123456789876543210G x (a :: a) (a :: b) :: a where
+      Let0123456789876543210G x y _ = y
     type Let0123456789876543210XSym1 t = Let0123456789876543210X t
     instance SuppressUnusedWarnings Let0123456789876543210XSym0 where
       suppressUnusedWarnings
@@ -114,6 +157,14 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
       Let0123456789876543210Scrutinee_0123456789876543210 x = Apply JustSym0 x
     type family Case_0123456789876543210 x t where
       Case_0123456789876543210 x (Just y :: Maybe Bool) = (y :: Bool)
+    type Foo9Sym1 (t :: a0123456789876543210) = Foo9 t
+    instance SuppressUnusedWarnings Foo9Sym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) Foo9Sym0KindInference) GHC.Tuple.())
+    data Foo9Sym0 (l :: TyFun a0123456789876543210 a0123456789876543210)
+      = forall arg. SameKind (Apply Foo9Sym0 arg) (Foo9Sym1 arg) =>
+        Foo9Sym0KindInference
+    type instance Apply Foo9Sym0 l = Foo9 l
     type Foo8Sym1 (t :: Maybe a0123456789876543210) = Foo8 t
     instance SuppressUnusedWarnings Foo8Sym0 where
       suppressUnusedWarnings
@@ -220,6 +271,8 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
       = forall arg. SameKind (Apply F1Sym0 arg) (F1Sym1 arg) =>
         F1Sym0KindInference
     type instance Apply F1Sym0 l = F1 l
+    type family Foo9 (a :: a) :: a where
+      Foo9 (x :: a) = Apply (Apply (Let0123456789876543210GSym1 x) x) Tuple0Sym0
     type family Foo8 (a :: Maybe a) :: Maybe a where
       Foo8 (Just (wild_0123456789876543210 :: a) :: Maybe a) = Let0123456789876543210XSym1 wild_0123456789876543210
     type family Foo7 (a :: a) (a :: b) :: a where
@@ -244,29 +297,46 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
       F2 (x :: Maybe a) = (x :: Maybe a)
     type family F1 a where
       F1 (x :: Maybe Bool) = (x :: Maybe Bool)
+    sFoo9 :: forall a (t :: a). Sing t -> Sing (Apply Foo9Sym0 t :: a)
     sFoo8 ::
-      forall (t :: Maybe a). Sing t -> Sing (Apply Foo8Sym0 t :: Maybe a)
+      forall a (t :: Maybe a).
+      Sing t -> Sing (Apply Foo8Sym0 t :: Maybe a)
     sFoo7 ::
-      forall (t :: a) (t :: b).
+      forall a b (t :: a) (t :: b).
       Sing t -> Sing t -> Sing (Apply (Apply Foo7Sym0 t) t :: a)
     sFoo6 ::
-      forall (t :: Maybe (Maybe a)).
+      forall a (t :: Maybe (Maybe a)).
       Sing t -> Sing (Apply Foo6Sym0 t :: Maybe (Maybe a))
     sFoo5 ::
-      forall (t :: Maybe (Maybe a)).
+      forall a (t :: Maybe (Maybe a)).
       Sing t -> Sing (Apply Foo5Sym0 t :: Maybe (Maybe a))
     sFoo4 ::
-      forall (t :: (a, b)). Sing t -> Sing (Apply Foo4Sym0 t :: (b, a))
+      forall a b (t :: (a, b)).
+      Sing t -> Sing (Apply Foo4Sym0 t :: (b, a))
     sFoo3 ::
-      forall (t :: Maybe a). Sing t -> Sing (Apply Foo3Sym0 t :: a)
+      forall a (t :: Maybe a). Sing t -> Sing (Apply Foo3Sym0 t :: a)
     sFoo2 ::
-      forall (t :: Maybe a). Sing t -> Sing (Apply Foo2Sym0 t :: a)
+      forall a (t :: Maybe a). Sing t -> Sing (Apply Foo2Sym0 t :: a)
     sFoo1 ::
-      forall (t :: Maybe a). Sing t -> Sing (Apply Foo1Sym0 t :: a)
+      forall a (t :: Maybe a). Sing t -> Sing (Apply Foo1Sym0 t :: a)
     sG :: forall arg. Sing arg -> Sing (Apply GSym0 arg)
     sF3 :: forall arg. Sing arg -> Sing (Apply F3Sym0 arg)
     sF2 :: forall arg. Sing arg -> Sing (Apply F2Sym0 arg)
     sF1 :: forall arg. Sing arg -> Sing (Apply F1Sym0 arg)
+    sFoo9 (sX :: Sing x)
+      = case sX :: Sing x of {
+          _ :: Sing (x :: a)
+            -> let
+                 sG ::
+                   forall b (t :: a) (t :: b).
+                   Sing t
+                   -> Sing t
+                      -> Sing (Apply (Apply (Let0123456789876543210GSym1 x) t) t :: a)
+                 sG (sY :: Sing y) _ = sY
+               in
+                 (applySing
+                    ((applySing ((singFun2 @(Let0123456789876543210GSym1 x)) sG)) sX))
+                   STuple0 }
     sFoo8
       (SJust (sWild_0123456789876543210 :: Sing wild_0123456789876543210))
       = case

--- a/tests/compile-and-dump/Singletons/T183.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T183.ghc84.template
@@ -1,0 +1,370 @@
+Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
+    singletons
+      [d| f1 (x :: Maybe Bool) = (x :: Maybe Bool)
+          f2 (x :: Maybe a) = (x :: Maybe a)
+          f3 (Just a :: Maybe Bool) = "hi"
+          g x = case Just x of { (Just y :: Maybe Bool) -> (y :: Bool) }
+          foo1 :: Maybe a -> a
+          foo1 (Just x :: Maybe a) = (x :: a)
+          foo2, foo3 :: forall a. Maybe a -> a
+          foo2 (Just x :: Maybe a) = (x :: a)
+          foo3 (Just x) = (x :: a)
+          foo4 :: (a, b) -> (b, a)
+          foo4 = \ (x :: a, y :: b) -> (y :: b, x :: a)
+          foo5, foo6 :: Maybe (Maybe a) -> Maybe (Maybe a)
+          foo5 (Just (Just (x :: a) :: Maybe a) :: Maybe (Maybe a))
+            = Just (Just (x :: a) :: Maybe a) :: Maybe (Maybe a)
+          foo6 (Just x :: Maybe (Maybe a))
+            = case x :: Maybe a of {
+                (Just (y :: a) :: Maybe a) -> Just (Just (y :: a) :: Maybe a) }
+          foo7 :: a -> b -> a
+          foo7 (x :: a) (_ :: b) = (x :: a)
+          foo8 :: forall a. Maybe a -> Maybe a
+          foo8 x@(Just (_ :: a) :: Maybe a) = x |]
+  ======>
+    f1 (x :: Maybe Bool) = x :: Maybe Bool
+    f2 (x :: Maybe a) = x :: Maybe a
+    f3 (Just a :: Maybe Bool) = "hi"
+    g x = case Just x of { Just y :: Maybe Bool -> y :: Bool }
+    foo1 :: Maybe a -> a
+    foo1 (Just x :: Maybe a) = x :: a
+    foo2 :: forall a. Maybe a -> a
+    foo3 :: forall a. Maybe a -> a
+    foo2 (Just x :: Maybe a) = x :: a
+    foo3 (Just x) = x :: a
+    foo4 :: (a, b) -> (b, a)
+    foo4 = \ (x :: a, y :: b) -> (y :: b, x :: a)
+    foo5 :: Maybe (Maybe a) -> Maybe (Maybe a)
+    foo6 :: Maybe (Maybe a) -> Maybe (Maybe a)
+    foo5 (Just (Just (x :: a) :: Maybe a) :: Maybe (Maybe a))
+      = Just (Just (x :: a) :: Maybe a) :: Maybe (Maybe a)
+    foo6 (Just x :: Maybe (Maybe a))
+      = case x :: Maybe a of {
+          Just (y :: a) :: Maybe a -> Just (Just (y :: a) :: Maybe a) }
+    foo7 :: a -> b -> a
+    foo7 (x :: a) (_ :: b) = x :: a
+    foo8 :: forall a. Maybe a -> Maybe a
+    foo8 x@(Just (_ :: a) :: Maybe a) = x
+    type Let0123456789876543210XSym1 t = Let0123456789876543210X t
+    instance SuppressUnusedWarnings Let0123456789876543210XSym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Let0123456789876543210XSym0KindInference)
+               GHC.Tuple.())
+    data Let0123456789876543210XSym0 l
+      = forall arg. SameKind (Apply Let0123456789876543210XSym0 arg) (Let0123456789876543210XSym1 arg) =>
+        Let0123456789876543210XSym0KindInference
+    type instance Apply Let0123456789876543210XSym0 l = Let0123456789876543210X l
+    type family Let0123456789876543210X wild_0123456789876543210 where
+      Let0123456789876543210X wild_0123456789876543210 = (Apply JustSym0 (wild_0123456789876543210 :: a) :: Maybe a)
+    type Let0123456789876543210Scrutinee_0123456789876543210Sym1 t =
+        Let0123456789876543210Scrutinee_0123456789876543210 t
+    instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,)
+                Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data Let0123456789876543210Scrutinee_0123456789876543210Sym0 l
+      = forall arg. SameKind (Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 arg) (Let0123456789876543210Scrutinee_0123456789876543210Sym1 arg) =>
+        Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference
+    type instance Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 l = Let0123456789876543210Scrutinee_0123456789876543210 l
+    type family Let0123456789876543210Scrutinee_0123456789876543210 x where
+      Let0123456789876543210Scrutinee_0123456789876543210 x = (x :: Maybe a)
+    type family Case_0123456789876543210 x t where
+      Case_0123456789876543210 x (Just (y :: a) :: Maybe a) = Apply JustSym0 (Apply JustSym0 (y :: a) :: Maybe a)
+    type family Case_0123456789876543210 arg_0123456789876543210 a_0123456789876543210 t where
+      Case_0123456789876543210 arg_0123456789876543210 a_0123456789876543210 '((x :: a),
+                                                                               (y :: b)) = Apply (Apply Tuple2Sym0 (y :: b)) (x :: a)
+    type family Lambda_0123456789876543210 a_0123456789876543210 t where
+      Lambda_0123456789876543210 a_0123456789876543210 arg_0123456789876543210 = Case_0123456789876543210 arg_0123456789876543210 a_0123456789876543210 arg_0123456789876543210
+    type Lambda_0123456789876543210Sym2 t t =
+        Lambda_0123456789876543210 t t
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym1 l l
+      = forall arg. SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
+        Lambda_0123456789876543210Sym1KindInference
+    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210 l l
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym0 l
+      = forall arg. SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
+        Lambda_0123456789876543210Sym0KindInference
+    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+    type Let0123456789876543210Scrutinee_0123456789876543210Sym1 t =
+        Let0123456789876543210Scrutinee_0123456789876543210 t
+    instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,)
+                Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data Let0123456789876543210Scrutinee_0123456789876543210Sym0 l
+      = forall arg. SameKind (Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 arg) (Let0123456789876543210Scrutinee_0123456789876543210Sym1 arg) =>
+        Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference
+    type instance Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 l = Let0123456789876543210Scrutinee_0123456789876543210 l
+    type family Let0123456789876543210Scrutinee_0123456789876543210 x where
+      Let0123456789876543210Scrutinee_0123456789876543210 x = Apply JustSym0 x
+    type family Case_0123456789876543210 x t where
+      Case_0123456789876543210 x (Just y :: Maybe Bool) = (y :: Bool)
+    type Foo8Sym1 (t :: Maybe a0123456789876543210) = Foo8 t
+    instance SuppressUnusedWarnings Foo8Sym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) Foo8Sym0KindInference) GHC.Tuple.())
+    data Foo8Sym0 (l :: TyFun (Maybe a0123456789876543210) (Maybe a0123456789876543210))
+      = forall arg. SameKind (Apply Foo8Sym0 arg) (Foo8Sym1 arg) =>
+        Foo8Sym0KindInference
+    type instance Apply Foo8Sym0 l = Foo8 l
+    type Foo7Sym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
+        Foo7 t t
+    instance SuppressUnusedWarnings Foo7Sym1 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) Foo7Sym1KindInference) GHC.Tuple.())
+    data Foo7Sym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 a0123456789876543210)
+      = forall arg. SameKind (Apply (Foo7Sym1 l) arg) (Foo7Sym2 l arg) =>
+        Foo7Sym1KindInference
+    type instance Apply (Foo7Sym1 l) l = Foo7 l l
+    instance SuppressUnusedWarnings Foo7Sym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) Foo7Sym0KindInference) GHC.Tuple.())
+    data Foo7Sym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 a0123456789876543210))
+      = forall arg. SameKind (Apply Foo7Sym0 arg) (Foo7Sym1 arg) =>
+        Foo7Sym0KindInference
+    type instance Apply Foo7Sym0 l = Foo7Sym1 l
+    type Foo6Sym1 (t :: Maybe (Maybe a0123456789876543210)) = Foo6 t
+    instance SuppressUnusedWarnings Foo6Sym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) Foo6Sym0KindInference) GHC.Tuple.())
+    data Foo6Sym0 (l :: TyFun (Maybe (Maybe a0123456789876543210)) (Maybe (Maybe a0123456789876543210)))
+      = forall arg. SameKind (Apply Foo6Sym0 arg) (Foo6Sym1 arg) =>
+        Foo6Sym0KindInference
+    type instance Apply Foo6Sym0 l = Foo6 l
+    type Foo5Sym1 (t :: Maybe (Maybe a0123456789876543210)) = Foo5 t
+    instance SuppressUnusedWarnings Foo5Sym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) Foo5Sym0KindInference) GHC.Tuple.())
+    data Foo5Sym0 (l :: TyFun (Maybe (Maybe a0123456789876543210)) (Maybe (Maybe a0123456789876543210)))
+      = forall arg. SameKind (Apply Foo5Sym0 arg) (Foo5Sym1 arg) =>
+        Foo5Sym0KindInference
+    type instance Apply Foo5Sym0 l = Foo5 l
+    type Foo4Sym1 (t :: (a0123456789876543210, b0123456789876543210)) =
+        Foo4 t
+    instance SuppressUnusedWarnings Foo4Sym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) Foo4Sym0KindInference) GHC.Tuple.())
+    data Foo4Sym0 (l :: TyFun (a0123456789876543210,
+                               b0123456789876543210) (b0123456789876543210, a0123456789876543210))
+      = forall arg. SameKind (Apply Foo4Sym0 arg) (Foo4Sym1 arg) =>
+        Foo4Sym0KindInference
+    type instance Apply Foo4Sym0 l = Foo4 l
+    type Foo3Sym1 (t :: Maybe a0123456789876543210) = Foo3 t
+    instance SuppressUnusedWarnings Foo3Sym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) Foo3Sym0KindInference) GHC.Tuple.())
+    data Foo3Sym0 (l :: TyFun (Maybe a0123456789876543210) a0123456789876543210)
+      = forall arg. SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
+        Foo3Sym0KindInference
+    type instance Apply Foo3Sym0 l = Foo3 l
+    type Foo2Sym1 (t :: Maybe a0123456789876543210) = Foo2 t
+    instance SuppressUnusedWarnings Foo2Sym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) Foo2Sym0KindInference) GHC.Tuple.())
+    data Foo2Sym0 (l :: TyFun (Maybe a0123456789876543210) a0123456789876543210)
+      = forall arg. SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) =>
+        Foo2Sym0KindInference
+    type instance Apply Foo2Sym0 l = Foo2 l
+    type Foo1Sym1 (t :: Maybe a0123456789876543210) = Foo1 t
+    instance SuppressUnusedWarnings Foo1Sym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) Foo1Sym0KindInference) GHC.Tuple.())
+    data Foo1Sym0 (l :: TyFun (Maybe a0123456789876543210) a0123456789876543210)
+      = forall arg. SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
+        Foo1Sym0KindInference
+    type instance Apply Foo1Sym0 l = Foo1 l
+    type GSym1 t = G t
+    instance SuppressUnusedWarnings GSym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) GSym0KindInference) GHC.Tuple.())
+    data GSym0 l
+      = forall arg. SameKind (Apply GSym0 arg) (GSym1 arg) =>
+        GSym0KindInference
+    type instance Apply GSym0 l = G l
+    type F3Sym1 t = F3 t
+    instance SuppressUnusedWarnings F3Sym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) F3Sym0KindInference) GHC.Tuple.())
+    data F3Sym0 l
+      = forall arg. SameKind (Apply F3Sym0 arg) (F3Sym1 arg) =>
+        F3Sym0KindInference
+    type instance Apply F3Sym0 l = F3 l
+    type F2Sym1 t = F2 t
+    instance SuppressUnusedWarnings F2Sym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) F2Sym0KindInference) GHC.Tuple.())
+    data F2Sym0 l
+      = forall arg. SameKind (Apply F2Sym0 arg) (F2Sym1 arg) =>
+        F2Sym0KindInference
+    type instance Apply F2Sym0 l = F2 l
+    type F1Sym1 t = F1 t
+    instance SuppressUnusedWarnings F1Sym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) F1Sym0KindInference) GHC.Tuple.())
+    data F1Sym0 l
+      = forall arg. SameKind (Apply F1Sym0 arg) (F1Sym1 arg) =>
+        F1Sym0KindInference
+    type instance Apply F1Sym0 l = F1 l
+    type family Foo8 (a :: Maybe a) :: Maybe a where
+      Foo8 (Just (wild_0123456789876543210 :: a) :: Maybe a) = Let0123456789876543210XSym1 wild_0123456789876543210
+    type family Foo7 (a :: a) (a :: b) :: a where
+      Foo7 (x :: a) (wild_0123456789876543210 :: b) = (x :: a)
+    type family Foo6 (a :: Maybe (Maybe a)) :: Maybe (Maybe a) where
+      Foo6 (Just x :: Maybe (Maybe a)) = Case_0123456789876543210 x (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x)
+    type family Foo5 (a :: Maybe (Maybe a)) :: Maybe (Maybe a) where
+      Foo5 (Just (Just (x :: a) :: Maybe a) :: Maybe (Maybe a)) = (Apply JustSym0 (Apply JustSym0 (x :: a) :: Maybe a) :: Maybe (Maybe a))
+    type family Foo4 (a :: (a, b)) :: (b, a) where
+      Foo4 a_0123456789876543210 = Apply (Apply Lambda_0123456789876543210Sym0 a_0123456789876543210) a_0123456789876543210
+    type family Foo3 (a :: Maybe a) :: a where
+      Foo3 (Just x) = (x :: a)
+    type family Foo2 (a :: Maybe a) :: a where
+      Foo2 (Just x :: Maybe a) = (x :: a)
+    type family Foo1 (a :: Maybe a) :: a where
+      Foo1 (Just x :: Maybe a) = (x :: a)
+    type family G a where
+      G x = Case_0123456789876543210 x (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x)
+    type family F3 a where
+      F3 (Just a :: Maybe Bool) = "hi"
+    type family F2 a where
+      F2 (x :: Maybe a) = (x :: Maybe a)
+    type family F1 a where
+      F1 (x :: Maybe Bool) = (x :: Maybe Bool)
+    sFoo8 ::
+      forall (t :: Maybe a). Sing t -> Sing (Apply Foo8Sym0 t :: Maybe a)
+    sFoo7 ::
+      forall (t :: a) (t :: b).
+      Sing t -> Sing t -> Sing (Apply (Apply Foo7Sym0 t) t :: a)
+    sFoo6 ::
+      forall (t :: Maybe (Maybe a)).
+      Sing t -> Sing (Apply Foo6Sym0 t :: Maybe (Maybe a))
+    sFoo5 ::
+      forall (t :: Maybe (Maybe a)).
+      Sing t -> Sing (Apply Foo5Sym0 t :: Maybe (Maybe a))
+    sFoo4 ::
+      forall (t :: (a, b)). Sing t -> Sing (Apply Foo4Sym0 t :: (b, a))
+    sFoo3 ::
+      forall (t :: Maybe a). Sing t -> Sing (Apply Foo3Sym0 t :: a)
+    sFoo2 ::
+      forall (t :: Maybe a). Sing t -> Sing (Apply Foo2Sym0 t :: a)
+    sFoo1 ::
+      forall (t :: Maybe a). Sing t -> Sing (Apply Foo1Sym0 t :: a)
+    sG :: forall arg. Sing arg -> Sing (Apply GSym0 arg)
+    sF3 :: forall arg. Sing arg -> Sing (Apply F3Sym0 arg)
+    sF2 :: forall arg. Sing arg -> Sing (Apply F2Sym0 arg)
+    sF1 :: forall arg. Sing arg -> Sing (Apply F1Sym0 arg)
+    sFoo8
+      (SJust (sWild_0123456789876543210 :: Sing wild_0123456789876543210))
+      = case
+            (GHC.Tuple.(,)
+               (sWild_0123456789876543210 :: Sing wild_0123456789876543210))
+              (SJust
+                 (sWild_0123456789876543210 :: Sing wild_0123456789876543210))
+        of {
+          GHC.Tuple.(,) (_ :: Sing (wild_0123456789876543210 :: a))
+                        (_ :: Sing (Just (wild_0123456789876543210 :: a) :: Maybe a))
+            -> let
+                 sX :: Sing (Let0123456789876543210XSym1 wild_0123456789876543210)
+                 sX
+                   = (applySing ((singFun1 @JustSym0) SJust))
+                       (sWild_0123456789876543210 ::
+                          Sing (wild_0123456789876543210 :: a)) ::
+                       Sing (Apply JustSym0 (wild_0123456789876543210 :: a) :: Maybe a)
+               in sX }
+    sFoo7
+      (sX :: Sing x)
+      (sWild_0123456789876543210 :: Sing wild_0123456789876543210)
+      = case
+            (GHC.Tuple.(,) (sX :: Sing x))
+              (sWild_0123456789876543210 :: Sing wild_0123456789876543210)
+        of {
+          GHC.Tuple.(,) (_ :: Sing (x :: a))
+                        (_ :: Sing (wild_0123456789876543210 :: b))
+            -> sX :: Sing (x :: a) }
+    sFoo6 (SJust (sX :: Sing x))
+      = case SJust (sX :: Sing x) of {
+          _ :: Sing (Just x :: Maybe (Maybe a))
+            -> let
+                 sScrutinee_0123456789876543210 ::
+                   Sing (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x)
+                 sScrutinee_0123456789876543210 = sX :: Sing (x :: Maybe a)
+               in  case sScrutinee_0123456789876543210 of {
+                     SJust (sY :: Sing y)
+                       -> case (GHC.Tuple.(,) (sY :: Sing y)) (SJust (sY :: Sing y)) of {
+                            GHC.Tuple.(,) (_ :: Sing (y :: a))
+                                          (_ :: Sing (Just (y :: a) :: Maybe a))
+                              -> (applySing ((singFun1 @JustSym0) SJust))
+                                   ((applySing ((singFun1 @JustSym0) SJust))
+                                      (sY :: Sing (y :: a)) ::
+                                      Sing (Apply JustSym0 (y :: a) :: Maybe a)) } } ::
+                     Sing (Case_0123456789876543210 x (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x) :: Maybe (Maybe a)) }
+    sFoo5 (SJust (SJust (sX :: Sing x)))
+      = case
+            ((GHC.Tuple.(,,) (sX :: Sing x)) (SJust (sX :: Sing x)))
+              (SJust (SJust (sX :: Sing x)))
+        of {
+          GHC.Tuple.(,,) (_ :: Sing (x :: a))
+                         (_ :: Sing (Just (x :: a) :: Maybe a))
+                         (_ :: Sing (Just (Just (x :: a) :: Maybe a) :: Maybe (Maybe a)))
+            -> (applySing ((singFun1 @JustSym0) SJust))
+                 ((applySing ((singFun1 @JustSym0) SJust)) (sX :: Sing (x :: a)) ::
+                    Sing (Apply JustSym0 (x :: a) :: Maybe a)) ::
+                 Sing (Apply JustSym0 (Apply JustSym0 (x :: a) :: Maybe a) :: Maybe (Maybe a)) }
+    sFoo4 (sA_0123456789876543210 :: Sing a_0123456789876543210)
+      = (applySing
+           ((singFun1
+               @(Apply Lambda_0123456789876543210Sym0 a_0123456789876543210))
+              (\ sArg_0123456789876543210
+                 -> case sArg_0123456789876543210 of {
+                      _ :: Sing arg_0123456789876543210
+                        -> case sArg_0123456789876543210 of {
+                             STuple2 (sX :: Sing x) (sY :: Sing y)
+                               -> case (GHC.Tuple.(,) (sX :: Sing x)) (sY :: Sing y) of {
+                                    GHC.Tuple.(,) (_ :: Sing (x :: a)) (_ :: Sing (y :: b))
+                                      -> (applySing
+                                            ((applySing ((singFun2 @Tuple2Sym0) STuple2))
+                                               (sY :: Sing (y :: b))))
+                                           (sX :: Sing (x :: a)) } } ::
+                             Sing (Case_0123456789876543210 arg_0123456789876543210 a_0123456789876543210 arg_0123456789876543210) })))
+          sA_0123456789876543210
+    sFoo3 (SJust (sX :: Sing x)) = sX :: Sing (x :: a)
+    sFoo2 (SJust (sX :: Sing x))
+      = case SJust (sX :: Sing x) of {
+          _ :: Sing (Just x :: Maybe a) -> sX :: Sing (x :: a) }
+    sFoo1 (SJust (sX :: Sing x))
+      = case SJust (sX :: Sing x) of {
+          _ :: Sing (Just x :: Maybe a) -> sX :: Sing (x :: a) }
+    sG (sX :: Sing x)
+      = let
+          sScrutinee_0123456789876543210 ::
+            Sing (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x)
+          sScrutinee_0123456789876543210
+            = (applySing ((singFun1 @JustSym0) SJust)) sX
+        in  case sScrutinee_0123456789876543210 of {
+              SJust (sY :: Sing y)
+                -> case SJust (sY :: Sing y) of {
+                     _ :: Sing (Just y :: Maybe Bool) -> sY :: Sing (y :: Bool) } } ::
+              Sing (Case_0123456789876543210 x (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x))
+    sF3 (SJust (sA :: Sing a))
+      = case SJust (sA :: Sing a) of {
+          _ :: Sing (Just a :: Maybe Bool) -> sing :: Sing "hi" }
+    sF2 (sX :: Sing x)
+      = case sX :: Sing x of {
+          _ :: Sing (x :: Maybe a) -> sX :: Sing (x :: Maybe a) }
+    sF1 (sX :: Sing x)
+      = case sX :: Sing x of {
+          _ :: Sing (x :: Maybe Bool) -> sX :: Sing (x :: Maybe Bool) }

--- a/tests/compile-and-dump/Singletons/T183.hs
+++ b/tests/compile-and-dump/Singletons/T183.hs
@@ -1,0 +1,55 @@
+module T183 where
+
+import Data.Singletons.Prelude
+import Data.Singletons.TH
+
+$(singletons [d|
+  -----
+  -- Examples from #183
+  -----
+
+  f1 (x :: Maybe Bool) = (x :: Maybe Bool)
+  f2 (x :: Maybe a) = (x :: Maybe a)
+  f3 (Just a :: Maybe Bool) = "hi"
+
+  g x = case Just x of
+    (Just y :: Maybe Bool) -> (y :: Bool)
+
+  -----
+  -- Using explicit type signatures
+  -----
+
+  -- No explicit forall
+  foo1 :: Maybe a -> a
+  foo1 (Just x :: Maybe a) = (x :: a)
+
+  -- Explicit forall
+  foo2, foo3 :: forall a. Maybe a -> a
+  foo2 (Just x :: Maybe a) = (x :: a)
+  foo3 (Just x) = (x :: a)
+
+  -----
+  -- Multiple pattern signatures
+  -----
+
+  foo4 :: (a, b) -> (b, a)
+  foo4 = \(x :: a, y :: b) -> (y :: b, x :: a)
+
+  foo5, foo6 :: Maybe (Maybe a) -> Maybe (Maybe a)
+  foo5 (Just (Just (x :: a) :: Maybe a) :: Maybe (Maybe a))
+      = Just (Just (x :: a) :: Maybe a) :: Maybe (Maybe a)
+  foo6 (Just x :: Maybe (Maybe a))
+      = case x :: Maybe a of
+          (Just (y :: a) :: Maybe a) -> Just (Just (y :: a) :: Maybe a)
+
+  -----
+  -- Other pattern features
+  -----
+
+  foo7 :: a -> b -> a
+  foo7 (x :: a) (_ :: b) = (x :: a)
+
+  foo8 :: forall a. Maybe a -> Maybe a
+  foo8 x@(Just (_ :: a) :: Maybe a) = x
+  -- foo8 x@(Nothing :: Maybe a)       = x
+  |])

--- a/tests/compile-and-dump/Singletons/T183.hs
+++ b/tests/compile-and-dump/Singletons/T183.hs
@@ -51,5 +51,15 @@ $(singletons [d|
 
   foo8 :: forall a. Maybe a -> Maybe a
   foo8 x@(Just (_ :: a) :: Maybe a) = x
-  -- foo8 x@(Nothing :: Maybe a)       = x
+  -- foo8 x@(Nothing :: Maybe a)       = x -- #296
+
+  -----
+  -- Type variable scoping (vis-à-vis #297)
+  -----
+
+  foo9 :: a -> a
+  foo9 (x :: a)
+    = let g :: a -> b -> a
+          g y _ = y
+      in g x ()
   |])

--- a/tests/compile-and-dump/Singletons/T197b.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T197b.ghc84.template
@@ -45,7 +45,7 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
     infixr 9 `SPair`
     data instance Sing (z :: (:*:) a b)
       where
-        (:%*:) :: forall (n :: a) (n :: b).
+        (:%*:) :: forall a b (n :: a) (n :: b).
                   (Sing (n :: a)) -> (Sing (n :: b)) -> Sing ((:*:) n n)
     type %:*: = (Sing :: (:*:) a b -> GHC.Types.Type)
     instance (SingKind a, SingKind b) => SingKind ((:*:) a b) where
@@ -59,7 +59,7 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
               -> SomeSing (((:%*:) c) c) }
     data instance Sing (z :: Pair a b)
       where
-        SMkPair :: forall (n :: a) (n :: b).
+        SMkPair :: forall a b (n :: a) (n :: b).
                    (Sing (n :: a)) -> (Sing (n :: b)) -> Sing (MkPair n n)
     type SPair = (Sing :: Pair a b -> GHC.Types.Type)
     instance (SingKind a, SingKind b) => SingKind (Pair a b) where

--- a/tests/compile-and-dump/Singletons/T209.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T209.ghc84.template
@@ -47,7 +47,7 @@ Singletons/T209.hs:(0,0)-(0,0): Splicing declarations
     instance PC Bool Hm
     instance PC a (Maybe a)
     sM ::
-      forall (t :: a) (t :: b) (t :: Bool).
+      forall a b (t :: a) (t :: b) (t :: Bool).
       Sing t
       -> Sing t
          -> Sing t -> Sing (Apply (Apply (Apply MSym0 t) t) t :: Bool)

--- a/tests/compile-and-dump/Singletons/T249.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T249.ghc84.template
@@ -33,7 +33,7 @@ Singletons/T249.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply MkFoo3Sym0 l = MkFoo3 l
     data instance Sing (z :: Foo1 a)
       where
-        SMkFoo1 :: forall (n :: a). (Sing (n :: a)) -> Sing (MkFoo1 n)
+        SMkFoo1 :: forall a (n :: a). (Sing (n :: a)) -> Sing (MkFoo1 n)
     type SFoo1 = (Sing :: Foo1 a -> Type)
     instance SingKind a => SingKind (Foo1 a) where
       type Demote (Foo1 a) = Foo1 (Demote a)
@@ -43,7 +43,7 @@ Singletons/T249.hs:(0,0)-(0,0): Splicing declarations
             SomeSing c -> SomeSing (SMkFoo1 c) }
     data instance Sing (z :: Foo2 a)
       where
-        SMkFoo2 :: forall (n :: x). (Sing (n :: x)) -> Sing (MkFoo2 n)
+        SMkFoo2 :: forall x (n :: x). (Sing (n :: x)) -> Sing (MkFoo2 n)
     type SFoo2 = (Sing :: Foo2 a -> Type)
     instance SingKind a => SingKind (Foo2 a) where
       type Demote (Foo2 a) = Foo2 (Demote a)
@@ -53,7 +53,7 @@ Singletons/T249.hs:(0,0)-(0,0): Splicing declarations
             SomeSing c -> SomeSing (SMkFoo2 c) }
     data instance Sing (z :: Foo3 a)
       where
-        SMkFoo3 :: forall (n :: x). (Sing (n :: x)) -> Sing (MkFoo3 n)
+        SMkFoo3 :: forall x (n :: x). (Sing (n :: x)) -> Sing (MkFoo3 n)
     type SFoo3 = (Sing :: Foo3 a -> Type)
     instance SingKind a => SingKind (Foo3 a) where
       type Demote (Foo3 a) = Foo3 (Demote a)

--- a/tests/compile-and-dump/Singletons/T271.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T271.ghc84.template
@@ -89,7 +89,8 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
       type (==) a b = Equals_0123456789876543210 a b
     data instance Sing (z :: Constant a b)
       where
-        SConstant :: forall (n :: a). (Sing (n :: a)) -> Sing (Constant n)
+        SConstant :: forall a (n :: a).
+                     (Sing (n :: a)) -> Sing (Constant n)
     type SConstant = (Sing :: Constant a b -> Type)
     instance (SingKind a, SingKind b) => SingKind (Constant a b) where
       type Demote (Constant a b) = Constant (Demote a) (Demote b)
@@ -99,7 +100,8 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
             SomeSing c -> SomeSing (SConstant c) }
     data instance Sing (z :: Identity a)
       where
-        SIdentity :: forall (n :: a). (Sing (n :: a)) -> Sing (Identity n)
+        SIdentity :: forall a (n :: a).
+                     (Sing (n :: a)) -> Sing (Identity n)
     type SIdentity = (Sing :: Identity a -> Type)
     instance SingKind a => SingKind (Identity a) where
       type Demote (Identity a) = Identity (Demote a)

--- a/tests/compile-and-dump/Singletons/T297.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T297.ghc84.template
@@ -1,0 +1,55 @@
+Singletons/T297.hs:(0,0)-(0,0): Splicing declarations
+    singletons
+      [d| f MyProxy
+            = let
+                x = let
+                      z :: MyProxy a
+                      z = MyProxy
+                    in z
+              in x
+          
+          data MyProxy (a :: Type) = MyProxy |]
+  ======>
+    data MyProxy (a :: Type) = MyProxy
+    f MyProxy
+      = let
+          x = let
+                z :: MyProxy a
+                z = MyProxy
+              in z
+        in x
+    type MyProxySym0 = MyProxy
+    type Let0123456789876543210ZSym0 = Let0123456789876543210Z
+    type family Let0123456789876543210Z :: MyProxy a where
+      Let0123456789876543210Z = MyProxySym0
+    type Let0123456789876543210XSym0 = Let0123456789876543210X
+    type family Let0123456789876543210X where
+      Let0123456789876543210X = Let0123456789876543210ZSym0
+    type FSym1 t = F t
+    instance SuppressUnusedWarnings FSym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) FSym0KindInference) GHC.Tuple.())
+    data FSym0 l
+      = forall arg. SameKind (Apply FSym0 arg) (FSym1 arg) =>
+        FSym0KindInference
+    type instance Apply FSym0 l = F l
+    type family F a where
+      F MyProxy = Let0123456789876543210XSym0
+    sF :: forall arg. Sing arg -> Sing (Apply FSym0 arg)
+    sF SMyProxy
+      = let
+          sX :: Sing Let0123456789876543210XSym0
+          sX
+            = let
+                sZ :: forall a. Sing (Let0123456789876543210ZSym0 :: MyProxy a)
+                sZ = SMyProxy
+              in sZ
+        in sX
+    data instance Sing (z :: MyProxy a) where SMyProxy :: Sing MyProxy
+    type SMyProxy = (Sing :: MyProxy a -> Type)
+    instance SingKind a => SingKind (MyProxy a) where
+      type Demote (MyProxy a) = MyProxy (Demote a)
+      fromSing SMyProxy = MyProxy
+      toSing MyProxy = SomeSing SMyProxy
+    instance SingI MyProxy where
+      sing = SMyProxy

--- a/tests/compile-and-dump/Singletons/T297.hs
+++ b/tests/compile-and-dump/Singletons/T297.hs
@@ -1,0 +1,13 @@
+module T297 where
+
+import Data.Kind
+import Data.Singletons.TH
+
+$(singletons [d|
+  data MyProxy (a :: Type) = MyProxy
+
+  f MyProxy =
+    let x = let z :: MyProxy a -- When singled, this `a` should be explicitly quantified
+                z = MyProxy in z
+    in x
+  |])

--- a/tests/compile-and-dump/Singletons/TopLevelPatterns.ghc84.template
+++ b/tests/compile-and-dump/Singletons/TopLevelPatterns.ghc84.template
@@ -212,7 +212,7 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
     sFalse_ :: Sing False_Sym0
     sNot ::
       forall (t :: Bool). Sing t -> Sing (Apply NotSym0 t :: Bool)
-    sId :: forall (t :: a). Sing t -> Sing (Apply IdSym0 t :: a)
+    sId :: forall a (t :: a). Sing t -> Sing (Apply IdSym0 t :: a)
     sF :: forall (t :: Bool). Sing t -> Sing (Apply FSym0 t :: Bool)
     sG :: forall (t :: Bool). Sing t -> Sing (Apply GSym0 t :: Bool)
     sH :: forall (t :: Bool). Sing t -> Sing (Apply HSym0 t :: Bool)


### PR DESCRIPTION
See `Note [Explicitly binding kind variables]`. In summary, we now track bound kind variables in `PrEnv`, and stash the set of bound kind variables in scope in each `ALetDecEnv`, and use this information when determining which kind variables to explicitly quantify during singling.

This PR supersedes #298. Unlike #298, this does the bound variable tracking during promotion instead of singling. This results in slightly cleaner code in some cases (except for `singInstD`, but that function was a hot mess to being with) and will hopefully make it simpler to implement a fix for #296 when that becomes unblocked.

This is based on top of #295, to demonstrate the changes needed to `promotePat` in order to bind pattern signatures' kind variables.