### PR TITLE
Fix #184 by adding support for monads 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,10 @@ Changelog for singletons project
   `(%<>)`, as they are superseded by the corresponding methods from
   `PSemigroup` and `SSemigroup`.
 
+* Add promoted and singled versions of the `Functor`, `Applicative`,
+  `Alternative`, `Monad`, `MonadPlus`, and `MonadZip`. This grants the ability
+  to promote or single `do`-notation and list comprehensions.
+
 * Promote and single the `Down` newtype in `Data.Singletons.Prelude.Ord`.
 
 * To match the `base` library, the promoted/singled versions of `comparing`

--- a/README.md
+++ b/README.md
@@ -561,7 +561,8 @@ The following constructs are fully supported:
 * infix expressions and types
 * `_` patterns
 * aliased patterns
-* lists
+* lists (including list comprehensions)
+* `do`-notation
 * sections
 * undefined
 * error
@@ -618,18 +619,11 @@ overlaps with `pred x` guard.
 
 The following constructs are not supported:
 
-* list comprehensions
-* do
 * arithmetic sequences
 * datatypes that store arrows, `Nat`, or `Symbol`
 * literals (limited support)
 
-Why are these out of reach? The first two depend on monads, which mention a
-higher-kinded type variable. GHC did not support higher-sorted kind variables,
-which are be necessary to promote/singletonize monads, and `singletons` has
-not be rewritten to accommodate this new ability. [This bug
-report](https://github.com/goldfirere/singletons/issues/184) is a feature request
-looking for support for these constructs.
+Why are these out of reach?
 
 Arithmetic sequences are defined using `Enum` typeclass, which uses infinite
 lists.

--- a/singletons.cabal
+++ b/singletons.cabal
@@ -74,17 +74,21 @@ library
                       Data.Singletons.TypeRepTYPE
                       Data.Singletons.TH
                       Data.Singletons.Prelude
+                      Data.Singletons.Prelude.Applicative
                       Data.Singletons.Prelude.Base
                       Data.Singletons.Prelude.Bool
                       Data.Singletons.Prelude.Either
                       Data.Singletons.Prelude.Enum
                       Data.Singletons.Prelude.Eq
                       Data.Singletons.Prelude.Function
+                      Data.Singletons.Prelude.Functor
                       Data.Singletons.Prelude.IsString
                       Data.Singletons.Prelude.Ord
                       Data.Singletons.Prelude.List
                       Data.Singletons.Prelude.List.NonEmpty
                       Data.Singletons.Prelude.Maybe
+                      Data.Singletons.Prelude.Monad
+                      Data.Singletons.Prelude.Monad.Zip
                       Data.Singletons.Prelude.Monoid
                       Data.Singletons.Prelude.Num
                       Data.Singletons.Prelude.Semigroup
@@ -93,17 +97,21 @@ library
                       Data.Singletons.Prelude.Void
                       Data.Promotion.Prelude
                       Data.Promotion.TH
+                      Data.Promotion.Prelude.Applicative
                       Data.Promotion.Prelude.Base
                       Data.Promotion.Prelude.Bool
                       Data.Promotion.Prelude.Either
                       Data.Promotion.Prelude.Eq
                       Data.Promotion.Prelude.Function
+                      Data.Promotion.Prelude.Functor
                       Data.Promotion.Prelude.IsString
                       Data.Promotion.Prelude.Ord
                       Data.Promotion.Prelude.Enum
                       Data.Promotion.Prelude.List
                       Data.Promotion.Prelude.List.NonEmpty
                       Data.Promotion.Prelude.Maybe
+                      Data.Promotion.Prelude.Monad
+                      Data.Promotion.Prelude.Monad.Zip
                       Data.Promotion.Prelude.Monoid
                       Data.Promotion.Prelude.Num
                       Data.Promotion.Prelude.Semigroup
@@ -125,6 +133,7 @@ library
                       Data.Singletons.Deriving.Util
                       Data.Singletons.Internal
                       Data.Singletons.Prelude.List.NonEmpty.Internal
+                      Data.Singletons.Prelude.Monad.Internal
                       Data.Singletons.Prelude.Semigroup.Internal
                       Data.Singletons.Promote
                       Data.Singletons.Promote.Monad

--- a/src/Data/Promotion/Prelude.hs
+++ b/src/Data/Promotion/Prelude.hs
@@ -49,6 +49,13 @@ module Data.Promotion.Prelude (
   -- * Promoted 'Semigroup' and 'Monoid'
   PSemigroup(type (<>)), PMonoid(..),
 
+  -- * Promoted 'Functor', 'Applicative', and 'Monad'
+  PFunctor(Fmap, type (<$)),
+  PApplicative(Pure, type (<*>), type (*>), type (<*)),
+  PMonad(type (>>=), type (>>), Return, Fail),
+  -- MapM_,
+  type (=<<),
+
   -- ** Miscellaneous functions
   Id, Const, (:.), type ($), type ($!), Flip, AsTypeOf, Until, Seq,
 
@@ -131,6 +138,18 @@ module Data.Promotion.Prelude (
   MappendSym0, MappendSym1, MappendSym2,
   MconcatSym0, MconcatSym1,
 
+  FmapSym0, FmapSym1, FmapSym2,
+  type (<$@#@$),  type (<$@#@$$),  type (<$@#@$$$),
+  type (<$>@#@$), type (<$>@#@$$), type (<$>@#@$$$),
+  PureSym0, PureSym1,
+  type (<*>@#@$), type (<*>@#@$$), type (<*>@#@$$$),
+  type (*>@#@$),  type (*>@#@$$),  type (*>@#@$$$),
+  type (<*@#@$),  type (<*@#@$$),  type (<*@#@$$$),
+  type (>>=@#@$), type (>>=@#@$$), type (>>=@#@$$$),
+  type (>>@#@$),  type (>>@#@$$),  type (>>@#@$$$),
+  ReturnSym0, ReturnSym1, FailSym0, FailSym1,
+  type (=<<@#@$), type (=<<@#@$$), type (=<<@#@$$$),
+
   IdSym0, IdSym1, ConstSym0, ConstSym1, ConstSym2,
   type (.@#@$), type (.@#@$$), type (.@#@$$$),
   type ($@#@$),  type ($@#@$$),  type ($@#@$$$),
@@ -189,11 +208,14 @@ module Data.Promotion.Prelude (
   type (!!@#@$), type (!!@#@$$), type (!!@#@$$$),
   ) where
 
+import Data.Promotion.Prelude.Applicative
 import Data.Promotion.Prelude.Base
 import Data.Promotion.Prelude.Bool
 import Data.Promotion.Prelude.Either
+import Data.Promotion.Prelude.Functor
 import Data.Promotion.Prelude.List
 import Data.Promotion.Prelude.Maybe
+import Data.Promotion.Prelude.Monad
 import Data.Promotion.Prelude.Tuple
 import Data.Promotion.Prelude.Eq
 import Data.Promotion.Prelude.Ord

--- a/src/Data/Promotion/Prelude/Applicative.hs
+++ b/src/Data/Promotion/Prelude/Applicative.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE ExplicitNamespaces #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Promotion.Prelude.Applicative
+-- Copyright   :  (C) 2018 Ryan Scott
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Defines the promoted version of the 'Applicative' type class.
+--
+----------------------------------------------------------------------------
+
+module Data.Promotion.Prelude.Applicative (
+  PApplicative(..), PAlternative(..),
+  -- Const, GetConst,
+  type (<$>), type (<$), type (<**>),
+  LiftA, LiftA3, Optional,
+
+  -- * Defunctionalization symbols
+  PureSym0, PureSym1,
+  type (<*>@#@$), type (<*>@#@$$), type (<*>@#@$$$),
+  type (*>@#@$),  type (*>@#@$$),  type (*>@#@$$$),
+  type (<*@#@$),  type (<*@#@$$),  type (<*@#@$$$),
+  EmptySym0, type (<|>@#@$), type (<|>@#@$$), type (<|>@#@$$$),
+  -- ConstSym0, ConstSym1, GetConstSym0, GetConstSym1,
+  type (<$>@#@$),  type (<$>@#@$$),  type (<$>@#@$$$),
+  type (<$@#@$),   type (<$@#@$$),   type (<$@#@$$$),
+  type (<**>@#@$), type (<**>@#@$$), type (<**>@#@$$$),
+  LiftASym0,  LiftASym1,  LiftASym2,
+  LiftA2Sym0, LiftA2Sym1, LiftA2Sym2, LiftA2Sym3,
+  LiftA3Sym0, LiftA3Sym1, LiftA3Sym2, LiftA3Sym3,
+  OptionalSym0, OptionalSym1
+  ) where
+
+import Data.Singletons.Prelude.Applicative

--- a/src/Data/Promotion/Prelude/Functor.hs
+++ b/src/Data/Promotion/Prelude/Functor.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE ExplicitNamespaces #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Promotion.Prelude.Functor
+-- Copyright   :  (C) 2018 Ryan Scott
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Defines the promoted version of the 'Functor' type class.
+--
+----------------------------------------------------------------------------
+
+module Data.Promotion.Prelude.Functor (
+  PFunctor(..),
+  type ($>), type (<$>), type (<&>), Void,
+
+  -- * Defunctionalization symbols
+  FmapSym0, FmapSym1, FmapSym2,
+  type (<$@#@$),  type (<$@#@$$),  type (<$@#@$$$),
+  type ($>@#@$),  type ($>@#@$$),  type ($>@#@$$$),
+  type (<$>@#@$), type (<$>@#@$$), type (<$>@#@$$$),
+  type (<&>@#@$), type (<&>@#@$$), type (<&>@#@$$$),
+  VoidSym0, VoidSym1
+  ) where
+
+import Data.Singletons.Prelude.Functor

--- a/src/Data/Promotion/Prelude/Monad.hs
+++ b/src/Data/Promotion/Prelude/Monad.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE ExplicitNamespaces #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Promotion.Prelude.Monad
+-- Copyright   :  (C) 2018 Ryan Scott
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Defines the promoted version of the 'Monad' type class.
+--
+----------------------------------------------------------------------------
+
+module Data.Promotion.Prelude.Monad (
+  PFunctor(Fmap),
+  PMonad(..), PMonadPlus(..),
+
+  -- MapM, MapM_, ForM, Sequence, Sequence_,
+  type (=<<), type (>=>), type (<=<),
+  -- Forever,
+  Void,
+
+  Join,
+  -- Msum,
+  Mfilter, FilterM,
+  -- MapAndUnzipM, ZipWithM, ZipWithM_, FoldlM,
+  ReplicateM, ReplicateM_,
+
+  Guard, When, Unless,
+
+  LiftM, LiftM2, LiftM3, LiftM4, LiftM5, Ap,
+
+  type (<$!>),
+
+  -- * Defunctionalization symbols
+  FmapSym0, FmapSym1, FmapSym2,
+  type (>>=@#@$), type (>>=@#@$$), type (>>=@#@$$$),
+  type (>>@#@$),  type (>>@#@$$),  type (>>@#@$$$),
+  ReturnSym0, ReturnSym1, FailSym0, FailSym1,
+  MzeroSym0, MplusSym0, MplusSym1, MplusSym2,
+
+  {-
+  MapMSym0,  MapMSym1,  MapMSym2,
+  MapM_Sym0, MapM_Sym1, MapM_Sym2,
+  ForMSym0,  ForMSym1,  ForMSym2,
+  SequenceSym0,  SequenceSym1,
+  Sequence_Sym0, Sequence_Sym1,
+  -}
+  type (=<<@#@$), type (=<<@#@$$), type (=<<@#@$$$),
+  type (>=>@#@$), type (>=>@#@$$), type (>=>@#@$$$),
+  type (<=<@#@$), type (<=<@#@$$), type (<=<@#@$$$),
+  -- ForeverSym0, ForeverSym1,
+  VoidSym0, VoidSym1,
+
+  JoinSym0, JoinSym1,
+  -- MsumSym0, MsumSym1,
+  MfilterSym0, MfilterSym1, MfilterSym2,
+  FilterMSym0, FilterMSym1, FilterMSym2,
+  {-
+  MapAndUnzipMSym0, MapAndUnzipMSym1, MapAndUnzipMSym2,
+  ZipWithMSym0,  ZipWithMSym1,  ZipWithMSym2,  ZipWithMSym3,
+  ZipWithM_Sym0, ZipWithM_Sym1, ZipWithM_Sym2, ZipWithM_Sym3,
+  FoldlMSym0,    FoldlMSym1,    FoldlMSym2,    FoldlMSym3,
+  -}
+  ReplicateMSym0,  ReplicateMSym1,  ReplicateMSym2,
+  ReplicateM_Sym0, ReplicateM_Sym1, ReplicateM_Sym2,
+
+  GuardSym0, GuardSym1,
+  WhenSym0, WhenSym1, WhenSym2,
+  UnlessSym0, UnlessSym1, UnlessSym2,
+
+  LiftMSym0,  LiftMSym1,  LiftMSym2,
+  LiftM2Sym0, LiftM2Sym1, LiftM2Sym2, LiftM2Sym3,
+  LiftM3Sym0, LiftM3Sym1, LiftM3Sym2, LiftM3Sym3, LiftM3Sym4,
+  LiftM4Sym0, LiftM4Sym1, LiftM4Sym2, LiftM4Sym3, LiftM4Sym4, LiftM4Sym5,
+  LiftM5Sym0, LiftM5Sym1, LiftM5Sym2, LiftM5Sym3, LiftM5Sym4, LiftM5Sym5, LiftM5Sym6,
+  ApSym0, ApSym1, ApSym2,
+
+  type (<$!>@#@$), type (<$!>@#@$$), type (<$!>@#@$$$),
+  ) where
+
+import Data.Singletons.Prelude.Monad

--- a/src/Data/Promotion/Prelude/Monad/Zip.hs
+++ b/src/Data/Promotion/Prelude/Monad/Zip.hs
@@ -1,0 +1,23 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Promotion.Prelude.Monad.Zip
+-- Copyright   :  (C) 2018 Ryan Scott
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Defines the promoted version of the 'MonadZip' type class.
+--
+----------------------------------------------------------------------------
+
+module Data.Promotion.Prelude.Monad.Zip (
+  PMonadZip(..),
+
+  -- * Defunctionalization symbols
+  MzipSym0, MzipSym1, MzipSym2,
+  MzipWithSym0, MzipWithSym1, MzipWithSym2, MzipWithSym3,
+  MunzipSym0, MunzipSym1,
+  ) where
+
+import Data.Singletons.Prelude.Monad.Zip

--- a/src/Data/Singletons/Prelude.hs
+++ b/src/Data/Singletons/Prelude.hs
@@ -65,6 +65,15 @@ module Data.Singletons.Prelude (
   PSemigroup(type (<>)), SSemigroup((%<>)),
   PMonoid(..), SMonoid(..),
 
+  -- * Singleton 'Functor', 'Applicative', and 'Monad'
+  PFunctor(Fmap, type (<$)), SFunctor(sFmap, (%<$)), type (<$>), (%<$>),
+  PApplicative(Pure, type (<*>), type (*>), type (<*)),
+  SApplicative(sPure, (%<*>), (%*>), (%<*)),
+  PMonad(type (>>=), type (>>), Return, Fail),
+  SMonad((%>>=), (%>>), sReturn, sFail),
+  -- MapM_, sMapM_,
+  type (=<<), (%=<<),
+
   -- ** Miscellaneous functions
   Id, sId, Const, sConst, (:.), (%.), type ($), (%$), type ($!), (%$!),
   Flip, sFlip, AsTypeOf, sAsTypeOf,
@@ -157,6 +166,18 @@ module Data.Singletons.Prelude (
   MappendSym0, MappendSym1, MappendSym2,
   MconcatSym0, MconcatSym1,
 
+  FmapSym0, FmapSym1, FmapSym2,
+  type (<$@#@$),  type (<$@#@$$),  type (<$@#@$$$),
+  type (<$>@#@$), type (<$>@#@$$), type (<$>@#@$$$),
+  PureSym0, PureSym1,
+  type (<*>@#@$), type (<*>@#@$$), type (<*>@#@$$$),
+  type (*>@#@$),  type (*>@#@$$),  type (*>@#@$$$),
+  type (<*@#@$),  type (<*@#@$$),  type (<*@#@$$$),
+  type (>>=@#@$), type (>>=@#@$$), type (>>=@#@$$$),
+  type (>>@#@$),  type (>>@#@$$),  type (>>@#@$$$),
+  ReturnSym0, ReturnSym1, FailSym0, FailSym1,
+  type (=<<@#@$), type (=<<@#@$$), type (=<<@#@$$$),
+
   IdSym0, IdSym1, ConstSym0, ConstSym1, ConstSym2,
   type (.@#@$),  type (.@#@$$),  type (.@#@$$$),
   type ($@#@$),  type ($@#@$$),  type ($@#@$$$),
@@ -209,11 +230,14 @@ module Data.Singletons.Prelude (
   ) where
 
 import Data.Singletons
+import Data.Singletons.Prelude.Applicative
 import Data.Singletons.Prelude.Base
 import Data.Singletons.Prelude.Bool
 import Data.Singletons.Prelude.Either
+import Data.Singletons.Prelude.Functor
 import Data.Singletons.Prelude.List
 import Data.Singletons.Prelude.Maybe
+import Data.Singletons.Prelude.Monad
 import Data.Singletons.Prelude.Tuple
 import Data.Singletons.Prelude.Eq
 import Data.Singletons.Prelude.Ord

--- a/src/Data/Singletons/Prelude/Applicative.hs
+++ b/src/Data/Singletons/Prelude/Applicative.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeInType #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Singletons.Prelude.Applicative
+-- Copyright   :  (C) 2018 Ryan Scott
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Defines the promoted and singled versions of the 'Applicative' type class.
+--
+----------------------------------------------------------------------------
+
+module Data.Singletons.Prelude.Applicative (
+  PApplicative(..), SApplicative(..),
+  PAlternative(..), SAlternative(..),
+  -- Sing (SConst, sGetConst), SConst, Const, GetConst,
+  type (<$>), (%<$>), type (<$), (%<$), type (<**>), (%<**>),
+  LiftA, sLiftA, LiftA3, sLiftA3, Optional, sOptional,
+
+  -- * Defunctionalization symbols
+  PureSym0, PureSym1,
+  type (<*>@#@$), type (<*>@#@$$), type (<*>@#@$$$),
+  type (*>@#@$),  type (*>@#@$$),  type (*>@#@$$$),
+  type (<*@#@$),  type (<*@#@$$),  type (<*@#@$$$),
+  EmptySym0, type (<|>@#@$), type (<|>@#@$$), type (<|>@#@$$$),
+  -- ConstSym0, ConstSym1, GetConstSym0, GetConstSym1,
+  type (<$>@#@$),  type (<$>@#@$$),  type (<$>@#@$$$),
+  type (<$@#@$),   type (<$@#@$$),   type (<$@#@$$$),
+  type (<**>@#@$), type (<**>@#@$$), type (<**>@#@$$$),
+  LiftASym0,  LiftASym1,  LiftASym2,
+  LiftA2Sym0, LiftA2Sym1, LiftA2Sym2, LiftA2Sym3,
+  LiftA3Sym0, LiftA3Sym1, LiftA3Sym2, LiftA3Sym3,
+  OptionalSym0, OptionalSym1
+  ) where
+
+import Control.Applicative
+import Data.Ord (Down(..))
+import Data.Singletons.Prelude.Functor
+import Data.Singletons.Prelude.Instances
+import Data.Singletons.Prelude.Monad.Internal
+import Data.Singletons.Prelude.Monoid
+import Data.Singletons.Prelude.Ord
+import Data.Singletons.Single
+
+$(singletonsOnly [d|
+  -- -| One or none.
+  optional :: Alternative f => f a -> f (Maybe a)
+  optional v = Just <$> v <|> pure Nothing
+
+  instance Monoid a => Applicative ((,) a) where
+      pure x = (mempty, x)
+      (u, f) <*> (v, x) = (u `mappend` v, f x)
+      liftA2 f (u, x) (v, y) = (u `mappend` v, f x y)
+
+  instance Applicative Down where
+    pure = Down
+    Down f <*> Down x = Down (f x)
+  |])

--- a/src/Data/Singletons/Prelude/Functor.hs
+++ b/src/Data/Singletons/Prelude/Functor.hs
@@ -1,0 +1,209 @@
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeInType #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Singletons.Prelude.Functor
+-- Copyright   :  (C) 2018 Ryan Scott
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Defines the promoted and singled versions of the 'Functor' type class.
+--
+----------------------------------------------------------------------------
+
+module Data.Singletons.Prelude.Functor (
+  PFunctor(..), SFunctor(..),
+  type ($>),  (%$>),
+  type (<$>), (%<$>),
+  type (<&>), (%<&>),
+  Void, sVoid,
+
+  -- * Defunctionalization symbols
+  FmapSym0, FmapSym1, FmapSym2,
+  type (<$@#@$),  type (<$@#@$$),  type (<$@#@$$$),
+  type ($>@#@$),  type ($>@#@$$),  type ($>@#@$$$),
+  type (<$>@#@$), type (<$>@#@$$), type (<$>@#@$$$),
+  type (<&>@#@$), type (<&>@#@$$), type (<&>@#@$$$),
+  VoidSym0, VoidSym1
+  ) where
+
+import Data.Ord (Down(..))
+import Data.Singletons.Prelude.Base
+import Data.Singletons.Prelude.Instances
+import Data.Singletons.Prelude.Monad.Internal
+import Data.Singletons.Prelude.Ord
+import Data.Singletons.Single
+
+$(singletonsOnly [d|
+  infixl 4 <$>
+
+  -- -| An infix synonym for 'fmap'.
+  --
+  -- The name of this operator is an allusion to '$'.
+  -- Note the similarities between their types:
+  --
+  -- >  ($)  ::              (a -> b) ->   a ->   b
+  -- > (<$>) :: Functor f => (a -> b) -> f a -> f b
+  --
+  -- Whereas '$' is function application, '<$>' is function
+  -- application lifted over a 'Functor'.
+  --
+  -- ==== __Examples__
+  --
+  -- Convert from a @'Maybe' 'Int'@ to a @'Maybe' 'String'@ using 'show':
+  --
+  -- >>> show <$> Nothing
+  -- Nothing
+  -- >>> show <$> Just 3
+  -- Just "3"
+  --
+  -- Convert from an @'Either' 'Int' 'Int'@ to an @'Either' 'Int'@
+  -- 'String' using 'show':
+  --
+  -- >>> show <$> Left 17
+  -- Left 17
+  -- >>> show <$> Right 17
+  -- Right "17"
+  --
+  -- Double each element of a list:
+  --
+  -- >>> (*2) <$> [1,2,3]
+  -- [2,4,6]
+  --
+  -- Apply 'even' to the second element of a pair:
+  --
+  -- >>> even <$> (2,2)
+  -- (2,True)
+  --
+  (<$>) :: Functor f => (a -> b) -> f a -> f b
+  (<$>) = fmap
+
+  infixl 4 $>
+
+  -- -| Flipped version of '<$>'.
+  --
+  -- @
+  -- ('<&>') = 'flip' 'fmap'
+  -- @
+  --
+  -- @since 4.11.0.0
+  --
+  -- ==== __Examples__
+  -- Apply @(+1)@ to a list, a 'Data.Maybe.Just' and a 'Data.Either.Right':
+  --
+  -- >>> Just 2 <&> (+1)
+  -- Just 3
+  --
+  -- >>> [1,2,3] <&> (+1)
+  -- [2,3,4]
+  --
+  -- >>> Right 3 <&> (+1)
+  -- Right 4
+  --
+  (<&>) :: Functor f => f a -> (a -> b) -> f b
+  as <&> f = f <$> as
+
+  infixl 1 <&>
+
+  -- -| Flipped version of '<$'.
+  --
+  -- @since 4.7.0.0
+  --
+  -- ==== __Examples__
+  --
+  -- Replace the contents of a @'Maybe' 'Int'@ with a constant 'String':
+  --
+  -- >>> Nothing $> "foo"
+  -- Nothing
+  -- >>> Just 90210 $> "foo"
+  -- Just "foo"
+  --
+  -- Replace the contents of an @'Either' 'Int' 'Int'@ with a constant
+  -- 'String', resulting in an @'Either' 'Int' 'String'@:
+  --
+  -- >>> Left 8675309 $> "foo"
+  -- Left 8675309
+  -- >>> Right 8675309 $> "foo"
+  -- Right "foo"
+  --
+  -- Replace each element of a list with a constant 'String':
+  --
+  -- >>> [1,2,3] $> "foo"
+  -- ["foo","foo","foo"]
+  --
+  -- Replace the second element of a pair with a constant 'String':
+  --
+  -- >>> (1,2) $> "foo"
+  -- (1,"foo")
+  --
+  ($>) :: Functor f => f a -> b -> f b
+  ($>) = flip (<$)
+
+  -- -| @'void' value@ discards or ignores the result of evaluation, such
+  -- as the return value of an 'System.IO.IO' action.
+  --
+  -- ==== __Examples__
+  --
+  -- Replace the contents of a @'Maybe' 'Int'@ with unit:
+  --
+  -- >>> void Nothing
+  -- Nothing
+  -- >>> void (Just 3)
+  -- Just ()
+  --
+  -- Replace the contents of an @'Either' 'Int' 'Int'@ with unit,
+  -- resulting in an @'Either' 'Int' '()'@:
+  --
+  -- >>> void (Left 8675309)
+  -- Left 8675309
+  -- >>> void (Right 8675309)
+  -- Right ()
+  --
+  -- Replace every element of a list with unit:
+  --
+  -- >>> void [1,2,3]
+  -- [(),(),()]
+  --
+  -- Replace the second element of a pair with unit:
+  --
+  -- >>> void (1,2)
+  -- (1,())
+  --
+  -- Discard the result of an 'System.IO.IO' action:
+  --
+  -- >>> mapM print [1,2]
+  -- 1
+  -- 2
+  -- [(),()]
+  -- >>> void $ mapM print [1,2]
+  -- 1
+  -- 2
+  --
+  void :: Functor f => f a -> f ()
+  void x = () <$ x
+
+  -- deriving instance Functor ((,) a)
+  instance Functor ((,) a) where
+      fmap f (x,y) = (x, f y)
+
+  -- deriving instance Functor Down
+  instance Functor Down where
+    fmap f (Down x) = Down (f x)
+  |])
+
+-- Workaround for #326
+infixl 4 <$>
+infixl 4 $>
+infixl 1 <&>

--- a/src/Data/Singletons/Prelude/List/NonEmpty.hs
+++ b/src/Data/Singletons/Prelude/List/NonEmpty.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TemplateHaskell, ScopedTypeVariables, TypeInType, TypeOperators,
-             TypeFamilies, GADTs, UndecidableInstances #-}
+             TypeFamilies, GADTs, UndecidableInstances, InstanceSigs #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -145,6 +146,7 @@ module Data.Singletons.Prelude.List.NonEmpty (
   XorSym0, XorSym1
   ) where
 
+import Control.Monad.Zip
 import Data.List.NonEmpty
 import Data.Singletons.Prelude.List.NonEmpty.Internal
 import Data.Singletons.Prelude.Instances
@@ -153,6 +155,7 @@ import Data.Singletons.Prelude.Maybe
 import Data.Singletons.Prelude.Num
 import Data.Singletons.Prelude.Bool
 import Data.Singletons.Prelude.Eq
+import Data.Singletons.Prelude.Monad.Zip
 import Data.Singletons.Prelude.Ord
 import Data.Singletons.Prelude.Function
 import Data.Function
@@ -172,13 +175,12 @@ $(singletonsOnly [d|
   instance MonadFix NonEmpty where
     mfix f = case fix (f . head) of
                ~(x :| _) -> x :| mfix (tail . f)
+  -}
 
-  -- | @since 4.9.0.0
   instance MonadZip NonEmpty where
     mzip     = zip
     mzipWith = zipWith
     munzip   = unzip
-  -}
 
   -- needed to implement other functions
   fmap :: (a -> b) -> NonEmpty a -> NonEmpty b

--- a/src/Data/Singletons/Prelude/Monad.hs
+++ b/src/Data/Singletons/Prelude/Monad.hs
@@ -1,0 +1,307 @@
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeInType #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Singletons.Prelude.Monad
+-- Copyright   :  (C) 2018 Ryan Scott
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Defines the promoted and singled versions of the 'Monad' type class.
+--
+----------------------------------------------------------------------------
+
+module Data.Singletons.Prelude.Monad (
+  PFunctor(Fmap), SFunctor(sFmap),
+  PMonad(..), SMonad(..), PMonadPlus(..), SMonadPlus(..),
+
+  {-
+  MapM, sMapM, MapM_, sMapM_, ForM, sForM,
+  Sequence, sSequence, Sequence_, sSequence_,
+  -}
+  type (=<<), (%=<<), type (>=>), (%>=>), type (<=<), (%<=<),
+  -- Forever, sForever,
+  Void, sVoid,
+
+  Join, sJoin,
+  -- Msum, sMsum,
+  Mfilter, sMfilter, FilterM, sFilterM,
+  {-
+  MapAndUnzipM, sMapAndUnzipM, ZipWithM, sZipWithM,
+  ZipWithM_, sZipWithM_, FoldlM, sFoldlM,
+  -}
+  ReplicateM, sReplicateM, ReplicateM_, sReplicateM_,
+
+  Guard, sGuard, When, sWhen, Unless, sUnless,
+
+  LiftM, sLiftM, LiftM2, sLiftM2, LiftM3, sLiftM3,
+  LiftM4, sLiftM4, LiftM5, sLiftM5, Ap, sAp,
+
+  type (<$!>), (%<$!>),
+
+  -- * Defunctionalization symbols
+  FmapSym0, FmapSym1, FmapSym2,
+  type (>>=@#@$), type (>>=@#@$$), type (>>=@#@$$$),
+  type (>>@#@$),  type (>>@#@$$),  type (>>@#@$$$),
+  ReturnSym0, ReturnSym1, FailSym0, FailSym1,
+  MzeroSym0, MplusSym0, MplusSym1, MplusSym2,
+
+  {-
+  MapMSym0,  MapMSym1,  MapMSym2,
+  MapM_Sym0, MapM_Sym1, MapM_Sym2,
+  ForMSym0,  ForMSym1,  ForMSym2,
+  SequenceSym0,  SequenceSym1,
+  Sequence_Sym0, Sequence_Sym1,
+  -}
+  type (=<<@#@$), type (=<<@#@$$), type (=<<@#@$$$),
+  type (>=>@#@$), type (>=>@#@$$), type (>=>@#@$$$),
+  type (<=<@#@$), type (<=<@#@$$), type (<=<@#@$$$),
+  -- ForeverSym0, ForeverSym1,
+  VoidSym0, VoidSym1,
+
+  JoinSym0, JoinSym1,
+  -- MsumSym0, MsumSym1,
+  MfilterSym0, MfilterSym1, MfilterSym2,
+  FilterMSym0, FilterMSym1, FilterMSym2,
+  {-
+  MapAndUnzipMSym0, MapAndUnzipMSym1, MapAndUnzipMSym2,
+  ZipWithMSym0,  ZipWithMSym1,  ZipWithMSym2,  ZipWithMSym3,
+  ZipWithM_Sym0, ZipWithM_Sym1, ZipWithM_Sym2, ZipWithM_Sym3,
+  FoldlMSym0,    FoldlMSym1,    FoldlMSym2,    FoldlMSym3,
+  -}
+  ReplicateMSym0,  ReplicateMSym1,  ReplicateMSym2,
+  ReplicateM_Sym0, ReplicateM_Sym1, ReplicateM_Sym2,
+
+  GuardSym0, GuardSym1,
+  WhenSym0, WhenSym1, WhenSym2,
+  UnlessSym0, UnlessSym1, UnlessSym2,
+
+  LiftMSym0,  LiftMSym1,  LiftMSym2,
+  LiftM2Sym0, LiftM2Sym1, LiftM2Sym2, LiftM2Sym3,
+  LiftM3Sym0, LiftM3Sym1, LiftM3Sym2, LiftM3Sym3, LiftM3Sym4,
+  LiftM4Sym0, LiftM4Sym1, LiftM4Sym2, LiftM4Sym3, LiftM4Sym4, LiftM4Sym5,
+  LiftM5Sym0, LiftM5Sym1, LiftM5Sym2, LiftM5Sym3, LiftM5Sym4, LiftM5Sym5, LiftM5Sym6,
+  ApSym0, ApSym1, ApSym2,
+
+  type (<$!>@#@$), type (<$!>@#@$$), type (<$!>@#@$$$),
+  ) where
+
+import Control.Applicative
+import Control.Monad
+import Data.Ord (Down(..))
+import Data.Singletons.Prelude.Applicative ()
+import Data.Singletons.Prelude.Base
+import Data.Singletons.Prelude.Functor
+import Data.Singletons.Prelude.Instances
+import Data.Singletons.Prelude.Monad.Internal
+import Data.Singletons.Prelude.Monoid
+import Data.Singletons.Prelude.Num
+import Data.Singletons.Prelude.Ord
+import Data.Singletons.Single
+import GHC.TypeNats
+
+$(singletonsOnly [d|
+  -- -----------------------------------------------------------------------------
+  -- Functions mandated by the Prelude
+
+  -- -| @'guard' b@ is @'pure' ()@ if @b@ is 'True',
+  -- and 'empty' if @b@ is 'False'.
+  guard           :: (Alternative f) => Bool -> f ()
+  guard True      =  pure ()
+  guard False     =  empty
+
+  -- -| This generalizes the list-based 'filter' function.
+
+  filterM          :: (Applicative m) => (a -> m Bool) -> [a] -> m [a]
+  filterM p        = foldr (\ x -> liftA2 (\ flg -> if flg then (x:) else id) (p x)) (pure [])
+
+  infixr 1 <=<, >=>
+
+  -- -| Left-to-right Kleisli composition of monads.
+  (>=>)       :: Monad m => (a -> m b) -> (b -> m c) -> (a -> m c)
+  f >=> g     = \x -> f x >>= g
+
+  -- -| Right-to-left Kleisli composition of monads. @('>=>')@, with the arguments flipped.
+  --
+  -- Note how this operator resembles function composition @('.')@:
+  --
+  -- > (.)   ::            (b ->   c) -> (a ->   b) -> a ->   c
+  -- > (<=<) :: Monad m => (b -> m c) -> (a -> m b) -> a -> m c
+  (<=<)       :: Monad m => (b -> m c) -> (a -> m b) -> (a -> m c)
+  (<=<)       = flip (>=>)
+
+  {-
+  Relies on infinite lists
+
+  -- -| @'forever' act@ repeats the action infinitely.
+  forever     :: (Applicative f) => (f :: Type -> Type) a -> f b
+  forever a   = let a' = a *> a' in a'
+  -- Use explicit sharing here, as it prevents a space leak regardless of
+  -- optimizations.
+  -}
+
+  -- -----------------------------------------------------------------------------
+  -- Other monad functions
+
+  {-
+  -- -| The 'mapAndUnzipM' function maps its first argument over a list, returning
+  -- the result as a pair of lists. This function is mainly used with complicated
+  -- data structures or a state-transforming monad.
+  mapAndUnzipM      :: (Applicative m) => (a -> m (b,c)) -> [a] -> m ([b], [c])
+  mapAndUnzipM f xs =  unzip <$> traverse f xs
+
+  -- -| The 'zipWithM' function generalizes 'zipWith' to arbitrary applicative functors.
+  zipWithM          :: (Applicative m) => (a -> b -> m c) -> [a] -> [b] -> m [c]
+  zipWithM f xs ys  =  sequenceA (zipWith f xs ys)
+
+  -- -| 'zipWithM_' is the extension of 'zipWithM' which ignores the final result.
+  zipWithM_         :: (Applicative m) => (a -> b -> m c) -> [a] -> [b] -> m ()
+  zipWithM_ f xs ys =  sequenceA_ (zipWith f xs ys)
+
+  {- -| The 'foldM' function is analogous to 'foldl', except that its result is
+  encapsulated in a monad. Note that 'foldM' works from left-to-right over
+  the list arguments. This could be an issue where @('>>')@ and the `folded
+  function' are not commutative.
+
+
+  >       foldM f a1 [x1, x2, ..., xm]
+
+  ==
+
+  >       do
+  >         a2 <- f a1 x1
+  >         a3 <- f a2 x2
+  >         ...
+  >         f am xm
+
+  If right-to-left evaluation is required, the input list should be reversed.
+
+  Note: 'foldM' is the same as 'foldlM'
+  -}
+
+  foldM          :: (Foldable t, Monad m) => (b -> a -> m b) -> b -> t a -> m b
+  foldM          = foldlM
+
+  -- -| Like 'foldM', but discards the result.
+  foldM_         :: (Foldable t, Monad m) => (b -> a -> m b) -> b -> t a -> m ()
+  foldM_ f a xs  = foldlM f a xs >> return ()
+  -}
+
+  {-
+  Note [Worker/wrapper transform on replicateM/replicateM_]
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  The implementations of replicateM and replicateM_ both leverage the
+  worker/wrapper transform. The simpler implementation of replicateM_, as an
+  example, would be:
+
+      replicateM_ 0 _ = pure ()
+      replicateM_ n f = f *> replicateM_ (n - 1) f
+
+  However, the self-recursive nature of this implementation inhibits inlining,
+  which means we never get to specialise to the action (`f` in the code above).
+  By contrast, the implementation below with a local loop makes it possible to
+  inline the entire definition (as happens for foldr, for example) thereby
+  specialising for the particular action.
+
+  For further information, see this Trac comment, which includes side-by-side
+  Core: https://ghc.haskell.org/trac/ghc/ticket/11795#comment:6
+  -}
+
+  -- -| @'replicateM' n act@ performs the action @n@ times,
+  -- gathering the results.
+  replicateM        :: (Applicative m) => Nat -> m a -> m [a]
+  replicateM cnt0 f =
+      loop cnt0
+    where
+      loop cnt
+          | cnt <= 0  = pure []
+          | otherwise = liftA2 (:) f (loop (cnt - 1))
+
+  -- -| Like 'replicateM', but discards the result.
+  replicateM_       :: (Applicative m) => Nat -> m a -> m ()
+  replicateM_ cnt0 f =
+      loop cnt0
+    where
+      loop cnt
+          | cnt <= 0  = pure ()
+          | otherwise = f *> loop (cnt - 1)
+
+
+  -- -| The reverse of 'when'.
+  unless            :: (Applicative f) => Bool -> f () -> f ()
+  unless p s        =  if p then pure () else s
+
+  infixl 4 <$!>
+
+  -- -| Strict version of 'Data.Functor.<$>'.
+  --
+  -- @since 4.8.0.0
+  (<$!>) :: Monad m => (a -> b) -> m a -> m b
+  f <$!> m = do
+    x <- m
+    let z = f x
+    z `seq` return z
+
+
+  -- -----------------------------------------------------------------------------
+  -- Other MonadPlus functions
+
+  -- -| Direct 'MonadPlus' equivalent of 'filter'
+  -- @'filter'@ = @(mfilter:: (a -> Bool) -> [a] -> [a]@
+  -- applicable to any 'MonadPlus', for example
+  -- @mfilter odd (Just 1) == Just 1@
+  -- @mfilter odd (Just 2) == Nothing@
+
+  mfilter :: (MonadPlus m) => (a -> Bool) -> m a -> m a
+  mfilter p ma = do
+    a <- ma
+    if p a then return a else mzero
+
+  {- -$naming
+
+  The functions in this library use the following naming conventions:
+
+  * A postfix \'@M@\' always stands for a function in the Kleisli category:
+    The monad type constructor @m@ is added to function results
+    (modulo currying) and nowhere else.  So, for example,
+
+  >  filter  ::              (a ->   Bool) -> [a] ->   [a]
+  >  filterM :: (Monad m) => (a -> m Bool) -> [a] -> m [a]
+
+  * A postfix \'@_@\' changes the result type from @(m a)@ to @(m ())@.
+    Thus, for example:
+
+  >  sequence  :: Monad m => [m a] -> m [a]
+  >  sequence_ :: Monad m => [m a] -> m ()
+
+  * A prefix \'@m@\' generalizes an existing function to a monadic form.
+    Thus, for example:
+
+  >  sum  :: Num a       => [a]   -> a
+  >  msum :: MonadPlus m => [m a] -> m a
+
+  -}
+
+  instance Monoid a => Monad ((,) a) where
+      (u, a) >>= k = case k a of (v, b) -> (u `mappend` v, b)
+
+  instance Monad Down where
+    Down a >>= k = k a
+  |])
+
+-- Workaround for #326
+infixr 1 <=<, >=>
+infixl 4 <$!>

--- a/src/Data/Singletons/Prelude/Monad/Internal.hs
+++ b/src/Data/Singletons/Prelude/Monad/Internal.hs
@@ -1,0 +1,511 @@
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeInType #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Singletons.Prelude.Monad.Internal
+-- Copyright   :  (C) 2018 Ryan Scott
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Defines the promoted and singled versions of:
+--
+-- * Functor
+-- * Applicative
+-- * Alternative
+-- * Monad
+-- * MonadPlus
+--
+-- As well as auxiliary definitions.
+--
+-- This module exists to break up import cycles.
+--
+----------------------------------------------------------------------------
+
+module Data.Singletons.Prelude.Monad.Internal where
+
+import Data.Kind
+import Data.List.NonEmpty (NonEmpty(..))
+import Data.Singletons.Prelude.Base
+import Data.Singletons.Prelude.Instances
+import Data.Singletons.Single
+import Data.Singletons.TypeLits.Internal
+
+$(singletonsOnly [d|
+  infixl 4  <$
+
+  {- -| The 'Functor' class is used for types that can be mapped over.
+  Instances of 'Functor' should satisfy the following laws:
+
+  > fmap id  ==  id
+  > fmap (f . g)  ==  fmap f . fmap g
+
+  The instances of 'Functor' for lists, 'Data.Maybe.Maybe' and 'System.IO.IO'
+  satisfy these laws.
+  -}
+
+  class  Functor (f :: Type -> Type)  where
+      fmap        :: (a -> b) -> f a -> f b
+
+      -- -| Replace all locations in the input with the same value.
+      -- The default definition is @'fmap' . 'const'@, but this may be
+      -- overridden with a more efficient version.
+      (<$)        :: a -> f b -> f a
+      (<$)        =  fmap . const
+
+  infixl 4 <*>, <*, *>, <**>
+
+  -- -| A functor with application, providing operations to
+  --
+  -- -* embed pure expressions ('pure'), and
+  --
+  -- -* sequence computations and combine their results ('<*>' and 'liftA2').
+  --
+  -- A minimal complete definition must include implementations of 'pure'
+  -- and of either '<*>' or 'liftA2'. If it defines both, then they must behave
+  -- the same as their default definitions:
+  --
+  --      @('<*>') = 'liftA2' 'id'@
+  --
+  --      @'liftA2' f x y = f '<$>' x '<*>' y@
+  --
+  -- Further, any definition must satisfy the following:
+  --
+  -- [/identity/]
+  --
+  --      @'pure' 'id' '<*>' v = v@
+  --
+  -- [/composition/]
+  --
+  --      @'pure' (.) '<*>' u '<*>' v '<*>' w = u '<*>' (v '<*>' w)@
+  --
+  -- [/homomorphism/]
+  --
+  --      @'pure' f '<*>' 'pure' x = 'pure' (f x)@
+  --
+  -- [/interchange/]
+  --
+  --      @u '<*>' 'pure' y = 'pure' ('$' y) '<*>' u@
+  --
+  --
+  -- The other methods have the following default definitions, which may
+  -- be overridden with equivalent specialized implementations:
+  --
+  --   * @u '*>' v = ('id' '<$' u) '<*>' v@
+  --
+  --   * @u '<*' v = 'liftA2' 'const' u v@
+  --
+  -- As a consequence of these laws, the 'Functor' instance for @f@ will satisfy
+  --
+  --   * @'fmap' f x = 'pure' f '<*>' x@
+  --
+  --
+  -- It may be useful to note that supposing
+  --
+  --      @forall x y. p (q x y) = f x . g y@
+  --
+  -- it follows from the above that
+  --
+  --      @'liftA2' p ('liftA2' q u v) = 'liftA2' f u . 'liftA2' g v@
+  --
+  --
+  -- If @f@ is also a 'Monad', it should satisfy
+  --
+  --   * @'pure' = 'return'@
+  --
+  --   * @('<*>') = 'ap'@
+  --
+  --   * @('*>') = ('>>')@
+  --
+  -- (which implies that 'pure' and '<*>' satisfy the applicative functor laws).
+
+  class Functor f => Applicative (f :: Type -> Type) where
+      -- {-# MINIMAL pure, ((<*>) | liftA2) #-}
+      -- -| Lift a value.
+      pure :: a -> f a
+
+      -- -| Sequential application.
+      --
+      -- A few functors support an implementation of '<*>' that is more
+      -- efficient than the default one.
+      (<*>) :: f (a -> b) -> f a -> f b
+      (<*>) = liftA2 id
+
+      -- -| Lift a binary function to actions.
+      --
+      -- Some functors support an implementation of 'liftA2' that is more
+      -- efficient than the default one. In particular, if 'fmap' is an
+      -- expensive operation, it is likely better to use 'liftA2' than to
+      -- 'fmap' over the structure and then use '<*>'.
+      liftA2 :: (a -> b -> c) -> f a -> f b -> f c
+      liftA2 f x = (<*>) (fmap f x)
+
+      -- -| Sequence actions, discarding the value of the first argument.
+      (*>) :: (f :: Type -> Type) a -> f b -> f b
+      a1 *> a2 = (id <$ a1) <*> a2
+      -- This is essentially the same as liftA2 (flip const), but if the
+      -- Functor instance has an optimized (<$), it may be better to use
+      -- that instead. Before liftA2 became a method, this definition
+      -- was strictly better, but now it depends on the functor. For a
+      -- functor supporting a sharing-enhancing (<$), this definition
+      -- may reduce allocation by preventing a1 from ever being fully
+      -- realized. In an implementation with a boring (<$) but an optimizing
+      -- liftA2, it would likely be better to define (*>) using liftA2.
+
+      -- -| Sequence actions, discarding the value of the second argument.
+      (<*) :: (f :: Type -> Type) a -> f b -> f a
+      (<*) = liftA2 const
+
+  -- -| A variant of '<*>' with the arguments reversed.
+  (<**>) :: Applicative f => f a -> f (a -> b) -> f b
+  (<**>) = liftA2 (\a f -> f a)
+  -- Don't use $ here, see the note at the top of the page
+
+  -- -| Lift a function to actions.
+  -- This function may be used as a value for `fmap` in a `Functor` instance.
+  liftA :: Applicative f => (a -> b) -> f a -> f b
+  liftA f a = pure f <*> a
+  -- Caution: since this may be used for `fmap`, we can't use the obvious
+  -- definition of liftA = fmap.
+
+  -- -| Lift a ternary function to actions.
+  liftA3 :: Applicative f => (a -> b -> c -> d) -> f a -> f b -> f c -> f d
+  liftA3 f a b c = liftA2 f a b <*> c
+
+  infixl 1  >>, >>=
+  infixr 1  =<<
+
+  -- -| The 'join' function is the conventional monad join operator. It
+  -- is used to remove one level of monadic structure, projecting its
+  -- bound argument into the outer level.
+  --
+  -- ==== __Examples__
+  --
+  -- A common use of 'join' is to run an 'IO' computation returned from
+  -- an 'GHC.Conc.STM' transaction, since 'GHC.Conc.STM' transactions
+  -- can't perform 'IO' directly. Recall that
+  --
+  -- @
+  -- 'GHC.Conc.atomically' :: STM a -> IO a
+  -- @
+  --
+  -- is used to run 'GHC.Conc.STM' transactions atomically. So, by
+  -- specializing the types of 'GHC.Conc.atomically' and 'join' to
+  --
+  -- @
+  -- 'GHC.Conc.atomically' :: STM (IO b) -> IO (IO b)
+  -- 'join'       :: IO (IO b)  -> IO b
+  -- @
+  --
+  -- we can compose them as
+  --
+  -- @
+  -- 'join' . 'GHC.Conc.atomically' :: STM (IO b) -> IO b
+  -- @
+  --
+  -- to run an 'GHC.Conc.STM' transaction and the 'IO' action it
+  -- returns.
+  join              :: (Monad m) => m (m a) -> m a
+  join x            =  x >>= id
+
+  {- -| The 'Monad' class defines the basic operations over a /monad/,
+  a concept from a branch of mathematics known as /category theory/.
+  From the perspective of a Haskell programmer, however, it is best to
+  think of a monad as an /abstract datatype/ of actions.
+  Haskell's @do@ expressions provide a convenient syntax for writing
+  monadic expressions.
+
+  Instances of 'Monad' should satisfy the following laws:
+
+  * @'return' a '>>=' k  =  k a@
+  * @m '>>=' 'return'  =  m@
+  * @m '>>=' (\\x -> k x '>>=' h)  =  (m '>>=' k) '>>=' h@
+
+  Furthermore, the 'Monad' and 'Applicative' operations should relate as follows:
+
+  * @'pure' = 'return'@
+  * @('<*>') = 'ap'@
+
+  The above laws imply:
+
+  * @'fmap' f xs  =  xs '>>=' 'return' . f@
+  * @('>>') = ('*>')@
+
+  and that 'pure' and ('<*>') satisfy the applicative functor laws.
+
+  The instances of 'Monad' for lists, 'Data.Maybe.Maybe' and 'System.IO.IO'
+  defined in the "Prelude" satisfy these laws.
+  -}
+  class Applicative m => Monad (m :: Type -> Type) where
+      -- -| Sequentially compose two actions, passing any value produced
+      -- by the first as an argument to the second.
+      (>>=)       :: forall a b. m a -> (a -> m b) -> m b
+
+      -- -| Sequentially compose two actions, discarding any value produced
+      -- by the first, like sequencing operators (such as the semicolon)
+      -- in imperative languages.
+      (>>)        :: forall a b. (m :: Type -> Type) a -> m b -> m b
+      m >> k = m >>= \_ -> k -- See Note [Recursive bindings for Applicative/Monad]
+
+      -- -| Inject a value into the monadic type.
+      return      :: a -> m a
+      return      = pure
+
+      -- -| Fail with a message.  This operation is not part of the
+      -- mathematical definition of a monad, but is invoked on pattern-match
+      -- failure in a @do@ expression.
+      --
+      -- As part of the MonadFail proposal (MFP), this function is moved
+      -- to its own class 'MonadFail' (see "Control.Monad.Fail" for more
+      -- details). The definition here will be removed in a future
+      -- release.
+      fail        :: Symbol -> (m :: Type -> Type) a
+      fail s      = error s
+
+  {- Note [Recursive bindings for Applicative/Monad]
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  The original Applicative/Monad proposal stated that after
+  implementation, the designated implementation of (>>) would become
+
+    (>>) :: forall a b. m a -> m b -> m b
+    (>>) = (*>)
+
+  by default. You might be inclined to change this to reflect the stated
+  proposal, but you really shouldn't! Why? Because people tend to define
+  such instances the /other/ way around: in particular, it is perfectly
+  legitimate to define an instance of Applicative (*>) in terms of (>>),
+  which would lead to an infinite loop for the default implementation of
+  Monad! And people do this in the wild.
+
+  This turned into a nasty bug that was tricky to track down, and rather
+  than eliminate it everywhere upstream, it's easier to just retain the
+  original default.
+
+  -}
+
+  -- -| Same as '>>=', but with the arguments interchanged.
+  (=<<)           :: Monad m => (a -> m b) -> m a -> m b
+  f =<< x         = x >>= f
+
+  -- -| Conditional execution of 'Applicative' expressions. For example,
+  --
+  -- > when debug (putStrLn "Debugging")
+  --
+  -- will output the string @Debugging@ if the Boolean value @debug@
+  -- is 'True', and otherwise do nothing.
+  when      :: (Applicative f) => Bool -> f () -> f ()
+  when p s  = if p then s else pure ()
+
+  -- -| Promote a function to a monad.
+  liftM   :: (Monad m) => (a1 -> r) -> m a1 -> m r
+  liftM f m1              = do { x1 <- m1; return (f x1) }
+
+  -- -| Promote a function to a monad, scanning the monadic arguments from
+  -- left to right.  For example,
+  --
+  -- > liftM2 (+) [0,1] [0,2] = [0,2,1,3]
+  -- > liftM2 (+) (Just 1) Nothing = Nothing
+  --
+  liftM2  :: (Monad m) => (a1 -> a2 -> r) -> m a1 -> m a2 -> m r
+  liftM2 f m1 m2          = do { x1 <- m1; x2 <- m2; return (f x1 x2) }
+  -- Caution: since this may be used for `liftA2`, we can't use the obvious
+  -- definition of liftM2 = liftA2.
+
+  -- -| Promote a function to a monad, scanning the monadic arguments from
+  -- left to right (cf. 'liftM2').
+  liftM3  :: (Monad m) => (a1 -> a2 -> a3 -> r) -> m a1 -> m a2 -> m a3 -> m r
+  liftM3 f m1 m2 m3       = do { x1 <- m1; x2 <- m2; x3 <- m3; return (f x1 x2 x3) }
+
+  -- -| Promote a function to a monad, scanning the monadic arguments from
+  -- left to right (cf. 'liftM2').
+  liftM4  :: (Monad m) => (a1 -> a2 -> a3 -> a4 -> r) -> m a1 -> m a2 -> m a3 -> m a4 -> m r
+  liftM4 f m1 m2 m3 m4    = do { x1 <- m1; x2 <- m2; x3 <- m3; x4 <- m4; return (f x1 x2 x3 x4) }
+
+  -- -| Promote a function to a monad, scanning the monadic arguments from
+  -- left to right (cf. 'liftM2').
+  liftM5  :: (Monad m) => (a1 -> a2 -> a3 -> a4 -> a5 -> r) -> m a1 -> m a2 -> m a3 -> m a4 -> m a5 -> m r
+  liftM5 f m1 m2 m3 m4 m5 = do { x1 <- m1; x2 <- m2; x3 <- m3; x4 <- m4; x5 <- m5; return (f x1 x2 x3 x4 x5) }
+
+  {- -| In many situations, the 'liftM' operations can be replaced by uses of
+  'ap', which promotes function application.
+
+  > return f `ap` x1 `ap` ... `ap` xn
+
+  is equivalent to
+
+  > liftMn f x1 x2 ... xn
+
+  -}
+
+  ap                :: (Monad m) => m (a -> b) -> m a -> m b
+  ap m1 m2          = do { x1 <- m1; x2 <- m2; return (x1 x2) }
+  -- Since many Applicative instances define (<*>) = ap, we
+  -- cannot define ap = (<*>)
+
+  -- -----------------------------------------------------------------------------
+  -- The Alternative class definition
+
+  infixl 3 <|>
+
+  -- -| A monoid on applicative functors.
+  --
+  -- If defined, 'some' and 'many' should be the least solutions
+  -- of the equations:
+  --
+  -- -* @'some' v = (:) '<$>' v '<*>' 'many' v@
+  --
+  -- -* @'many' v = 'some' v '<|>' 'pure' []@
+  class Applicative f => Alternative (f :: Type -> Type) where
+      -- -| The identity of '<|>'
+      empty :: (f :: Type -> Type) a
+      -- -| An associative binary operation
+      (<|>) :: (f :: Type -> Type) a -> f a -> f a
+
+      {-
+      some and many rely on infinite lists
+
+      -- -| One or more.
+      some :: f a -> f [a]
+      some v = some_v
+        where
+          many_v = some_v <|> pure []
+          some_v = liftA2 (:) v many_v
+
+      -- -| Zero or more.
+      many :: f a -> f [a]
+      many v = many_v
+        where
+          many_v = some_v <|> pure []
+          some_v = liftA2 (:) v many_v
+      -}
+
+  -- -----------------------------------------------------------------------------
+  -- The MonadPlus class definition
+
+  -- -| Monads that also support choice and failure.
+  class (Alternative m, Monad m) => MonadPlus (m :: Type -> Type) where
+     -- -| The identity of 'mplus'.  It should also satisfy the equations
+     --
+     -- > mzero >>= f  =  mzero
+     -- > v >> mzero   =  mzero
+     --
+     -- The default definition is
+     --
+     -- @
+     -- mzero = 'empty'
+     -- @
+     mzero :: (m :: Type -> Type) a
+     mzero = empty
+
+     -- -| An associative operation. The default definition is
+     --
+     -- @
+     -- mplus = ('<|>')
+     -- @
+     mplus :: (m :: Type -> Type) a -> m a -> m a
+     mplus = (<|>)
+
+  -------------------------------------------------------------------------------
+  -- Instances
+
+  -- deriving instance Functor Maybe
+  instance  Functor Maybe  where
+      fmap _ Nothing       = Nothing
+      fmap f (Just a)      = Just (f a)
+
+  -- deriving instance Functor NonEmpty
+  instance Functor NonEmpty where
+    fmap f (a :| as) = f a :| fmap f as
+    b <$ (_ :| as)   = b   :| (b <$ as)
+
+  -- deriving instance Functor []
+  instance Functor [] where
+      fmap = map
+
+  -- deriving instance Functor (Either a)
+  instance Functor (Either a) where
+    fmap _ (Left x) = Left x
+    fmap f (Right y) = Right (f y)
+
+  instance Applicative Maybe where
+      pure = Just
+
+      Just f  <*> m       = fmap f m
+      Nothing <*> _m      = Nothing
+
+      liftA2 f (Just x) (Just y) = Just (f x y)
+      liftA2 _ Just{}   Nothing  = Nothing
+      liftA2 _ Nothing  Just{}   = Nothing
+      liftA2 _ Nothing  Nothing  = Nothing
+
+      Just _m1 *> m2      = m2
+      Nothing  *> _m2     = Nothing
+
+  instance Applicative NonEmpty where
+    pure a = a :| []
+    (<*>) = ap
+    liftA2 = liftM2
+
+  instance Applicative [] where
+      pure x = [x]
+      (<*>)  = ap
+      liftA2 = liftM2
+      (*>)   = (>>)
+
+  instance Applicative (Either e) where
+      pure          = Right
+      Left  e <*> _ = Left e
+      Right f <*> r = fmap f r
+
+  instance  Monad Maybe  where
+      (Just x) >>= k      = k x
+      Nothing  >>= _      = Nothing
+
+      (>>) = (*>)
+
+      fail _              = Nothing
+
+  instance Monad NonEmpty where
+    (a :| as) >>= f = b :| (bs ++ bs')
+      where b :| bs = f a
+            bs' = as >>= toList . f
+            toList (c :| cs) = c : cs
+
+  instance Monad []  where
+      xs >>= f = foldr ((++) . f) [] xs
+      fail _ = []
+
+  instance Monad (Either e) where
+      Left  l >>= _ = Left l
+      Right r >>= k = k r
+
+  instance Alternative Maybe where
+      empty = Nothing
+      Nothing    <|> r = r
+      l@(Just{}) <|> _ = l
+
+  instance Alternative [] where
+      empty = []
+      (<|>) = (++)
+
+  instance MonadPlus Maybe
+  instance MonadPlus []
+  |])
+
+-- Workaround for #326
+infixl 4 <$
+infixl 4 <*>, <*, *>, <**>
+infixl 1 >>, >>=
+infixr 1 =<<
+infixl 3 <|>

--- a/src/Data/Singletons/Prelude/Monad/Zip.hs
+++ b/src/Data/Singletons/Prelude/Monad/Zip.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeInType #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Singletons.Prelude.Monad.Zip
+-- Copyright   :  (C) 2018 Ryan Scott
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Defines the promoted and singled versions of the 'MonadZip' type class.
+--
+----------------------------------------------------------------------------
+
+module Data.Singletons.Prelude.Monad.Zip (
+  PMonadZip(..), SMonadZip(..),
+
+  -- * Defunctionalization symbols
+  MzipSym0, MzipSym1, MzipSym2,
+  MzipWithSym0, MzipWithSym1, MzipWithSym2, MzipWithSym3,
+  MunzipSym0, MunzipSym1,
+  ) where
+
+import Control.Monad.Zip
+import Data.Kind
+import Data.Monoid
+import Data.Singletons.Prelude.Instances
+import Data.Singletons.Prelude.List
+       ( ZipSym0, ZipWithSym0, UnzipSym0
+       , sZip,    sZipWith,    sUnzip )
+import Data.Singletons.Prelude.Monad.Internal
+import Data.Singletons.Prelude.Monoid ()
+import Data.Singletons.Prelude.Tuple
+import Data.Singletons.Single
+
+$(singletonsOnly [d|
+  -- -| `MonadZip` type class. Minimal definition: `mzip` or `mzipWith`
+  --
+  -- Instances should satisfy the laws:
+  --
+  -- -* Naturality :
+  --
+  --   > liftM (f *** g) (mzip ma mb) = mzip (liftM f ma) (liftM g mb)
+  --
+  -- -* Information Preservation:
+  --
+  --   > liftM (const ()) ma = liftM (const ()) mb
+  --   > ==>
+  --   > munzip (mzip ma mb) = (ma, mb)
+  --
+  class Monad m => MonadZip (m :: Type -> Type) where
+      -- {-# MINIMAL mzip | mzipWith #-}
+
+      mzip :: m a -> m b -> m (a,b)
+      mzip = mzipWith (,)
+
+      mzipWith :: (a -> b -> c) -> m a -> m b -> m c
+      mzipWith f ma mb = liftM (uncurry f) (mzip ma mb)
+
+      munzip :: m (a,b) -> (m a, m b)
+      munzip mab = (liftM fst mab, liftM snd mab)
+      -- munzip is a member of the class because sometimes
+      -- you can implement it more efficiently than the
+      -- above default code.  See Trac #4370 comment by giorgidze
+
+  instance MonadZip [] where
+      mzip     = zip
+      mzipWith = zipWith
+      munzip   = unzip
+
+  instance MonadZip Dual where
+      -- Cannot use coerce, it's unsafe
+      mzipWith = liftM2
+
+  instance MonadZip Sum where
+      mzipWith = liftM2
+
+  instance MonadZip Product where
+      mzipWith = liftM2
+
+  instance MonadZip Maybe where
+      mzipWith = liftM2
+
+  instance MonadZip First where
+      mzipWith = liftM2
+
+  instance MonadZip Last where
+      mzipWith = liftM2
+  |])

--- a/src/Data/Singletons/Prelude/Monoid.hs
+++ b/src/Data/Singletons/Prelude/Monoid.hs
@@ -52,6 +52,7 @@ import Data.Semigroup hiding (First(..), Last(..))
 import Data.Singletons.Prelude.Base
 import Data.Singletons.Prelude.Eq
 import Data.Singletons.Prelude.Instances
+import Data.Singletons.Prelude.Monad.Internal
 import Data.Singletons.Prelude.Num
 import Data.Singletons.Prelude.Ord
 import Data.Singletons.Prelude.Semigroup.Internal hiding
@@ -172,12 +173,38 @@ $(singletonsOnly [d|
       mempty = Down mempty
       Down a `mappend` Down b = Down (a `mappend` b)
 
+  -- deriving newtype instance Applicative First
+  instance Applicative First where
+    pure = First . pure
+    First f <*> First x = First (f <*> x)
+
+  -- deriving instance Functor First
+  instance Functor First where
+    fmap f (First x) = First (fmap f x)
+
+  -- deriving newtype instance Monad First
+  instance Monad First where
+    First a >>= k = First (a >>= \x -> case k x of First y -> y)
+
   instance Semigroup (First a) where
           First Nothing    <> b = b
           a@(First Just{}) <> _ = a
 
   instance Monoid (First a) where
           mempty = First Nothing
+
+  -- deriving newtype instance Applicative Last
+  instance Applicative Last where
+    pure = Last . pure
+    Last f <*> Last x = Last (f <*> x)
+
+  -- deriving instance Functor Last
+  instance Functor Last where
+    fmap f (Last x) = Last (fmap f x)
+
+  -- deriving newtype instance Monad Last
+  instance Monad Last where
+    Last a >>= k = Last (a >>= \x -> case k x of Last y -> y)
 
   instance Semigroup (Last a) where
           a <> Last Nothing     = a

--- a/src/Data/Singletons/Prelude/Semigroup.hs
+++ b/src/Data/Singletons/Prelude/Semigroup.hs
@@ -59,6 +59,8 @@ module Data.Singletons.Prelude.Semigroup (
   ArgSym0, ArgSym1, ArgSym2
   ) where
 
+import Control.Applicative
+import Control.Monad
 import qualified Data.Semigroup as Semi (Min(..), Max(..))
 import Data.Semigroup (First(..), Last(..), WrappedMonoid(..), Option(..), Arg(..))
 import Data.Singletons.Prelude.Base
@@ -66,6 +68,7 @@ import Data.Singletons.Prelude.Enum
 import Data.Singletons.Prelude.Eq
 import Data.Singletons.Prelude.Instances
 import Data.Singletons.Prelude.Maybe
+import Data.Singletons.Prelude.Monad.Internal
 import Data.Singletons.Prelude.Monoid hiding
        (Sing(SFirst, SLast), SFirst, sGetFirst, SLast, sGetLast,
         FirstSym0, FirstSym1, LastSym0, LastSym1,
@@ -84,6 +87,13 @@ $(showSingInstances $ ''Option : semigroupBasicTypes)
 $(singShowInstances $ ''Option : semigroupBasicTypes)
 
 $(singletonsOnly [d|
+  instance Applicative Semi.Min where
+    pure = Semi.Min
+    a <* _ = a
+    _ *> a = a
+    Semi.Min f <*> Semi.Min x = Semi.Min (f x)
+    liftA2 f (Semi.Min a) (Semi.Min b) = Semi.Min (f a b)
+
   instance Enum a => Enum (Semi.Min a) where
     succ (Semi.Min a) = Semi.Min (succ a)
     pred (Semi.Min a) = Semi.Min (pred a)
@@ -91,6 +101,14 @@ $(singletonsOnly [d|
     fromEnum (Semi.Min a) = fromEnum a
     enumFromTo (Semi.Min a) (Semi.Min b) = Semi.Min `map` enumFromTo a b
     enumFromThenTo (Semi.Min a) (Semi.Min b) (Semi.Min c) = Semi.Min `map` enumFromThenTo a b c
+
+  -- deriving instance Functor Semi.Min
+  instance Functor Semi.Min where
+    fmap f (Semi.Min x) = Semi.Min (f x)
+
+  instance Monad Semi.Min where
+    (>>) = (*>)
+    Semi.Min a >>= f = f a
 
   instance Ord a => Semigroup (Semi.Min a) where
     Semi.Min a <> Semi.Min b = Semi.Min (a `min_` b)
@@ -107,6 +125,13 @@ $(singletonsOnly [d|
     signum (Semi.Min a) = Semi.Min (signum a)
     fromInteger         = Semi.Min . fromInteger
 
+  instance Applicative Semi.Max where
+    pure = Semi.Max
+    a <* _ = a
+    _ *> a = a
+    Semi.Max f <*> Semi.Max x = Semi.Max (f x)
+    liftA2 f (Semi.Max a) (Semi.Max b) = Semi.Max (f a b)
+
   instance Enum a => Enum (Semi.Max a) where
     succ (Semi.Max a) = Semi.Max (succ a)
     pred (Semi.Max a) = Semi.Max (pred a)
@@ -114,6 +139,14 @@ $(singletonsOnly [d|
     fromEnum (Semi.Max a) = fromEnum a
     enumFromTo (Semi.Max a) (Semi.Max b) = Semi.Max `map` enumFromTo a b
     enumFromThenTo (Semi.Max a) (Semi.Max b) (Semi.Max c) = Semi.Max `map` enumFromThenTo a b c
+
+  -- deriving instance Functor Semi.Max
+  instance Functor Semi.Max where
+    fmap f (Semi.Max x) = Semi.Max (f x)
+
+  instance Monad Semi.Max where
+    (>>) = (*>)
+    Semi.Max a >>= f = f a
 
   instance Ord a => Semigroup (Semi.Max a) where
     Semi.Max a <> Semi.Max b = Semi.Max (a `max_` b)
@@ -133,6 +166,10 @@ $(singletonsOnly [d|
   instance Eq a => Eq (Arg a b) where
     Arg a _ == Arg b _ = a == b
 
+  -- deriving instance Functor (Arg a)
+  instance Functor (Arg a) where
+    fmap f (Arg x a) = Arg x (f a)
+
   instance Ord a => Ord (Arg a b) where
     Arg a _ `compare` Arg b _ = compare a b
     min x@(Arg a _) y@(Arg b _)
@@ -144,6 +181,13 @@ $(singletonsOnly [d|
 
   deriving instance (Show a, Show b) => Show (Arg a b)
 
+  instance Applicative First where
+    pure x = First x
+    a <* _ = a
+    _ *> a = a
+    First f <*> First x = First (f x)
+    liftA2 f (First a) (First b) = First (f a b)
+
   instance Enum a => Enum (First a) where
     succ (First a) = First (succ a)
     pred (First a) = First (pred a)
@@ -152,8 +196,23 @@ $(singletonsOnly [d|
     enumFromTo (First a) (First b) = First `map` enumFromTo a b
     enumFromThenTo (First a) (First b) (First c) = First `map` enumFromThenTo a b c
 
+  -- deriving instance Functor First
+  instance Functor First where
+    fmap f (First x) = First (f x)
+
+  instance Monad First where
+    (>>) = (*>)
+    First a >>= f = f a
+
   instance Semigroup (First a) where
     a <> _ = a
+
+  instance Applicative Last where
+    pure x = Last x
+    a <* _ = a
+    _ *> a = a
+    Last f <*> Last x = Last (f x)
+    liftA2 f (Last a) (Last b) = Last (f a b)
 
   instance Enum a => Enum (Last a) where
     succ (Last a) = Last (succ a)
@@ -162,6 +221,15 @@ $(singletonsOnly [d|
     fromEnum (Last a) = fromEnum a
     enumFromTo (Last a) (Last b) = Last `map` enumFromTo a b
     enumFromThenTo (Last a) (Last b) (Last c) = Last `map` enumFromThenTo a b c
+
+  -- deriving instance Functor Last
+  instance Functor Last where
+    fmap f (Last x) = Last (f x)
+    a <$ _ = Last a
+
+  instance Monad Last where
+    (>>) = (*>)
+    Last a >>= f = f a
 
   instance Semigroup (Last a) where
     _ <> b = b
@@ -180,6 +248,30 @@ $(singletonsOnly [d|
     enumFromTo (WrapMonoid a) (WrapMonoid b) = WrapMonoid `map` enumFromTo a b
     enumFromThenTo (WrapMonoid a) (WrapMonoid b) (WrapMonoid c) =
         WrapMonoid `map` enumFromThenTo a b c
+
+  instance Alternative Option where
+    empty = Option Nothing
+    Option Nothing    <|> b = b
+    a@(Option Just{}) <|> _ = a
+
+  instance Applicative Option where
+    pure a = Option (Just a)
+    Option a <*> Option b = Option (a <*> b)
+    liftA2 f (Option x) (Option y) = Option (liftA2 f x y)
+
+    Option Nothing  *>  _ = Option Nothing
+    Option Just{}   *>  b = b
+
+  -- deriving instance Functor Option
+  instance Functor Option where
+    fmap f (Option a) = Option (fmap f a)
+
+  instance Monad Option where
+    Option (Just a) >>= k = k a
+    Option Nothing  >>= _ = Option Nothing
+    (>>) = (*>)
+
+  instance MonadPlus Option
 
   -- deriving newtype instance Semigroup a => Semigroup (Option a)
   instance Semigroup a => Semigroup (Option a) where

--- a/src/Data/Singletons/Prelude/Semigroup/Internal.hs
+++ b/src/Data/Singletons/Prelude/Semigroup/Internal.hs
@@ -41,6 +41,7 @@ import Data.Singletons.Prelude.Bool
 import Data.Singletons.Prelude.Enum
 import Data.Singletons.Prelude.Eq
 import Data.Singletons.Prelude.Instances
+import Data.Singletons.Prelude.Monad.Internal
 import Data.Singletons.Prelude.Num
 import Data.Singletons.Prelude.Ord hiding (MinSym0, MinSym1, MaxSym0, MaxSym1)
 import Data.Singletons.Promote
@@ -153,6 +154,17 @@ $(singDecideInstances $ ''Option : semigroupBasicTypes)
 $(singOrdInstances    $ ''Option : semigroupBasicTypes)
 
 $(singletonsOnly [d|
+  instance Applicative Dual where
+    pure = Dual
+    Dual f <*> Dual x = Dual (f x)
+
+  -- deriving instance Functor Dual
+  instance Functor Dual where
+    fmap f (Dual x) = Dual (f x)
+
+  instance Monad Dual where
+    Dual a >>= k = k a
+
   instance Semigroup a => Semigroup (Dual a) where
           Dual a <> Dual b = Dual (b <> a)
 
@@ -161,6 +173,17 @@ $(singletonsOnly [d|
 
   instance Semigroup Any where
           Any a <> Any b = Any (a || b)
+
+  instance Applicative Sum where
+    pure = Sum
+    Sum f <*> Sum x = Sum (f x)
+
+  -- deriving instance Functor Sum
+  instance Functor Sum where
+    fmap f (Sum x) = Sum (f x)
+
+  instance Monad Sum where
+    Sum a >>= k = k a
 
   instance Num a => Semigroup (Sum a) where
           Sum a <> Sum b = Sum (a + b)
@@ -174,6 +197,17 @@ $(singletonsOnly [d|
       abs    (Sum a) = Sum (abs a)
       signum (Sum a) = Sum (signum a)
       fromInteger n  = Sum (fromInteger n)
+
+  instance Applicative Product where
+    pure = Product
+    Product f <*> Product x = Product (f x)
+
+  -- deriving instance Functor Product
+  instance Functor Product where
+    fmap f (Product x) = Product (f x)
+
+  instance Monad Product where
+    Product a >>= k = k a
 
   instance Num a => Semigroup (Product a) where
           Product a <> Product b = Product (a * b)

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -71,6 +71,7 @@ tests =
     , compileAndDumpStdTest "T176"
     , compileAndDumpStdTest "T178"
     , compileAndDumpStdTest "T183"
+    , compileAndDumpStdTest "T184"
     , compileAndDumpStdTest "T187"
     , compileAndDumpStdTest "T190"
     , compileAndDumpStdTest "ShowDeriving"

--- a/tests/compile-and-dump/Singletons/T184.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T184.ghc84.template
@@ -1,0 +1,496 @@
+Singletons/T184.hs:(0,0)-(0,0): Splicing declarations
+    singletons
+      [d| boogie :: Maybe a -> Maybe Bool -> Maybe a
+          boogie ma mb
+            = do a <- ma
+                 b <- mb
+                 guard b
+                 return a
+          zip' :: [a] -> [b] -> [(a, b)]
+          zip' xs ys = [(x, y) | x <- xs |  y <- ys]
+          cartProd :: [a] -> [b] -> [(a, b)]
+          cartProd xs ys = [(x, y) | x <- xs, y <- ys]
+          trues :: [Bool] -> [Bool]
+          trues xs = [x | x <- xs, x] |]
+  ======>
+    boogie :: Maybe a -> Maybe Bool -> Maybe a
+    boogie ma mb
+      = do a <- ma
+           b <- mb
+           guard b
+           return a
+    zip' :: [a] -> [b] -> [(a, b)]
+    zip' xs ys = [(x, y) | x <- xs |  y <- ys]
+    cartProd :: [a] -> [b] -> [(a, b)]
+    cartProd xs ys = [(x, y) | x <- xs, y <- ys]
+    trues :: [Bool] -> [Bool]
+    trues xs = [x | x <- xs, x]
+    type family Lambda_0123456789876543210 xs t where
+      Lambda_0123456789876543210 xs x = Apply (Apply (>>@#@$) (Apply GuardSym0 x)) (Apply ReturnSym0 x)
+    type Lambda_0123456789876543210Sym2 t t =
+        Lambda_0123456789876543210 t t
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+      where
+        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
+                                                       Lambda_0123456789876543210Sym1 l l
+    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210 l l
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+      where
+        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+                                                       SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
+                                                       Lambda_0123456789876543210Sym0 l
+    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+    type family Lambda_0123456789876543210 xs ys x t where
+      Lambda_0123456789876543210 xs ys x y = Apply ReturnSym0 (Apply (Apply Tuple2Sym0 x) y)
+    type Lambda_0123456789876543210Sym4 t t t t =
+        Lambda_0123456789876543210 t t t t
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym3 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym3KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym3 l l l l :: GHC.Types.Type
+      where
+        Lambda_0123456789876543210Sym3KindInference :: forall l l l l arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym3 l l l) arg) (Lambda_0123456789876543210Sym4 l l l arg) =>
+                                                       Lambda_0123456789876543210Sym3 l l l l
+    type instance Apply (Lambda_0123456789876543210Sym3 l l l) l = Lambda_0123456789876543210 l l l l
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+      where
+        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
+                                                       Lambda_0123456789876543210Sym2 l l l
+    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210Sym3 l l l
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+      where
+        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
+                                                       Lambda_0123456789876543210Sym1 l l
+    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+      where
+        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+                                                       SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
+                                                       Lambda_0123456789876543210Sym0 l
+    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+    type family Lambda_0123456789876543210 xs ys t where
+      Lambda_0123456789876543210 xs ys x = Apply (Apply (>>=@#@$) ys) (Apply (Apply (Apply Lambda_0123456789876543210Sym0 xs) ys) x)
+    type Lambda_0123456789876543210Sym3 t t t =
+        Lambda_0123456789876543210 t t t
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+      where
+        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
+                                                       Lambda_0123456789876543210Sym2 l l l
+    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+      where
+        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
+                                                       Lambda_0123456789876543210Sym1 l l
+    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+      where
+        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+                                                       SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
+                                                       Lambda_0123456789876543210Sym0 l
+    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+    type family Lambda_0123456789876543210 xs ys t where
+      Lambda_0123456789876543210 xs ys x = Apply ReturnSym0 x
+    type Lambda_0123456789876543210Sym3 t t t =
+        Lambda_0123456789876543210 t t t
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+      where
+        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
+                                                       Lambda_0123456789876543210Sym2 l l l
+    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+      where
+        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
+                                                       Lambda_0123456789876543210Sym1 l l
+    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+      where
+        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+                                                       SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
+                                                       Lambda_0123456789876543210Sym0 l
+    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+    type family Lambda_0123456789876543210 xs ys t where
+      Lambda_0123456789876543210 xs ys y = Apply ReturnSym0 y
+    type Lambda_0123456789876543210Sym3 t t t =
+        Lambda_0123456789876543210 t t t
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+      where
+        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
+                                                       Lambda_0123456789876543210Sym2 l l l
+    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+      where
+        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
+                                                       Lambda_0123456789876543210Sym1 l l
+    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+      where
+        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+                                                       SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
+                                                       Lambda_0123456789876543210Sym0 l
+    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+    type family Case_0123456789876543210 xs ys arg_0123456789876543210 t where
+      Case_0123456789876543210 xs ys arg_0123456789876543210 (GHC.Tuple.(,) x y) = Apply ReturnSym0 (Apply (Apply Tuple2Sym0 x) y)
+    type family Lambda_0123456789876543210 xs ys t where
+      Lambda_0123456789876543210 xs ys arg_0123456789876543210 = Case_0123456789876543210 xs ys arg_0123456789876543210 arg_0123456789876543210
+    type Lambda_0123456789876543210Sym3 t t t =
+        Lambda_0123456789876543210 t t t
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+      where
+        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
+                                                       Lambda_0123456789876543210Sym2 l l l
+    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+      where
+        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
+                                                       Lambda_0123456789876543210Sym1 l l
+    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+      where
+        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+                                                       SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
+                                                       Lambda_0123456789876543210Sym0 l
+    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+    type family Lambda_0123456789876543210 ma mb a t where
+      Lambda_0123456789876543210 ma mb a b = Apply (Apply (>>@#@$) (Apply GuardSym0 b)) (Apply ReturnSym0 a)
+    type Lambda_0123456789876543210Sym4 t t t t =
+        Lambda_0123456789876543210 t t t t
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym3 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym3KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym3 l l l l :: GHC.Types.Type
+      where
+        Lambda_0123456789876543210Sym3KindInference :: forall l l l l arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym3 l l l) arg) (Lambda_0123456789876543210Sym4 l l l arg) =>
+                                                       Lambda_0123456789876543210Sym3 l l l l
+    type instance Apply (Lambda_0123456789876543210Sym3 l l l) l = Lambda_0123456789876543210 l l l l
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+      where
+        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
+                                                       Lambda_0123456789876543210Sym2 l l l
+    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210Sym3 l l l
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+      where
+        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
+                                                       Lambda_0123456789876543210Sym1 l l
+    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+      where
+        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+                                                       SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
+                                                       Lambda_0123456789876543210Sym0 l
+    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+    type family Lambda_0123456789876543210 ma mb t where
+      Lambda_0123456789876543210 ma mb a = Apply (Apply (>>=@#@$) mb) (Apply (Apply (Apply Lambda_0123456789876543210Sym0 ma) mb) a)
+    type Lambda_0123456789876543210Sym3 t t t =
+        Lambda_0123456789876543210 t t t
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+      where
+        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
+                                                       Lambda_0123456789876543210Sym2 l l l
+    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+      where
+        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
+                                                       Lambda_0123456789876543210Sym1 l l
+    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd
+            ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
+               GHC.Tuple.())
+    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+      where
+        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+                                                       SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
+                                                       Lambda_0123456789876543210Sym0 l
+    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+    type TruesSym1 (t :: [Bool]) = Trues t
+    instance SuppressUnusedWarnings TruesSym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) TruesSym0KindInference) GHC.Tuple.())
+    data TruesSym0 (l :: TyFun [Bool] [Bool]) :: GHC.Types.Type
+      where
+        TruesSym0KindInference :: forall l arg.
+                                  SameKind (Apply TruesSym0 arg) (TruesSym1 arg) => TruesSym0 l
+    type instance Apply TruesSym0 l = Trues l
+    type CartProdSym2 (t :: [a0123456789876543210]) (t :: [b0123456789876543210]) =
+        CartProd t t
+    instance SuppressUnusedWarnings CartProdSym1 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) CartProdSym1KindInference) GHC.Tuple.())
+    data CartProdSym1 (l :: [a0123456789876543210]) (l :: TyFun [b0123456789876543210] [(a0123456789876543210,
+                                                                                         b0123456789876543210)]) :: GHC.Types.Type
+      where
+        CartProdSym1KindInference :: forall l l arg.
+                                     SameKind (Apply (CartProdSym1 l) arg) (CartProdSym2 l arg) =>
+                                     CartProdSym1 l l
+    type instance Apply (CartProdSym1 l) l = CartProd l l
+    instance SuppressUnusedWarnings CartProdSym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) CartProdSym0KindInference) GHC.Tuple.())
+    data CartProdSym0 (l :: TyFun [a0123456789876543210] ((~>) [b0123456789876543210] [(a0123456789876543210,
+                                                                                        b0123456789876543210)])) :: GHC.Types.Type
+      where
+        CartProdSym0KindInference :: forall l arg.
+                                     SameKind (Apply CartProdSym0 arg) (CartProdSym1 arg) =>
+                                     CartProdSym0 l
+    type instance Apply CartProdSym0 l = CartProdSym1 l
+    type Zip'Sym2 (t :: [a0123456789876543210]) (t :: [b0123456789876543210]) =
+        Zip' t t
+    instance SuppressUnusedWarnings Zip'Sym1 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) Zip'Sym1KindInference) GHC.Tuple.())
+    data Zip'Sym1 (l :: [a0123456789876543210]) (l :: TyFun [b0123456789876543210] [(a0123456789876543210,
+                                                                                     b0123456789876543210)]) :: GHC.Types.Type
+      where
+        Zip'Sym1KindInference :: forall l l arg.
+                                 SameKind (Apply (Zip'Sym1 l) arg) (Zip'Sym2 l arg) => Zip'Sym1 l l
+    type instance Apply (Zip'Sym1 l) l = Zip' l l
+    instance SuppressUnusedWarnings Zip'Sym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) Zip'Sym0KindInference) GHC.Tuple.())
+    data Zip'Sym0 (l :: TyFun [a0123456789876543210] ((~>) [b0123456789876543210] [(a0123456789876543210,
+                                                                                    b0123456789876543210)])) :: GHC.Types.Type
+      where
+        Zip'Sym0KindInference :: forall l arg.
+                                 SameKind (Apply Zip'Sym0 arg) (Zip'Sym1 arg) => Zip'Sym0 l
+    type instance Apply Zip'Sym0 l = Zip'Sym1 l
+    type BoogieSym2 (t :: Maybe a0123456789876543210) (t :: Maybe Bool) =
+        Boogie t t
+    instance SuppressUnusedWarnings BoogieSym1 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) BoogieSym1KindInference) GHC.Tuple.())
+    data BoogieSym1 (l :: Maybe a0123456789876543210) (l :: TyFun (Maybe Bool) (Maybe a0123456789876543210)) :: GHC.Types.Type
+      where
+        BoogieSym1KindInference :: forall l l arg.
+                                   SameKind (Apply (BoogieSym1 l) arg) (BoogieSym2 l arg) =>
+                                   BoogieSym1 l l
+    type instance Apply (BoogieSym1 l) l = Boogie l l
+    instance SuppressUnusedWarnings BoogieSym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) BoogieSym0KindInference) GHC.Tuple.())
+    data BoogieSym0 (l :: TyFun (Maybe a0123456789876543210) ((~>) (Maybe Bool) (Maybe a0123456789876543210))) :: GHC.Types.Type
+      where
+        BoogieSym0KindInference :: forall l arg.
+                                   SameKind (Apply BoogieSym0 arg) (BoogieSym1 arg) => BoogieSym0 l
+    type instance Apply BoogieSym0 l = BoogieSym1 l
+    type family Trues (a :: [Bool]) :: [Bool] where
+      Trues xs = Apply (Apply (>>=@#@$) xs) (Apply Lambda_0123456789876543210Sym0 xs)
+    type family CartProd (a :: [a]) (a :: [b]) :: [(a, b)] where
+      CartProd xs ys = Apply (Apply (>>=@#@$) xs) (Apply (Apply Lambda_0123456789876543210Sym0 xs) ys)
+    type family Zip' (a :: [a]) (a :: [b]) :: [(a, b)] where
+      Zip' xs ys = Apply (Apply (>>=@#@$) (Apply (Apply MzipSym0 (Apply (Apply (>>=@#@$) xs) (Apply (Apply Lambda_0123456789876543210Sym0 xs) ys))) (Apply (Apply (>>=@#@$) ys) (Apply (Apply Lambda_0123456789876543210Sym0 xs) ys)))) (Apply (Apply Lambda_0123456789876543210Sym0 xs) ys)
+    type family Boogie (a :: Maybe a) (a :: Maybe Bool) :: Maybe a where
+      Boogie ma mb = Apply (Apply (>>=@#@$) ma) (Apply (Apply Lambda_0123456789876543210Sym0 ma) mb)
+    sTrues ::
+      forall (t :: [Bool]). Sing t -> Sing (Apply TruesSym0 t :: [Bool])
+    sCartProd ::
+      forall a b (t :: [a]) (t :: [b]).
+      Sing t
+      -> Sing t -> Sing (Apply (Apply CartProdSym0 t) t :: [(a, b)])
+    sZip' ::
+      forall a b (t :: [a]) (t :: [b]).
+      Sing t -> Sing t -> Sing (Apply (Apply Zip'Sym0 t) t :: [(a, b)])
+    sBoogie ::
+      forall a (t :: Maybe a) (t :: Maybe Bool).
+      Sing t -> Sing t -> Sing (Apply (Apply BoogieSym0 t) t :: Maybe a)
+    sTrues (sXs :: Sing xs)
+      = (applySing ((applySing ((singFun2 @(>>=@#@$)) (%>>=))) sXs))
+          ((singFun1 @(Apply Lambda_0123456789876543210Sym0 xs))
+             (\ sX
+                -> case sX of {
+                     _ :: Sing x
+                       -> (applySing
+                             ((applySing ((singFun2 @(>>@#@$)) (%>>)))
+                                ((applySing ((singFun1 @GuardSym0) sGuard)) sX)))
+                            ((applySing ((singFun1 @ReturnSym0) sReturn)) sX) }))
+    sCartProd (sXs :: Sing xs) (sYs :: Sing ys)
+      = (applySing ((applySing ((singFun2 @(>>=@#@$)) (%>>=))) sXs))
+          ((singFun1 @(Apply (Apply Lambda_0123456789876543210Sym0 xs) ys))
+             (\ sX
+                -> case sX of {
+                     _ :: Sing x
+                       -> (applySing ((applySing ((singFun2 @(>>=@#@$)) (%>>=))) sYs))
+                            ((singFun1
+                                @(Apply (Apply (Apply Lambda_0123456789876543210Sym0 xs) ys) x))
+                               (\ sY
+                                  -> case sY of {
+                                       _ :: Sing y
+                                         -> (applySing ((singFun1 @ReturnSym0) sReturn))
+                                              ((applySing
+                                                  ((applySing ((singFun2 @Tuple2Sym0) STuple2)) sX))
+                                                 sY) })) }))
+    sZip' (sXs :: Sing xs) (sYs :: Sing ys)
+      = (applySing
+           ((applySing ((singFun2 @(>>=@#@$)) (%>>=)))
+              ((applySing
+                  ((applySing ((singFun2 @MzipSym0) sMzip))
+                     ((applySing ((applySing ((singFun2 @(>>=@#@$)) (%>>=))) sXs))
+                        ((singFun1 @(Apply (Apply Lambda_0123456789876543210Sym0 xs) ys))
+                           (\ sX
+                              -> case sX of {
+                                   _ :: Sing x
+                                     -> (applySing ((singFun1 @ReturnSym0) sReturn)) sX })))))
+                 ((applySing ((applySing ((singFun2 @(>>=@#@$)) (%>>=))) sYs))
+                    ((singFun1 @(Apply (Apply Lambda_0123456789876543210Sym0 xs) ys))
+                       (\ sY
+                          -> case sY of {
+                               _ :: Sing y
+                                 -> (applySing ((singFun1 @ReturnSym0) sReturn)) sY }))))))
+          ((singFun1 @(Apply (Apply Lambda_0123456789876543210Sym0 xs) ys))
+             (\ sArg_0123456789876543210
+                -> case sArg_0123456789876543210 of {
+                     _ :: Sing arg_0123456789876543210
+                       -> case sArg_0123456789876543210 of {
+                            STuple2 (sX :: Sing x) (sY :: Sing y)
+                              -> (applySing ((singFun1 @ReturnSym0) sReturn))
+                                   ((applySing ((applySing ((singFun2 @Tuple2Sym0) STuple2)) sX))
+                                      sY) } ::
+                            Sing (Case_0123456789876543210 xs ys arg_0123456789876543210 arg_0123456789876543210) }))
+    sBoogie (sMa :: Sing ma) (sMb :: Sing mb)
+      = (applySing ((applySing ((singFun2 @(>>=@#@$)) (%>>=))) sMa))
+          ((singFun1 @(Apply (Apply Lambda_0123456789876543210Sym0 ma) mb))
+             (\ sA
+                -> case sA of {
+                     _ :: Sing a
+                       -> (applySing ((applySing ((singFun2 @(>>=@#@$)) (%>>=))) sMb))
+                            ((singFun1
+                                @(Apply (Apply (Apply Lambda_0123456789876543210Sym0 ma) mb) a))
+                               (\ sB
+                                  -> case sB of {
+                                       _ :: Sing b
+                                         -> (applySing
+                                               ((applySing ((singFun2 @(>>@#@$)) (%>>)))
+                                                  ((applySing ((singFun1 @GuardSym0) sGuard)) sB)))
+                                              ((applySing ((singFun1 @ReturnSym0) sReturn))
+                                                 sA) })) }))

--- a/tests/compile-and-dump/Singletons/T184.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T184.ghc84.template
@@ -494,3 +494,20 @@ Singletons/T184.hs:(0,0)-(0,0): Splicing declarations
                                                   ((applySing ((singFun1 @GuardSym0) sGuard)) sB)))
                                               ((applySing ((singFun1 @ReturnSym0) sReturn))
                                                  sA) })) }))
+    instance SingI (TruesSym0 :: (~>) [Bool] [Bool]) where
+      sing = (singFun1 @TruesSym0) sTrues
+    instance SingI (CartProdSym0 :: (~>) [a] ((~>) [b] [(a, b)])) where
+      sing = (singFun2 @CartProdSym0) sCartProd
+    instance SingI d =>
+             SingI (CartProdSym1 (d :: [a]) :: (~>) [b] [(a, b)]) where
+      sing = (singFun1 @(CartProdSym1 (d :: [a]))) (sCartProd (sing @d))
+    instance SingI (Zip'Sym0 :: (~>) [a] ((~>) [b] [(a, b)])) where
+      sing = (singFun2 @Zip'Sym0) sZip'
+    instance SingI d =>
+             SingI (Zip'Sym1 (d :: [a]) :: (~>) [b] [(a, b)]) where
+      sing = (singFun1 @(Zip'Sym1 (d :: [a]))) (sZip' (sing @d))
+    instance SingI (BoogieSym0 :: (~>) (Maybe a) ((~>) (Maybe Bool) (Maybe a))) where
+      sing = (singFun2 @BoogieSym0) sBoogie
+    instance SingI d =>
+             SingI (BoogieSym1 (d :: Maybe a) :: (~>) (Maybe Bool) (Maybe a)) where
+      sing = (singFun1 @(BoogieSym1 (d :: Maybe a))) (sBoogie (sing @d))

--- a/tests/compile-and-dump/Singletons/T184.hs
+++ b/tests/compile-and-dump/Singletons/T184.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE ParallelListComp #-}
+module T184 where
+
+import Control.Monad
+import Data.Singletons.Prelude
+import Data.Singletons.Prelude.Monad
+import Data.Singletons.Prelude.Monad.Zip
+import Data.Singletons.TH
+
+$(singletons [d|
+  boogie :: Maybe a -> Maybe Bool -> Maybe a
+  boogie ma mb = do
+    a <- ma
+    b <- mb
+    guard b
+    return a
+
+  zip' :: [a] -> [b] -> [(a, b)]
+  zip' xs ys = [(x, y) | x <- xs | y <- ys]
+
+  cartProd :: [a] -> [b] -> [(a, b)]
+  cartProd xs ys = [(x, y) | x <- xs, y <- ys]
+
+  trues :: [Bool] -> [Bool]
+  trues xs = [x | x <- xs, x]
+  |])


### PR DESCRIPTION
At long last, this adds supports for `Monad` and friends. This means we can properly promote and single:

* `do`-notation
* List comprehensions
* `ParallelListComp` (through the `Data.Singletons.Prelude.Monad.Zip` module)

Nothing needed to be changed from the code generation side to make this work—all that was needed was some minor tweaks to the original source code:

* Some extra kind signatures had to be inserted to avoid CUSK issues (e.g., `class Functor (f :: Type -> Type)`).
* Some definitions which rely on infinite lists, such as `some`, `many`, and `forever`, cannot be promoted.

One thing this patch does _not_ do (since it's already pretty large) is add support for `Foldable` and `Traversable`. As a result, I've left some exports from `Data.Singletons.Prelude.Monad` commented out, since they're supposed to be re-exported from `Traversable`.