### PR TITLE
Generate SingI instances for defunctionalization symbols

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,10 @@ Changelog for singletons project
   Haskell-generated code may require `GADTs` in situations that didn't require
   it before.
 
+* `singletons` now generates `SingI` instances for defunctionalization symbols
+  through Template Haskell. As a result, you may need to enable
+  `FlexibleInstances` in more places.
+
 * Rename `Data.Singletons.TypeRepStar` to `Data.Singletons.TypeRepTYPE`, and
   generalize the `Sing :: Type -> Type` instance to `Sing :: TYPE rep -> Type`,
   allowing it to work over more open kinds. Also rename `SomeTypeRepStar` to

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,11 @@ Changelog for singletons project
   Haskell-generated code may require `GADTs` in situations that didn't require
   it before.
 
+* The kind of the type parameter to `SingI` is no longer specified. This only
+  affects you if you were using the `sing` method with `TypeApplications`. For
+  instance, if you were using `sing @Bool @True` before, then you will now need
+  to now use `sing @Bool` instead.
+
 * `singletons` now generates `SingI` instances for defunctionalization symbols
   through Template Haskell. As a result, you may need to enable
   `FlexibleInstances` in more places.

--- a/singletons.cabal
+++ b/singletons.cabal
@@ -139,6 +139,7 @@ library
                       Data.Singletons.Single.Type
                       Data.Singletons.Single.Eq
                       Data.Singletons.Single.Data
+                      Data.Singletons.Single.Defun
                       Data.Singletons.Single.Fixity
                       Data.Singletons.Single
                       Data.Singletons.TypeLits.Internal

--- a/src/Data/Singletons/Internal.hs
+++ b/src/Data/Singletons/Internal.hs
@@ -51,7 +51,7 @@ data family Sing :: k -> Type
 -- | A 'SingI' constraint is essentially an implicitly-passed singleton.
 -- If you need to satisfy this constraint with an explicit singleton, please
 -- see 'withSingI' or the 'Sing' pattern synonym.
-class SingI (a :: k) where
+class SingI a where
   -- | Produce the singleton explicitly. You will likely need the @ScopedTypeVariables@
   -- extension to use this method the way you want.
   sing :: Sing a
@@ -425,4 +425,4 @@ singByProxy# _ = sing
 -- >>> demote @(Nothing :: Maybe Ordering)
 -- Nothing
 demote :: forall a. (SingKind (KindOf a), SingI a) => Demote (KindOf a)
-demote = fromSing (sing @(KindOf a) @a)
+demote = fromSing (sing @a)

--- a/src/Data/Singletons/Prelude/Bool.hs
+++ b/src/Data/Singletons/Prelude/Bool.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TemplateHaskell, TypeFamilies, TypeInType, TypeOperators,
+{-# LANGUAGE TemplateHaskell, TypeApplications, TypeFamilies, TypeInType, TypeOperators,
              GADTs, ScopedTypeVariables, DeriveDataTypeable, UndecidableInstances #-}
 
 -----------------------------------------------------------------------------
@@ -77,6 +77,10 @@ SFalse %&& _ = SFalse
 STrue  %&& a = a
 infixr 3 %&&
 $(genDefunSymbols [''(&&)])
+instance SingI (&&@#@$) where
+  sing = singFun2 (%&&)
+instance SingI x => SingI ((&&@#@$$) x) where
+  sing = singFun1 (sing @_ @x  %&&)
 
 -- | Disjunction of singletons
 (%||) :: Sing a -> Sing b -> Sing (a || b)
@@ -84,12 +88,18 @@ SFalse %|| a = a
 STrue  %|| _ = STrue
 infixr 2 %||
 $(genDefunSymbols [''(||)])
+instance SingI (||@#@$) where
+  sing = singFun2 (%||)
+instance SingI x => SingI ((||@#@$$) x) where
+  sing = singFun1 (sing @_ @x %||)
 
 -- | Negation of a singleton
 sNot :: Sing a -> Sing (Not a)
 sNot SFalse = STrue
 sNot STrue  = SFalse
 $(genDefunSymbols [''Not])
+instance SingI NotSym0 where
+  sing = singFun1 sNot
 
 -- | Conditional over singletons
 sIf :: Sing a -> Sing b -> Sing c -> Sing (If a b c)

--- a/src/Data/Singletons/Prelude/Bool.hs
+++ b/src/Data/Singletons/Prelude/Bool.hs
@@ -80,7 +80,7 @@ $(genDefunSymbols [''(&&)])
 instance SingI (&&@#@$) where
   sing = singFun2 (%&&)
 instance SingI x => SingI ((&&@#@$$) x) where
-  sing = singFun1 (sing @_ @x  %&&)
+  sing = singFun1 (sing @x %&&)
 
 -- | Disjunction of singletons
 (%||) :: Sing a -> Sing b -> Sing (a || b)
@@ -91,7 +91,7 @@ $(genDefunSymbols [''(||)])
 instance SingI (||@#@$) where
   sing = singFun2 (%||)
 instance SingI x => SingI ((||@#@$$) x) where
-  sing = singFun1 (sing @_ @x %||)
+  sing = singFun1 (sing @x %||)
 
 -- | Negation of a singleton
 sNot :: Sing a -> Sing (Not a)

--- a/src/Data/Singletons/Prelude/Eq.hs
+++ b/src/Data/Singletons/Prelude/Eq.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE TypeOperators, DataKinds, PolyKinds, TypeFamilies, TypeInType,
              RankNTypes, FlexibleContexts, TemplateHaskell,
-             UndecidableInstances, GADTs, DefaultSignatures #-}
+             UndecidableInstances, GADTs, DefaultSignatures,
+             ScopedTypeVariables, TypeApplications #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -21,6 +22,7 @@ module Data.Singletons.Prelude.Eq (
   type (/=@#@$), type (/=@#@$$), type (/=@#@$$$)
   ) where
 
+import Data.Singletons.Internal
 import Data.Singletons.Prelude.Bool
 import Data.Singletons.Single
 import Data.Singletons.Prelude.Instances
@@ -61,3 +63,13 @@ class SEq k where
   infix 4 %/=
 
 $(singEqInstances basicTypes)
+
+instance SEq a => SingI ((==@#@$) :: a ~> a ~> Bool) where
+  sing = singFun2 (%==)
+instance (SEq a, SingI x) => SingI ((==@#@$$) x :: a ~> Bool) where
+  sing = singFun1 (sing @_ @x %==)
+
+instance SEq a => SingI ((/=@#@$) :: a ~> a ~> Bool) where
+  sing = singFun2 (%/=)
+instance (SEq a, SingI x) => SingI ((/=@#@$$) x :: a ~> Bool) where
+  sing = singFun1 (sing @_ @x %/=)

--- a/src/Data/Singletons/Prelude/Eq.hs
+++ b/src/Data/Singletons/Prelude/Eq.hs
@@ -67,9 +67,9 @@ $(singEqInstances basicTypes)
 instance SEq a => SingI ((==@#@$) :: a ~> a ~> Bool) where
   sing = singFun2 (%==)
 instance (SEq a, SingI x) => SingI ((==@#@$$) x :: a ~> Bool) where
-  sing = singFun1 (sing @_ @x %==)
+  sing = singFun1 (sing @x %==)
 
 instance SEq a => SingI ((/=@#@$) :: a ~> a ~> Bool) where
   sing = singFun2 (%/=)
 instance (SEq a, SingI x) => SingI ((/=@#@$$) x :: a ~> Bool) where
-  sing = singFun1 (sing @_ @x %/=)
+  sing = singFun1 (sing @x %/=)

--- a/src/Data/Singletons/Prelude/Ord.hs
+++ b/src/Data/Singletons/Prelude/Ord.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE TemplateHaskell, DataKinds, PolyKinds, ScopedTypeVariables,
              TypeFamilies, TypeOperators, GADTs, UndecidableInstances,
              FlexibleContexts, DefaultSignatures, InstanceSigs, TypeInType,
-             StandaloneDeriving #-}
+             StandaloneDeriving, FlexibleInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -----------------------------------------------------------------------------

--- a/src/Data/Singletons/Single.hs
+++ b/src/Data/Singletons/Single.hs
@@ -531,20 +531,19 @@ singLetDecRHS :: Map Name [Name]
               -> Map Name DKind   -- result kind (might not be known)
               -> Name -> ALetDecRHS -> SgM DLetDec
 singLetDecRHS bound_names cxts res_kis name ld_rhs =
-  bindContext (Map.findWithDefault [] name cxts) $ go ld_rhs
-  where
-    go :: ALetDecRHS -> SgM DLetDec
-    go  (AValue prom num_arrows exp) =
-      DValD (DVarPa (singValName name)) <$>
-      (wrapUnSingFun num_arrows prom <$> singExp exp (Map.lookup name res_kis))
-    go (AFunction prom_fun num_arrows clauses) =
-      let tyvar_names = case Map.lookup name bound_names of
-                          Nothing -> []
-                          Just ns -> ns
-          res_ki = Map.lookup name res_kis
-      in
-      DFunD (singValName name) <$>
-            mapM (singClause prom_fun num_arrows tyvar_names res_ki) clauses
+  bindContext (Map.findWithDefault [] name cxts) $
+    case ld_rhs of
+      AValue prom num_arrows exp ->
+        DValD (DVarPa (singValName name)) <$>
+        (wrapUnSingFun num_arrows prom <$> singExp exp (Map.lookup name res_kis))
+      AFunction prom_fun num_arrows clauses ->
+        let tyvar_names = case Map.lookup name bound_names of
+                            Nothing -> []
+                            Just ns -> ns
+            res_ki = Map.lookup name res_kis
+        in
+        DFunD (singValName name) <$>
+              mapM (singClause prom_fun num_arrows tyvar_names res_ki) clauses
 
 singClause :: DType   -- the promoted function
            -> Int     -- the number of arrows in the type. If this is more

--- a/src/Data/Singletons/Single.hs
+++ b/src/Data/Singletons/Single.hs
@@ -12,7 +12,7 @@ module Data.Singletons.Single where
 
 import Prelude hiding ( exp )
 import Language.Haskell.TH hiding ( cxt )
-import Language.Haskell.TH.Syntax (Quasi(..))
+import Language.Haskell.TH.Syntax (NameSpace(..), Quasi(..))
 import Data.Singletons.Deriving.Infer
 import Data.Singletons.Deriving.Ord
 import Data.Singletons.Deriving.Bounded
@@ -28,6 +28,7 @@ import Data.Singletons.Names
 import Data.Singletons.Single.Monad
 import Data.Singletons.Single.Type
 import Data.Singletons.Single.Data
+import Data.Singletons.Single.Defun
 import Data.Singletons.Single.Fixity
 import Data.Singletons.Single.Eq
 import Data.Singletons.Syntax
@@ -263,7 +264,8 @@ singTopLevelDecs locals raw_decls = withLocalDeclarations locals $ do
   singDecsM locals $ do
     let letBinds = concatMap buildDataLets datas
                 ++ concatMap buildMethLets classes
-    (newLetDecls, newDecls) <- bindLets letBinds $
+    (newLetDecls, singIDefunDecls, newDecls)
+                            <- bindLets letBinds $
                                singLetDecEnv letDecEnv $ do
                                  newDataDecls <- concatMapM singDataD datas
                                  newClassDecls <- mapM singClassD classes'
@@ -274,7 +276,7 @@ singTopLevelDecs locals raw_decls = withLocalDeclarations locals $ do
                                                        ++ newInstDecls
                                                        ++ newDerivedEqDecs
                                                        ++ newDerivedShowDecs
-    return $ promDecls ++ (map DLetDec newLetDecls) ++ newDecls
+    return $ promDecls ++ (map DLetDec newLetDecls) ++ singIDefunDecls ++ newDecls
 
 -- see comment at top of file
 buildDataLets :: DataDecl -> [(Name, DExp)]
@@ -313,24 +315,27 @@ singClassD (ClassDecl { cd_cxt  = cls_cxt
                                             , lde_types     = meth_sigs
                                             , lde_infix     = fixities
                                             , lde_proms     = promoted_defaults
-                                            , lde_bound_kvs = meth_bound_kvs } }) = do
-  (sing_sigs, _, tyvar_names, res_kis)
-    <- unzip4 <$> zipWithM (singTySig no_meth_defns meth_sigs meth_bound_kvs)
-                           meth_names (map promoteValRhs meth_names)
-  let default_sigs = catMaybes $
-                     zipWith4 mk_default_sig meth_names sing_sigs tyvar_names res_kis
-      res_ki_map   = Map.fromList (zip meth_names
-                                       (map (fromMaybe always_sig) res_kis))
-  sing_meths <- mapM (uncurry (singLetDecRHS (Map.fromList tyvar_names)
-                                             res_ki_map))
-                     (Map.toList default_defns)
-  fixities' <- traverse (uncurry singInfixDecl) $ Map.toList fixities
-  cls_cxt' <- mapM singPred cls_cxt
-  return $ DClassD cls_cxt'
-                   (singClassName cls_name)
-                   cls_tvbs
-                   cls_fundeps   -- they are fine without modification
-                   (map DLetDec (sing_sigs ++ sing_meths ++ fixities') ++ default_sigs)
+                                            , lde_bound_kvs = meth_bound_kvs } }) =
+  bindContext [foldPredTvbs (DConPr cls_name) cls_tvbs] $ do
+    (sing_sigs, _, tyvar_names, cxts, res_kis, singIDefunss)
+      <- unzip6 <$> zipWithM (singTySig no_meth_defns meth_sigs meth_bound_kvs)
+                             meth_names (map promoteValRhs meth_names)
+    emitDecs $ concat singIDefunss
+    let default_sigs = catMaybes $
+                       zipWith4 mk_default_sig meth_names sing_sigs tyvar_names res_kis
+        res_ki_map   = Map.fromList (zip meth_names
+                                         (map (fromMaybe always_sig) res_kis))
+    sing_meths <- mapM (uncurry (singLetDecRHS (Map.fromList tyvar_names)
+                                               (Map.fromList cxts)
+                                               res_ki_map))
+                       (Map.toList default_defns)
+    fixities' <- traverse (uncurry singInfixDecl) $ Map.toList fixities
+    cls_cxt' <- mapM singPred cls_cxt
+    return $ DClassD cls_cxt'
+                     (singClassName cls_name)
+                     cls_tvbs
+                     cls_fundeps   -- they are fine without modification
+                     (map DLetDec (sing_sigs ++ sing_meths ++ fixities') ++ default_sigs)
   where
     no_meth_defns = error "Internal error: can't find declared method type"
     always_sig    = error "Internal error: no signature for default method"
@@ -342,7 +347,7 @@ singClassD (ClassDecl { cd_cxt  = cls_cxt
 
     add_constraints meth_name sty (_, bound_kvs) res_ki = do  -- Maybe monad
       prom_dflt <- Map.lookup meth_name promoted_defaults
-      let default_pred = foldl DAppPr (DConPr equalityName)
+      let default_pred = foldPred (DConPr equalityName)
                                 -- NB: Need the res_ki here to prevent ambiguous
                                 -- kinds in result-inferred default methods.
                                 -- See #175
@@ -374,13 +379,14 @@ singClassD (ClassDecl { cd_cxt  = cls_cxt
 singInstD :: AInstDecl -> SgM DDec
 singInstD (InstDecl { id_cxt = cxt, id_name = inst_name
                     , id_arg_tys = inst_tys, id_meths = ann_meths }) = do
-  cxt' <- mapM singPred cxt
-  inst_kis <- mapM promoteType inst_tys
-  meths <- concatMapM (uncurry sing_meth) ann_meths
-  return (DInstanceD Nothing
-                     cxt'
-                     (foldl DAppT (DConT s_inst_name) inst_kis)
-                     meths)
+  bindContext cxt $ do
+    cxt' <- mapM singPred cxt
+    inst_kis <- mapM promoteType inst_tys
+    meths <- concatMapM (uncurry sing_meth) ann_meths
+    return (DInstanceD Nothing
+                       cxt'
+                       (foldl DAppT (DConT s_inst_name) inst_kis)
+                       meths)
 
   where
     s_inst_name = singClassName inst_name
@@ -390,15 +396,18 @@ singInstD (InstDecl { id_cxt = cxt, id_name = inst_name
       mb_s_info <- dsReify (singValName name)
       inst_kis <- mapM promoteType inst_tys
       let mk_subst cls_tvbs = Map.fromList (zip (map extractTvbName cls_tvbs) inst_kis)
-      (s_ty, tyvar_names, m_res_ki) <- case mb_s_info of
+      (s_ty, tyvar_names, ctxt, m_res_ki) <- case mb_s_info of
         Just (DVarI _ (DForallT cls_tvbs _cls_pred s_ty) _) -> do
           let subst = mk_subst cls_tvbs
-              (sing_tvbs, _pred, _args, res_ty) = unravel s_ty
+              (sing_tvbs, ctxt, _args, res_ty) = unravel s_ty
               m_res_ki = case res_ty of
                 _sing `DAppT` (_prom_func `DSigT` res_ki) -> Just (substKind subst res_ki)
                 _                                         -> Nothing
 
-          return (substType subst s_ty, map extractTvbName sing_tvbs, m_res_ki)
+          return ( substType subst s_ty
+                 , map extractTvbName sing_tvbs
+                 , map (substPred subst) ctxt
+                 , m_res_ki )
         _ -> do
           mb_info <- dsReify name
           case mb_info of
@@ -410,17 +419,29 @@ singInstD (InstDecl { id_cxt = cxt, id_name = inst_name
               -- Make sure to expand through type synonyms here! Not doing so
               -- resulted in #167.
               raw_ty <- expand inner_ty
-              (s_ty, _num_args, tyvar_names, res_ki)
+              (s_ty, _num_args, tyvar_names, ctxt, _arg_kis, res_ki)
                 <- singType cls_bound (promoteValRhs name) raw_ty
-              return (substType subst s_ty, tyvar_names, Just (substKind subst res_ki))
+              return ( substType subst s_ty
+                     , tyvar_names
+                     , ctxt
+                     , Just (substKind subst res_ki) )
             _ -> fail $ "Cannot find type of method " ++ show name
 
       let kind_map = maybe Map.empty (Map.singleton name) m_res_ki
       meth' <- singLetDecRHS (Map.singleton name tyvar_names)
+                             (Map.singleton name ctxt)
                              kind_map name rhs
       return $ map DLetDec [DSigD (singValName name) s_ty, meth']
 
-singLetDecEnv :: ALetDecEnv -> SgM a -> SgM ([DLetDec], a)
+singLetDecEnv :: ALetDecEnv
+              -> SgM a
+              -> SgM ([DLetDec], [DDec], a)
+                 -- Return:
+                 --
+                 -- 1. The singled let-decs
+                 -- 2. SingI instances for any defunctionalization symbols
+                 --    (see Data.Singletons.Single.Defun)
+                 -- 3. The result of running the `SgM a` action
 singLetDecEnv (LetDecEnv { lde_defns     = defns
                          , lde_types     = types
                          , lde_infix     = infix_decls
@@ -428,16 +449,18 @@ singLetDecEnv (LetDecEnv { lde_defns     = defns
                          , lde_bound_kvs = bound_kvs })
               thing_inside = do
   let prom_list = Map.toList proms
-  (typeSigs, letBinds, tyvarNames, res_kis)
-    <- unzip4 <$> mapM (uncurry (singTySig defns types bound_kvs)) prom_list
+  (typeSigs, letBinds, tyvarNames, cxts, res_kis, singIDefunss)
+    <- unzip6 <$> mapM (uncurry (singTySig defns types bound_kvs)) prom_list
   infix_decls' <- traverse (uncurry singInfixDecl) $ Map.toList infix_decls
   let res_ki_map = Map.fromList [ (name, res_ki) | ((name, _), Just res_ki)
                                                      <- zip prom_list res_kis ]
   bindLets letBinds $ do
-    let_decs <- mapM (uncurry (singLetDecRHS (Map.fromList tyvarNames) res_ki_map))
+    let_decs <- mapM (uncurry (singLetDecRHS (Map.fromList tyvarNames)
+                                             (Map.fromList cxts)
+                                             res_ki_map))
                      (Map.toList defns)
     thing <- thing_inside
-    return (infix_decls' ++ typeSigs ++ let_decs, thing)
+    return (infix_decls' ++ typeSigs ++ let_decs, concat singIDefunss, thing)
 
 singTySig :: Map Name ALetDecRHS  -- definitions
           -> Map Name DType       -- type signatures
@@ -446,7 +469,9 @@ singTySig :: Map Name ALetDecRHS  -- definitions
           -> SgM ( DLetDec               -- the new type signature
                  , (Name, DExp)          -- the let-bind entry
                  , (Name, [Name])        -- the scoped tyvar names in the tysig
+                 , (Name, DCxt)          -- the context of the type signature
                  , Maybe DKind           -- the result kind in the tysig
+                 , [DDec]                -- SingI instances for defun symbols
                  )
 singTySig defns types bound_kvs name prom_ty =
   let sName = singValName name in
@@ -454,17 +479,27 @@ singTySig defns types bound_kvs name prom_ty =
     Nothing -> do
       num_args <- guess_num_args
       (sty, tyvar_names) <- mk_sing_ty num_args
+      singIDefuns <- singDefuns name VarName []
+                                (map (const Nothing) tyvar_names) Nothing
       return ( DSigD sName sty
              , (name, wrapSingFun num_args prom_ty (DVarE sName))
              , (name, tyvar_names)
-             , Nothing )
+             , (name, [])
+             , Nothing
+             , singIDefuns )
     Just ty -> do
       all_bound_kvs <- lookup_bound_kvs
-      (sty, num_args, tyvar_names, res_ki) <- singType all_bound_kvs prom_ty ty
+      (sty, num_args, tyvar_names, ctxt, arg_kis, res_ki)
+        <- singType all_bound_kvs prom_ty ty
+      bound_cxt <- askContext
+      singIDefuns <- singDefuns name VarName (bound_cxt ++ ctxt)
+                                (map Just arg_kis) (Just res_ki)
       return ( DSigD sName sty
              , (name, wrapSingFun num_args prom_ty (DVarE sName))
              , (name, tyvar_names)
-             , Just res_ki )
+             , (name, ctxt)
+             , Just res_ki
+             , singIDefuns )
   where
     guess_num_args :: SgM Int
     guess_num_args =
@@ -491,19 +526,25 @@ singTySig defns types bound_kvs name prom_ty =
              , arg_names )
 
 singLetDecRHS :: Map Name [Name]
+              -> Map Name DCxt    -- the context of the type signature
+                                  -- (might not be known)
               -> Map Name DKind   -- result kind (might not be known)
               -> Name -> ALetDecRHS -> SgM DLetDec
-singLetDecRHS _bound_names res_kis name (AValue prom num_arrows exp) =
-  DValD (DVarPa (singValName name)) <$>
-  (wrapUnSingFun num_arrows prom <$> singExp exp (Map.lookup name res_kis))
-singLetDecRHS bound_names res_kis name (AFunction prom_fun num_arrows clauses) =
-  let tyvar_names = case Map.lookup name bound_names of
-                      Nothing -> []
-                      Just ns -> ns
-      res_ki = Map.lookup name res_kis
-  in
-  DFunD (singValName name) <$>
-        mapM (singClause prom_fun num_arrows tyvar_names res_ki) clauses
+singLetDecRHS bound_names cxts res_kis name ld_rhs =
+  bindContext (Map.findWithDefault [] name cxts) $ go ld_rhs
+  where
+    go :: ALetDecRHS -> SgM DLetDec
+    go  (AValue prom num_arrows exp) =
+      DValD (DVarPa (singValName name)) <$>
+      (wrapUnSingFun num_arrows prom <$> singExp exp (Map.lookup name res_kis))
+    go (AFunction prom_fun num_arrows clauses) =
+      let tyvar_names = case Map.lookup name bound_names of
+                          Nothing -> []
+                          Just ns -> ns
+          res_ki = Map.lookup name res_kis
+      in
+      DFunD (singValName name) <$>
+            mapM (singClause prom_fun num_arrows tyvar_names res_ki) clauses
 
 singClause :: DType   -- the promoted function
            -> Int     -- the number of arrows in the type. If this is more
@@ -708,8 +749,12 @@ singExp (ADCaseE exp matches ret_ty) res_ki =
     -- See Note [Annotate case return type]
   DSigE <$> (DCaseE <$> singExp exp Nothing <*> mapM (singMatch res_ki) matches)
         <*> pure (singFamily `DAppT` (ret_ty `maybeSigT` res_ki))
-singExp (ADLetE env exp) res_ki =
-  uncurry DLetE <$> singLetDecEnv env (singExp exp res_ki)
+singExp (ADLetE env exp) res_ki = do
+  -- We intentionally discard the SingI instances for exp's defunctionalization
+  -- symbols, as we also do not generate the declarations for the
+  -- defunctionalization symbols in the first place during promotion.
+  (let_decs, _, exp') <- singLetDecEnv env $ singExp exp res_ki
+  pure $ DLetE let_decs exp'
 singExp (ADSigE prom_exp exp ty) _ = do
   exp' <- singExp exp (Just ty)
   pure $ DSigE exp' $ DConT singFamilyName `DAppT` DSigT prom_exp ty

--- a/src/Data/Singletons/Single/Defun.hs
+++ b/src/Data/Singletons/Single/Defun.hs
@@ -1,0 +1,220 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Singletons.Single.Defun
+-- Copyright   :  (C) 2018 Ryan Scott
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Creates 'SingI' instances for promoted types' defunctionalization symbols.
+--
+-----------------------------------------------------------------------------
+
+module Data.Singletons.Single.Defun (singDefuns) where
+
+import Data.List
+import Data.Singletons.Names
+import Data.Singletons.Promote.Defun
+import Data.Singletons.Single.Monad
+import Data.Singletons.Single.Type
+import Data.Singletons.Util
+import Language.Haskell.TH.Desugar
+import Language.Haskell.TH.Syntax
+
+-- Given the Name of something, take the defunctionalization symbols for its
+-- promoted counterpart and create SingI instances for them. As a concrete
+-- example, if you have:
+--
+--   foo :: Eq a => a -> a -> Bool
+--
+-- Then foo's promoted counterpart, Foo, will have two defunctionalization
+-- symbols:
+--
+--   FooSym0 :: a ~> a ~> Bool
+--   FooSym1 :: a -> a ~> Bool
+--
+-- We can declare SingI instances for these two symbols like so:
+--
+--   instance SEq a => Sing (FooSym0 :: a ~> a ~> Bool) where
+--     sing = singFun2 sFoo
+--
+--   instance (SEq a, SingI x) => SingI (FooSym1 x :: a ~> Bool) where
+--     sing = singFun1 (sFoo (sing @_ @x))
+--
+-- Note that singDefuns takes Maybe DKinds for the promoted argument and result
+-- types, in case we have an entity whose type needs to be inferred.
+-- See Note [singDefuns and type inference].
+--
+-- Note that in the particular case of a data constructor, we actually generate
+-- /two/ SingI instances partial application—one for the defunctionalization
+-- symbol, and one for the data constructor placed inside TyCon{N}.
+-- See Note [SingI instances for partially applied constructors].
+singDefuns :: Name      -- The Name of the thing to promote.
+           -> NameSpace -- Whether the above Name is a value, data constructor,
+                        -- or a type constructor.
+                        -- See Note [SingI instances for partially applied constructors]
+           -> DCxt      -- The type's context.
+           -> [Maybe DKind] -- The promoted argument types (if known).
+           -> Maybe DKind   -- The promoted result type (if known).
+           -> SgM [DDec]
+singDefuns n ns ty_ctxt mb_ty_args mb_ty_res =
+  case mb_ty_args of
+    [] -> pure [] -- If a function has no arguments, then it has no
+                  -- defunctionalization symbols, so there's nothing to be done.
+    _  -> do sty_ctxt <- mapM singPred ty_ctxt
+             go 0 sty_ctxt [] mb_ty_args
+  where
+    num_ty_args :: Int
+    num_ty_args = length mb_ty_args
+
+    -- Sadly, this algorithm is quadratic, because in each iteration of the loop
+    -- we must:
+    --
+    -- * Construct an arrow type of the form (a ~> ... ~> z), using a suffix of
+    --   the promoted argument types.
+    -- * Append a new type variable to the end of an ordered list.
+    --
+    -- In practice, this is unlikely to be a bottleneck, as singletons does not
+    -- support functions with more than 7 or so arguments anyways.
+    go :: Int -> DCxt -> [DTyVarBndr] -> [Maybe DKind] -> SgM [DDec]
+    go sym_num sty_ctxt tvbs mb_tyss
+      | sym_num < num_ty_args
+      , mb_ty:mb_tys <- mb_tyss
+      = do new_tvb_name <- qNewName "d"
+           let new_tvb = inferMaybeKindTV new_tvb_name mb_ty
+           insts <- go (sym_num + 1) sty_ctxt (tvbs ++ [new_tvb]) mb_tys
+           pure $ new_insts ++ insts
+      | otherwise
+      = pure []
+      where
+        sing_fun_num :: Int
+        sing_fun_num = num_ty_args - sym_num
+
+        mk_sing_fun_expr :: DExp -> DExp
+        mk_sing_fun_expr sing_expr =
+          foldl' (\f tvb_n -> f `DAppE` (DVarE singMethName
+                                          `DAppTypeE` DWildCardT
+                                          `DAppTypeE` DVarT tvb_n))
+                 sing_expr
+                 (map extractTvbName tvbs)
+
+        singI_ctxt :: DCxt
+        singI_ctxt = map (DAppPr (DConPr singIName) . tvbToType) tvbs
+
+        mk_inst_ty :: DType -> DType
+        mk_inst_ty inst_head
+          = case mb_inst_kind of
+              Just inst_kind -> inst_head `DSigT` inst_kind
+              Nothing        -> inst_head
+
+        tvb_tys :: [DType]
+        tvb_tys = map dTyVarBndrToDType tvbs
+
+        -- Construct the arrow kind used to annotate the defunctionalization
+        -- symbol (e.g., the `a ~> a ~> Bool` in
+        -- `SingI (FooSym0 :: a ~> a ~> Bool)`).
+        -- If any of the argument kinds or result kind isn't known (i.e., is
+        -- Nothing), then we opt not to construct this arrow kind altogether.
+        -- See Note [singDefuns and type inference]
+        mb_inst_kind :: Maybe DType
+        mb_inst_kind = foldr buildTyFunArrow_maybe mb_ty_res mb_tyss
+
+        new_insts :: [DDec]
+        new_insts
+          | DataName <- ns
+          = -- See Note [SingI instances for partially applied constructors]
+            let s_data_con = DConE $ singDataConName n in
+            [ mk_inst defun_inst_ty s_data_con
+            , mk_inst tycon_inst_ty s_data_con ]
+          | otherwise
+          = [mk_inst defun_inst_ty $ DVarE $ singValName n]
+          where
+            mk_inst :: DType -> DExp -> DDec
+            mk_inst inst_head sing_exp
+              = DInstanceD Nothing
+                           (sty_ctxt ++ singI_ctxt)
+                           (DConT singIName `DAppT` mk_inst_ty inst_head)
+                           [DLetDec $ DValD (DVarPa singMethName)
+                                    $ wrapSingFun sing_fun_num inst_head
+                                    $ mk_sing_fun_expr sing_exp ]
+
+            defun_inst_ty, tycon_inst_ty :: DType
+            defun_inst_ty = foldType (DConT (promoteTySym n sym_num)) tvb_tys
+            tycon_inst_ty = DConT (mkTyConName sing_fun_num) `DAppT`
+                            foldType (DConT n) tvb_tys
+
+-- | Convert a 'DTyVarBndr' into a 'DType'.
+dTyVarBndrToDType :: DTyVarBndr -> DType
+dTyVarBndrToDType (DPlainTV a)    = DVarT a
+dTyVarBndrToDType (DKindedTV a k) = DVarT a `DSigT` k
+
+{-
+Note [singDefuns and type inference]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Consider the following function:
+
+  foo :: a -> Bool
+  foo _ = True
+
+singDefuns would give the following SingI instance for FooSym0, with an
+explicit kind signature:
+
+  instance SingI (FooSym0 :: a ~> Bool) where ...
+
+What happens if we leave off the type signature for foo?
+
+  foo _ = True
+
+Can singDefuns still do its job? Yes! It will simply generate:
+
+  instance SingI FooSym0 where ...
+
+In general, if any of the promoted argument or result types given to singDefun
+are Nothing, then we avoid crafting an explicit kind signature. You might worry
+that this could lead to SingI instances being generated that GHC cannot infer
+the type for, such as:
+
+  bar x = x == x
+  ==>
+  instance SingI BarSym0 -- Missing an SEq constraint?
+
+This is true, but also not unprecedented, as the singled version of bar, sBar,
+will /also/ fail to typecheck due to a missing SEq constraint. Therefore, this
+design choice fits within the existing tradition of type inference in
+singletons.
+
+Note [SingI instances for partially applied constructors]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Unlike normal functions, where we generate one SingI instance for each of its
+partial applications (one per defunctionalization symbol), we generate *two*
+SingI instances for each partial application of a data constructor. That is,
+if we have:
+
+  data D a where
+    K :: a -> D a
+
+K has an partial application, so we will generate the following two SingI
+instances:
+
+  instance SingI KSym0          where sing = singFun1 SK
+  instance SingI (TyCon1 KSym0) where sing = singFun1 SK
+
+The first instance is exactly the same as what we'd generate for a normal,
+partially applied function's defun symbol. The second one, while functionally
+equivalent, is a bit dissatisfying: in general, adopting this approach means
+that we end up generating many instances of the form:
+
+  instance SingI (TyCon1 S1)
+  instance SingI (TyCon1 S2)
+  ...
+
+Ideally, we'd have a single instance SingI (TyCon1 s) to rule them all. But
+doing so would require writing something akin to:
+
+  instance (forall a. SingI a => SingI (f a)) => SingI (TyCon1 f) where
+    sing = SLambda $ \(x :: Sing a) -> withSingI x $ sing @_ @(f a)
+
+But this would require quantified constraints. Until GHC gains these, we
+compensate by generating out several SingI (TyCon1 s) instances.
+-}

--- a/src/Data/Singletons/Single/Defun.hs
+++ b/src/Data/Singletons/Single/Defun.hs
@@ -36,7 +36,7 @@ import Language.Haskell.TH.Syntax
 --
 -- We can declare SingI instances for these two symbols like so:
 --
---   instance SEq a => Sing (FooSym0 :: a ~> a ~> Bool) where
+--   instance SEq a => SingI (FooSym0 :: a ~> a ~> Bool) where
 --     sing = singFun2 sFoo
 --
 --   instance (SEq a, SingI x) => SingI (FooSym1 x :: a ~> Bool) where
@@ -93,9 +93,7 @@ singDefuns n ns ty_ctxt mb_ty_args mb_ty_res =
 
         mk_sing_fun_expr :: DExp -> DExp
         mk_sing_fun_expr sing_expr =
-          foldl' (\f tvb_n -> f `DAppE` (DVarE singMethName
-                                          `DAppTypeE` DWildCardT
-                                          `DAppTypeE` DVarT tvb_n))
+          foldl' (\f tvb_n -> f `DAppE` (DVarE singMethName `DAppTypeE` DVarT tvb_n))
                  sing_expr
                  (map extractTvbName tvbs)
 

--- a/src/Data/Singletons/TypeError.hs
+++ b/src/Data/Singletons/TypeError.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeInType #-}
 {-# LANGUAGE TypeOperators #-}
@@ -153,3 +154,34 @@ sTypeError :: HasCallStack => Sing err -> Sing (TypeError err)
 sTypeError = typeError . fromSing
 
 $(genDefunSymbols [''ErrorMessage', ''TypeError])
+
+instance SingI (TextSym0 :: Symbol ~> PErrorMessage) where
+  sing = singFun1 SText
+instance SingI (TyCon1 'Text :: Symbol ~> PErrorMessage) where
+  sing = singFun1 SText
+
+instance SingI (ShowTypeSym0 :: t ~> PErrorMessage) where
+  sing = singFun1 SShowType
+instance SingI (TyCon1 'ShowType :: t ~> PErrorMessage) where
+  sing = singFun1 SShowType
+
+instance SingI ((:<>:@#@$) :: PErrorMessage ~> PErrorMessage ~> PErrorMessage) where
+  sing = singFun2 (:%<>:)
+instance SingI (TyCon2 '(:<>:) :: PErrorMessage ~> PErrorMessage ~> PErrorMessage) where
+  sing = singFun2 (:%<>:)
+instance SingI x => SingI ((:<>:@#@$$) x :: PErrorMessage ~> PErrorMessage) where
+  sing = singFun1 (sing @_ @x :%<>:)
+instance SingI x => SingI (TyCon1 ('(:<>:) x) :: PErrorMessage ~> PErrorMessage) where
+  sing = singFun1 (sing @_ @x :%<>:)
+
+instance SingI ((:$$:@#@$) :: PErrorMessage ~> PErrorMessage ~> PErrorMessage) where
+  sing = singFun2 (:%$$:)
+instance SingI (TyCon2 '(:$$:) :: PErrorMessage ~> PErrorMessage ~> PErrorMessage) where
+  sing = singFun2 (:%$$:)
+instance SingI x => SingI ((:$$:@#@$$) x :: PErrorMessage ~> PErrorMessage) where
+  sing = singFun1 (sing @_ @x :%$$:)
+instance SingI x => SingI (TyCon1 ('(:$$:) x) :: PErrorMessage ~> PErrorMessage) where
+  sing = singFun1 (sing @_ @x :%$$:)
+
+instance SingI TypeErrorSym0 where
+  sing = singFun1 sTypeError

--- a/src/Data/Singletons/TypeError.hs
+++ b/src/Data/Singletons/TypeError.hs
@@ -170,18 +170,18 @@ instance SingI ((:<>:@#@$) :: PErrorMessage ~> PErrorMessage ~> PErrorMessage) w
 instance SingI (TyCon2 '(:<>:) :: PErrorMessage ~> PErrorMessage ~> PErrorMessage) where
   sing = singFun2 (:%<>:)
 instance SingI x => SingI ((:<>:@#@$$) x :: PErrorMessage ~> PErrorMessage) where
-  sing = singFun1 (sing @_ @x :%<>:)
+  sing = singFun1 (sing @x :%<>:)
 instance SingI x => SingI (TyCon1 ('(:<>:) x) :: PErrorMessage ~> PErrorMessage) where
-  sing = singFun1 (sing @_ @x :%<>:)
+  sing = singFun1 (sing @x :%<>:)
 
 instance SingI ((:$$:@#@$) :: PErrorMessage ~> PErrorMessage ~> PErrorMessage) where
   sing = singFun2 (:%$$:)
 instance SingI (TyCon2 '(:$$:) :: PErrorMessage ~> PErrorMessage ~> PErrorMessage) where
   sing = singFun2 (:%$$:)
 instance SingI x => SingI ((:$$:@#@$$) x :: PErrorMessage ~> PErrorMessage) where
-  sing = singFun1 (sing @_ @x :%$$:)
+  sing = singFun1 (sing @x :%$$:)
 instance SingI x => SingI (TyCon1 ('(:$$:) x) :: PErrorMessage ~> PErrorMessage) where
-  sing = singFun1 (sing @_ @x :%$$:)
+  sing = singFun1 (sing @x :%$$:)
 
 instance SingI TypeErrorSym0 where
   sing = singFun1 sTypeError

--- a/src/Data/Singletons/TypeLits.hs
+++ b/src/Data/Singletons/TypeLits.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE TemplateHaskell, ScopedTypeVariables, TypeInType, ConstraintKinds,
-             GADTs, TypeFamilies, UndecidableInstances #-}
+             GADTs, TypeApplications, TypeFamilies, UndecidableInstances #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -142,6 +142,8 @@ sLog2 sx =
          _ -> case TN.someNatVal (genLog2 x) of
                 SomeNat (_ :: Proxy res) -> unsafeCoerce (SNat :: Sing res)
 $(genDefunSymbols [''TN.Log2])
+instance SingI Log2Sym0 where
+  sing = singFun1 sLog2
 
 sDiv :: Sing x -> Sing y -> Sing (Div x y)
 sDiv sx sy =
@@ -152,6 +154,10 @@ sDiv sx sy =
          SomeNat (_ :: Proxy res) -> unsafeCoerce (SNat :: Sing res)
 infixl 7 `sDiv`
 $(genDefunSymbols [''Div])
+instance SingI DivSym0 where
+  sing = singFun2 sDiv
+instance SingI x => SingI (DivSym1 x) where
+  sing = singFun1 $ sDiv (sing @_ @x)
 
 sMod :: Sing x -> Sing y -> Sing (Mod x y)
 sMod sx sy =
@@ -162,6 +168,10 @@ sMod sx sy =
          SomeNat (_ :: Proxy res) -> unsafeCoerce (SNat :: Sing res)
 infixl 7 `sMod`
 $(genDefunSymbols [''Mod])
+instance SingI ModSym0 where
+  sing = singFun2 sMod
+instance SingI x => SingI (ModSym1 x) where
+  sing = singFun1 $ sMod $ sing @_ @x
 
 $(promoteOnly [d|
   divMod :: Nat -> Nat -> (Nat, Nat)

--- a/src/Data/Singletons/TypeLits.hs
+++ b/src/Data/Singletons/TypeLits.hs
@@ -157,7 +157,7 @@ $(genDefunSymbols [''Div])
 instance SingI DivSym0 where
   sing = singFun2 sDiv
 instance SingI x => SingI (DivSym1 x) where
-  sing = singFun1 $ sDiv (sing @_ @x)
+  sing = singFun1 $ sDiv (sing @x)
 
 sMod :: Sing x -> Sing y -> Sing (Mod x y)
 sMod sx sy =
@@ -171,7 +171,7 @@ $(genDefunSymbols [''Mod])
 instance SingI ModSym0 where
   sing = singFun2 sMod
 instance SingI x => SingI (ModSym1 x) where
-  sing = singFun1 $ sMod $ sing @_ @x
+  sing = singFun1 $ sMod $ sing @x
 
 $(promoteOnly [d|
   divMod :: Nat -> Nat -> (Nat, Nat)

--- a/src/Data/Singletons/TypeLits/Internal.hs
+++ b/src/Data/Singletons/TypeLits/Internal.hs
@@ -160,6 +160,8 @@ withKnownSymbol SSym f = f
 -- easier use.
 type family Error (str :: k0) :: k where {}
 $(genDefunSymbols [''Error])
+instance SingI (ErrorSym0 :: Symbol ~> a) where
+  sing = singFun1 sError
 
 -- | The singleton for 'error'
 sError :: HasCallStack => Sing (str :: Symbol) -> a
@@ -169,6 +171,8 @@ sError sstr = error (T.unpack (fromSing sstr))
 -- poly-kinded for easier use.
 type family ErrorWithoutStackTrace (str :: k0) :: k where {}
 $(genDefunSymbols [''ErrorWithoutStackTrace])
+instance SingI (ErrorWithoutStackTraceSym0 :: Symbol ~> a) where
+  sing = singFun1 sErrorWithoutStackTrace
 
 -- | The singleton for 'errorWithoutStackTrace'.
 sErrorWithoutStackTrace :: Sing (str :: Symbol) -> a
@@ -195,6 +199,10 @@ infixr 8 %^
 
 -- Defunctionalization symbols for type-level (^)
 $(genDefunSymbols [''(^)])
+instance SingI (^@#@$) where
+  sing = singFun2 (%^)
+instance SingI x => SingI ((^@#@$$) x) where
+  sing = singFun1 (sing @_ @x %^)
 
 -- | The singleton analogue of 'TN.<=?'
 --
@@ -219,3 +227,7 @@ infix 4 %<=?
 
 -- Defunctionalization symbols for (<=?)
 $(genDefunSymbols [''(<=?)])
+instance SingI (<=?@#@$) where
+  sing = singFun2 (%<=?)
+instance SingI x => SingI ((<=?@#@$$) x) where
+  sing = singFun1 (sing @_ @x %<=?)

--- a/src/Data/Singletons/TypeLits/Internal.hs
+++ b/src/Data/Singletons/TypeLits/Internal.hs
@@ -202,7 +202,7 @@ $(genDefunSymbols [''(^)])
 instance SingI (^@#@$) where
   sing = singFun2 (%^)
 instance SingI x => SingI ((^@#@$$) x) where
-  sing = singFun1 (sing @_ @x %^)
+  sing = singFun1 (sing @x %^)
 
 -- | The singleton analogue of 'TN.<=?'
 --
@@ -230,4 +230,4 @@ $(genDefunSymbols [''(<=?)])
 instance SingI (<=?@#@$) where
   sing = singFun2 (%<=?)
 instance SingI x => SingI ((<=?@#@$$) x) where
-  sing = singFun1 (sing @_ @x %<=?)
+  sing = singFun1 (sing @x %<=?)

--- a/src/Data/Singletons/Util.hs
+++ b/src/Data/Singletons/Util.hs
@@ -343,6 +343,14 @@ foldType = foldl DAppT
 foldTypeTvbs :: DType -> [DTyVarBndr] -> DType
 foldTypeTvbs ty = foldType ty . map tvbToType
 
+-- apply a pred to a list of types
+foldPred :: DPred -> [DType] -> DPred
+foldPred = foldl DAppPr
+
+-- apply a pred to a list of type variable binders
+foldPredTvbs :: DPred -> [DTyVarBndr] -> DPred
+foldPredTvbs pr = foldPred pr . map tvbToType
+
 -- | Decompose an applied type into its individual components. For example, this:
 --
 -- @

--- a/tests/compile-and-dump/GradingClient/Database.ghc84.template
+++ b/tests/compile-and-dump/GradingClient/Database.ghc84.template
@@ -116,6 +116,10 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       sing = SZero
     instance SingI n => SingI (Succ (n :: Nat)) where
       sing = SSucc sing
+    instance SingI (SuccSym0 :: (~>) Nat Nat) where
+      sing = (singFun1 @SuccSym0) SSucc
+    instance SingI (TyCon1 Succ :: (~>) Nat Nat) where
+      sing = (singFun1 @(TyCon1 Succ)) SSucc
 GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     singletons
       [d| append :: Schema -> Schema -> Schema
@@ -679,6 +683,37 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     sAppend (SSch (sS1 :: Sing s1)) (SSch (sS2 :: Sing s2))
       = (applySing ((singFun1 @SchSym0) SSch))
           ((applySing ((applySing ((singFun2 @(++@#@$)) (%++))) sS1)) sS2)
+    instance SingI (LookupSym0 :: (~>) [AChar] ((~>) Schema U)) where
+      sing = (singFun2 @LookupSym0) sLookup
+    instance SingI d =>
+             SingI (LookupSym1 (d :: [AChar]) :: (~>) Schema U) where
+      sing
+        = (singFun1 @(LookupSym1 (d :: [AChar]))) (sLookup (sing @_ @d))
+    instance SingI (OccursSym0 :: (~>) [AChar] ((~>) Schema Bool)) where
+      sing = (singFun2 @OccursSym0) sOccurs
+    instance SingI d =>
+             SingI (OccursSym1 (d :: [AChar]) :: (~>) Schema Bool) where
+      sing
+        = (singFun1 @(OccursSym1 (d :: [AChar]))) (sOccurs (sing @_ @d))
+    instance SingI (AttrNotInSym0 :: (~>) Attribute ((~>) Schema Bool)) where
+      sing = (singFun2 @AttrNotInSym0) sAttrNotIn
+    instance SingI d =>
+             SingI (AttrNotInSym1 (d :: Attribute) :: (~>) Schema Bool) where
+      sing
+        = (singFun1 @(AttrNotInSym1 (d :: Attribute)))
+            (sAttrNotIn (sing @_ @d))
+    instance SingI (DisjointSym0 :: (~>) Schema ((~>) Schema Bool)) where
+      sing = (singFun2 @DisjointSym0) sDisjoint
+    instance SingI d =>
+             SingI (DisjointSym1 (d :: Schema) :: (~>) Schema Bool) where
+      sing
+        = (singFun1 @(DisjointSym1 (d :: Schema))) (sDisjoint (sing @_ @d))
+    instance SingI (AppendSym0 :: (~>) Schema ((~>) Schema Schema)) where
+      sing = (singFun2 @AppendSym0) sAppend
+    instance SingI d =>
+             SingI (AppendSym1 (d :: Schema) :: (~>) Schema Schema) where
+      sing
+        = (singFun1 @(AppendSym1 (d :: Schema))) (sAppend (sing @_ @d))
     data instance Sing :: U -> Type :: U -> Type
       where
         SBOOL :: Sing BOOL
@@ -2540,6 +2575,15 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance (SingI n, SingI n) =>
              SingI (VEC (n :: U) (n :: Nat)) where
       sing = (SVEC sing) sing
+    instance SingI (VECSym0 :: (~>) U ((~>) Nat U)) where
+      sing = (singFun2 @VECSym0) SVEC
+    instance SingI (TyCon2 VEC :: (~>) U ((~>) Nat U)) where
+      sing = (singFun2 @(TyCon2 VEC)) SVEC
+    instance SingI d => SingI (VECSym1 (d :: U) :: (~>) Nat U) where
+      sing = (singFun1 @(VECSym1 (d :: U))) (SVEC (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon1 (VEC (d :: U)) :: (~>) Nat U) where
+      sing = (singFun1 @(TyCon1 (VEC (d :: U)))) (SVEC (sing @_ @d))
     instance SingI CA where
       sing = SCA
     instance SingI CB where
@@ -2595,8 +2639,23 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance (SingI n, SingI n) =>
              SingI (Attr (n :: [AChar]) (n :: U)) where
       sing = (SAttr sing) sing
+    instance SingI (AttrSym0 :: (~>) [AChar] ((~>) U Attribute)) where
+      sing = (singFun2 @AttrSym0) SAttr
+    instance SingI (TyCon2 Attr :: (~>) [AChar] ((~>) U Attribute)) where
+      sing = (singFun2 @(TyCon2 Attr)) SAttr
+    instance SingI d =>
+             SingI (AttrSym1 (d :: [AChar]) :: (~>) U Attribute) where
+      sing = (singFun1 @(AttrSym1 (d :: [AChar]))) (SAttr (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon1 (Attr (d :: [AChar])) :: (~>) U Attribute) where
+      sing
+        = (singFun1 @(TyCon1 (Attr (d :: [AChar])))) (SAttr (sing @_ @d))
     instance SingI n => SingI (Sch (n :: [Attribute])) where
       sing = SSch sing
+    instance SingI (SchSym0 :: (~>) [Attribute] Schema) where
+      sing = (singFun1 @SchSym0) SSch
+    instance SingI (TyCon1 Sch :: (~>) [Attribute] Schema) where
+      sing = (singFun1 @(TyCon1 Sch)) SSch
 GradingClient/Database.hs:0:0:: Splicing declarations
     return [] ======>
 GradingClient/Database.hs:(0,0)-(0,0): Splicing expression

--- a/tests/compile-and-dump/GradingClient/Database.ghc84.template
+++ b/tests/compile-and-dump/GradingClient/Database.ghc84.template
@@ -687,33 +687,30 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @LookupSym0) sLookup
     instance SingI d =>
              SingI (LookupSym1 (d :: [AChar]) :: (~>) Schema U) where
-      sing
-        = (singFun1 @(LookupSym1 (d :: [AChar]))) (sLookup (sing @_ @d))
+      sing = (singFun1 @(LookupSym1 (d :: [AChar]))) (sLookup (sing @d))
     instance SingI (OccursSym0 :: (~>) [AChar] ((~>) Schema Bool)) where
       sing = (singFun2 @OccursSym0) sOccurs
     instance SingI d =>
              SingI (OccursSym1 (d :: [AChar]) :: (~>) Schema Bool) where
-      sing
-        = (singFun1 @(OccursSym1 (d :: [AChar]))) (sOccurs (sing @_ @d))
+      sing = (singFun1 @(OccursSym1 (d :: [AChar]))) (sOccurs (sing @d))
     instance SingI (AttrNotInSym0 :: (~>) Attribute ((~>) Schema Bool)) where
       sing = (singFun2 @AttrNotInSym0) sAttrNotIn
     instance SingI d =>
              SingI (AttrNotInSym1 (d :: Attribute) :: (~>) Schema Bool) where
       sing
         = (singFun1 @(AttrNotInSym1 (d :: Attribute)))
-            (sAttrNotIn (sing @_ @d))
+            (sAttrNotIn (sing @d))
     instance SingI (DisjointSym0 :: (~>) Schema ((~>) Schema Bool)) where
       sing = (singFun2 @DisjointSym0) sDisjoint
     instance SingI d =>
              SingI (DisjointSym1 (d :: Schema) :: (~>) Schema Bool) where
       sing
-        = (singFun1 @(DisjointSym1 (d :: Schema))) (sDisjoint (sing @_ @d))
+        = (singFun1 @(DisjointSym1 (d :: Schema))) (sDisjoint (sing @d))
     instance SingI (AppendSym0 :: (~>) Schema ((~>) Schema Schema)) where
       sing = (singFun2 @AppendSym0) sAppend
     instance SingI d =>
              SingI (AppendSym1 (d :: Schema) :: (~>) Schema Schema) where
-      sing
-        = (singFun1 @(AppendSym1 (d :: Schema))) (sAppend (sing @_ @d))
+      sing = (singFun1 @(AppendSym1 (d :: Schema))) (sAppend (sing @d))
     data instance Sing :: U -> Type :: U -> Type
       where
         SBOOL :: Sing BOOL
@@ -2580,10 +2577,10 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SingI (TyCon2 VEC :: (~>) U ((~>) Nat U)) where
       sing = (singFun2 @(TyCon2 VEC)) SVEC
     instance SingI d => SingI (VECSym1 (d :: U) :: (~>) Nat U) where
-      sing = (singFun1 @(VECSym1 (d :: U))) (SVEC (sing @_ @d))
+      sing = (singFun1 @(VECSym1 (d :: U))) (SVEC (sing @d))
     instance SingI d =>
              SingI (TyCon1 (VEC (d :: U)) :: (~>) Nat U) where
-      sing = (singFun1 @(TyCon1 (VEC (d :: U)))) (SVEC (sing @_ @d))
+      sing = (singFun1 @(TyCon1 (VEC (d :: U)))) (SVEC (sing @d))
     instance SingI CA where
       sing = SCA
     instance SingI CB where
@@ -2645,11 +2642,10 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @(TyCon2 Attr)) SAttr
     instance SingI d =>
              SingI (AttrSym1 (d :: [AChar]) :: (~>) U Attribute) where
-      sing = (singFun1 @(AttrSym1 (d :: [AChar]))) (SAttr (sing @_ @d))
+      sing = (singFun1 @(AttrSym1 (d :: [AChar]))) (SAttr (sing @d))
     instance SingI d =>
              SingI (TyCon1 (Attr (d :: [AChar])) :: (~>) U Attribute) where
-      sing
-        = (singFun1 @(TyCon1 (Attr (d :: [AChar])))) (SAttr (sing @_ @d))
+      sing = (singFun1 @(TyCon1 (Attr (d :: [AChar])))) (SAttr (sing @d))
     instance SingI n => SingI (Sch (n :: [Attribute])) where
       sing = SSch sing
     instance SingI (SchSym0 :: (~>) [Attribute] Schema) where

--- a/tests/compile-and-dump/InsertionSort/InsertionSortImp.ghc84.template
+++ b/tests/compile-and-dump/InsertionSort/InsertionSortImp.ghc84.template
@@ -29,6 +29,10 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
       sing = SZero
     instance SingI n => SingI (Succ (n :: Nat)) where
       sing = SSucc sing
+    instance SingI (SuccSym0 :: (~>) Nat Nat) where
+      sing = (singFun1 @SuccSym0) SSucc
+    instance SingI (TyCon1 Succ :: (~>) Nat Nat) where
+      sing = (singFun1 @(TyCon1 Succ)) SSucc
 InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
     singletons
       [d| leq :: Nat -> Nat -> Bool
@@ -195,3 +199,15 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
     sInsertionSort (SCons (sH :: Sing h) (sT :: Sing t))
       = (applySing ((applySing ((singFun2 @InsertSym0) sInsert)) sH))
           ((applySing ((singFun1 @InsertionSortSym0) sInsertionSort)) sT)
+    instance SingI (LeqSym0 :: (~>) Nat ((~>) Nat Bool)) where
+      sing = (singFun2 @LeqSym0) sLeq
+    instance SingI d =>
+             SingI (LeqSym1 (d :: Nat) :: (~>) Nat Bool) where
+      sing = (singFun1 @(LeqSym1 (d :: Nat))) (sLeq (sing @_ @d))
+    instance SingI (InsertSym0 :: (~>) Nat ((~>) [Nat] [Nat])) where
+      sing = (singFun2 @InsertSym0) sInsert
+    instance SingI d =>
+             SingI (InsertSym1 (d :: Nat) :: (~>) [Nat] [Nat]) where
+      sing = (singFun1 @(InsertSym1 (d :: Nat))) (sInsert (sing @_ @d))
+    instance SingI (InsertionSortSym0 :: (~>) [Nat] [Nat]) where
+      sing = (singFun1 @InsertionSortSym0) sInsertionSort

--- a/tests/compile-and-dump/InsertionSort/InsertionSortImp.ghc84.template
+++ b/tests/compile-and-dump/InsertionSort/InsertionSortImp.ghc84.template
@@ -203,11 +203,11 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @LeqSym0) sLeq
     instance SingI d =>
              SingI (LeqSym1 (d :: Nat) :: (~>) Nat Bool) where
-      sing = (singFun1 @(LeqSym1 (d :: Nat))) (sLeq (sing @_ @d))
+      sing = (singFun1 @(LeqSym1 (d :: Nat))) (sLeq (sing @d))
     instance SingI (InsertSym0 :: (~>) Nat ((~>) [Nat] [Nat])) where
       sing = (singFun2 @InsertSym0) sInsert
     instance SingI d =>
              SingI (InsertSym1 (d :: Nat) :: (~>) [Nat] [Nat]) where
-      sing = (singFun1 @(InsertSym1 (d :: Nat))) (sInsert (sing @_ @d))
+      sing = (singFun1 @(InsertSym1 (d :: Nat))) (sInsert (sing @d))
     instance SingI (InsertionSortSym0 :: (~>) [Nat] [Nat]) where
       sing = (singFun1 @InsertionSortSym0) sInsertionSort

--- a/tests/compile-and-dump/Singletons/AsPattern.ghc84.template
+++ b/tests/compile-and-dump/Singletons/AsPattern.ghc84.template
@@ -355,6 +355,16 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
           sP :: Sing Let0123456789876543210PSym0
           sP = SNothing
         in sP
+    instance SingI (FooSym0 :: (~>) [Nat] [Nat]) where
+      sing = (singFun1 @FooSym0) sFoo
+    instance SingI (TupSym0 :: (~>) (Nat, Nat) (Nat, Nat)) where
+      sing = (singFun1 @TupSym0) sTup
+    instance SingI (Baz_Sym0 :: (~>) (Maybe Baz) (Maybe Baz)) where
+      sing = (singFun1 @Baz_Sym0) sBaz_
+    instance SingI (BarSym0 :: (~>) (Maybe Nat) (Maybe Nat)) where
+      sing = (singFun1 @BarSym0) sBar
+    instance SingI (MaybePlusSym0 :: (~>) (Maybe Nat) (Maybe Nat)) where
+      sing = (singFun1 @MaybePlusSym0) sMaybePlus
     data instance Sing :: Baz -> GHC.Types.Type :: Baz
                                                    -> GHC.Types.Type
       where
@@ -377,3 +387,23 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
     instance (SingI n, SingI n, SingI n) =>
              SingI (Baz (n :: Nat) (n :: Nat) (n :: Nat)) where
       sing = ((SBaz sing) sing) sing
+    instance SingI (BazSym0 :: (~>) Nat ((~>) Nat ((~>) Nat Baz))) where
+      sing = (singFun3 @BazSym0) SBaz
+    instance SingI (TyCon3 Baz :: (~>) Nat ((~>) Nat ((~>) Nat Baz))) where
+      sing = (singFun3 @(TyCon3 Baz)) SBaz
+    instance SingI d =>
+             SingI (BazSym1 (d :: Nat) :: (~>) Nat ((~>) Nat Baz)) where
+      sing = (singFun2 @(BazSym1 (d :: Nat))) (SBaz (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon2 (Baz (d :: Nat)) :: (~>) Nat ((~>) Nat Baz)) where
+      sing = (singFun2 @(TyCon2 (Baz (d :: Nat)))) (SBaz (sing @_ @d))
+    instance (SingI d, SingI d) =>
+             SingI (BazSym2 (d :: Nat) (d :: Nat) :: (~>) Nat Baz) where
+      sing
+        = (singFun1 @(BazSym2 (d :: Nat) (d :: Nat)))
+            ((SBaz (sing @_ @d)) (sing @_ @d))
+    instance (SingI d, SingI d) =>
+             SingI (TyCon1 (Baz (d :: Nat) (d :: Nat)) :: (~>) Nat Baz) where
+      sing
+        = (singFun1 @(TyCon1 (Baz (d :: Nat) (d :: Nat))))
+            ((SBaz (sing @_ @d)) (sing @_ @d))

--- a/tests/compile-and-dump/Singletons/AsPattern.ghc84.template
+++ b/tests/compile-and-dump/Singletons/AsPattern.ghc84.template
@@ -393,17 +393,17 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun3 @(TyCon3 Baz)) SBaz
     instance SingI d =>
              SingI (BazSym1 (d :: Nat) :: (~>) Nat ((~>) Nat Baz)) where
-      sing = (singFun2 @(BazSym1 (d :: Nat))) (SBaz (sing @_ @d))
+      sing = (singFun2 @(BazSym1 (d :: Nat))) (SBaz (sing @d))
     instance SingI d =>
              SingI (TyCon2 (Baz (d :: Nat)) :: (~>) Nat ((~>) Nat Baz)) where
-      sing = (singFun2 @(TyCon2 (Baz (d :: Nat)))) (SBaz (sing @_ @d))
+      sing = (singFun2 @(TyCon2 (Baz (d :: Nat)))) (SBaz (sing @d))
     instance (SingI d, SingI d) =>
              SingI (BazSym2 (d :: Nat) (d :: Nat) :: (~>) Nat Baz) where
       sing
         = (singFun1 @(BazSym2 (d :: Nat) (d :: Nat)))
-            ((SBaz (sing @_ @d)) (sing @_ @d))
+            ((SBaz (sing @d)) (sing @d))
     instance (SingI d, SingI d) =>
              SingI (TyCon1 (Baz (d :: Nat) (d :: Nat)) :: (~>) Nat Baz) where
       sing
         = (singFun1 @(TyCon1 (Baz (d :: Nat) (d :: Nat))))
-            ((SBaz (sing @_ @d)) (sing @_ @d))
+            ((SBaz (sing @d)) (sing @d))

--- a/tests/compile-and-dump/Singletons/BoundedDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/BoundedDeriving.ghc84.template
@@ -224,6 +224,10 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
       sing = SE
     instance SingI n => SingI (Foo3 (n :: a)) where
       sing = SFoo3 sing
+    instance SingI (Foo3Sym0 :: (~>) a (Foo3 a)) where
+      sing = (singFun1 @Foo3Sym0) SFoo3
+    instance SingI (TyCon1 Foo3 :: (~>) a (Foo3 a)) where
+      sing = (singFun1 @(TyCon1 Foo3)) SFoo3
     instance SingI Foo41 where
       sing = SFoo41
     instance SingI Foo42 where
@@ -231,3 +235,13 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance (SingI n, SingI n) =>
              SingI (Pair (n :: Bool) (n :: Bool)) where
       sing = (SPair sing) sing
+    instance SingI (PairSym0 :: (~>) Bool ((~>) Bool Pair)) where
+      sing = (singFun2 @PairSym0) SPair
+    instance SingI (TyCon2 Pair :: (~>) Bool ((~>) Bool Pair)) where
+      sing = (singFun2 @(TyCon2 Pair)) SPair
+    instance SingI d =>
+             SingI (PairSym1 (d :: Bool) :: (~>) Bool Pair) where
+      sing = (singFun1 @(PairSym1 (d :: Bool))) (SPair (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon1 (Pair (d :: Bool)) :: (~>) Bool Pair) where
+      sing = (singFun1 @(TyCon1 (Pair (d :: Bool)))) (SPair (sing @_ @d))

--- a/tests/compile-and-dump/Singletons/BoundedDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/BoundedDeriving.ghc84.template
@@ -241,7 +241,7 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @(TyCon2 Pair)) SPair
     instance SingI d =>
              SingI (PairSym1 (d :: Bool) :: (~>) Bool Pair) where
-      sing = (singFun1 @(PairSym1 (d :: Bool))) (SPair (sing @_ @d))
+      sing = (singFun1 @(PairSym1 (d :: Bool))) (SPair (sing @d))
     instance SingI d =>
              SingI (TyCon1 (Pair (d :: Bool)) :: (~>) Bool Pair) where
-      sing = (singFun1 @(TyCon1 (Pair (d :: Bool)))) (SPair (sing @_ @d))
+      sing = (singFun1 @(TyCon1 (Pair (d :: Bool)))) (SPair (sing @d))

--- a/tests/compile-and-dump/Singletons/BoxUnBox.ghc84.template
+++ b/tests/compile-and-dump/Singletons/BoxUnBox.ghc84.template
@@ -31,6 +31,8 @@ Singletons/BoxUnBox.hs:(0,0)-(0,0): Splicing declarations
     sUnBox ::
       forall a (t :: Box a). Sing t -> Sing (Apply UnBoxSym0 t :: a)
     sUnBox (SFBox (sA :: Sing a)) = sA
+    instance SingI (UnBoxSym0 :: (~>) (Box a) a) where
+      sing = (singFun1 @UnBoxSym0) sUnBox
     data instance Sing :: Box a -> GHC.Types.Type :: Box a
                                                      -> GHC.Types.Type
       where SFBox :: forall a (n :: a). (Sing (n :: a)) -> Sing (FBox n)
@@ -43,3 +45,7 @@ Singletons/BoxUnBox.hs:(0,0)-(0,0): Splicing declarations
             SomeSing c -> SomeSing (SFBox c) }
     instance SingI n => SingI (FBox (n :: a)) where
       sing = SFBox sing
+    instance SingI (FBoxSym0 :: (~>) a (Box a)) where
+      sing = (singFun1 @FBoxSym0) SFBox
+    instance SingI (TyCon1 FBox :: (~>) a (Box a)) where
+      sing = (singFun1 @(TyCon1 FBox)) SFBox

--- a/tests/compile-and-dump/Singletons/CaseExpressions.ghc84.template
+++ b/tests/compile-and-dump/Singletons/CaseExpressions.ghc84.template
@@ -296,3 +296,21 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
           SJust (sY :: Sing y) -> sY
           SNothing -> sD ::
           Sing (Case_0123456789876543210 d x x :: a)
+    instance SingI (Foo5Sym0 :: (~>) a a) where
+      sing = (singFun1 @Foo5Sym0) sFoo5
+    instance SingI (Foo4Sym0 :: (~>) a a) where
+      sing = (singFun1 @Foo4Sym0) sFoo4
+    instance SingI (Foo3Sym0 :: (~>) a ((~>) b a)) where
+      sing = (singFun2 @Foo3Sym0) sFoo3
+    instance SingI d => SingI (Foo3Sym1 (d :: a) :: (~>) b a) where
+      sing = (singFun1 @(Foo3Sym1 (d :: a))) (sFoo3 (sing @_ @d))
+    instance SingI (Foo2Sym0 :: (~>) a ((~>) (Maybe a) a)) where
+      sing = (singFun2 @Foo2Sym0) sFoo2
+    instance SingI d =>
+             SingI (Foo2Sym1 (d :: a) :: (~>) (Maybe a) a) where
+      sing = (singFun1 @(Foo2Sym1 (d :: a))) (sFoo2 (sing @_ @d))
+    instance SingI (Foo1Sym0 :: (~>) a ((~>) (Maybe a) a)) where
+      sing = (singFun2 @Foo1Sym0) sFoo1
+    instance SingI d =>
+             SingI (Foo1Sym1 (d :: a) :: (~>) (Maybe a) a) where
+      sing = (singFun1 @(Foo1Sym1 (d :: a))) (sFoo1 (sing @_ @d))

--- a/tests/compile-and-dump/Singletons/CaseExpressions.ghc84.template
+++ b/tests/compile-and-dump/Singletons/CaseExpressions.ghc84.template
@@ -303,14 +303,14 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
     instance SingI (Foo3Sym0 :: (~>) a ((~>) b a)) where
       sing = (singFun2 @Foo3Sym0) sFoo3
     instance SingI d => SingI (Foo3Sym1 (d :: a) :: (~>) b a) where
-      sing = (singFun1 @(Foo3Sym1 (d :: a))) (sFoo3 (sing @_ @d))
+      sing = (singFun1 @(Foo3Sym1 (d :: a))) (sFoo3 (sing @d))
     instance SingI (Foo2Sym0 :: (~>) a ((~>) (Maybe a) a)) where
       sing = (singFun2 @Foo2Sym0) sFoo2
     instance SingI d =>
              SingI (Foo2Sym1 (d :: a) :: (~>) (Maybe a) a) where
-      sing = (singFun1 @(Foo2Sym1 (d :: a))) (sFoo2 (sing @_ @d))
+      sing = (singFun1 @(Foo2Sym1 (d :: a))) (sFoo2 (sing @d))
     instance SingI (Foo1Sym0 :: (~>) a ((~>) (Maybe a) a)) where
       sing = (singFun2 @Foo1Sym0) sFoo1
     instance SingI d =>
              SingI (Foo1Sym1 (d :: a) :: (~>) (Maybe a) a) where
-      sing = (singFun1 @(Foo1Sym1 (d :: a))) (sFoo1 (sing @_ @d))
+      sing = (singFun1 @(Foo1Sym1 (d :: a))) (sFoo1 (sing @d))

--- a/tests/compile-and-dump/Singletons/Classes.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Classes.ghc84.template
@@ -312,6 +312,17 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     sFooCompare SB SB = SGT
     sFooCompare SB SA = SEQ
     sConst (sX :: Sing x) _ = sX
+    instance SingI (FooCompareSym0 :: (~>) Foo ((~>) Foo Ordering)) where
+      sing = (singFun2 @FooCompareSym0) sFooCompare
+    instance SingI d =>
+             SingI (FooCompareSym1 (d :: Foo) :: (~>) Foo Ordering) where
+      sing
+        = (singFun1 @(FooCompareSym1 (d :: Foo)))
+            (sFooCompare (sing @_ @d))
+    instance SingI (ConstSym0 :: (~>) a ((~>) b a)) where
+      sing = (singFun2 @ConstSym0) sConst
+    instance SingI d => SingI (ConstSym1 (d :: a) :: (~>) b a) where
+      sing = (singFun1 @(ConstSym1 (d :: a))) (sConst (sing @_ @d))
     data instance Sing :: Foo -> GHC.Types.Type :: Foo
                                                    -> GHC.Types.Type
       where
@@ -402,6 +413,19 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       sing = SF
     instance SingI G where
       sing = SG
+    instance SMyOrd a =>
+             SingI (MycompareSym0 :: (~>) a ((~>) a Ordering)) where
+      sing = (singFun2 @MycompareSym0) sMycompare
+    instance (SMyOrd a, SingI d) =>
+             SingI (MycompareSym1 (d :: a) :: (~>) a Ordering) where
+      sing
+        = (singFun1 @(MycompareSym1 (d :: a))) (sMycompare (sing @_ @d))
+    instance SMyOrd a =>
+             SingI ((<=>@#@$) :: (~>) a ((~>) a Ordering)) where
+      sing = (singFun2 @(<=>@#@$)) (%<=>)
+    instance (SMyOrd a, SingI d) =>
+             SingI ((<=>@#@$$) (d :: a) :: (~>) a Ordering) where
+      sing = (singFun1 @((<=>@#@$$) (d :: a))) ((%<=>) (sing @_ @d))
 Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     promote
       [d| instance Ord Foo2 where
@@ -570,3 +594,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       sing = SZero'
     instance SingI n => SingI (Succ' (n :: Nat')) where
       sing = SSucc' sing
+    instance SingI (Succ'Sym0 :: (~>) Nat' Nat') where
+      sing = (singFun1 @Succ'Sym0) SSucc'
+    instance SingI (TyCon1 Succ' :: (~>) Nat' Nat') where
+      sing = (singFun1 @(TyCon1 Succ')) SSucc'

--- a/tests/compile-and-dump/Singletons/Classes.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Classes.ghc84.template
@@ -317,12 +317,11 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     instance SingI d =>
              SingI (FooCompareSym1 (d :: Foo) :: (~>) Foo Ordering) where
       sing
-        = (singFun1 @(FooCompareSym1 (d :: Foo)))
-            (sFooCompare (sing @_ @d))
+        = (singFun1 @(FooCompareSym1 (d :: Foo))) (sFooCompare (sing @d))
     instance SingI (ConstSym0 :: (~>) a ((~>) b a)) where
       sing = (singFun2 @ConstSym0) sConst
     instance SingI d => SingI (ConstSym1 (d :: a) :: (~>) b a) where
-      sing = (singFun1 @(ConstSym1 (d :: a))) (sConst (sing @_ @d))
+      sing = (singFun1 @(ConstSym1 (d :: a))) (sConst (sing @d))
     data instance Sing :: Foo -> GHC.Types.Type :: Foo
                                                    -> GHC.Types.Type
       where
@@ -418,14 +417,13 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @MycompareSym0) sMycompare
     instance (SMyOrd a, SingI d) =>
              SingI (MycompareSym1 (d :: a) :: (~>) a Ordering) where
-      sing
-        = (singFun1 @(MycompareSym1 (d :: a))) (sMycompare (sing @_ @d))
+      sing = (singFun1 @(MycompareSym1 (d :: a))) (sMycompare (sing @d))
     instance SMyOrd a =>
              SingI ((<=>@#@$) :: (~>) a ((~>) a Ordering)) where
       sing = (singFun2 @(<=>@#@$)) (%<=>)
     instance (SMyOrd a, SingI d) =>
              SingI ((<=>@#@$$) (d :: a) :: (~>) a Ordering) where
-      sing = (singFun1 @((<=>@#@$$) (d :: a))) ((%<=>) (sing @_ @d))
+      sing = (singFun1 @((<=>@#@$$) (d :: a))) ((%<=>) (sing @d))
 Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     promote
       [d| instance Ord Foo2 where

--- a/tests/compile-and-dump/Singletons/Classes2.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Classes2.ghc84.template
@@ -89,3 +89,7 @@ Singletons/Classes2.hs:(0,0)-(0,0): Splicing declarations
       sing = SZeroFoo
     instance SingI n => SingI (SuccFoo (n :: NatFoo)) where
       sing = SSuccFoo sing
+    instance SingI (SuccFooSym0 :: (~>) NatFoo NatFoo) where
+      sing = (singFun1 @SuccFooSym0) SSuccFoo
+    instance SingI (TyCon1 SuccFoo :: (~>) NatFoo NatFoo) where
+      sing = (singFun1 @(TyCon1 SuccFoo)) SSuccFoo

--- a/tests/compile-and-dump/Singletons/Contains.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Contains.ghc84.template
@@ -42,3 +42,9 @@ Singletons/Contains.hs:(0,0)-(0,0): Splicing declarations
           ((applySing
               ((applySing ((singFun2 @ContainsSym0) sContains)) sElt))
              sT)
+    instance SEq a =>
+             SingI (ContainsSym0 :: (~>) a ((~>) [a] Bool)) where
+      sing = (singFun2 @ContainsSym0) sContains
+    instance (SEq a, SingI d) =>
+             SingI (ContainsSym1 (d :: a) :: (~>) [a] Bool) where
+      sing = (singFun1 @(ContainsSym1 (d :: a))) (sContains (sing @_ @d))

--- a/tests/compile-and-dump/Singletons/Contains.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Contains.ghc84.template
@@ -47,4 +47,4 @@ Singletons/Contains.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @ContainsSym0) sContains
     instance (SEq a, SingI d) =>
              SingI (ContainsSym1 (d :: a) :: (~>) [a] Bool) where
-      sing = (singFun1 @(ContainsSym1 (d :: a))) (sContains (sing @_ @d))
+      sing = (singFun1 @(ContainsSym1 (d :: a))) (sContains (sing @d))

--- a/tests/compile-and-dump/Singletons/DataValues.ghc84.template
+++ b/tests/compile-and-dump/Singletons/DataValues.ghc84.template
@@ -188,3 +188,13 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
       showsPrec = Data.Singletons.ShowSing.showsSingPrec
     instance (SingI n, SingI n) => SingI (Pair (n :: a) (n :: b)) where
       sing = (SPair sing) sing
+    instance SingI (PairSym0 :: (~>) a ((~>) b (Pair a b))) where
+      sing = (singFun2 @PairSym0) SPair
+    instance SingI (TyCon2 Pair :: (~>) a ((~>) b (Pair a b))) where
+      sing = (singFun2 @(TyCon2 Pair)) SPair
+    instance SingI d =>
+             SingI (PairSym1 (d :: a) :: (~>) b (Pair a b)) where
+      sing = (singFun1 @(PairSym1 (d :: a))) (SPair (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon1 (Pair (d :: a)) :: (~>) b (Pair a b)) where
+      sing = (singFun1 @(TyCon1 (Pair (d :: a)))) (SPair (sing @_ @d))

--- a/tests/compile-and-dump/Singletons/DataValues.ghc84.template
+++ b/tests/compile-and-dump/Singletons/DataValues.ghc84.template
@@ -194,7 +194,7 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @(TyCon2 Pair)) SPair
     instance SingI d =>
              SingI (PairSym1 (d :: a) :: (~>) b (Pair a b)) where
-      sing = (singFun1 @(PairSym1 (d :: a))) (SPair (sing @_ @d))
+      sing = (singFun1 @(PairSym1 (d :: a))) (SPair (sing @d))
     instance SingI d =>
              SingI (TyCon1 (Pair (d :: a)) :: (~>) b (Pair a b)) where
-      sing = (singFun1 @(TyCon1 (Pair (d :: a)))) (SPair (sing @_ @d))
+      sing = (singFun1 @(TyCon1 (Pair (d :: a)))) (SPair (sing @d))

--- a/tests/compile-and-dump/Singletons/Error.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Error.ghc84.template
@@ -24,3 +24,5 @@ Singletons/Error.hs:(0,0)-(0,0): Splicing declarations
     sHead (SCons (sA :: Sing a) _) = sA
     sHead SNil
       = sError (sing :: Sing "Data.Singletons.List.head: empty list")
+    instance SingI (HeadSym0 :: (~>) [a] a) where
+      sing = (singFun1 @HeadSym0) sHead

--- a/tests/compile-and-dump/Singletons/Error.hs
+++ b/tests/compile-and-dump/Singletons/Error.hs
@@ -1,7 +1,7 @@
 module Singletons.Error where
 
 import Data.Singletons
-import Data.Singletons.Prelude hiding (Head, HeadSym0, HeadSym1)
+import Data.Singletons.Prelude hiding (Head, HeadSym0, HeadSym1, sHead)
 import Data.Singletons.TH
 
 $(singletons [d|

--- a/tests/compile-and-dump/Singletons/Fixity.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Fixity.ghc84.template
@@ -68,7 +68,17 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
       forall a (t :: a) (t :: a).
       Sing t -> Sing t -> Sing (Apply (Apply (====@#@$) t) t :: a)
     (%====) (sA :: Sing a) _ = sA
+    instance SingI ((====@#@$) :: (~>) a ((~>) a a)) where
+      sing = (singFun2 @(====@#@$)) (%====)
+    instance SingI d => SingI ((====@#@$$) (d :: a) :: (~>) a a) where
+      sing = (singFun1 @((====@#@$$) (d :: a))) ((%====) (sing @_ @d))
     class SMyOrd a where
       (%<=>) ::
         forall (t :: a) (t :: a).
         Sing t -> Sing t -> Sing (Apply (Apply (<=>@#@$) t) t :: Ordering)
+    instance SMyOrd a =>
+             SingI ((<=>@#@$) :: (~>) a ((~>) a Ordering)) where
+      sing = (singFun2 @(<=>@#@$)) (%<=>)
+    instance (SMyOrd a, SingI d) =>
+             SingI ((<=>@#@$$) (d :: a) :: (~>) a Ordering) where
+      sing = (singFun1 @((<=>@#@$$) (d :: a))) ((%<=>) (sing @_ @d))

--- a/tests/compile-and-dump/Singletons/Fixity.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Fixity.ghc84.template
@@ -71,7 +71,7 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
     instance SingI ((====@#@$) :: (~>) a ((~>) a a)) where
       sing = (singFun2 @(====@#@$)) (%====)
     instance SingI d => SingI ((====@#@$$) (d :: a) :: (~>) a a) where
-      sing = (singFun1 @((====@#@$$) (d :: a))) ((%====) (sing @_ @d))
+      sing = (singFun1 @((====@#@$$) (d :: a))) ((%====) (sing @d))
     class SMyOrd a where
       (%<=>) ::
         forall (t :: a) (t :: a).
@@ -81,4 +81,4 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @(<=>@#@$)) (%<=>)
     instance (SMyOrd a, SingI d) =>
              SingI ((<=>@#@$$) (d :: a) :: (~>) a Ordering) where
-      sing = (singFun1 @((<=>@#@$$) (d :: a))) ((%<=>) (sing @_ @d))
+      sing = (singFun1 @((<=>@#@$$) (d :: a))) ((%<=>) (sing @d))

--- a/tests/compile-and-dump/Singletons/FunDeps.ghc84.template
+++ b/tests/compile-and-dump/Singletons/FunDeps.ghc84.template
@@ -90,3 +90,7 @@ Singletons/FunDeps.hs:(0,0)-(0,0): Splicing declarations
         = (applySing ((singFun1 @NotSym0) sNot)) sA_0123456789876543210
       sL2r SFalse = sFromInteger (sing :: Sing 0)
       sL2r STrue = sFromInteger (sing :: Sing 1)
+    instance SFD a b => SingI (MethSym0 :: (~>) a a) where
+      sing = (singFun1 @MethSym0) sMeth
+    instance SFD a b => SingI (L2rSym0 :: (~>) a b) where
+      sing = (singFun1 @L2rSym0) sL2r

--- a/tests/compile-and-dump/Singletons/HigherOrder.ghc84.template
+++ b/tests/compile-and-dump/Singletons/HigherOrder.ghc84.template
@@ -394,6 +394,54 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
       = (applySing
            ((applySing ((singFun2 @(:@#@$)) SCons)) ((applySing sF) sH)))
           ((applySing ((applySing ((singFun2 @MapSym0) sMap)) sF)) sT)
+    instance SingI (FooSym0 :: (~>) ((~>) ((~>) a b) ((~>) a b)) ((~>) ((~>) a b) ((~>) a b))) where
+      sing = (singFun3 @FooSym0) sFoo
+    instance SingI d =>
+             SingI (FooSym1 (d :: (~>) ((~>) a b) ((~>) a b)) :: (~>) ((~>) a b) ((~>) a b)) where
+      sing
+        = (singFun2 @(FooSym1 (d :: (~>) ((~>) a b) ((~>) a b))))
+            (sFoo (sing @_ @d))
+    instance (SingI d, SingI d) =>
+             SingI (FooSym2 (d :: (~>) ((~>) a b) ((~>) a b)) (d :: (~>) a b) :: (~>) a b) where
+      sing
+        = (singFun1
+             @(FooSym2 (d :: (~>) ((~>) a b) ((~>) a b)) (d :: (~>) a b)))
+            ((sFoo (sing @_ @d)) (sing @_ @d))
+    instance SingI (ZipWithSym0 :: (~>) ((~>) a ((~>) b c)) ((~>) [a] ((~>) [b] [c]))) where
+      sing = (singFun3 @ZipWithSym0) sZipWith
+    instance SingI d =>
+             SingI (ZipWithSym1 (d :: (~>) a ((~>) b c)) :: (~>) [a] ((~>) [b] [c])) where
+      sing
+        = (singFun2 @(ZipWithSym1 (d :: (~>) a ((~>) b c))))
+            (sZipWith (sing @_ @d))
+    instance (SingI d, SingI d) =>
+             SingI (ZipWithSym2 (d :: (~>) a ((~>) b c)) (d :: [a]) :: (~>) [b] [c]) where
+      sing
+        = (singFun1 @(ZipWithSym2 (d :: (~>) a ((~>) b c)) (d :: [a])))
+            ((sZipWith (sing @_ @d)) (sing @_ @d))
+    instance SingI (SplungeSym0 :: (~>) [Nat] ((~>) [Bool] [Nat])) where
+      sing = (singFun2 @SplungeSym0) sSplunge
+    instance SingI d =>
+             SingI (SplungeSym1 (d :: [Nat]) :: (~>) [Bool] [Nat]) where
+      sing
+        = (singFun1 @(SplungeSym1 (d :: [Nat]))) (sSplunge (sing @_ @d))
+    instance SingI (EtadSym0 :: (~>) [Nat] ((~>) [Bool] [Nat])) where
+      sing = (singFun2 @EtadSym0) sEtad
+    instance SingI d =>
+             SingI (EtadSym1 (d :: [Nat]) :: (~>) [Bool] [Nat]) where
+      sing = (singFun1 @(EtadSym1 (d :: [Nat]))) (sEtad (sing @_ @d))
+    instance SingI (LiftMaybeSym0 :: (~>) ((~>) a b) ((~>) (Maybe a) (Maybe b))) where
+      sing = (singFun2 @LiftMaybeSym0) sLiftMaybe
+    instance SingI d =>
+             SingI (LiftMaybeSym1 (d :: (~>) a b) :: (~>) (Maybe a) (Maybe b)) where
+      sing
+        = (singFun1 @(LiftMaybeSym1 (d :: (~>) a b)))
+            (sLiftMaybe (sing @_ @d))
+    instance SingI (MapSym0 :: (~>) ((~>) a b) ((~>) [a] [b])) where
+      sing = (singFun2 @MapSym0) sMap
+    instance SingI d =>
+             SingI (MapSym1 (d :: (~>) a b) :: (~>) [a] [b]) where
+      sing = (singFun1 @(MapSym1 (d :: (~>) a b))) (sMap (sing @_ @d))
     data instance Sing :: Either a b -> GHC.Types.Type :: Either a b
                                                           -> GHC.Types.Type
       where
@@ -412,5 +460,13 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
             SomeSing c -> SomeSing (SRight c) }
     instance SingI n => SingI (Left (n :: a)) where
       sing = SLeft sing
+    instance SingI (LeftSym0 :: (~>) a (Either a b)) where
+      sing = (singFun1 @LeftSym0) SLeft
+    instance SingI (TyCon1 Left :: (~>) a (Either a b)) where
+      sing = (singFun1 @(TyCon1 Left)) SLeft
     instance SingI n => SingI (Right (n :: b)) where
       sing = SRight sing
+    instance SingI (RightSym0 :: (~>) b (Either a b)) where
+      sing = (singFun1 @RightSym0) SRight
+    instance SingI (TyCon1 Right :: (~>) b (Either a b)) where
+      sing = (singFun1 @(TyCon1 Right)) SRight

--- a/tests/compile-and-dump/Singletons/HigherOrder.ghc84.template
+++ b/tests/compile-and-dump/Singletons/HigherOrder.ghc84.template
@@ -400,48 +400,47 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
              SingI (FooSym1 (d :: (~>) ((~>) a b) ((~>) a b)) :: (~>) ((~>) a b) ((~>) a b)) where
       sing
         = (singFun2 @(FooSym1 (d :: (~>) ((~>) a b) ((~>) a b))))
-            (sFoo (sing @_ @d))
+            (sFoo (sing @d))
     instance (SingI d, SingI d) =>
              SingI (FooSym2 (d :: (~>) ((~>) a b) ((~>) a b)) (d :: (~>) a b) :: (~>) a b) where
       sing
         = (singFun1
              @(FooSym2 (d :: (~>) ((~>) a b) ((~>) a b)) (d :: (~>) a b)))
-            ((sFoo (sing @_ @d)) (sing @_ @d))
+            ((sFoo (sing @d)) (sing @d))
     instance SingI (ZipWithSym0 :: (~>) ((~>) a ((~>) b c)) ((~>) [a] ((~>) [b] [c]))) where
       sing = (singFun3 @ZipWithSym0) sZipWith
     instance SingI d =>
              SingI (ZipWithSym1 (d :: (~>) a ((~>) b c)) :: (~>) [a] ((~>) [b] [c])) where
       sing
         = (singFun2 @(ZipWithSym1 (d :: (~>) a ((~>) b c))))
-            (sZipWith (sing @_ @d))
+            (sZipWith (sing @d))
     instance (SingI d, SingI d) =>
              SingI (ZipWithSym2 (d :: (~>) a ((~>) b c)) (d :: [a]) :: (~>) [b] [c]) where
       sing
         = (singFun1 @(ZipWithSym2 (d :: (~>) a ((~>) b c)) (d :: [a])))
-            ((sZipWith (sing @_ @d)) (sing @_ @d))
+            ((sZipWith (sing @d)) (sing @d))
     instance SingI (SplungeSym0 :: (~>) [Nat] ((~>) [Bool] [Nat])) where
       sing = (singFun2 @SplungeSym0) sSplunge
     instance SingI d =>
              SingI (SplungeSym1 (d :: [Nat]) :: (~>) [Bool] [Nat]) where
-      sing
-        = (singFun1 @(SplungeSym1 (d :: [Nat]))) (sSplunge (sing @_ @d))
+      sing = (singFun1 @(SplungeSym1 (d :: [Nat]))) (sSplunge (sing @d))
     instance SingI (EtadSym0 :: (~>) [Nat] ((~>) [Bool] [Nat])) where
       sing = (singFun2 @EtadSym0) sEtad
     instance SingI d =>
              SingI (EtadSym1 (d :: [Nat]) :: (~>) [Bool] [Nat]) where
-      sing = (singFun1 @(EtadSym1 (d :: [Nat]))) (sEtad (sing @_ @d))
+      sing = (singFun1 @(EtadSym1 (d :: [Nat]))) (sEtad (sing @d))
     instance SingI (LiftMaybeSym0 :: (~>) ((~>) a b) ((~>) (Maybe a) (Maybe b))) where
       sing = (singFun2 @LiftMaybeSym0) sLiftMaybe
     instance SingI d =>
              SingI (LiftMaybeSym1 (d :: (~>) a b) :: (~>) (Maybe a) (Maybe b)) where
       sing
         = (singFun1 @(LiftMaybeSym1 (d :: (~>) a b)))
-            (sLiftMaybe (sing @_ @d))
+            (sLiftMaybe (sing @d))
     instance SingI (MapSym0 :: (~>) ((~>) a b) ((~>) [a] [b])) where
       sing = (singFun2 @MapSym0) sMap
     instance SingI d =>
              SingI (MapSym1 (d :: (~>) a b) :: (~>) [a] [b]) where
-      sing = (singFun1 @(MapSym1 (d :: (~>) a b))) (sMap (sing @_ @d))
+      sing = (singFun1 @(MapSym1 (d :: (~>) a b))) (sMap (sing @d))
     data instance Sing :: Either a b -> GHC.Types.Type :: Either a b
                                                           -> GHC.Types.Type
       where

--- a/tests/compile-and-dump/Singletons/LambdaCase.ghc84.template
+++ b/tests/compile-and-dump/Singletons/LambdaCase.ghc84.template
@@ -238,3 +238,17 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
                              SNothing -> sD ::
                              Sing (Case_0123456789876543210 d x x_0123456789876543210 x_0123456789876543210) })))
           sX
+    instance SingI (Foo3Sym0 :: (~>) a ((~>) b a)) where
+      sing = (singFun2 @Foo3Sym0) sFoo3
+    instance SingI d => SingI (Foo3Sym1 (d :: a) :: (~>) b a) where
+      sing = (singFun1 @(Foo3Sym1 (d :: a))) (sFoo3 (sing @_ @d))
+    instance SingI (Foo2Sym0 :: (~>) a ((~>) (Maybe a) a)) where
+      sing = (singFun2 @Foo2Sym0) sFoo2
+    instance SingI d =>
+             SingI (Foo2Sym1 (d :: a) :: (~>) (Maybe a) a) where
+      sing = (singFun1 @(Foo2Sym1 (d :: a))) (sFoo2 (sing @_ @d))
+    instance SingI (Foo1Sym0 :: (~>) a ((~>) (Maybe a) a)) where
+      sing = (singFun2 @Foo1Sym0) sFoo1
+    instance SingI d =>
+             SingI (Foo1Sym1 (d :: a) :: (~>) (Maybe a) a) where
+      sing = (singFun1 @(Foo1Sym1 (d :: a))) (sFoo1 (sing @_ @d))

--- a/tests/compile-and-dump/Singletons/LambdaCase.ghc84.template
+++ b/tests/compile-and-dump/Singletons/LambdaCase.ghc84.template
@@ -241,14 +241,14 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
     instance SingI (Foo3Sym0 :: (~>) a ((~>) b a)) where
       sing = (singFun2 @Foo3Sym0) sFoo3
     instance SingI d => SingI (Foo3Sym1 (d :: a) :: (~>) b a) where
-      sing = (singFun1 @(Foo3Sym1 (d :: a))) (sFoo3 (sing @_ @d))
+      sing = (singFun1 @(Foo3Sym1 (d :: a))) (sFoo3 (sing @d))
     instance SingI (Foo2Sym0 :: (~>) a ((~>) (Maybe a) a)) where
       sing = (singFun2 @Foo2Sym0) sFoo2
     instance SingI d =>
              SingI (Foo2Sym1 (d :: a) :: (~>) (Maybe a) a) where
-      sing = (singFun1 @(Foo2Sym1 (d :: a))) (sFoo2 (sing @_ @d))
+      sing = (singFun1 @(Foo2Sym1 (d :: a))) (sFoo2 (sing @d))
     instance SingI (Foo1Sym0 :: (~>) a ((~>) (Maybe a) a)) where
       sing = (singFun2 @Foo1Sym0) sFoo1
     instance SingI d =>
              SingI (Foo1Sym1 (d :: a) :: (~>) (Maybe a) a) where
-      sing = (singFun1 @(Foo1Sym1 (d :: a))) (sFoo1 (sing @_ @d))
+      sing = (singFun1 @(Foo1Sym1 (d :: a))) (sFoo1 (sing @d))

--- a/tests/compile-and-dump/Singletons/Lambdas.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Lambdas.ghc84.template
@@ -765,6 +765,44 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
                           GHC.Tuple.(,) (_ :: Sing x) (_ :: Sing y) -> sX })))
               sA_0123456789876543210))
           sA_0123456789876543210
+    instance SingI (Foo8Sym0 :: (~>) (Foo a b) a) where
+      sing = (singFun1 @Foo8Sym0) sFoo8
+    instance SingI (Foo7Sym0 :: (~>) a ((~>) b b)) where
+      sing = (singFun2 @Foo7Sym0) sFoo7
+    instance SingI d => SingI (Foo7Sym1 (d :: a) :: (~>) b b) where
+      sing = (singFun1 @(Foo7Sym1 (d :: a))) (sFoo7 (sing @_ @d))
+    instance SingI (Foo6Sym0 :: (~>) a ((~>) b a)) where
+      sing = (singFun2 @Foo6Sym0) sFoo6
+    instance SingI d => SingI (Foo6Sym1 (d :: a) :: (~>) b a) where
+      sing = (singFun1 @(Foo6Sym1 (d :: a))) (sFoo6 (sing @_ @d))
+    instance SingI (Foo5Sym0 :: (~>) a ((~>) b b)) where
+      sing = (singFun2 @Foo5Sym0) sFoo5
+    instance SingI d => SingI (Foo5Sym1 (d :: a) :: (~>) b b) where
+      sing = (singFun1 @(Foo5Sym1 (d :: a))) (sFoo5 (sing @_ @d))
+    instance SingI (Foo4Sym0 :: (~>) a ((~>) b ((~>) c a))) where
+      sing = (singFun3 @Foo4Sym0) sFoo4
+    instance SingI d =>
+             SingI (Foo4Sym1 (d :: a) :: (~>) b ((~>) c a)) where
+      sing = (singFun2 @(Foo4Sym1 (d :: a))) (sFoo4 (sing @_ @d))
+    instance (SingI d, SingI d) =>
+             SingI (Foo4Sym2 (d :: a) (d :: b) :: (~>) c a) where
+      sing
+        = (singFun1 @(Foo4Sym2 (d :: a) (d :: b)))
+            ((sFoo4 (sing @_ @d)) (sing @_ @d))
+    instance SingI (Foo3Sym0 :: (~>) a a) where
+      sing = (singFun1 @Foo3Sym0) sFoo3
+    instance SingI (Foo2Sym0 :: (~>) a ((~>) b a)) where
+      sing = (singFun2 @Foo2Sym0) sFoo2
+    instance SingI d => SingI (Foo2Sym1 (d :: a) :: (~>) b a) where
+      sing = (singFun1 @(Foo2Sym1 (d :: a))) (sFoo2 (sing @_ @d))
+    instance SingI (Foo1Sym0 :: (~>) a ((~>) b a)) where
+      sing = (singFun2 @Foo1Sym0) sFoo1
+    instance SingI d => SingI (Foo1Sym1 (d :: a) :: (~>) b a) where
+      sing = (singFun1 @(Foo1Sym1 (d :: a))) (sFoo1 (sing @_ @d))
+    instance SingI (Foo0Sym0 :: (~>) a ((~>) b a)) where
+      sing = (singFun2 @Foo0Sym0) sFoo0
+    instance SingI d => SingI (Foo0Sym1 (d :: a) :: (~>) b a) where
+      sing = (singFun1 @(Foo0Sym1 (d :: a))) (sFoo0 (sing @_ @d))
     data instance Sing :: Foo a b -> GHC.Types.Type :: Foo a b
                                                        -> GHC.Types.Type
       where
@@ -781,3 +819,13 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
             GHC.Tuple.(,) (SomeSing c) (SomeSing c) -> SomeSing ((SFoo c) c) }
     instance (SingI n, SingI n) => SingI (Foo (n :: a) (n :: b)) where
       sing = (SFoo sing) sing
+    instance SingI (FooSym0 :: (~>) a ((~>) b (Foo a b))) where
+      sing = (singFun2 @FooSym0) SFoo
+    instance SingI (TyCon2 Foo :: (~>) a ((~>) b (Foo a b))) where
+      sing = (singFun2 @(TyCon2 Foo)) SFoo
+    instance SingI d =>
+             SingI (FooSym1 (d :: a) :: (~>) b (Foo a b)) where
+      sing = (singFun1 @(FooSym1 (d :: a))) (SFoo (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon1 (Foo (d :: a)) :: (~>) b (Foo a b)) where
+      sing = (singFun1 @(TyCon1 (Foo (d :: a)))) (SFoo (sing @_ @d))

--- a/tests/compile-and-dump/Singletons/Lambdas.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Lambdas.ghc84.template
@@ -770,39 +770,39 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SingI (Foo7Sym0 :: (~>) a ((~>) b b)) where
       sing = (singFun2 @Foo7Sym0) sFoo7
     instance SingI d => SingI (Foo7Sym1 (d :: a) :: (~>) b b) where
-      sing = (singFun1 @(Foo7Sym1 (d :: a))) (sFoo7 (sing @_ @d))
+      sing = (singFun1 @(Foo7Sym1 (d :: a))) (sFoo7 (sing @d))
     instance SingI (Foo6Sym0 :: (~>) a ((~>) b a)) where
       sing = (singFun2 @Foo6Sym0) sFoo6
     instance SingI d => SingI (Foo6Sym1 (d :: a) :: (~>) b a) where
-      sing = (singFun1 @(Foo6Sym1 (d :: a))) (sFoo6 (sing @_ @d))
+      sing = (singFun1 @(Foo6Sym1 (d :: a))) (sFoo6 (sing @d))
     instance SingI (Foo5Sym0 :: (~>) a ((~>) b b)) where
       sing = (singFun2 @Foo5Sym0) sFoo5
     instance SingI d => SingI (Foo5Sym1 (d :: a) :: (~>) b b) where
-      sing = (singFun1 @(Foo5Sym1 (d :: a))) (sFoo5 (sing @_ @d))
+      sing = (singFun1 @(Foo5Sym1 (d :: a))) (sFoo5 (sing @d))
     instance SingI (Foo4Sym0 :: (~>) a ((~>) b ((~>) c a))) where
       sing = (singFun3 @Foo4Sym0) sFoo4
     instance SingI d =>
              SingI (Foo4Sym1 (d :: a) :: (~>) b ((~>) c a)) where
-      sing = (singFun2 @(Foo4Sym1 (d :: a))) (sFoo4 (sing @_ @d))
+      sing = (singFun2 @(Foo4Sym1 (d :: a))) (sFoo4 (sing @d))
     instance (SingI d, SingI d) =>
              SingI (Foo4Sym2 (d :: a) (d :: b) :: (~>) c a) where
       sing
         = (singFun1 @(Foo4Sym2 (d :: a) (d :: b)))
-            ((sFoo4 (sing @_ @d)) (sing @_ @d))
+            ((sFoo4 (sing @d)) (sing @d))
     instance SingI (Foo3Sym0 :: (~>) a a) where
       sing = (singFun1 @Foo3Sym0) sFoo3
     instance SingI (Foo2Sym0 :: (~>) a ((~>) b a)) where
       sing = (singFun2 @Foo2Sym0) sFoo2
     instance SingI d => SingI (Foo2Sym1 (d :: a) :: (~>) b a) where
-      sing = (singFun1 @(Foo2Sym1 (d :: a))) (sFoo2 (sing @_ @d))
+      sing = (singFun1 @(Foo2Sym1 (d :: a))) (sFoo2 (sing @d))
     instance SingI (Foo1Sym0 :: (~>) a ((~>) b a)) where
       sing = (singFun2 @Foo1Sym0) sFoo1
     instance SingI d => SingI (Foo1Sym1 (d :: a) :: (~>) b a) where
-      sing = (singFun1 @(Foo1Sym1 (d :: a))) (sFoo1 (sing @_ @d))
+      sing = (singFun1 @(Foo1Sym1 (d :: a))) (sFoo1 (sing @d))
     instance SingI (Foo0Sym0 :: (~>) a ((~>) b a)) where
       sing = (singFun2 @Foo0Sym0) sFoo0
     instance SingI d => SingI (Foo0Sym1 (d :: a) :: (~>) b a) where
-      sing = (singFun1 @(Foo0Sym1 (d :: a))) (sFoo0 (sing @_ @d))
+      sing = (singFun1 @(Foo0Sym1 (d :: a))) (sFoo0 (sing @d))
     data instance Sing :: Foo a b -> GHC.Types.Type :: Foo a b
                                                        -> GHC.Types.Type
       where
@@ -825,7 +825,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @(TyCon2 Foo)) SFoo
     instance SingI d =>
              SingI (FooSym1 (d :: a) :: (~>) b (Foo a b)) where
-      sing = (singFun1 @(FooSym1 (d :: a))) (SFoo (sing @_ @d))
+      sing = (singFun1 @(FooSym1 (d :: a))) (SFoo (sing @d))
     instance SingI d =>
              SingI (TyCon1 (Foo (d :: a)) :: (~>) b (Foo a b)) where
-      sing = (singFun1 @(TyCon1 (Foo (d :: a)))) (SFoo (sing @_ @d))
+      sing = (singFun1 @(TyCon1 (Foo (d :: a)))) (SFoo (sing @d))

--- a/tests/compile-and-dump/Singletons/LetStatements.ghc84.template
+++ b/tests/compile-and-dump/Singletons/LetStatements.ghc84.template
@@ -985,3 +985,31 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
           sY :: Sing (Let0123456789876543210YSym1 x :: Nat)
           sY = (applySing ((singFun1 @SuccSym0) SSucc)) SZero
         in sY
+    instance SingI (Foo14Sym0 :: (~>) Nat (Nat, Nat)) where
+      sing = (singFun1 @Foo14Sym0) sFoo14
+    instance SingI (Foo13_Sym0 :: (~>) a a) where
+      sing = (singFun1 @Foo13_Sym0) sFoo13_
+    instance SingI (Foo13Sym0 :: (~>) a a) where
+      sing = (singFun1 @Foo13Sym0) sFoo13
+    instance SingI (Foo12Sym0 :: (~>) Nat Nat) where
+      sing = (singFun1 @Foo12Sym0) sFoo12
+    instance SingI (Foo11Sym0 :: (~>) Nat Nat) where
+      sing = (singFun1 @Foo11Sym0) sFoo11
+    instance SingI (Foo10Sym0 :: (~>) Nat Nat) where
+      sing = (singFun1 @Foo10Sym0) sFoo10
+    instance SingI (Foo9Sym0 :: (~>) Nat Nat) where
+      sing = (singFun1 @Foo9Sym0) sFoo9
+    instance SingI (Foo8Sym0 :: (~>) Nat Nat) where
+      sing = (singFun1 @Foo8Sym0) sFoo8
+    instance SingI (Foo7Sym0 :: (~>) Nat Nat) where
+      sing = (singFun1 @Foo7Sym0) sFoo7
+    instance SingI (Foo6Sym0 :: (~>) Nat Nat) where
+      sing = (singFun1 @Foo6Sym0) sFoo6
+    instance SingI (Foo5Sym0 :: (~>) Nat Nat) where
+      sing = (singFun1 @Foo5Sym0) sFoo5
+    instance SingI (Foo4Sym0 :: (~>) Nat Nat) where
+      sing = (singFun1 @Foo4Sym0) sFoo4
+    instance SingI (Foo3Sym0 :: (~>) Nat Nat) where
+      sing = (singFun1 @Foo3Sym0) sFoo3
+    instance SingI (Foo1Sym0 :: (~>) Nat Nat) where
+      sing = (singFun1 @Foo1Sym0) sFoo1

--- a/tests/compile-and-dump/Singletons/Maybe.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Maybe.ghc84.template
@@ -146,3 +146,7 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
       sing = SNothing
     instance SingI n => SingI (Just (n :: a)) where
       sing = SJust sing
+    instance SingI (JustSym0 :: (~>) a (Maybe a)) where
+      sing = (singFun1 @JustSym0) SJust
+    instance SingI (TyCon1 Just :: (~>) a (Maybe a)) where
+      sing = (singFun1 @(TyCon1 Just)) SJust

--- a/tests/compile-and-dump/Singletons/Nat.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Nat.ghc84.template
@@ -154,6 +154,13 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
     sPlus (SSucc (sN :: Sing n)) (sM :: Sing m)
       = (applySing ((singFun1 @SuccSym0) SSucc))
           ((applySing ((applySing ((singFun2 @PlusSym0) sPlus)) sN)) sM)
+    instance SingI (PredSym0 :: (~>) Nat Nat) where
+      sing = (singFun1 @PredSym0) sPred
+    instance SingI (PlusSym0 :: (~>) Nat ((~>) Nat Nat)) where
+      sing = (singFun2 @PlusSym0) sPlus
+    instance SingI d =>
+             SingI (PlusSym1 (d :: Nat) :: (~>) Nat Nat) where
+      sing = (singFun1 @(PlusSym1 (d :: Nat))) (sPlus (sing @_ @d))
     data instance Sing :: Nat -> GHC.Types.Type :: Nat
                                                    -> GHC.Types.Type
       where
@@ -267,3 +274,7 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
       sing = SZero
     instance SingI n => SingI (Succ (n :: Nat)) where
       sing = SSucc sing
+    instance SingI (SuccSym0 :: (~>) Nat Nat) where
+      sing = (singFun1 @SuccSym0) SSucc
+    instance SingI (TyCon1 Succ :: (~>) Nat Nat) where
+      sing = (singFun1 @(TyCon1 Succ)) SSucc

--- a/tests/compile-and-dump/Singletons/Nat.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Nat.ghc84.template
@@ -160,7 +160,7 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @PlusSym0) sPlus
     instance SingI d =>
              SingI (PlusSym1 (d :: Nat) :: (~>) Nat Nat) where
-      sing = (singFun1 @(PlusSym1 (d :: Nat))) (sPlus (sing @_ @d))
+      sing = (singFun1 @(PlusSym1 (d :: Nat))) (sPlus (sing @d))
     data instance Sing :: Nat -> GHC.Types.Type :: Nat
                                                    -> GHC.Types.Type
       where

--- a/tests/compile-and-dump/Singletons/Operators.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Operators.ghc84.template
@@ -84,6 +84,13 @@ Singletons/Operators.hs:(0,0)-(0,0): Splicing declarations
           ((applySing ((applySing ((singFun2 @(+@#@$)) (%+))) sN)) sM)
     sChild SFLeaf = SFLeaf
     sChild ((:%+:) (sA :: Sing a) _) = sA
+    instance SingI ((+@#@$) :: (~>) Nat ((~>) Nat Nat)) where
+      sing = (singFun2 @(+@#@$)) (%+)
+    instance SingI d =>
+             SingI ((+@#@$$) (d :: Nat) :: (~>) Nat Nat) where
+      sing = (singFun1 @((+@#@$$) (d :: Nat))) ((%+) (sing @_ @d))
+    instance SingI (ChildSym0 :: (~>) Foo Foo) where
+      sing = (singFun1 @ChildSym0) sChild
     data instance Sing :: Foo -> GHC.Types.Type :: Foo
                                                    -> GHC.Types.Type
       where
@@ -108,3 +115,14 @@ Singletons/Operators.hs:(0,0)-(0,0): Splicing declarations
     instance (SingI n, SingI n) =>
              SingI ((:+:) (n :: Foo) (n :: Foo)) where
       sing = ((:%+:) sing) sing
+    instance SingI ((:+:@#@$) :: (~>) Foo ((~>) Foo Foo)) where
+      sing = (singFun2 @(:+:@#@$)) (:%+:)
+    instance SingI (TyCon2 (:+:) :: (~>) Foo ((~>) Foo Foo)) where
+      sing = (singFun2 @(TyCon2 (:+:))) (:%+:)
+    instance SingI d =>
+             SingI ((:+:@#@$$) (d :: Foo) :: (~>) Foo Foo) where
+      sing = (singFun1 @((:+:@#@$$) (d :: Foo))) ((:%+:) (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon1 ((:+:) (d :: Foo)) :: (~>) Foo Foo) where
+      sing
+        = (singFun1 @(TyCon1 ((:+:) (d :: Foo)))) ((:%+:) (sing @_ @d))

--- a/tests/compile-and-dump/Singletons/Operators.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Operators.ghc84.template
@@ -88,7 +88,7 @@ Singletons/Operators.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @(+@#@$)) (%+)
     instance SingI d =>
              SingI ((+@#@$$) (d :: Nat) :: (~>) Nat Nat) where
-      sing = (singFun1 @((+@#@$$) (d :: Nat))) ((%+) (sing @_ @d))
+      sing = (singFun1 @((+@#@$$) (d :: Nat))) ((%+) (sing @d))
     instance SingI (ChildSym0 :: (~>) Foo Foo) where
       sing = (singFun1 @ChildSym0) sChild
     data instance Sing :: Foo -> GHC.Types.Type :: Foo
@@ -121,8 +121,7 @@ Singletons/Operators.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @(TyCon2 (:+:))) (:%+:)
     instance SingI d =>
              SingI ((:+:@#@$$) (d :: Foo) :: (~>) Foo Foo) where
-      sing = (singFun1 @((:+:@#@$$) (d :: Foo))) ((:%+:) (sing @_ @d))
+      sing = (singFun1 @((:+:@#@$$) (d :: Foo))) ((:%+:) (sing @d))
     instance SingI d =>
              SingI (TyCon1 ((:+:) (d :: Foo)) :: (~>) Foo Foo) where
-      sing
-        = (singFun1 @(TyCon1 ((:+:) (d :: Foo)))) ((:%+:) (sing @_ @d))
+      sing = (singFun1 @(TyCon1 ((:+:) (d :: Foo)))) ((:%+:) (sing @d))

--- a/tests/compile-and-dump/Singletons/OrdDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/OrdDeriving.ghc84.template
@@ -980,21 +980,205 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       sing = SZero
     instance SingI n => SingI (Succ (n :: Nat)) where
       sing = SSucc sing
+    instance SingI (SuccSym0 :: (~>) Nat Nat) where
+      sing = (singFun1 @SuccSym0) SSucc
+    instance SingI (TyCon1 Succ :: (~>) Nat Nat) where
+      sing = (singFun1 @(TyCon1 Succ)) SSucc
     instance (SingI n, SingI n, SingI n, SingI n) =>
              SingI (A (n :: a) (n :: b) (n :: c) (n :: d)) where
       sing = (((SA sing) sing) sing) sing
+    instance SingI (ASym0 :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))) where
+      sing = (singFun4 @ASym0) SA
+    instance SingI (TyCon4 A :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))) where
+      sing = (singFun4 @(TyCon4 A)) SA
+    instance SingI d =>
+             SingI (ASym1 (d :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
+      sing = (singFun3 @(ASym1 (d :: a))) (SA (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon3 (A (d :: a)) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
+      sing = (singFun3 @(TyCon3 (A (d :: a)))) (SA (sing @_ @d))
+    instance (SingI d, SingI d) =>
+             SingI (ASym2 (d :: a) (d :: b) :: (~>) c ((~>) d (Foo a b c d))) where
+      sing
+        = (singFun2 @(ASym2 (d :: a) (d :: b)))
+            ((SA (sing @_ @d)) (sing @_ @d))
+    instance (SingI d, SingI d) =>
+             SingI (TyCon2 (A (d :: a) (d :: b)) :: (~>) c ((~>) d (Foo a b c d))) where
+      sing
+        = (singFun2 @(TyCon2 (A (d :: a) (d :: b))))
+            ((SA (sing @_ @d)) (sing @_ @d))
+    instance (SingI d, SingI d, SingI d) =>
+             SingI (ASym3 (d :: a) (d :: b) (d :: c) :: (~>) d (Foo a b c d)) where
+      sing
+        = (singFun1 @(ASym3 (d :: a) (d :: b) (d :: c)))
+            (((SA (sing @_ @d)) (sing @_ @d)) (sing @_ @d))
+    instance (SingI d, SingI d, SingI d) =>
+             SingI (TyCon1 (A (d :: a) (d :: b) (d :: c)) :: (~>) d (Foo a b c d)) where
+      sing
+        = (singFun1 @(TyCon1 (A (d :: a) (d :: b) (d :: c))))
+            (((SA (sing @_ @d)) (sing @_ @d)) (sing @_ @d))
     instance (SingI n, SingI n, SingI n, SingI n) =>
              SingI (B (n :: a) (n :: b) (n :: c) (n :: d)) where
       sing = (((SB sing) sing) sing) sing
+    instance SingI (BSym0 :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))) where
+      sing = (singFun4 @BSym0) SB
+    instance SingI (TyCon4 B :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))) where
+      sing = (singFun4 @(TyCon4 B)) SB
+    instance SingI d =>
+             SingI (BSym1 (d :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
+      sing = (singFun3 @(BSym1 (d :: a))) (SB (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon3 (B (d :: a)) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
+      sing = (singFun3 @(TyCon3 (B (d :: a)))) (SB (sing @_ @d))
+    instance (SingI d, SingI d) =>
+             SingI (BSym2 (d :: a) (d :: b) :: (~>) c ((~>) d (Foo a b c d))) where
+      sing
+        = (singFun2 @(BSym2 (d :: a) (d :: b)))
+            ((SB (sing @_ @d)) (sing @_ @d))
+    instance (SingI d, SingI d) =>
+             SingI (TyCon2 (B (d :: a) (d :: b)) :: (~>) c ((~>) d (Foo a b c d))) where
+      sing
+        = (singFun2 @(TyCon2 (B (d :: a) (d :: b))))
+            ((SB (sing @_ @d)) (sing @_ @d))
+    instance (SingI d, SingI d, SingI d) =>
+             SingI (BSym3 (d :: a) (d :: b) (d :: c) :: (~>) d (Foo a b c d)) where
+      sing
+        = (singFun1 @(BSym3 (d :: a) (d :: b) (d :: c)))
+            (((SB (sing @_ @d)) (sing @_ @d)) (sing @_ @d))
+    instance (SingI d, SingI d, SingI d) =>
+             SingI (TyCon1 (B (d :: a) (d :: b) (d :: c)) :: (~>) d (Foo a b c d)) where
+      sing
+        = (singFun1 @(TyCon1 (B (d :: a) (d :: b) (d :: c))))
+            (((SB (sing @_ @d)) (sing @_ @d)) (sing @_ @d))
     instance (SingI n, SingI n, SingI n, SingI n) =>
              SingI (C (n :: a) (n :: b) (n :: c) (n :: d)) where
       sing = (((SC sing) sing) sing) sing
+    instance SingI (CSym0 :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))) where
+      sing = (singFun4 @CSym0) SC
+    instance SingI (TyCon4 C :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))) where
+      sing = (singFun4 @(TyCon4 C)) SC
+    instance SingI d =>
+             SingI (CSym1 (d :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
+      sing = (singFun3 @(CSym1 (d :: a))) (SC (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon3 (C (d :: a)) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
+      sing = (singFun3 @(TyCon3 (C (d :: a)))) (SC (sing @_ @d))
+    instance (SingI d, SingI d) =>
+             SingI (CSym2 (d :: a) (d :: b) :: (~>) c ((~>) d (Foo a b c d))) where
+      sing
+        = (singFun2 @(CSym2 (d :: a) (d :: b)))
+            ((SC (sing @_ @d)) (sing @_ @d))
+    instance (SingI d, SingI d) =>
+             SingI (TyCon2 (C (d :: a) (d :: b)) :: (~>) c ((~>) d (Foo a b c d))) where
+      sing
+        = (singFun2 @(TyCon2 (C (d :: a) (d :: b))))
+            ((SC (sing @_ @d)) (sing @_ @d))
+    instance (SingI d, SingI d, SingI d) =>
+             SingI (CSym3 (d :: a) (d :: b) (d :: c) :: (~>) d (Foo a b c d)) where
+      sing
+        = (singFun1 @(CSym3 (d :: a) (d :: b) (d :: c)))
+            (((SC (sing @_ @d)) (sing @_ @d)) (sing @_ @d))
+    instance (SingI d, SingI d, SingI d) =>
+             SingI (TyCon1 (C (d :: a) (d :: b) (d :: c)) :: (~>) d (Foo a b c d)) where
+      sing
+        = (singFun1 @(TyCon1 (C (d :: a) (d :: b) (d :: c))))
+            (((SC (sing @_ @d)) (sing @_ @d)) (sing @_ @d))
     instance (SingI n, SingI n, SingI n, SingI n) =>
              SingI (D (n :: a) (n :: b) (n :: c) (n :: d)) where
       sing = (((SD sing) sing) sing) sing
+    instance SingI (DSym0 :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))) where
+      sing = (singFun4 @DSym0) SD
+    instance SingI (TyCon4 D :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))) where
+      sing = (singFun4 @(TyCon4 D)) SD
+    instance SingI d =>
+             SingI (DSym1 (d :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
+      sing = (singFun3 @(DSym1 (d :: a))) (SD (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon3 (D (d :: a)) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
+      sing = (singFun3 @(TyCon3 (D (d :: a)))) (SD (sing @_ @d))
+    instance (SingI d, SingI d) =>
+             SingI (DSym2 (d :: a) (d :: b) :: (~>) c ((~>) d (Foo a b c d))) where
+      sing
+        = (singFun2 @(DSym2 (d :: a) (d :: b)))
+            ((SD (sing @_ @d)) (sing @_ @d))
+    instance (SingI d, SingI d) =>
+             SingI (TyCon2 (D (d :: a) (d :: b)) :: (~>) c ((~>) d (Foo a b c d))) where
+      sing
+        = (singFun2 @(TyCon2 (D (d :: a) (d :: b))))
+            ((SD (sing @_ @d)) (sing @_ @d))
+    instance (SingI d, SingI d, SingI d) =>
+             SingI (DSym3 (d :: a) (d :: b) (d :: c) :: (~>) d (Foo a b c d)) where
+      sing
+        = (singFun1 @(DSym3 (d :: a) (d :: b) (d :: c)))
+            (((SD (sing @_ @d)) (sing @_ @d)) (sing @_ @d))
+    instance (SingI d, SingI d, SingI d) =>
+             SingI (TyCon1 (D (d :: a) (d :: b) (d :: c)) :: (~>) d (Foo a b c d)) where
+      sing
+        = (singFun1 @(TyCon1 (D (d :: a) (d :: b) (d :: c))))
+            (((SD (sing @_ @d)) (sing @_ @d)) (sing @_ @d))
     instance (SingI n, SingI n, SingI n, SingI n) =>
              SingI (E (n :: a) (n :: b) (n :: c) (n :: d)) where
       sing = (((SE sing) sing) sing) sing
+    instance SingI (ESym0 :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))) where
+      sing = (singFun4 @ESym0) SE
+    instance SingI (TyCon4 E :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))) where
+      sing = (singFun4 @(TyCon4 E)) SE
+    instance SingI d =>
+             SingI (ESym1 (d :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
+      sing = (singFun3 @(ESym1 (d :: a))) (SE (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon3 (E (d :: a)) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
+      sing = (singFun3 @(TyCon3 (E (d :: a)))) (SE (sing @_ @d))
+    instance (SingI d, SingI d) =>
+             SingI (ESym2 (d :: a) (d :: b) :: (~>) c ((~>) d (Foo a b c d))) where
+      sing
+        = (singFun2 @(ESym2 (d :: a) (d :: b)))
+            ((SE (sing @_ @d)) (sing @_ @d))
+    instance (SingI d, SingI d) =>
+             SingI (TyCon2 (E (d :: a) (d :: b)) :: (~>) c ((~>) d (Foo a b c d))) where
+      sing
+        = (singFun2 @(TyCon2 (E (d :: a) (d :: b))))
+            ((SE (sing @_ @d)) (sing @_ @d))
+    instance (SingI d, SingI d, SingI d) =>
+             SingI (ESym3 (d :: a) (d :: b) (d :: c) :: (~>) d (Foo a b c d)) where
+      sing
+        = (singFun1 @(ESym3 (d :: a) (d :: b) (d :: c)))
+            (((SE (sing @_ @d)) (sing @_ @d)) (sing @_ @d))
+    instance (SingI d, SingI d, SingI d) =>
+             SingI (TyCon1 (E (d :: a) (d :: b) (d :: c)) :: (~>) d (Foo a b c d)) where
+      sing
+        = (singFun1 @(TyCon1 (E (d :: a) (d :: b) (d :: c))))
+            (((SE (sing @_ @d)) (sing @_ @d)) (sing @_ @d))
     instance (SingI n, SingI n, SingI n, SingI n) =>
              SingI (F (n :: a) (n :: b) (n :: c) (n :: d)) where
       sing = (((SF sing) sing) sing) sing
+    instance SingI (FSym0 :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))) where
+      sing = (singFun4 @FSym0) SF
+    instance SingI (TyCon4 F :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))) where
+      sing = (singFun4 @(TyCon4 F)) SF
+    instance SingI d =>
+             SingI (FSym1 (d :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
+      sing = (singFun3 @(FSym1 (d :: a))) (SF (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon3 (F (d :: a)) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
+      sing = (singFun3 @(TyCon3 (F (d :: a)))) (SF (sing @_ @d))
+    instance (SingI d, SingI d) =>
+             SingI (FSym2 (d :: a) (d :: b) :: (~>) c ((~>) d (Foo a b c d))) where
+      sing
+        = (singFun2 @(FSym2 (d :: a) (d :: b)))
+            ((SF (sing @_ @d)) (sing @_ @d))
+    instance (SingI d, SingI d) =>
+             SingI (TyCon2 (F (d :: a) (d :: b)) :: (~>) c ((~>) d (Foo a b c d))) where
+      sing
+        = (singFun2 @(TyCon2 (F (d :: a) (d :: b))))
+            ((SF (sing @_ @d)) (sing @_ @d))
+    instance (SingI d, SingI d, SingI d) =>
+             SingI (FSym3 (d :: a) (d :: b) (d :: c) :: (~>) d (Foo a b c d)) where
+      sing
+        = (singFun1 @(FSym3 (d :: a) (d :: b) (d :: c)))
+            (((SF (sing @_ @d)) (sing @_ @d)) (sing @_ @d))
+    instance (SingI d, SingI d, SingI d) =>
+             SingI (TyCon1 (F (d :: a) (d :: b) (d :: c)) :: (~>) d (Foo a b c d)) where
+      sing
+        = (singFun1 @(TyCon1 (F (d :: a) (d :: b) (d :: c))))
+            (((SF (sing @_ @d)) (sing @_ @d)) (sing @_ @d))

--- a/tests/compile-and-dump/Singletons/OrdDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/OrdDeriving.ghc84.template
@@ -993,30 +993,29 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun4 @(TyCon4 A)) SA
     instance SingI d =>
              SingI (ASym1 (d :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
-      sing = (singFun3 @(ASym1 (d :: a))) (SA (sing @_ @d))
+      sing = (singFun3 @(ASym1 (d :: a))) (SA (sing @d))
     instance SingI d =>
              SingI (TyCon3 (A (d :: a)) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
-      sing = (singFun3 @(TyCon3 (A (d :: a)))) (SA (sing @_ @d))
+      sing = (singFun3 @(TyCon3 (A (d :: a)))) (SA (sing @d))
     instance (SingI d, SingI d) =>
              SingI (ASym2 (d :: a) (d :: b) :: (~>) c ((~>) d (Foo a b c d))) where
       sing
-        = (singFun2 @(ASym2 (d :: a) (d :: b)))
-            ((SA (sing @_ @d)) (sing @_ @d))
+        = (singFun2 @(ASym2 (d :: a) (d :: b))) ((SA (sing @d)) (sing @d))
     instance (SingI d, SingI d) =>
              SingI (TyCon2 (A (d :: a) (d :: b)) :: (~>) c ((~>) d (Foo a b c d))) where
       sing
         = (singFun2 @(TyCon2 (A (d :: a) (d :: b))))
-            ((SA (sing @_ @d)) (sing @_ @d))
+            ((SA (sing @d)) (sing @d))
     instance (SingI d, SingI d, SingI d) =>
              SingI (ASym3 (d :: a) (d :: b) (d :: c) :: (~>) d (Foo a b c d)) where
       sing
         = (singFun1 @(ASym3 (d :: a) (d :: b) (d :: c)))
-            (((SA (sing @_ @d)) (sing @_ @d)) (sing @_ @d))
+            (((SA (sing @d)) (sing @d)) (sing @d))
     instance (SingI d, SingI d, SingI d) =>
              SingI (TyCon1 (A (d :: a) (d :: b) (d :: c)) :: (~>) d (Foo a b c d)) where
       sing
         = (singFun1 @(TyCon1 (A (d :: a) (d :: b) (d :: c))))
-            (((SA (sing @_ @d)) (sing @_ @d)) (sing @_ @d))
+            (((SA (sing @d)) (sing @d)) (sing @d))
     instance (SingI n, SingI n, SingI n, SingI n) =>
              SingI (B (n :: a) (n :: b) (n :: c) (n :: d)) where
       sing = (((SB sing) sing) sing) sing
@@ -1026,30 +1025,29 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun4 @(TyCon4 B)) SB
     instance SingI d =>
              SingI (BSym1 (d :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
-      sing = (singFun3 @(BSym1 (d :: a))) (SB (sing @_ @d))
+      sing = (singFun3 @(BSym1 (d :: a))) (SB (sing @d))
     instance SingI d =>
              SingI (TyCon3 (B (d :: a)) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
-      sing = (singFun3 @(TyCon3 (B (d :: a)))) (SB (sing @_ @d))
+      sing = (singFun3 @(TyCon3 (B (d :: a)))) (SB (sing @d))
     instance (SingI d, SingI d) =>
              SingI (BSym2 (d :: a) (d :: b) :: (~>) c ((~>) d (Foo a b c d))) where
       sing
-        = (singFun2 @(BSym2 (d :: a) (d :: b)))
-            ((SB (sing @_ @d)) (sing @_ @d))
+        = (singFun2 @(BSym2 (d :: a) (d :: b))) ((SB (sing @d)) (sing @d))
     instance (SingI d, SingI d) =>
              SingI (TyCon2 (B (d :: a) (d :: b)) :: (~>) c ((~>) d (Foo a b c d))) where
       sing
         = (singFun2 @(TyCon2 (B (d :: a) (d :: b))))
-            ((SB (sing @_ @d)) (sing @_ @d))
+            ((SB (sing @d)) (sing @d))
     instance (SingI d, SingI d, SingI d) =>
              SingI (BSym3 (d :: a) (d :: b) (d :: c) :: (~>) d (Foo a b c d)) where
       sing
         = (singFun1 @(BSym3 (d :: a) (d :: b) (d :: c)))
-            (((SB (sing @_ @d)) (sing @_ @d)) (sing @_ @d))
+            (((SB (sing @d)) (sing @d)) (sing @d))
     instance (SingI d, SingI d, SingI d) =>
              SingI (TyCon1 (B (d :: a) (d :: b) (d :: c)) :: (~>) d (Foo a b c d)) where
       sing
         = (singFun1 @(TyCon1 (B (d :: a) (d :: b) (d :: c))))
-            (((SB (sing @_ @d)) (sing @_ @d)) (sing @_ @d))
+            (((SB (sing @d)) (sing @d)) (sing @d))
     instance (SingI n, SingI n, SingI n, SingI n) =>
              SingI (C (n :: a) (n :: b) (n :: c) (n :: d)) where
       sing = (((SC sing) sing) sing) sing
@@ -1059,30 +1057,29 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun4 @(TyCon4 C)) SC
     instance SingI d =>
              SingI (CSym1 (d :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
-      sing = (singFun3 @(CSym1 (d :: a))) (SC (sing @_ @d))
+      sing = (singFun3 @(CSym1 (d :: a))) (SC (sing @d))
     instance SingI d =>
              SingI (TyCon3 (C (d :: a)) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
-      sing = (singFun3 @(TyCon3 (C (d :: a)))) (SC (sing @_ @d))
+      sing = (singFun3 @(TyCon3 (C (d :: a)))) (SC (sing @d))
     instance (SingI d, SingI d) =>
              SingI (CSym2 (d :: a) (d :: b) :: (~>) c ((~>) d (Foo a b c d))) where
       sing
-        = (singFun2 @(CSym2 (d :: a) (d :: b)))
-            ((SC (sing @_ @d)) (sing @_ @d))
+        = (singFun2 @(CSym2 (d :: a) (d :: b))) ((SC (sing @d)) (sing @d))
     instance (SingI d, SingI d) =>
              SingI (TyCon2 (C (d :: a) (d :: b)) :: (~>) c ((~>) d (Foo a b c d))) where
       sing
         = (singFun2 @(TyCon2 (C (d :: a) (d :: b))))
-            ((SC (sing @_ @d)) (sing @_ @d))
+            ((SC (sing @d)) (sing @d))
     instance (SingI d, SingI d, SingI d) =>
              SingI (CSym3 (d :: a) (d :: b) (d :: c) :: (~>) d (Foo a b c d)) where
       sing
         = (singFun1 @(CSym3 (d :: a) (d :: b) (d :: c)))
-            (((SC (sing @_ @d)) (sing @_ @d)) (sing @_ @d))
+            (((SC (sing @d)) (sing @d)) (sing @d))
     instance (SingI d, SingI d, SingI d) =>
              SingI (TyCon1 (C (d :: a) (d :: b) (d :: c)) :: (~>) d (Foo a b c d)) where
       sing
         = (singFun1 @(TyCon1 (C (d :: a) (d :: b) (d :: c))))
-            (((SC (sing @_ @d)) (sing @_ @d)) (sing @_ @d))
+            (((SC (sing @d)) (sing @d)) (sing @d))
     instance (SingI n, SingI n, SingI n, SingI n) =>
              SingI (D (n :: a) (n :: b) (n :: c) (n :: d)) where
       sing = (((SD sing) sing) sing) sing
@@ -1092,30 +1089,29 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun4 @(TyCon4 D)) SD
     instance SingI d =>
              SingI (DSym1 (d :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
-      sing = (singFun3 @(DSym1 (d :: a))) (SD (sing @_ @d))
+      sing = (singFun3 @(DSym1 (d :: a))) (SD (sing @d))
     instance SingI d =>
              SingI (TyCon3 (D (d :: a)) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
-      sing = (singFun3 @(TyCon3 (D (d :: a)))) (SD (sing @_ @d))
+      sing = (singFun3 @(TyCon3 (D (d :: a)))) (SD (sing @d))
     instance (SingI d, SingI d) =>
              SingI (DSym2 (d :: a) (d :: b) :: (~>) c ((~>) d (Foo a b c d))) where
       sing
-        = (singFun2 @(DSym2 (d :: a) (d :: b)))
-            ((SD (sing @_ @d)) (sing @_ @d))
+        = (singFun2 @(DSym2 (d :: a) (d :: b))) ((SD (sing @d)) (sing @d))
     instance (SingI d, SingI d) =>
              SingI (TyCon2 (D (d :: a) (d :: b)) :: (~>) c ((~>) d (Foo a b c d))) where
       sing
         = (singFun2 @(TyCon2 (D (d :: a) (d :: b))))
-            ((SD (sing @_ @d)) (sing @_ @d))
+            ((SD (sing @d)) (sing @d))
     instance (SingI d, SingI d, SingI d) =>
              SingI (DSym3 (d :: a) (d :: b) (d :: c) :: (~>) d (Foo a b c d)) where
       sing
         = (singFun1 @(DSym3 (d :: a) (d :: b) (d :: c)))
-            (((SD (sing @_ @d)) (sing @_ @d)) (sing @_ @d))
+            (((SD (sing @d)) (sing @d)) (sing @d))
     instance (SingI d, SingI d, SingI d) =>
              SingI (TyCon1 (D (d :: a) (d :: b) (d :: c)) :: (~>) d (Foo a b c d)) where
       sing
         = (singFun1 @(TyCon1 (D (d :: a) (d :: b) (d :: c))))
-            (((SD (sing @_ @d)) (sing @_ @d)) (sing @_ @d))
+            (((SD (sing @d)) (sing @d)) (sing @d))
     instance (SingI n, SingI n, SingI n, SingI n) =>
              SingI (E (n :: a) (n :: b) (n :: c) (n :: d)) where
       sing = (((SE sing) sing) sing) sing
@@ -1125,30 +1121,29 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun4 @(TyCon4 E)) SE
     instance SingI d =>
              SingI (ESym1 (d :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
-      sing = (singFun3 @(ESym1 (d :: a))) (SE (sing @_ @d))
+      sing = (singFun3 @(ESym1 (d :: a))) (SE (sing @d))
     instance SingI d =>
              SingI (TyCon3 (E (d :: a)) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
-      sing = (singFun3 @(TyCon3 (E (d :: a)))) (SE (sing @_ @d))
+      sing = (singFun3 @(TyCon3 (E (d :: a)))) (SE (sing @d))
     instance (SingI d, SingI d) =>
              SingI (ESym2 (d :: a) (d :: b) :: (~>) c ((~>) d (Foo a b c d))) where
       sing
-        = (singFun2 @(ESym2 (d :: a) (d :: b)))
-            ((SE (sing @_ @d)) (sing @_ @d))
+        = (singFun2 @(ESym2 (d :: a) (d :: b))) ((SE (sing @d)) (sing @d))
     instance (SingI d, SingI d) =>
              SingI (TyCon2 (E (d :: a) (d :: b)) :: (~>) c ((~>) d (Foo a b c d))) where
       sing
         = (singFun2 @(TyCon2 (E (d :: a) (d :: b))))
-            ((SE (sing @_ @d)) (sing @_ @d))
+            ((SE (sing @d)) (sing @d))
     instance (SingI d, SingI d, SingI d) =>
              SingI (ESym3 (d :: a) (d :: b) (d :: c) :: (~>) d (Foo a b c d)) where
       sing
         = (singFun1 @(ESym3 (d :: a) (d :: b) (d :: c)))
-            (((SE (sing @_ @d)) (sing @_ @d)) (sing @_ @d))
+            (((SE (sing @d)) (sing @d)) (sing @d))
     instance (SingI d, SingI d, SingI d) =>
              SingI (TyCon1 (E (d :: a) (d :: b) (d :: c)) :: (~>) d (Foo a b c d)) where
       sing
         = (singFun1 @(TyCon1 (E (d :: a) (d :: b) (d :: c))))
-            (((SE (sing @_ @d)) (sing @_ @d)) (sing @_ @d))
+            (((SE (sing @d)) (sing @d)) (sing @d))
     instance (SingI n, SingI n, SingI n, SingI n) =>
              SingI (F (n :: a) (n :: b) (n :: c) (n :: d)) where
       sing = (((SF sing) sing) sing) sing
@@ -1158,27 +1153,26 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun4 @(TyCon4 F)) SF
     instance SingI d =>
              SingI (FSym1 (d :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
-      sing = (singFun3 @(FSym1 (d :: a))) (SF (sing @_ @d))
+      sing = (singFun3 @(FSym1 (d :: a))) (SF (sing @d))
     instance SingI d =>
              SingI (TyCon3 (F (d :: a)) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
-      sing = (singFun3 @(TyCon3 (F (d :: a)))) (SF (sing @_ @d))
+      sing = (singFun3 @(TyCon3 (F (d :: a)))) (SF (sing @d))
     instance (SingI d, SingI d) =>
              SingI (FSym2 (d :: a) (d :: b) :: (~>) c ((~>) d (Foo a b c d))) where
       sing
-        = (singFun2 @(FSym2 (d :: a) (d :: b)))
-            ((SF (sing @_ @d)) (sing @_ @d))
+        = (singFun2 @(FSym2 (d :: a) (d :: b))) ((SF (sing @d)) (sing @d))
     instance (SingI d, SingI d) =>
              SingI (TyCon2 (F (d :: a) (d :: b)) :: (~>) c ((~>) d (Foo a b c d))) where
       sing
         = (singFun2 @(TyCon2 (F (d :: a) (d :: b))))
-            ((SF (sing @_ @d)) (sing @_ @d))
+            ((SF (sing @d)) (sing @d))
     instance (SingI d, SingI d, SingI d) =>
              SingI (FSym3 (d :: a) (d :: b) (d :: c) :: (~>) d (Foo a b c d)) where
       sing
         = (singFun1 @(FSym3 (d :: a) (d :: b) (d :: c)))
-            (((SF (sing @_ @d)) (sing @_ @d)) (sing @_ @d))
+            (((SF (sing @d)) (sing @d)) (sing @d))
     instance (SingI d, SingI d, SingI d) =>
              SingI (TyCon1 (F (d :: a) (d :: b) (d :: c)) :: (~>) d (Foo a b c d)) where
       sing
         = (singFun1 @(TyCon1 (F (d :: a) (d :: b) (d :: c))))
-            (((SF (sing @_ @d)) (sing @_ @d)) (sing @_ @d))
+            (((SF (sing @d)) (sing @d)) (sing @d))

--- a/tests/compile-and-dump/Singletons/OverloadedStrings.ghc84.template
+++ b/tests/compile-and-dump/Singletons/OverloadedStrings.ghc84.template
@@ -30,3 +30,5 @@ Singletons/OverloadedStrings.hs:(0,0)-(0,0): Splicing declarations
     sFoo
       = (applySing ((singFun1 @SymIdSym0) sSymId))
           (Data.Singletons.Prelude.IsString.sFromString (sing :: Sing "foo"))
+    instance SingI (SymIdSym0 :: (~>) Symbol Symbol) where
+      sing = (singFun1 @SymIdSym0) sSymId

--- a/tests/compile-and-dump/Singletons/PatternMatching.ghc84.template
+++ b/tests/compile-and-dump/Singletons/PatternMatching.ghc84.template
@@ -188,6 +188,16 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
       showsPrec = Data.Singletons.ShowSing.showsSingPrec
     instance (SingI n, SingI n) => SingI (Pair (n :: a) (n :: b)) where
       sing = (SPair sing) sing
+    instance SingI (PairSym0 :: (~>) a ((~>) b (Pair a b))) where
+      sing = (singFun2 @PairSym0) SPair
+    instance SingI (TyCon2 Pair :: (~>) a ((~>) b (Pair a b))) where
+      sing = (singFun2 @(TyCon2 Pair)) SPair
+    instance SingI d =>
+             SingI (PairSym1 (d :: a) :: (~>) b (Pair a b)) where
+      sing = (singFun1 @(PairSym1 (d :: a))) (SPair (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon1 (Pair (d :: a)) :: (~>) b (Pair a b)) where
+      sing = (singFun1 @(TyCon1 (Pair (d :: a)))) (SPair (sing @_ @d))
 Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     singletons
       [d| Pair sz lz = pr
@@ -565,3 +575,9 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     sX_0123456789876543210 = sComplex
     sX_0123456789876543210 = sTuple
     sX_0123456789876543210 = sAList
+    instance SingI (SillySym0 :: (~>) a ()) where
+      sing = (singFun1 @SillySym0) sSilly
+    instance SingI (Foo2Sym0 :: (~>) (a, b) a) where
+      sing = (singFun1 @Foo2Sym0) sFoo2
+    instance SingI (Foo1Sym0 :: (~>) (a, b) a) where
+      sing = (singFun1 @Foo1Sym0) sFoo1

--- a/tests/compile-and-dump/Singletons/PatternMatching.ghc84.template
+++ b/tests/compile-and-dump/Singletons/PatternMatching.ghc84.template
@@ -194,10 +194,10 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @(TyCon2 Pair)) SPair
     instance SingI d =>
              SingI (PairSym1 (d :: a) :: (~>) b (Pair a b)) where
-      sing = (singFun1 @(PairSym1 (d :: a))) (SPair (sing @_ @d))
+      sing = (singFun1 @(PairSym1 (d :: a))) (SPair (sing @d))
     instance SingI d =>
              SingI (TyCon1 (Pair (d :: a)) :: (~>) b (Pair a b)) where
-      sing = (singFun1 @(TyCon1 (Pair (d :: a)))) (SPair (sing @_ @d))
+      sing = (singFun1 @(TyCon1 (Pair (d :: a)))) (SPair (sing @d))
 Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     singletons
       [d| Pair sz lz = pr

--- a/tests/compile-and-dump/Singletons/PolyKinds.ghc84.template
+++ b/tests/compile-and-dump/Singletons/PolyKinds.ghc84.template
@@ -21,3 +21,6 @@ Singletons/PolyKinds.hs:(0,0)-(0,0): Splicing declarations
       sFff ::
         forall (t :: Proxy (a :: k)).
         Sing t -> Sing (Apply FffSym0 t :: ())
+    instance SCls a =>
+             SingI (FffSym0 :: (~>) (Proxy (a :: k)) ()) where
+      sing = (singFun1 @FffSym0) sFff

--- a/tests/compile-and-dump/Singletons/Records.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Records.ghc84.template
@@ -65,3 +65,14 @@ Singletons/Records.hs:(0,0)-(0,0): Splicing declarations
     instance (SingI n, SingI n) =>
              SingI (MkRecord (n :: a) (n :: Bool)) where
       sing = (SMkRecord sing) sing
+    instance SingI (MkRecordSym0 :: (~>) a ((~>) Bool (Record a))) where
+      sing = (singFun2 @MkRecordSym0) SMkRecord
+    instance SingI (TyCon2 MkRecord :: (~>) a ((~>) Bool (Record a))) where
+      sing = (singFun2 @(TyCon2 MkRecord)) SMkRecord
+    instance SingI d =>
+             SingI (MkRecordSym1 (d :: a) :: (~>) Bool (Record a)) where
+      sing = (singFun1 @(MkRecordSym1 (d :: a))) (SMkRecord (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon1 (MkRecord (d :: a)) :: (~>) Bool (Record a)) where
+      sing
+        = (singFun1 @(TyCon1 (MkRecord (d :: a)))) (SMkRecord (sing @_ @d))

--- a/tests/compile-and-dump/Singletons/Records.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Records.ghc84.template
@@ -71,8 +71,8 @@ Singletons/Records.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @(TyCon2 MkRecord)) SMkRecord
     instance SingI d =>
              SingI (MkRecordSym1 (d :: a) :: (~>) Bool (Record a)) where
-      sing = (singFun1 @(MkRecordSym1 (d :: a))) (SMkRecord (sing @_ @d))
+      sing = (singFun1 @(MkRecordSym1 (d :: a))) (SMkRecord (sing @d))
     instance SingI d =>
              SingI (TyCon1 (MkRecord (d :: a)) :: (~>) Bool (Record a)) where
       sing
-        = (singFun1 @(TyCon1 (MkRecord (d :: a)))) (SMkRecord (sing @_ @d))
+        = (singFun1 @(TyCon1 (MkRecord (d :: a)))) (SMkRecord (sing @d))

--- a/tests/compile-and-dump/Singletons/ReturnFunc.ghc84.template
+++ b/tests/compile-and-dump/Singletons/ReturnFunc.ghc84.template
@@ -80,3 +80,16 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
       _
       (sA_0123456789876543210 :: Sing a_0123456789876543210)
       = (applySing ((singFun1 @SuccSym0) SSucc)) sA_0123456789876543210
+    instance SingI (IdSym0 :: (~>) a a) where
+      sing = (singFun1 @IdSym0) sId
+    instance SingI (IdFooSym0 :: (~>) c ((~>) a a)) where
+      sing = (singFun2 @IdFooSym0) sIdFoo
+    instance SingI d => SingI (IdFooSym1 (d :: c) :: (~>) a a) where
+      sing = (singFun1 @(IdFooSym1 (d :: c))) (sIdFoo (sing @_ @d))
+    instance SingI (ReturnFuncSym0 :: (~>) Nat ((~>) Nat Nat)) where
+      sing = (singFun2 @ReturnFuncSym0) sReturnFunc
+    instance SingI d =>
+             SingI (ReturnFuncSym1 (d :: Nat) :: (~>) Nat Nat) where
+      sing
+        = (singFun1 @(ReturnFuncSym1 (d :: Nat)))
+            (sReturnFunc (sing @_ @d))

--- a/tests/compile-and-dump/Singletons/ReturnFunc.ghc84.template
+++ b/tests/compile-and-dump/Singletons/ReturnFunc.ghc84.template
@@ -85,11 +85,10 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
     instance SingI (IdFooSym0 :: (~>) c ((~>) a a)) where
       sing = (singFun2 @IdFooSym0) sIdFoo
     instance SingI d => SingI (IdFooSym1 (d :: c) :: (~>) a a) where
-      sing = (singFun1 @(IdFooSym1 (d :: c))) (sIdFoo (sing @_ @d))
+      sing = (singFun1 @(IdFooSym1 (d :: c))) (sIdFoo (sing @d))
     instance SingI (ReturnFuncSym0 :: (~>) Nat ((~>) Nat Nat)) where
       sing = (singFun2 @ReturnFuncSym0) sReturnFunc
     instance SingI d =>
              SingI (ReturnFuncSym1 (d :: Nat) :: (~>) Nat Nat) where
       sing
-        = (singFun1 @(ReturnFuncSym1 (d :: Nat)))
-            (sReturnFunc (sing @_ @d))
+        = (singFun1 @(ReturnFuncSym1 (d :: Nat))) (sReturnFunc (sing @d))

--- a/tests/compile-and-dump/Singletons/Sections.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Sections.ghc84.template
@@ -115,3 +115,8 @@ Singletons/Sections.hs:(0,0)-(0,0): Splicing declarations
                  ((applySing ((singFun2 @(:@#@$)) SCons))
                     ((applySing ((singFun1 @SuccSym0) SSucc)) SZero)))
                 SNil))
+    instance SingI ((+@#@$) :: (~>) Nat ((~>) Nat Nat)) where
+      sing = (singFun2 @(+@#@$)) (%+)
+    instance SingI d =>
+             SingI ((+@#@$$) (d :: Nat) :: (~>) Nat Nat) where
+      sing = (singFun1 @((+@#@$$) (d :: Nat))) ((%+) (sing @_ @d))

--- a/tests/compile-and-dump/Singletons/Sections.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Sections.ghc84.template
@@ -119,4 +119,4 @@ Singletons/Sections.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @(+@#@$)) (%+)
     instance SingI d =>
              SingI ((+@#@$$) (d :: Nat) :: (~>) Nat Nat) where
-      sing = (singFun1 @((+@#@$$) (d :: Nat))) ((%+) (sing @_ @d))
+      sing = (singFun1 @((+@#@$$) (d :: Nat))) ((%+) (sing @d))

--- a/tests/compile-and-dump/Singletons/ShowDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/ShowDeriving.ghc84.template
@@ -605,15 +605,68 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance (SingI n, SingI n) =>
              SingI (MkFoo2a (n :: a) (n :: a)) where
       sing = (SMkFoo2a sing) sing
+    instance SingI (MkFoo2aSym0 :: (~>) a ((~>) a (Foo2 a))) where
+      sing = (singFun2 @MkFoo2aSym0) SMkFoo2a
+    instance SingI (TyCon2 MkFoo2a :: (~>) a ((~>) a (Foo2 a))) where
+      sing = (singFun2 @(TyCon2 MkFoo2a)) SMkFoo2a
+    instance SingI d =>
+             SingI (MkFoo2aSym1 (d :: a) :: (~>) a (Foo2 a)) where
+      sing = (singFun1 @(MkFoo2aSym1 (d :: a))) (SMkFoo2a (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon1 (MkFoo2a (d :: a)) :: (~>) a (Foo2 a)) where
+      sing
+        = (singFun1 @(TyCon1 (MkFoo2a (d :: a)))) (SMkFoo2a (sing @_ @d))
     instance (SingI n, SingI n) =>
              SingI (MkFoo2b (n :: a) (n :: a)) where
       sing = (SMkFoo2b sing) sing
+    instance SingI (MkFoo2bSym0 :: (~>) a ((~>) a (Foo2 a))) where
+      sing = (singFun2 @MkFoo2bSym0) SMkFoo2b
+    instance SingI (TyCon2 MkFoo2b :: (~>) a ((~>) a (Foo2 a))) where
+      sing = (singFun2 @(TyCon2 MkFoo2b)) SMkFoo2b
+    instance SingI d =>
+             SingI (MkFoo2bSym1 (d :: a) :: (~>) a (Foo2 a)) where
+      sing = (singFun1 @(MkFoo2bSym1 (d :: a))) (SMkFoo2b (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon1 (MkFoo2b (d :: a)) :: (~>) a (Foo2 a)) where
+      sing
+        = (singFun1 @(TyCon1 (MkFoo2b (d :: a)))) (SMkFoo2b (sing @_ @d))
     instance (SingI n, SingI n) =>
              SingI ((:*:) (n :: a) (n :: a)) where
       sing = ((:%*:) sing) sing
+    instance SingI ((:*:@#@$) :: (~>) a ((~>) a (Foo2 a))) where
+      sing = (singFun2 @(:*:@#@$)) (:%*:)
+    instance SingI (TyCon2 (:*:) :: (~>) a ((~>) a (Foo2 a))) where
+      sing = (singFun2 @(TyCon2 (:*:))) (:%*:)
+    instance SingI d =>
+             SingI ((:*:@#@$$) (d :: a) :: (~>) a (Foo2 a)) where
+      sing = (singFun1 @((:*:@#@$$) (d :: a))) ((:%*:) (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon1 ((:*:) (d :: a)) :: (~>) a (Foo2 a)) where
+      sing = (singFun1 @(TyCon1 ((:*:) (d :: a)))) ((:%*:) (sing @_ @d))
     instance (SingI n, SingI n) =>
              SingI ((:&:) (n :: a) (n :: a)) where
       sing = ((:%&:) sing) sing
+    instance SingI ((:&:@#@$) :: (~>) a ((~>) a (Foo2 a))) where
+      sing = (singFun2 @(:&:@#@$)) (:%&:)
+    instance SingI (TyCon2 (:&:) :: (~>) a ((~>) a (Foo2 a))) where
+      sing = (singFun2 @(TyCon2 (:&:))) (:%&:)
+    instance SingI d =>
+             SingI ((:&:@#@$$) (d :: a) :: (~>) a (Foo2 a)) where
+      sing = (singFun1 @((:&:@#@$$) (d :: a))) ((:%&:) (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon1 ((:&:) (d :: a)) :: (~>) a (Foo2 a)) where
+      sing = (singFun1 @(TyCon1 ((:&:) (d :: a)))) ((:%&:) (sing @_ @d))
     instance (SingI n, SingI n) =>
              SingI (MkFoo3 (n :: Bool) (n :: Bool)) where
       sing = (SMkFoo3 sing) sing
+    instance SingI (MkFoo3Sym0 :: (~>) Bool ((~>) Bool Foo3)) where
+      sing = (singFun2 @MkFoo3Sym0) SMkFoo3
+    instance SingI (TyCon2 MkFoo3 :: (~>) Bool ((~>) Bool Foo3)) where
+      sing = (singFun2 @(TyCon2 MkFoo3)) SMkFoo3
+    instance SingI d =>
+             SingI (MkFoo3Sym1 (d :: Bool) :: (~>) Bool Foo3) where
+      sing = (singFun1 @(MkFoo3Sym1 (d :: Bool))) (SMkFoo3 (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon1 (MkFoo3 (d :: Bool)) :: (~>) Bool Foo3) where
+      sing
+        = (singFun1 @(TyCon1 (MkFoo3 (d :: Bool)))) (SMkFoo3 (sing @_ @d))

--- a/tests/compile-and-dump/Singletons/ShowDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/ShowDeriving.ghc84.template
@@ -611,11 +611,10 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @(TyCon2 MkFoo2a)) SMkFoo2a
     instance SingI d =>
              SingI (MkFoo2aSym1 (d :: a) :: (~>) a (Foo2 a)) where
-      sing = (singFun1 @(MkFoo2aSym1 (d :: a))) (SMkFoo2a (sing @_ @d))
+      sing = (singFun1 @(MkFoo2aSym1 (d :: a))) (SMkFoo2a (sing @d))
     instance SingI d =>
              SingI (TyCon1 (MkFoo2a (d :: a)) :: (~>) a (Foo2 a)) where
-      sing
-        = (singFun1 @(TyCon1 (MkFoo2a (d :: a)))) (SMkFoo2a (sing @_ @d))
+      sing = (singFun1 @(TyCon1 (MkFoo2a (d :: a)))) (SMkFoo2a (sing @d))
     instance (SingI n, SingI n) =>
              SingI (MkFoo2b (n :: a) (n :: a)) where
       sing = (SMkFoo2b sing) sing
@@ -625,11 +624,10 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @(TyCon2 MkFoo2b)) SMkFoo2b
     instance SingI d =>
              SingI (MkFoo2bSym1 (d :: a) :: (~>) a (Foo2 a)) where
-      sing = (singFun1 @(MkFoo2bSym1 (d :: a))) (SMkFoo2b (sing @_ @d))
+      sing = (singFun1 @(MkFoo2bSym1 (d :: a))) (SMkFoo2b (sing @d))
     instance SingI d =>
              SingI (TyCon1 (MkFoo2b (d :: a)) :: (~>) a (Foo2 a)) where
-      sing
-        = (singFun1 @(TyCon1 (MkFoo2b (d :: a)))) (SMkFoo2b (sing @_ @d))
+      sing = (singFun1 @(TyCon1 (MkFoo2b (d :: a)))) (SMkFoo2b (sing @d))
     instance (SingI n, SingI n) =>
              SingI ((:*:) (n :: a) (n :: a)) where
       sing = ((:%*:) sing) sing
@@ -639,10 +637,10 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @(TyCon2 (:*:))) (:%*:)
     instance SingI d =>
              SingI ((:*:@#@$$) (d :: a) :: (~>) a (Foo2 a)) where
-      sing = (singFun1 @((:*:@#@$$) (d :: a))) ((:%*:) (sing @_ @d))
+      sing = (singFun1 @((:*:@#@$$) (d :: a))) ((:%*:) (sing @d))
     instance SingI d =>
              SingI (TyCon1 ((:*:) (d :: a)) :: (~>) a (Foo2 a)) where
-      sing = (singFun1 @(TyCon1 ((:*:) (d :: a)))) ((:%*:) (sing @_ @d))
+      sing = (singFun1 @(TyCon1 ((:*:) (d :: a)))) ((:%*:) (sing @d))
     instance (SingI n, SingI n) =>
              SingI ((:&:) (n :: a) (n :: a)) where
       sing = ((:%&:) sing) sing
@@ -652,10 +650,10 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @(TyCon2 (:&:))) (:%&:)
     instance SingI d =>
              SingI ((:&:@#@$$) (d :: a) :: (~>) a (Foo2 a)) where
-      sing = (singFun1 @((:&:@#@$$) (d :: a))) ((:%&:) (sing @_ @d))
+      sing = (singFun1 @((:&:@#@$$) (d :: a))) ((:%&:) (sing @d))
     instance SingI d =>
              SingI (TyCon1 ((:&:) (d :: a)) :: (~>) a (Foo2 a)) where
-      sing = (singFun1 @(TyCon1 ((:&:) (d :: a)))) ((:%&:) (sing @_ @d))
+      sing = (singFun1 @(TyCon1 ((:&:) (d :: a)))) ((:%&:) (sing @d))
     instance (SingI n, SingI n) =>
              SingI (MkFoo3 (n :: Bool) (n :: Bool)) where
       sing = (SMkFoo3 sing) sing
@@ -665,8 +663,8 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @(TyCon2 MkFoo3)) SMkFoo3
     instance SingI d =>
              SingI (MkFoo3Sym1 (d :: Bool) :: (~>) Bool Foo3) where
-      sing = (singFun1 @(MkFoo3Sym1 (d :: Bool))) (SMkFoo3 (sing @_ @d))
+      sing = (singFun1 @(MkFoo3Sym1 (d :: Bool))) (SMkFoo3 (sing @d))
     instance SingI d =>
              SingI (TyCon1 (MkFoo3 (d :: Bool)) :: (~>) Bool Foo3) where
       sing
-        = (singFun1 @(TyCon1 (MkFoo3 (d :: Bool)))) (SMkFoo3 (sing @_ @d))
+        = (singFun1 @(TyCon1 (MkFoo3 (d :: Bool)))) (SMkFoo3 (sing @d))

--- a/tests/compile-and-dump/Singletons/StandaloneDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/StandaloneDeriving.ghc84.template
@@ -463,6 +463,16 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance (SingI n, SingI n) =>
              SingI ((:*:) (n :: a) (n :: b)) where
       sing = ((:%*:) sing) sing
+    instance SingI ((:*:@#@$) :: (~>) a ((~>) b (T a b))) where
+      sing = (singFun2 @(:*:@#@$)) (:%*:)
+    instance SingI (TyCon2 (:*:) :: (~>) a ((~>) b (T a b))) where
+      sing = (singFun2 @(TyCon2 (:*:))) (:%*:)
+    instance SingI d =>
+             SingI ((:*:@#@$$) (d :: a) :: (~>) b (T a b)) where
+      sing = (singFun1 @((:*:@#@$$) (d :: a))) ((:%*:) (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon1 ((:*:) (d :: a)) :: (~>) b (T a b)) where
+      sing = (singFun1 @(TyCon1 ((:*:) (d :: a)))) ((:%*:) (sing @_ @d))
     instance SingI S1 where
       sing = SS1
     instance SingI S2 where

--- a/tests/compile-and-dump/Singletons/StandaloneDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/StandaloneDeriving.ghc84.template
@@ -469,10 +469,10 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @(TyCon2 (:*:))) (:%*:)
     instance SingI d =>
              SingI ((:*:@#@$$) (d :: a) :: (~>) b (T a b)) where
-      sing = (singFun1 @((:*:@#@$$) (d :: a))) ((:%*:) (sing @_ @d))
+      sing = (singFun1 @((:*:@#@$$) (d :: a))) ((:%*:) (sing @d))
     instance SingI d =>
              SingI (TyCon1 ((:*:) (d :: a)) :: (~>) b (T a b)) where
-      sing = (singFun1 @(TyCon1 ((:*:) (d :: a)))) ((:%*:) (sing @_ @d))
+      sing = (singFun1 @(TyCon1 ((:*:) (d :: a)))) ((:%*:) (sing @d))
     instance SingI S1 where
       sing = SS1
     instance SingI S2 where

--- a/tests/compile-and-dump/Singletons/Star.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Star.ghc84.template
@@ -407,6 +407,20 @@ Singletons/Star.hs:0:0:: Splicing declarations
       sing = SString
     instance SingI n => SingI (Maybe (n :: Type)) where
       sing = SMaybe sing
+    instance SingI (MaybeSym0 :: (~>) Type Type) where
+      sing = (singFun1 @MaybeSym0) SMaybe
+    instance SingI (TyCon1 Maybe :: (~>) Type Type) where
+      sing = (singFun1 @(TyCon1 Maybe)) SMaybe
     instance (SingI n, SingI n) =>
              SingI (Vec (n :: Type) (n :: Nat)) where
       sing = (SVec sing) sing
+    instance SingI (VecSym0 :: (~>) Type ((~>) Nat Type)) where
+      sing = (singFun2 @VecSym0) SVec
+    instance SingI (TyCon2 Vec :: (~>) Type ((~>) Nat Type)) where
+      sing = (singFun2 @(TyCon2 Vec)) SVec
+    instance SingI d =>
+             SingI (VecSym1 (d :: Type) :: (~>) Nat Type) where
+      sing = (singFun1 @(VecSym1 (d :: Type))) (SVec (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon1 (Vec (d :: Type)) :: (~>) Nat Type) where
+      sing = (singFun1 @(TyCon1 (Vec (d :: Type)))) (SVec (sing @_ @d))

--- a/tests/compile-and-dump/Singletons/Star.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Star.ghc84.template
@@ -420,7 +420,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
       sing = (singFun2 @(TyCon2 Vec)) SVec
     instance SingI d =>
              SingI (VecSym1 (d :: Type) :: (~>) Nat Type) where
-      sing = (singFun1 @(VecSym1 (d :: Type))) (SVec (sing @_ @d))
+      sing = (singFun1 @(VecSym1 (d :: Type))) (SVec (sing @d))
     instance SingI d =>
              SingI (TyCon1 (Vec (d :: Type)) :: (~>) Nat Type) where
-      sing = (singFun1 @(TyCon1 (Vec (d :: Type)))) (SVec (sing @_ @d))
+      sing = (singFun1 @(TyCon1 (Vec (d :: Type)))) (SVec (sing @d))

--- a/tests/compile-and-dump/Singletons/T124.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T124.ghc84.template
@@ -22,6 +22,8 @@ Singletons/T124.hs:(0,0)-(0,0): Splicing declarations
     sFoo :: forall (t :: Bool). Sing t -> Sing (Apply FooSym0 t :: ())
     sFoo STrue = STuple0
     sFoo SFalse = STuple0
+    instance SingI (FooSym0 :: (~>) Bool ()) where
+      sing = (singFun1 @FooSym0) sFoo
 Singletons/T124.hs:0:0:: Splicing expression
     sCases ''Bool [| b |] [| STuple0 |]
   ======>

--- a/tests/compile-and-dump/Singletons/T136b.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T136b.ghc84.template
@@ -18,6 +18,8 @@ Singletons/T136b.hs:(0,0)-(0,0): Splicing declarations
       type Meth (arg :: a) :: a
     class SC a where
       sMeth :: forall (t :: a). Sing t -> Sing (Apply MethSym0 t :: a)
+    instance SC a => SingI (MethSym0 :: (~>) a a) where
+      sing = (singFun1 @MethSym0) sMeth
 Singletons/T136b.hs:(0,0)-(0,0): Splicing declarations
     singletons
       [d| instance C Bool where

--- a/tests/compile-and-dump/Singletons/T145.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T145.ghc84.template
@@ -29,3 +29,9 @@ Singletons/T145.hs:(0,0)-(0,0): Splicing declarations
       sCol ::
         forall a (t :: f a) (t :: a).
         Sing t -> Sing t -> Sing (Apply (Apply ColSym0 t) t :: Bool)
+    instance SColumn f =>
+             SingI (ColSym0 :: (~>) (f a) ((~>) a Bool)) where
+      sing = (singFun2 @ColSym0) sCol
+    instance (SColumn f, SingI d) =>
+             SingI (ColSym1 (d :: f a) :: (~>) a Bool) where
+      sing = (singFun1 @(ColSym1 (d :: f a))) (sCol (sing @_ @d))

--- a/tests/compile-and-dump/Singletons/T145.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T145.ghc84.template
@@ -34,4 +34,4 @@ Singletons/T145.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @ColSym0) sCol
     instance (SColumn f, SingI d) =>
              SingI (ColSym1 (d :: f a) :: (~>) a Bool) where
-      sing = (singFun1 @(ColSym1 (d :: f a))) (sCol (sing @_ @d))
+      sing = (singFun1 @(ColSym1 (d :: f a))) (sCol (sing @d))

--- a/tests/compile-and-dump/Singletons/T159.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T159.ghc84.template
@@ -113,9 +113,28 @@ Singletons/T159.hs:0:0:: Splicing declarations
       sing = SN1
     instance (SingI n, SingI n) => SingI (C1 (n :: T0) (n :: T1)) where
       sing = (SC1 sing) sing
+    instance SingI (C1Sym0 :: (~>) T0 ((~>) T1 T1)) where
+      sing = (singFun2 @C1Sym0) SC1
+    instance SingI (TyCon2 C1 :: (~>) T0 ((~>) T1 T1)) where
+      sing = (singFun2 @(TyCon2 C1)) SC1
+    instance SingI d => SingI (C1Sym1 (d :: T0) :: (~>) T1 T1) where
+      sing = (singFun1 @(C1Sym1 (d :: T0))) (SC1 (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon1 (C1 (d :: T0)) :: (~>) T1 T1) where
+      sing = (singFun1 @(TyCon1 (C1 (d :: T0)))) (SC1 (sing @_ @d))
     instance (SingI n, SingI n) =>
              SingI ((:&&) (n :: T0) (n :: T1)) where
       sing = ((:%&&) sing) sing
+    instance SingI ((:&&@#@$) :: (~>) T0 ((~>) T1 T1)) where
+      sing = (singFun2 @(:&&@#@$)) (:%&&)
+    instance SingI (TyCon2 (:&&) :: (~>) T0 ((~>) T1 T1)) where
+      sing = (singFun2 @(TyCon2 (:&&))) (:%&&)
+    instance SingI d =>
+             SingI ((:&&@#@$$) (d :: T0) :: (~>) T1 T1) where
+      sing = (singFun1 @((:&&@#@$$) (d :: T0))) ((:%&&) (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon1 ((:&&) (d :: T0)) :: (~>) T1 T1) where
+      sing = (singFun1 @(TyCon1 ((:&&) (d :: T0)))) ((:%&&) (sing @_ @d))
 Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
     singletons
       [d| infixr 5 :||
@@ -197,6 +216,25 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
       sing = SN2
     instance (SingI n, SingI n) => SingI (C2 (n :: T0) (n :: T2)) where
       sing = (SC2 sing) sing
+    instance SingI (C2Sym0 :: (~>) T0 ((~>) T2 T2)) where
+      sing = (singFun2 @C2Sym0) SC2
+    instance SingI (TyCon2 C2 :: (~>) T0 ((~>) T2 T2)) where
+      sing = (singFun2 @(TyCon2 C2)) SC2
+    instance SingI d => SingI (C2Sym1 (d :: T0) :: (~>) T2 T2) where
+      sing = (singFun1 @(C2Sym1 (d :: T0))) (SC2 (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon1 (C2 (d :: T0)) :: (~>) T2 T2) where
+      sing = (singFun1 @(TyCon1 (C2 (d :: T0)))) (SC2 (sing @_ @d))
     instance (SingI n, SingI n) =>
              SingI ((:||) (n :: T0) (n :: T2)) where
       sing = ((:%||) sing) sing
+    instance SingI ((:||@#@$) :: (~>) T0 ((~>) T2 T2)) where
+      sing = (singFun2 @(:||@#@$)) (:%||)
+    instance SingI (TyCon2 (:||) :: (~>) T0 ((~>) T2 T2)) where
+      sing = (singFun2 @(TyCon2 (:||))) (:%||)
+    instance SingI d =>
+             SingI ((:||@#@$$) (d :: T0) :: (~>) T2 T2) where
+      sing = (singFun1 @((:||@#@$$) (d :: T0))) ((:%||) (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon1 ((:||) (d :: T0)) :: (~>) T2 T2) where
+      sing = (singFun1 @(TyCon1 ((:||) (d :: T0)))) ((:%||) (sing @_ @d))

--- a/tests/compile-and-dump/Singletons/T159.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T159.ghc84.template
@@ -118,10 +118,10 @@ Singletons/T159.hs:0:0:: Splicing declarations
     instance SingI (TyCon2 C1 :: (~>) T0 ((~>) T1 T1)) where
       sing = (singFun2 @(TyCon2 C1)) SC1
     instance SingI d => SingI (C1Sym1 (d :: T0) :: (~>) T1 T1) where
-      sing = (singFun1 @(C1Sym1 (d :: T0))) (SC1 (sing @_ @d))
+      sing = (singFun1 @(C1Sym1 (d :: T0))) (SC1 (sing @d))
     instance SingI d =>
              SingI (TyCon1 (C1 (d :: T0)) :: (~>) T1 T1) where
-      sing = (singFun1 @(TyCon1 (C1 (d :: T0)))) (SC1 (sing @_ @d))
+      sing = (singFun1 @(TyCon1 (C1 (d :: T0)))) (SC1 (sing @d))
     instance (SingI n, SingI n) =>
              SingI ((:&&) (n :: T0) (n :: T1)) where
       sing = ((:%&&) sing) sing
@@ -131,10 +131,10 @@ Singletons/T159.hs:0:0:: Splicing declarations
       sing = (singFun2 @(TyCon2 (:&&))) (:%&&)
     instance SingI d =>
              SingI ((:&&@#@$$) (d :: T0) :: (~>) T1 T1) where
-      sing = (singFun1 @((:&&@#@$$) (d :: T0))) ((:%&&) (sing @_ @d))
+      sing = (singFun1 @((:&&@#@$$) (d :: T0))) ((:%&&) (sing @d))
     instance SingI d =>
              SingI (TyCon1 ((:&&) (d :: T0)) :: (~>) T1 T1) where
-      sing = (singFun1 @(TyCon1 ((:&&) (d :: T0)))) ((:%&&) (sing @_ @d))
+      sing = (singFun1 @(TyCon1 ((:&&) (d :: T0)))) ((:%&&) (sing @d))
 Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
     singletons
       [d| infixr 5 :||
@@ -221,10 +221,10 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
     instance SingI (TyCon2 C2 :: (~>) T0 ((~>) T2 T2)) where
       sing = (singFun2 @(TyCon2 C2)) SC2
     instance SingI d => SingI (C2Sym1 (d :: T0) :: (~>) T2 T2) where
-      sing = (singFun1 @(C2Sym1 (d :: T0))) (SC2 (sing @_ @d))
+      sing = (singFun1 @(C2Sym1 (d :: T0))) (SC2 (sing @d))
     instance SingI d =>
              SingI (TyCon1 (C2 (d :: T0)) :: (~>) T2 T2) where
-      sing = (singFun1 @(TyCon1 (C2 (d :: T0)))) (SC2 (sing @_ @d))
+      sing = (singFun1 @(TyCon1 (C2 (d :: T0)))) (SC2 (sing @d))
     instance (SingI n, SingI n) =>
              SingI ((:||) (n :: T0) (n :: T2)) where
       sing = ((:%||) sing) sing
@@ -234,7 +234,7 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @(TyCon2 (:||))) (:%||)
     instance SingI d =>
              SingI ((:||@#@$$) (d :: T0) :: (~>) T2 T2) where
-      sing = (singFun1 @((:||@#@$$) (d :: T0))) ((:%||) (sing @_ @d))
+      sing = (singFun1 @((:||@#@$$) (d :: T0))) ((:%||) (sing @d))
     instance SingI d =>
              SingI (TyCon1 ((:||) (d :: T0)) :: (~>) T2 T2) where
-      sing = (singFun1 @(TyCon1 ((:||) (d :: T0)))) ((:%||) (sing @_ @d))
+      sing = (singFun1 @(TyCon1 ((:||) (d :: T0)))) ((:%||) (sing @d))

--- a/tests/compile-and-dump/Singletons/T160.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T160.ghc84.template
@@ -52,6 +52,8 @@ Singletons/T160.hs:(0,0)-(0,0): Splicing declarations
                 -> (applySing ((applySing ((singFun2 @($@#@$)) (%$))) sTypeError))
                      ((applySing ((singFun1 @ShowTypeSym0) SShowType)) sX) ::
               Sing (Case_0123456789876543210 x (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x) :: a)
+    instance (SNum a, SEq a) => SingI (FooSym0 :: (~>) a a) where
+      sing = (singFun1 @FooSym0) sFoo
 
 Singletons/T160.hs:0:0: error:
     • t

--- a/tests/compile-and-dump/Singletons/T163.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T163.ghc84.template
@@ -36,5 +36,13 @@ Singletons/T163.hs:0:0:: Splicing declarations
         = case toSing b :: SomeSing b of { SomeSing c -> SomeSing (SR c) }
     instance SingI n => SingI (L (n :: a)) where
       sing = SL sing
+    instance SingI (LSym0 :: (~>) a ((+) a b)) where
+      sing = (singFun1 @LSym0) SL
+    instance SingI (TyCon1 L :: (~>) a ((+) a b)) where
+      sing = (singFun1 @(TyCon1 L)) SL
     instance SingI n => SingI (R (n :: b)) where
       sing = SR sing
+    instance SingI (RSym0 :: (~>) b ((+) a b)) where
+      sing = (singFun1 @RSym0) SR
+    instance SingI (TyCon1 R :: (~>) b ((+) a b)) where
+      sing = (singFun1 @(TyCon1 R)) SR

--- a/tests/compile-and-dump/Singletons/T166.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T166.ghc84.template
@@ -111,6 +111,20 @@ Singletons/T166.hs:(0,0)-(0,0): Splicing declarations
                                    (Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 0))))
                                sX))
                            sS })
+    instance SFoo a =>
+             SingI (FoosPrecSym0 :: (~>) Nat ((~>) a ((~>) [Bool] [Bool]))) where
+      sing = (singFun3 @FoosPrecSym0) sFoosPrec
+    instance (SFoo a, SingI d) =>
+             SingI (FoosPrecSym1 (d :: Nat) :: (~>) a ((~>) [Bool] [Bool])) where
+      sing
+        = (singFun2 @(FoosPrecSym1 (d :: Nat))) (sFoosPrec (sing @_ @d))
+    instance (SFoo a, SingI d, SingI d) =>
+             SingI (FoosPrecSym2 (d :: Nat) (d :: a) :: (~>) [Bool] [Bool]) where
+      sing
+        = (singFun1 @(FoosPrecSym2 (d :: Nat) (d :: a)))
+            ((sFoosPrec (sing @_ @d)) (sing @_ @d))
+    instance SFoo a => SingI (FooSym0 :: (~>) a [Bool]) where
+      sing = (singFun1 @FooSym0) sFoo
 
 Singletons/T166.hs:0:0: error:
     • Expecting one more argument to ‘Lambda_0123456789876543210Sym1 arg’

--- a/tests/compile-and-dump/Singletons/T166.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T166.ghc84.template
@@ -116,13 +116,12 @@ Singletons/T166.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun3 @FoosPrecSym0) sFoosPrec
     instance (SFoo a, SingI d) =>
              SingI (FoosPrecSym1 (d :: Nat) :: (~>) a ((~>) [Bool] [Bool])) where
-      sing
-        = (singFun2 @(FoosPrecSym1 (d :: Nat))) (sFoosPrec (sing @_ @d))
+      sing = (singFun2 @(FoosPrecSym1 (d :: Nat))) (sFoosPrec (sing @d))
     instance (SFoo a, SingI d, SingI d) =>
              SingI (FoosPrecSym2 (d :: Nat) (d :: a) :: (~>) [Bool] [Bool]) where
       sing
         = (singFun1 @(FoosPrecSym2 (d :: Nat) (d :: a)))
-            ((sFoosPrec (sing @_ @d)) (sing @_ @d))
+            ((sFoosPrec (sing @d)) (sing @d))
     instance SFoo a => SingI (FooSym0 :: (~>) a [Bool]) where
       sing = (singFun1 @FooSym0) sFoo
 

--- a/tests/compile-and-dump/Singletons/T167.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T167.ghc84.template
@@ -159,3 +159,21 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
              ((applySing ((singFun2 @FooListSym0) sFooList))
                 sA_0123456789876543210))
             sA_0123456789876543210
+    instance SFoo a =>
+             SingI (FoosPrecSym0 :: (~>) Nat ((~>) a ((~>) [Bool] [Bool]))) where
+      sing = (singFun3 @FoosPrecSym0) sFoosPrec
+    instance (SFoo a, SingI d) =>
+             SingI (FoosPrecSym1 (d :: Nat) :: (~>) a ((~>) [Bool] [Bool])) where
+      sing
+        = (singFun2 @(FoosPrecSym1 (d :: Nat))) (sFoosPrec (sing @_ @d))
+    instance (SFoo a, SingI d, SingI d) =>
+             SingI (FoosPrecSym2 (d :: Nat) (d :: a) :: (~>) [Bool] [Bool]) where
+      sing
+        = (singFun1 @(FoosPrecSym2 (d :: Nat) (d :: a)))
+            ((sFoosPrec (sing @_ @d)) (sing @_ @d))
+    instance SFoo a =>
+             SingI (FooListSym0 :: (~>) a ((~>) [Bool] [Bool])) where
+      sing = (singFun2 @FooListSym0) sFooList
+    instance (SFoo a, SingI d) =>
+             SingI (FooListSym1 (d :: a) :: (~>) [Bool] [Bool]) where
+      sing = (singFun1 @(FooListSym1 (d :: a))) (sFooList (sing @_ @d))

--- a/tests/compile-and-dump/Singletons/T167.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T167.ghc84.template
@@ -164,16 +164,15 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun3 @FoosPrecSym0) sFoosPrec
     instance (SFoo a, SingI d) =>
              SingI (FoosPrecSym1 (d :: Nat) :: (~>) a ((~>) [Bool] [Bool])) where
-      sing
-        = (singFun2 @(FoosPrecSym1 (d :: Nat))) (sFoosPrec (sing @_ @d))
+      sing = (singFun2 @(FoosPrecSym1 (d :: Nat))) (sFoosPrec (sing @d))
     instance (SFoo a, SingI d, SingI d) =>
              SingI (FoosPrecSym2 (d :: Nat) (d :: a) :: (~>) [Bool] [Bool]) where
       sing
         = (singFun1 @(FoosPrecSym2 (d :: Nat) (d :: a)))
-            ((sFoosPrec (sing @_ @d)) (sing @_ @d))
+            ((sFoosPrec (sing @d)) (sing @d))
     instance SFoo a =>
              SingI (FooListSym0 :: (~>) a ((~>) [Bool] [Bool])) where
       sing = (singFun2 @FooListSym0) sFooList
     instance (SFoo a, SingI d) =>
              SingI (FooListSym1 (d :: a) :: (~>) [Bool] [Bool]) where
-      sing = (singFun1 @(FooListSym1 (d :: a))) (sFooList (sing @_ @d))
+      sing = (singFun1 @(FooListSym1 (d :: a))) (sFooList (sing @d))

--- a/tests/compile-and-dump/Singletons/T172.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T172.ghc84.template
@@ -32,3 +32,8 @@ Singletons/T172.hs:(0,0)-(0,0): Splicing declarations
       = (applySing
            ((applySing ((singFun2 @(+@#@$)) (%+))) sA_0123456789876543210))
           sA_0123456789876543210
+    instance SingI (($>@#@$) :: (~>) Nat ((~>) Nat Nat)) where
+      sing = (singFun2 @($>@#@$)) (%$>)
+    instance SingI d =>
+             SingI (($>@#@$$) (d :: Nat) :: (~>) Nat Nat) where
+      sing = (singFun1 @(($>@#@$$) (d :: Nat))) ((%$>) (sing @_ @d))

--- a/tests/compile-and-dump/Singletons/T172.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T172.ghc84.template
@@ -36,4 +36,4 @@ Singletons/T172.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @($>@#@$)) (%$>)
     instance SingI d =>
              SingI (($>@#@$$) (d :: Nat) :: (~>) Nat Nat) where
-      sing = (singFun1 @(($>@#@$$) (d :: Nat))) ((%$>) (sing @_ @d))
+      sing = (singFun1 @(($>@#@$$) (d :: Nat))) ((%$>) (sing @d))

--- a/tests/compile-and-dump/Singletons/T176.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T176.ghc84.template
@@ -132,6 +132,10 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
                      _ :: Sing arg_0123456789876543210
                        -> case sArg_0123456789876543210 of { _ -> sBaz1 } ::
                             Sing (Case_0123456789876543210 x arg_0123456789876543210 arg_0123456789876543210) }))
+    instance SFoo2 a => SingI (Quux2Sym0 :: (~>) a a) where
+      sing = (singFun1 @Quux2Sym0) sQuux2
+    instance SFoo1 a => SingI (Quux1Sym0 :: (~>) a a) where
+      sing = (singFun1 @Quux1Sym0) sQuux1
     class SFoo1 a where
       sBar1 ::
         forall b (t :: a) (t :: (~>) a b).
@@ -142,3 +146,14 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
         forall b (t :: a) (t :: b).
         Sing t -> Sing t -> Sing (Apply (Apply Bar2Sym0 t) t :: b)
       sBaz2 :: Sing (Baz2Sym0 :: a)
+    instance SFoo1 a =>
+             SingI (Bar1Sym0 :: (~>) a ((~>) ((~>) a b) b)) where
+      sing = (singFun2 @Bar1Sym0) sBar1
+    instance (SFoo1 a, SingI d) =>
+             SingI (Bar1Sym1 (d :: a) :: (~>) ((~>) a b) b) where
+      sing = (singFun1 @(Bar1Sym1 (d :: a))) (sBar1 (sing @_ @d))
+    instance SFoo2 a => SingI (Bar2Sym0 :: (~>) a ((~>) b b)) where
+      sing = (singFun2 @Bar2Sym0) sBar2
+    instance (SFoo2 a, SingI d) =>
+             SingI (Bar2Sym1 (d :: a) :: (~>) b b) where
+      sing = (singFun1 @(Bar2Sym1 (d :: a))) (sBar2 (sing @_ @d))

--- a/tests/compile-and-dump/Singletons/T176.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T176.ghc84.template
@@ -151,9 +151,9 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @Bar1Sym0) sBar1
     instance (SFoo1 a, SingI d) =>
              SingI (Bar1Sym1 (d :: a) :: (~>) ((~>) a b) b) where
-      sing = (singFun1 @(Bar1Sym1 (d :: a))) (sBar1 (sing @_ @d))
+      sing = (singFun1 @(Bar1Sym1 (d :: a))) (sBar1 (sing @d))
     instance SFoo2 a => SingI (Bar2Sym0 :: (~>) a ((~>) b b)) where
       sing = (singFun2 @Bar2Sym0) sBar2
     instance (SFoo2 a, SingI d) =>
              SingI (Bar2Sym1 (d :: a) :: (~>) b b) where
-      sing = (singFun1 @(Bar2Sym1 (d :: a))) (sBar2 (sing @_ @d))
+      sing = (singFun1 @(Bar2Sym1 (d :: a))) (sBar2 (sing @d))

--- a/tests/compile-and-dump/Singletons/T183.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T183.ghc84.template
@@ -470,3 +470,31 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
     sF1 (sX :: Sing x)
       = case sX :: Sing x of {
           _ :: Sing (x :: Maybe Bool) -> sX :: Sing (x :: Maybe Bool) }
+    instance SingI (Foo9Sym0 :: (~>) a a) where
+      sing = (singFun1 @Foo9Sym0) sFoo9
+    instance SingI (Foo8Sym0 :: (~>) (Maybe a) (Maybe a)) where
+      sing = (singFun1 @Foo8Sym0) sFoo8
+    instance SingI (Foo7Sym0 :: (~>) a ((~>) b a)) where
+      sing = (singFun2 @Foo7Sym0) sFoo7
+    instance SingI d => SingI (Foo7Sym1 (d :: a) :: (~>) b a) where
+      sing = (singFun1 @(Foo7Sym1 (d :: a))) (sFoo7 (sing @_ @d))
+    instance SingI (Foo6Sym0 :: (~>) (Maybe (Maybe a)) (Maybe (Maybe a))) where
+      sing = (singFun1 @Foo6Sym0) sFoo6
+    instance SingI (Foo5Sym0 :: (~>) (Maybe (Maybe a)) (Maybe (Maybe a))) where
+      sing = (singFun1 @Foo5Sym0) sFoo5
+    instance SingI (Foo4Sym0 :: (~>) (a, b) (b, a)) where
+      sing = (singFun1 @Foo4Sym0) sFoo4
+    instance SingI (Foo3Sym0 :: (~>) (Maybe a) a) where
+      sing = (singFun1 @Foo3Sym0) sFoo3
+    instance SingI (Foo2Sym0 :: (~>) (Maybe a) a) where
+      sing = (singFun1 @Foo2Sym0) sFoo2
+    instance SingI (Foo1Sym0 :: (~>) (Maybe a) a) where
+      sing = (singFun1 @Foo1Sym0) sFoo1
+    instance SingI GSym0 where
+      sing = (singFun1 @GSym0) sG
+    instance SingI F3Sym0 where
+      sing = (singFun1 @F3Sym0) sF3
+    instance SingI F2Sym0 where
+      sing = (singFun1 @F2Sym0) sF2
+    instance SingI F1Sym0 where
+      sing = (singFun1 @F1Sym0) sF1

--- a/tests/compile-and-dump/Singletons/T183.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T183.ghc84.template
@@ -477,7 +477,7 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
     instance SingI (Foo7Sym0 :: (~>) a ((~>) b a)) where
       sing = (singFun2 @Foo7Sym0) sFoo7
     instance SingI d => SingI (Foo7Sym1 (d :: a) :: (~>) b a) where
-      sing = (singFun1 @(Foo7Sym1 (d :: a))) (sFoo7 (sing @_ @d))
+      sing = (singFun1 @(Foo7Sym1 (d :: a))) (sFoo7 (sing @d))
     instance SingI (Foo6Sym0 :: (~>) (Maybe (Maybe a)) (Maybe (Maybe a))) where
       sing = (singFun1 @Foo6Sym0) sFoo6
     instance SingI (Foo5Sym0 :: (~>) (Maybe (Maybe a)) (Maybe (Maybe a))) where

--- a/tests/compile-and-dump/Singletons/T197.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T197.ghc84.template
@@ -35,3 +35,8 @@ Singletons/T197.hs:(0,0)-(0,0): Splicing declarations
       forall (t :: Bool) (t :: Bool).
       Sing t -> Sing t -> Sing (Apply (Apply ($$:@#@$) t) t :: Bool)
     (%$$:) _ _ = SFalse
+    instance SingI (($$:@#@$) :: (~>) Bool ((~>) Bool Bool)) where
+      sing = (singFun2 @($$:@#@$)) (%$$:)
+    instance SingI d =>
+             SingI (($$:@#@$$) (d :: Bool) :: (~>) Bool Bool) where
+      sing = (singFun1 @(($$:@#@$$) (d :: Bool))) ((%$$:) (sing @_ @d))

--- a/tests/compile-and-dump/Singletons/T197.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T197.ghc84.template
@@ -39,4 +39,4 @@ Singletons/T197.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @($$:@#@$)) (%$$:)
     instance SingI d =>
              SingI (($$:@#@$$) (d :: Bool) :: (~>) Bool Bool) where
-      sing = (singFun1 @(($$:@#@$$) (d :: Bool))) ((%$$:) (sing @_ @d))
+      sing = (singFun1 @(($$:@#@$$) (d :: Bool))) ((%$$:) (sing @d))

--- a/tests/compile-and-dump/Singletons/T197b.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T197b.ghc84.template
@@ -84,6 +84,27 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
     instance (SingI n, SingI n) =>
              SingI ((:*:) (n :: a) (n :: b)) where
       sing = ((:%*:) sing) sing
+    instance SingI ((:*:@#@$) :: (~>) a ((~>) b ((:*:) a b))) where
+      sing = (singFun2 @(:*:@#@$)) (:%*:)
+    instance SingI (TyCon2 (:*:) :: (~>) a ((~>) b ((:*:) a b))) where
+      sing = (singFun2 @(TyCon2 (:*:))) (:%*:)
+    instance SingI d =>
+             SingI ((:*:@#@$$) (d :: a) :: (~>) b ((:*:) a b)) where
+      sing = (singFun1 @((:*:@#@$$) (d :: a))) ((:%*:) (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon1 ((:*:) (d :: a)) :: (~>) b ((:*:) a b)) where
+      sing = (singFun1 @(TyCon1 ((:*:) (d :: a)))) ((:%*:) (sing @_ @d))
     instance (SingI n, SingI n) =>
              SingI (MkPair (n :: a) (n :: b)) where
       sing = (SMkPair sing) sing
+    instance SingI (MkPairSym0 :: (~>) a ((~>) b (Pair a b))) where
+      sing = (singFun2 @MkPairSym0) SMkPair
+    instance SingI (TyCon2 MkPair :: (~>) a ((~>) b (Pair a b))) where
+      sing = (singFun2 @(TyCon2 MkPair)) SMkPair
+    instance SingI d =>
+             SingI (MkPairSym1 (d :: a) :: (~>) b (Pair a b)) where
+      sing = (singFun1 @(MkPairSym1 (d :: a))) (SMkPair (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon1 (MkPair (d :: a)) :: (~>) b (Pair a b)) where
+      sing
+        = (singFun1 @(TyCon1 (MkPair (d :: a)))) (SMkPair (sing @_ @d))

--- a/tests/compile-and-dump/Singletons/T197b.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T197b.ghc84.template
@@ -90,10 +90,10 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @(TyCon2 (:*:))) (:%*:)
     instance SingI d =>
              SingI ((:*:@#@$$) (d :: a) :: (~>) b ((:*:) a b)) where
-      sing = (singFun1 @((:*:@#@$$) (d :: a))) ((:%*:) (sing @_ @d))
+      sing = (singFun1 @((:*:@#@$$) (d :: a))) ((:%*:) (sing @d))
     instance SingI d =>
              SingI (TyCon1 ((:*:) (d :: a)) :: (~>) b ((:*:) a b)) where
-      sing = (singFun1 @(TyCon1 ((:*:) (d :: a)))) ((:%*:) (sing @_ @d))
+      sing = (singFun1 @(TyCon1 ((:*:) (d :: a)))) ((:%*:) (sing @d))
     instance (SingI n, SingI n) =>
              SingI (MkPair (n :: a) (n :: b)) where
       sing = (SMkPair sing) sing
@@ -103,8 +103,7 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @(TyCon2 MkPair)) SMkPair
     instance SingI d =>
              SingI (MkPairSym1 (d :: a) :: (~>) b (Pair a b)) where
-      sing = (singFun1 @(MkPairSym1 (d :: a))) (SMkPair (sing @_ @d))
+      sing = (singFun1 @(MkPairSym1 (d :: a))) (SMkPair (sing @d))
     instance SingI d =>
              SingI (TyCon1 (MkPair (d :: a)) :: (~>) b (Pair a b)) where
-      sing
-        = (singFun1 @(TyCon1 (MkPair (d :: a)))) (SMkPair (sing @_ @d))
+      sing = (singFun1 @(TyCon1 (MkPair (d :: a)))) (SMkPair (sing @d))

--- a/tests/compile-and-dump/Singletons/T200.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T200.ghc84.template
@@ -119,6 +119,20 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
       = (applySing ((applySing ((singFun2 @(:<>:@#@$)) (:%<>:))) sX)) sY
     (%$$:) (sX :: Sing x) (sY :: Sing y)
       = (applySing ((applySing ((singFun2 @(:$$:@#@$)) (:%$$:))) sX)) sY
+    instance SingI ((<>:@#@$) :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)) where
+      sing = (singFun2 @(<>:@#@$)) (%<>:)
+    instance SingI d =>
+             SingI ((<>:@#@$$) (d :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage) where
+      sing
+        = (singFun1 @((<>:@#@$$) (d :: ErrorMessage)))
+            ((%<>:) (sing @_ @d))
+    instance SingI (($$:@#@$) :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)) where
+      sing = (singFun2 @($$:@#@$)) (%$$:)
+    instance SingI d =>
+             SingI (($$:@#@$$) (d :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage) where
+      sing
+        = (singFun1 @(($$:@#@$$) (d :: ErrorMessage)))
+            ((%$$:) (sing @_ @d))
     data instance Sing :: ErrorMessage
                           -> GHC.Types.Type :: ErrorMessage -> GHC.Types.Type
       where
@@ -157,8 +171,40 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
     instance (SingI n, SingI n) =>
              SingI ((:$$:) (n :: ErrorMessage) (n :: ErrorMessage)) where
       sing = ((:%$$:) sing) sing
+    instance SingI ((:$$:@#@$) :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)) where
+      sing = (singFun2 @(:$$:@#@$)) (:%$$:)
+    instance SingI (TyCon2 (:$$:) :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)) where
+      sing = (singFun2 @(TyCon2 (:$$:))) (:%$$:)
+    instance SingI d =>
+             SingI ((:$$:@#@$$) (d :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage) where
+      sing
+        = (singFun1 @((:$$:@#@$$) (d :: ErrorMessage)))
+            ((:%$$:) (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon1 ((:$$:) (d :: ErrorMessage)) :: (~>) ErrorMessage ErrorMessage) where
+      sing
+        = (singFun1 @(TyCon1 ((:$$:) (d :: ErrorMessage))))
+            ((:%$$:) (sing @_ @d))
     instance (SingI n, SingI n) =>
              SingI ((:<>:) (n :: ErrorMessage) (n :: ErrorMessage)) where
       sing = ((:%<>:) sing) sing
+    instance SingI ((:<>:@#@$) :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)) where
+      sing = (singFun2 @(:<>:@#@$)) (:%<>:)
+    instance SingI (TyCon2 (:<>:) :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)) where
+      sing = (singFun2 @(TyCon2 (:<>:))) (:%<>:)
+    instance SingI d =>
+             SingI ((:<>:@#@$$) (d :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage) where
+      sing
+        = (singFun1 @((:<>:@#@$$) (d :: ErrorMessage)))
+            ((:%<>:) (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon1 ((:<>:) (d :: ErrorMessage)) :: (~>) ErrorMessage ErrorMessage) where
+      sing
+        = (singFun1 @(TyCon1 ((:<>:) (d :: ErrorMessage))))
+            ((:%<>:) (sing @_ @d))
     instance SingI n => SingI (EM (n :: [Bool])) where
       sing = SEM sing
+    instance SingI (EMSym0 :: (~>) [Bool] ErrorMessage) where
+      sing = (singFun1 @EMSym0) SEM
+    instance SingI (TyCon1 EM :: (~>) [Bool] ErrorMessage) where
+      sing = (singFun1 @(TyCon1 EM)) SEM

--- a/tests/compile-and-dump/Singletons/T200.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T200.ghc84.template
@@ -124,15 +124,13 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
     instance SingI d =>
              SingI ((<>:@#@$$) (d :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage) where
       sing
-        = (singFun1 @((<>:@#@$$) (d :: ErrorMessage)))
-            ((%<>:) (sing @_ @d))
+        = (singFun1 @((<>:@#@$$) (d :: ErrorMessage))) ((%<>:) (sing @d))
     instance SingI (($$:@#@$) :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)) where
       sing = (singFun2 @($$:@#@$)) (%$$:)
     instance SingI d =>
              SingI (($$:@#@$$) (d :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage) where
       sing
-        = (singFun1 @(($$:@#@$$) (d :: ErrorMessage)))
-            ((%$$:) (sing @_ @d))
+        = (singFun1 @(($$:@#@$$) (d :: ErrorMessage))) ((%$$:) (sing @d))
     data instance Sing :: ErrorMessage
                           -> GHC.Types.Type :: ErrorMessage -> GHC.Types.Type
       where
@@ -178,13 +176,12 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
     instance SingI d =>
              SingI ((:$$:@#@$$) (d :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage) where
       sing
-        = (singFun1 @((:$$:@#@$$) (d :: ErrorMessage)))
-            ((:%$$:) (sing @_ @d))
+        = (singFun1 @((:$$:@#@$$) (d :: ErrorMessage))) ((:%$$:) (sing @d))
     instance SingI d =>
              SingI (TyCon1 ((:$$:) (d :: ErrorMessage)) :: (~>) ErrorMessage ErrorMessage) where
       sing
         = (singFun1 @(TyCon1 ((:$$:) (d :: ErrorMessage))))
-            ((:%$$:) (sing @_ @d))
+            ((:%$$:) (sing @d))
     instance (SingI n, SingI n) =>
              SingI ((:<>:) (n :: ErrorMessage) (n :: ErrorMessage)) where
       sing = ((:%<>:) sing) sing
@@ -195,13 +192,12 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
     instance SingI d =>
              SingI ((:<>:@#@$$) (d :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage) where
       sing
-        = (singFun1 @((:<>:@#@$$) (d :: ErrorMessage)))
-            ((:%<>:) (sing @_ @d))
+        = (singFun1 @((:<>:@#@$$) (d :: ErrorMessage))) ((:%<>:) (sing @d))
     instance SingI d =>
              SingI (TyCon1 ((:<>:) (d :: ErrorMessage)) :: (~>) ErrorMessage ErrorMessage) where
       sing
         = (singFun1 @(TyCon1 ((:<>:) (d :: ErrorMessage))))
-            ((:%<>:) (sing @_ @d))
+            ((:%<>:) (sing @d))
     instance SingI n => SingI (EM (n :: [Bool])) where
       sing = SEM sing
     instance SingI (EMSym0 :: (~>) [Bool] ErrorMessage) where

--- a/tests/compile-and-dump/Singletons/T209.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T209.ghc84.template
@@ -55,6 +55,16 @@ Singletons/T209.hs:(0,0)-(0,0): Splicing declarations
       -> Sing t
          -> Sing t -> Sing (Apply (Apply (Apply MSym0 t) t) t :: Bool)
     sM _ _ (sX :: Sing x) = sX
+    instance SingI (MSym0 :: (~>) a ((~>) b ((~>) Bool Bool))) where
+      sing = (singFun3 @MSym0) sM
+    instance SingI d =>
+             SingI (MSym1 (d :: a) :: (~>) b ((~>) Bool Bool)) where
+      sing = (singFun2 @(MSym1 (d :: a))) (sM (sing @_ @d))
+    instance (SingI d, SingI d) =>
+             SingI (MSym2 (d :: a) (d :: b) :: (~>) Bool Bool) where
+      sing
+        = (singFun1 @(MSym2 (d :: a) (d :: b)))
+            ((sM (sing @_ @d)) (sing @_ @d))
     data instance Sing :: Hm -> GHC.Types.Type :: Hm -> GHC.Types.Type
       where SHm :: Sing Hm
     type SHm = (Sing :: Hm -> GHC.Types.Type)

--- a/tests/compile-and-dump/Singletons/T209.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T209.ghc84.template
@@ -59,12 +59,11 @@ Singletons/T209.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun3 @MSym0) sM
     instance SingI d =>
              SingI (MSym1 (d :: a) :: (~>) b ((~>) Bool Bool)) where
-      sing = (singFun2 @(MSym1 (d :: a))) (sM (sing @_ @d))
+      sing = (singFun2 @(MSym1 (d :: a))) (sM (sing @d))
     instance (SingI d, SingI d) =>
              SingI (MSym2 (d :: a) (d :: b) :: (~>) Bool Bool) where
       sing
-        = (singFun1 @(MSym2 (d :: a) (d :: b)))
-            ((sM (sing @_ @d)) (sing @_ @d))
+        = (singFun1 @(MSym2 (d :: a) (d :: b))) ((sM (sing @d)) (sing @d))
     data instance Sing :: Hm -> GHC.Types.Type :: Hm -> GHC.Types.Type
       where SHm :: Sing Hm
     type SHm = (Sing :: Hm -> GHC.Types.Type)

--- a/tests/compile-and-dump/Singletons/T229.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T229.ghc84.template
@@ -20,3 +20,5 @@ Singletons/T229.hs:(0,0)-(0,0): Splicing declarations
     ___sfoo ::
       forall (t :: Bool). Sing t -> Sing (Apply US___fooSym0 t :: Bool)
     ___sfoo _ = STrue
+    instance SingI (US___fooSym0 :: (~>) Bool Bool) where
+      sing = (singFun1 @US___fooSym0) ___sfoo

--- a/tests/compile-and-dump/Singletons/T249.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T249.ghc84.template
@@ -66,7 +66,19 @@ Singletons/T249.hs:(0,0)-(0,0): Splicing declarations
             SomeSing c -> SomeSing (SMkFoo3 c) }
     instance SingI n => SingI (MkFoo1 (n :: a)) where
       sing = SMkFoo1 sing
+    instance SingI (MkFoo1Sym0 :: (~>) a (Foo1 a)) where
+      sing = (singFun1 @MkFoo1Sym0) SMkFoo1
+    instance SingI (TyCon1 MkFoo1 :: (~>) a (Foo1 a)) where
+      sing = (singFun1 @(TyCon1 MkFoo1)) SMkFoo1
     instance SingI n => SingI (MkFoo2 (n :: x)) where
       sing = SMkFoo2 sing
+    instance SingI (MkFoo2Sym0 :: (~>) x (Foo2 x)) where
+      sing = (singFun1 @MkFoo2Sym0) SMkFoo2
+    instance SingI (TyCon1 MkFoo2 :: (~>) x (Foo2 x)) where
+      sing = (singFun1 @(TyCon1 MkFoo2)) SMkFoo2
     instance SingI n => SingI (MkFoo3 (n :: x)) where
       sing = SMkFoo3 sing
+    instance SingI (MkFoo3Sym0 :: (~>) x (Foo3 x)) where
+      sing = (singFun1 @MkFoo3Sym0) SMkFoo3
+    instance SingI (TyCon1 MkFoo3 :: (~>) x (Foo3 x)) where
+      sing = (singFun1 @(TyCon1 MkFoo3)) SMkFoo3

--- a/tests/compile-and-dump/Singletons/T271.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T271.ghc84.template
@@ -187,5 +187,13 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
               -> Disproved (\ refl -> case refl of { Refl -> contra Refl })
     instance SingI n => SingI (Constant (n :: a)) where
       sing = SConstant sing
+    instance SingI (ConstantSym0 :: (~>) a (Constant (a :: Type) (b :: Type))) where
+      sing = (singFun1 @ConstantSym0) SConstant
+    instance SingI (TyCon1 Constant :: (~>) a (Constant (a :: Type) (b :: Type))) where
+      sing = (singFun1 @(TyCon1 Constant)) SConstant
     instance SingI n => SingI (Identity (n :: a)) where
       sing = SIdentity sing
+    instance SingI (IdentitySym0 :: (~>) a (Identity a)) where
+      sing = (singFun1 @IdentitySym0) SIdentity
+    instance SingI (TyCon1 Identity :: (~>) a (Identity a)) where
+      sing = (singFun1 @(TyCon1 Identity)) SIdentity

--- a/tests/compile-and-dump/Singletons/T287.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T287.ghc84.template
@@ -112,3 +112,8 @@ Singletons/T287.hs:(0,0)-(0,0): Splicing declarations
                       -> (applySing
                             ((applySing ((singFun2 @(<<>>@#@$)) (%<<>>))) ((applySing sF) sX)))
                            ((applySing sG) sX) })
+    instance SS a => SingI ((<<>>@#@$) :: (~>) a ((~>) a a)) where
+      sing = (singFun2 @(<<>>@#@$)) (%<<>>)
+    instance (SS a, SingI d) =>
+             SingI ((<<>>@#@$$) (d :: a) :: (~>) a a) where
+      sing = (singFun1 @((<<>>@#@$$) (d :: a))) ((%<<>>) (sing @_ @d))

--- a/tests/compile-and-dump/Singletons/T287.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T287.ghc84.template
@@ -116,4 +116,4 @@ Singletons/T287.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @(<<>>@#@$)) (%<<>>)
     instance (SS a, SingI d) =>
              SingI ((<<>>@#@$$) (d :: a) :: (~>) a a) where
-      sing = (singFun1 @((<<>>@#@$$) (d :: a))) ((%<<>>) (sing @_ @d))
+      sing = (singFun1 @((<<>>@#@$$) (d :: a))) ((%<<>>) (sing @d))

--- a/tests/compile-and-dump/Singletons/T29.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T29.ghc84.template
@@ -101,3 +101,11 @@ Singletons/T29.hs:(0,0)-(0,0): Splicing declarations
            ((applySing ((singFun2 @($@#@$)) (%$)))
               ((singFun1 @NotSym0) sNot)))
           sX
+    instance SingI (BanSym0 :: (~>) Bool Bool) where
+      sing = (singFun1 @BanSym0) sBan
+    instance SingI (BazSym0 :: (~>) Bool Bool) where
+      sing = (singFun1 @BazSym0) sBaz
+    instance SingI (BarSym0 :: (~>) Bool Bool) where
+      sing = (singFun1 @BarSym0) sBar
+    instance SingI (FooSym0 :: (~>) Bool Bool) where
+      sing = (singFun1 @FooSym0) sFoo

--- a/tests/compile-and-dump/Singletons/T297.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T297.ghc84.template
@@ -46,6 +46,8 @@ Singletons/T297.hs:(0,0)-(0,0): Splicing declarations
                 sZ = SMyProxy
               in sZ
         in sX
+    instance SingI FSym0 where
+      sing = (singFun1 @FSym0) sF
     data instance Sing :: MyProxy a -> Type :: MyProxy a -> Type
       where SMyProxy :: Sing MyProxy
     type SMyProxy = (Sing :: MyProxy a -> Type)

--- a/tests/compile-and-dump/Singletons/T312.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T312.ghc84.template
@@ -63,3 +63,8 @@ Singletons/T312.hs:(0,0)-(0,0): Splicing declarations
                 (Apply (Apply BarSym0 t) t :: b) ~ Apply (Apply Bar_0123456789876543210Sym0 t) t =>
                 Sing t -> Sing t -> Sing (Apply (Apply BarSym0 t) t :: b)
       sBar _ (sX :: Sing x) = sX
+    instance SFoo a => SingI (BarSym0 :: (~>) a ((~>) b b)) where
+      sing = (singFun2 @BarSym0) sBar
+    instance (SFoo a, SingI d) =>
+             SingI (BarSym1 (d :: a) :: (~>) b b) where
+      sing = (singFun1 @(BarSym1 (d :: a))) (sBar (sing @_ @d))

--- a/tests/compile-and-dump/Singletons/T312.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T312.ghc84.template
@@ -67,4 +67,4 @@ Singletons/T312.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @BarSym0) sBar
     instance (SFoo a, SingI d) =>
              SingI (BarSym1 (d :: a) :: (~>) b b) where
-      sing = (singFun1 @(BarSym1 (d :: a))) (sBar (sing @_ @d))
+      sing = (singFun1 @(BarSym1 (d :: a))) (sBar (sing @d))

--- a/tests/compile-and-dump/Singletons/T322.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T322.ghc84.template
@@ -40,3 +40,8 @@ Singletons/T322.hs:(0,0)-(0,0): Splicing declarations
       = (applySing
            ((applySing ((singFun2 @(||@#@$)) (%||))) sA_0123456789876543210))
           sA_0123456789876543210
+    instance SingI ((!@#@$) :: (~>) Bool ((~>) Bool Bool)) where
+      sing = (singFun2 @(!@#@$)) (%!)
+    instance SingI d =>
+             SingI ((!@#@$$) (d :: Bool) :: (~>) Bool Bool) where
+      sing = (singFun1 @((!@#@$$) (d :: Bool))) ((%!) (sing @_ @d))

--- a/tests/compile-and-dump/Singletons/T322.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T322.ghc84.template
@@ -44,4 +44,4 @@ Singletons/T322.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @(!@#@$)) (%!)
     instance SingI d =>
              SingI ((!@#@$$) (d :: Bool) :: (~>) Bool Bool) where
-      sing = (singFun1 @((!@#@$$) (d :: Bool))) ((%!) (sing @_ @d))
+      sing = (singFun1 @((!@#@$$) (d :: Bool))) ((%!) (sing @d))

--- a/tests/compile-and-dump/Singletons/T33.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T33.ghc84.template
@@ -19,6 +19,8 @@ Singletons/T33.hs:(0,0)-(0,0): Splicing declarations
     sFoo ::
       forall (t :: (Bool, Bool)). Sing t -> Sing (Apply FooSym0 t :: ())
     sFoo (STuple2 _ _) = STuple0
+    instance SingI (FooSym0 :: (~>) (Bool, Bool) ()) where
+      sing = (singFun1 @FooSym0) sFoo
 
 Singletons/T33.hs:0:0: warning:
     Lazy pattern converted into regular pattern in promotion

--- a/tests/compile-and-dump/Singletons/T54.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T54.ghc84.template
@@ -50,3 +50,5 @@ Singletons/T54.hs:(0,0)-(0,0): Splicing declarations
                   SCons _ SNil -> (singFun1 @NotSym0) sNot } ::
                   Sing (Case_0123456789876543210 e (Let0123456789876543210Scrutinee_0123456789876543210Sym1 e))))
           sE
+    instance SingI (GSym0 :: (~>) Bool Bool) where
+      sing = (singFun1 @GSym0) sG

--- a/tests/compile-and-dump/Singletons/T78.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T78.ghc84.template
@@ -27,3 +27,5 @@ Singletons/T78.hs:(0,0)-(0,0): Splicing declarations
     sFoo (SJust SFalse) = SFalse
     sFoo (SJust STrue) = STrue
     sFoo SNothing = SFalse
+    instance SingI (FooSym0 :: (~>) (Maybe Bool) Bool) where
+      sing = (singFun1 @FooSym0) sFoo

--- a/tests/compile-and-dump/Singletons/TopLevelPatterns.ghc84.template
+++ b/tests/compile-and-dump/Singletons/TopLevelPatterns.ghc84.template
@@ -60,6 +60,16 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
     instance (SingI n, SingI n) =>
              SingI (Bar (n :: Bool) (n :: Bool)) where
       sing = (SBar sing) sing
+    instance SingI (BarSym0 :: (~>) Bool ((~>) Bool Foo)) where
+      sing = (singFun2 @BarSym0) SBar
+    instance SingI (TyCon2 Bar :: (~>) Bool ((~>) Bool Foo)) where
+      sing = (singFun2 @(TyCon2 Bar)) SBar
+    instance SingI d =>
+             SingI (BarSym1 (d :: Bool) :: (~>) Bool Foo) where
+      sing = (singFun1 @(BarSym1 (d :: Bool))) (SBar (sing @_ @d))
+    instance SingI d =>
+             SingI (TyCon1 (Bar (d :: Bool)) :: (~>) Bool Foo) where
+      sing = (singFun1 @(TyCon1 (Bar (d :: Bool)))) (SBar (sing @_ @d))
 Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
     singletons
       [d| otherwise :: Bool
@@ -314,3 +324,15 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
               ((applySing ((singFun2 @(:@#@$)) SCons))
                  ((applySing ((singFun1 @IdSym0) sId)) SFalse)))
              SNil)
+    instance SingI (NotSym0 :: (~>) Bool Bool) where
+      sing = (singFun1 @NotSym0) sNot
+    instance SingI (IdSym0 :: (~>) a a) where
+      sing = (singFun1 @IdSym0) sId
+    instance SingI (FSym0 :: (~>) Bool Bool) where
+      sing = (singFun1 @FSym0) sF
+    instance SingI (GSym0 :: (~>) Bool Bool) where
+      sing = (singFun1 @GSym0) sG
+    instance SingI (HSym0 :: (~>) Bool Bool) where
+      sing = (singFun1 @HSym0) sH
+    instance SingI (ISym0 :: (~>) Bool Bool) where
+      sing = (singFun1 @ISym0) sI

--- a/tests/compile-and-dump/Singletons/TopLevelPatterns.ghc84.template
+++ b/tests/compile-and-dump/Singletons/TopLevelPatterns.ghc84.template
@@ -66,10 +66,10 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @(TyCon2 Bar)) SBar
     instance SingI d =>
              SingI (BarSym1 (d :: Bool) :: (~>) Bool Foo) where
-      sing = (singFun1 @(BarSym1 (d :: Bool))) (SBar (sing @_ @d))
+      sing = (singFun1 @(BarSym1 (d :: Bool))) (SBar (sing @d))
     instance SingI d =>
              SingI (TyCon1 (Bar (d :: Bool)) :: (~>) Bool Foo) where
-      sing = (singFun1 @(TyCon1 (Bar (d :: Bool)))) (SBar (sing @_ @d))
+      sing = (singFun1 @(TyCon1 (Bar (d :: Bool)))) (SBar (sing @d))
 Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
     singletons
       [d| otherwise :: Bool

--- a/tests/compile-and-dump/Singletons/TypeRepTYPE.hs
+++ b/tests/compile-and-dump/Singletons/TypeRepTYPE.hs
@@ -16,9 +16,9 @@ eqTYPETest2 = Refl
 
 f :: Sing (a :: Type) -> Maybe a
 f tr
-  | Proved Refl <- tr %~ sing @Type @Bool
+  | Proved Refl <- tr %~ sing @Bool
   = Just True
-  | Proved Refl <- tr %~ sing @Type @Ordering
+  | Proved Refl <- tr %~ sing @Ordering
   = Just EQ
   | otherwise
   = Nothing
@@ -29,9 +29,9 @@ data MaybeWordRep (a :: TYPE 'WordRep)
 
 g :: Sing (a :: TYPE 'WordRep) -> MaybeWordRep a
 g tr
-  | Proved Refl <- tr %~ sing @(TYPE 'WordRep) @Word#
+  | Proved Refl <- tr %~ sing @Word#
   = JustWordRep 42##
-  | Proved Refl <- tr %~ sing @(TYPE 'WordRep) @Char#
+  | Proved Refl <- tr %~ sing @Char#
   = JustWordRep 'j'#
   | otherwise
   = NothingWordRep

--- a/tests/compile-and-dump/Singletons/Undef.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Undef.ghc84.template
@@ -39,3 +39,7 @@ Singletons/Undef.hs:(0,0)-(0,0): Splicing declarations
       = (sError (sing :: Sing "urk")) sA_0123456789876543210
     sFoo (sA_0123456789876543210 :: Sing a_0123456789876543210)
       = sUndefined sA_0123456789876543210
+    instance SingI (BarSym0 :: (~>) Bool Bool) where
+      sing = (singFun1 @BarSym0) sBar
+    instance SingI (FooSym0 :: (~>) Bool Bool) where
+      sing = (singFun1 @FooSym0) sFoo


### PR DESCRIPTION
When singling via Template Haskell, we now generate `SingI` instances for the generated defunctionalization symbols. For the most part, this is a straightforward algorithm over the type of the thing being singled—see the `singDefun` function in the new `Data.Singletons.Single.Defun` module.

Data constructors are interesting to handle because they are themselves matchable tycons, so we also generate extra `SingI` instances for when the data constructor appears inside of `TyCon{N}`. See `Note [SingI instances for partially applied constructors]`.

Fixes https://github.com/goldfirere/singletons/issues/252.