### PR TITLE
Fix #160 by introducing Data.Singletons.TypeError

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,9 @@ Changelog for singletons project
 
 * Permit singling of expression and pattern signatures.
 
+* Add `Data.Singletons.TypeError`, which provides a drop-in replacement for
+  `GHC.TypeLits.TypeError` which can be used at both the value- and type-level.
+
 2.4.1
 -----
 * Restore the `TyCon1`, `TyCon2`, etc. types. It turns out that the new

--- a/README.md
+++ b/README.md
@@ -244,6 +244,27 @@ quotes), but implementing this requires pattern-matching on character literals,
 something which is currently impossible at the type level. As a consequence, the
 type-level `Show` instance for `Symbol`s does not do any character escaping.
 
+Errors
+------
+
+The `singletons` library provides two different ways to handle errors:
+
+* The `Error` type family, from `Data.Singletons.TypeLits`:
+
+  ```haskell
+  type family Error (str :: a) :: k where {}
+  ```
+
+  This is simply an empty, closed type family, which means that it will fail
+  to reduce regardless of its input. The typical use case is giving it a
+  `Symbol` as an argument, so that something akin to
+  `Error "This is an error message"` appears in error messages.
+* The `TypeError` type family, from `Data.Singletons.TypeError`. This is a
+  drop-in replacement for `TypeError` from `GHC.TypeLits` which can be used
+  at both the type level and the value level (via the `typeError` function).
+
+  Unlike `Error`, `TypeError` will result in an actual compile-time error
+  message, which may be more desirable depending on the use case.
 
 Pre-defined singletons
 ----------------------

--- a/singletons.cabal
+++ b/singletons.cabal
@@ -55,6 +55,7 @@ library
                       template-haskell,
                       containers >= 0.5,
                       th-desugar >= 1.9 && < 1.10,
+                      pretty,
                       syb >= 0.4,
                       text >= 1.2,
                       transformers >= 0.5.2
@@ -104,6 +105,7 @@ library
                       Data.Promotion.Prelude.Show
                       Data.Promotion.Prelude.Tuple
                       Data.Promotion.Prelude.Void
+                      Data.Singletons.TypeError
                       Data.Singletons.TypeLits
                       Data.Singletons.Decide
                       Data.Singletons.ShowSing

--- a/src/Data/Singletons/TypeError.hs
+++ b/src/Data/Singletons/TypeError.hs
@@ -1,0 +1,154 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeInType #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Singletons.TypeError
+-- Copyright   :  (C) 2018 Ryan Scott
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Defines a drop-in replacement for 'TL.TypeError' (from "GHC.TypeLits")
+-- that can be used at the value level as well. Since this is a drop-in
+-- replacement, it is not recommended to import all of "GHC.TypeLits"
+-- and "Data.Singletons.TypeError" at the same time, as many of the definitons
+-- in the latter deliberately clash with the former.
+--
+----------------------------------------------------------------------------
+module Data.Singletons.TypeError (
+  TypeError, sTypeError, typeError,
+  ErrorMessage'(..), ErrorMessage, PErrorMessage,
+  Sing(SText, SShowType, (:%<>:), (:%$$:)), SErrorMessage,
+  ConvertPErrorMessage, showErrorMessage,
+
+  -- * Defunctionalization symbols
+  TextSym0, TextSym1,
+  ShowTypeSym0, ShowTypeSym1,
+  type (:<>:@#@$), type (:<>:@#@$$), type (:<>:@#@$$$),
+  type (:$$:@#@$), type (:$$:@#@$$), type (:$$:@#@$$$),
+  TypeErrorSym0, TypeErrorSym1
+  ) where
+
+import Data.Kind
+import Data.Singletons.TH
+import qualified Data.Text as Text
+import qualified GHC.TypeLits as TL (ErrorMessage(..), TypeError)
+import GHC.TypeLits hiding (ErrorMessage(..), TypeError)
+import Prelude hiding ((<>))
+import Text.PrettyPrint (Doc, text, (<>), ($$))
+
+-- | A description of a custom type error.
+--
+-- This is a variation on 'TL.ErrorMessage' that is parameterized over what
+-- text type is used in the 'Text' constructor. Instantiating it with
+-- 'Text.Text' gives you 'ErrorMessage', and instantiating it with 'Symbol'
+-- gives you 'PErrorMessage'.
+data ErrorMessage' s
+  = Text s
+    -- ^ Show the text as is.
+  | forall t. ShowType t
+    -- ^ Pretty print the type.
+    -- @ShowType :: k -> ErrorMessage@
+  | ErrorMessage' s :<>: ErrorMessage' s
+    -- ^ Put two pieces of error message next
+    -- to each other.
+  | ErrorMessage' s :$$: ErrorMessage' s
+    -- ^ Stack two pieces of error message on top
+    -- of each other.
+infixl 6 :<>:
+infixl 5 :$$:
+
+-- | A value-level `ErrorMessage'` which uses 'Text.Text' as its text type.
+type ErrorMessage  = ErrorMessage' Text.Text
+
+-- | A type-level `ErrorMessage'` which uses 'Symbol' as its text kind.
+type PErrorMessage = ErrorMessage' Symbol
+
+data instance Sing :: PErrorMessage -> Type where
+  -- It would be lovely to not have to write those (:: PErrorMessage) kind
+  -- ascriptions in the return types of each constructor.
+  -- See Trac #14111.
+  SText     :: Sing t             -> Sing ('Text t      :: PErrorMessage)
+  SShowType :: Sing ty            -> Sing ('ShowType ty :: PErrorMessage)
+  (:%<>:)   :: Sing e1 -> Sing e2 -> Sing (e1 ':<>: e2  :: PErrorMessage)
+  (:%$$:)   :: Sing e1 -> Sing e2 -> Sing (e1 ':$$: e2  :: PErrorMessage)
+infixl 6 :%<>:
+infixl 5 :%$$:
+
+type SErrorMessage = (Sing :: PErrorMessage -> Type)
+
+instance SingKind PErrorMessage where
+  type Demote PErrorMessage = ErrorMessage
+  fromSing (SText t)      = Text (fromSing t)
+  fromSing (SShowType{})  = ShowType (error "Can't single ShowType")
+  fromSing (e1 :%<>: e2)  = fromSing e1 :<>: fromSing e2
+  fromSing (e1 :%$$: e2)  = fromSing e1 :$$: fromSing e2
+  toSing (Text t)     = withSomeSing t  $ SomeSing . SText
+  toSing (ShowType{}) = SomeSing $ SShowType (error "Can't single ShowType")
+  toSing (e1 :<>: e2) = withSomeSing e1 $ \sE1 ->
+                        withSomeSing e2 $ \sE2 ->
+                        SomeSing (sE1 :%<>: sE2)
+  toSing (e1 :$$: e2) = withSomeSing e1 $ \sE1 ->
+                        withSomeSing e2 $ \sE2 ->
+                        SomeSing (sE1 :%$$: sE2)
+
+instance SingI t => SingI ('Text t :: PErrorMessage) where
+  sing = SText sing
+
+instance SingI ty => SingI ('ShowType ty :: PErrorMessage) where
+  sing = SShowType sing
+
+instance (SingI e1, SingI e2) => SingI (e1 ':<>: e2 :: PErrorMessage) where
+  sing = sing :%<>: sing
+
+instance (SingI e1, SingI e2) => SingI (e1 ':$$: e2 :: PErrorMessage) where
+  sing = sing :%$$: sing
+
+-- | Convert an 'ErrorMessage' into a human-readable 'String'.
+showErrorMessage :: ErrorMessage -> String
+showErrorMessage = show . go
+  where
+  go :: ErrorMessage -> Doc
+  go (Text t)     = text (Text.unpack t)
+  go (ShowType _) = text "<type>" -- Not much we can do here
+  go (e1 :<>: e2) = go e1 <> go e2
+  go (e1 :$$: e2) = go e1 $$ go e2
+
+-- | The value-level counterpart to 'TypeError'.
+--
+-- Note that this is not quite as expressive as 'TypeError', as it is unable
+-- to print the contents of 'ShowType' constructors (it will simply print
+-- @\"\<type\>\"@ in their place).
+typeError :: ErrorMessage -> a
+typeError = error . showErrorMessage
+
+-- | Convert a 'PErrorMessage' to a 'TL.ErrorMessage' from "GHC.TypeLits".
+type family ConvertPErrorMessage (a :: PErrorMessage) :: TL.ErrorMessage where
+  ConvertPErrorMessage ('Text t)      = 'TL.Text t
+  ConvertPErrorMessage ('ShowType ty) = 'TL.ShowType ty
+  ConvertPErrorMessage (e1 ':<>: e2)  = ConvertPErrorMessage e1 'TL.:<>: ConvertPErrorMessage e2
+  ConvertPErrorMessage (e1 ':$$: e2)  = ConvertPErrorMessage e1 'TL.:$$: ConvertPErrorMessage e2
+
+-- | A drop-in replacement for 'TL.TypeError'. This also exists at the
+-- value-level as 'typeError'.
+type family TypeError (a :: PErrorMessage) :: b where
+  -- We cannot define this as a type synonym due to Trac #12048.
+  TypeError a = TL.TypeError (ConvertPErrorMessage a)
+
+-- | The singleton for 'typeError'.
+--
+-- Note that this is not quite as expressive as 'TypeError', as it is unable
+-- to handle 'ShowType' constructors at all.
+sTypeError :: Sing err -> Sing (TypeError err)
+sTypeError = typeError . fromSing
+
+$(genDefunSymbols [''ErrorMessage', ''TypeError])

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -63,6 +63,7 @@ tests =
     , compileAndDumpStdTest "T145"
     , compileAndDumpStdTest "PolyKinds"
     , compileAndDumpStdTest "PolyKindsApp"
+    , compileAndDumpStdTest "T160"
     , compileAndDumpStdTest "T163"
     , compileAndDumpStdTest "T166"
     , compileAndDumpStdTest "T172"

--- a/tests/compile-and-dump/Singletons/T160.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T160.ghc84.template
@@ -1,0 +1,60 @@
+Singletons/T160.hs:(0,0)-(0,0): Splicing declarations
+    singletons
+      [d| foo :: (Num a, Eq a) => a -> a
+          foo x = if x == 0 then 1 else typeError $ ShowType x |]
+  ======>
+    foo :: (Num a, Eq a) => a -> a
+    foo x = if (x == 0) then 1 else (typeError $ (ShowType x))
+    type Let0123456789876543210Scrutinee_0123456789876543210Sym1 t =
+        Let0123456789876543210Scrutinee_0123456789876543210 t
+    instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,)
+                Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data Let0123456789876543210Scrutinee_0123456789876543210Sym0 l
+      = forall arg. SameKind (Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 arg) (Let0123456789876543210Scrutinee_0123456789876543210Sym1 arg) =>
+        Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference
+    type instance Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 l = Let0123456789876543210Scrutinee_0123456789876543210 l
+    type family Let0123456789876543210Scrutinee_0123456789876543210 x where
+      Let0123456789876543210Scrutinee_0123456789876543210 x = Apply (Apply (==@#@$) x) (FromInteger 0)
+    type family Case_0123456789876543210 x t where
+      Case_0123456789876543210 x True = FromInteger 1
+      Case_0123456789876543210 x False = Apply (Apply ($@#@$) TypeErrorSym0) (Apply ShowTypeSym0 x)
+    type FooSym1 (t :: a0123456789876543210) = Foo t
+    instance SuppressUnusedWarnings FooSym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) FooSym0KindInference) GHC.Tuple.())
+    data FooSym0 (l :: TyFun a0123456789876543210 a0123456789876543210)
+      = forall arg. SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
+        FooSym0KindInference
+    type instance Apply FooSym0 l = Foo l
+    type family Foo (a :: a) :: a where
+      Foo x = Case_0123456789876543210 x (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x)
+    sFoo ::
+      forall a (t :: a).
+      (SNum a, SEq a) => Sing t -> Sing (Apply FooSym0 t :: a)
+    sFoo (sX :: Sing x)
+      = let
+          sScrutinee_0123456789876543210 ::
+            Sing (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x)
+          sScrutinee_0123456789876543210
+            = (applySing ((applySing ((singFun2 @(==@#@$)) (%==))) sX))
+                (sFromInteger (sing :: Sing 0))
+        in  case sScrutinee_0123456789876543210 of
+              STrue -> sFromInteger (sing :: Sing 1)
+              SFalse
+                -> (applySing
+                      ((applySing ((singFun2 @($@#@$)) (%$)))
+                         ((singFun1 @TypeErrorSym0) sTypeError)))
+                     ((applySing ((singFun1 @ShowTypeSym0) SShowType)) sX) ::
+              Sing (Case_0123456789876543210 x (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x) :: a)
+
+Singletons/T160.hs:0:0: error:
+    • 1
+    • In the expression: Refl
+      In an equation for ‘f’: f = Refl
+   |
+13 | f = Refl
+   |     ^^^^

--- a/tests/compile-and-dump/Singletons/T160.hs
+++ b/tests/compile-and-dump/Singletons/T160.hs
@@ -1,0 +1,13 @@
+module T160 where
+
+import Data.Singletons.Prelude
+import Data.Singletons.TH
+import Data.Singletons.TypeError
+
+$(singletons
+  [d| foo :: (Num a, Eq a) => a -> a
+      foo x = if x == 0 then 1 else typeError $ ShowType x
+    |])
+
+f :: Foo 1 :~: 42
+f = Refl


### PR DESCRIPTION
This introduces `Data.Singletons.TypeError`, which provides a drop-in replacement for the `TypeError` API from `GHC.TypeLits`. This is based off the design in https://github.com/goldfirere/singletons/issues/160#issuecomment-338246486.