### PR TITLE
Add HasCallStack constraints to error-throwing functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,11 @@ Changelog for singletons project
 
 * Permit singling of expression and pattern signatures.
 
+* `sError` and `sUndefined` now have `HasCallStack` constraints, like their
+  counterparts `error` and `undefined`. The promoted and singled counterparts
+  to `errorWithoutStackTrace` have also been added in case you do not want
+  this behavior.
+
 * Add `Data.Singletons.TypeError`, which provides a drop-in replacement for
   `GHC.TypeLits.TypeError` which can be used at both the value- and type-level.
 

--- a/src/Data/Promotion/Prelude.hs
+++ b/src/Data/Promotion/Prelude.hs
@@ -24,7 +24,7 @@ module Data.Promotion.Prelude (
   Fst, Snd, Curry, Uncurry,
 
   -- * Error reporting
-  Error, Undefined,
+  Error, ErrorWithoutStackTrace, Undefined,
 
   -- * Promoted equality
   module Data.Promotion.Prelude.Eq,
@@ -103,7 +103,9 @@ module Data.Promotion.Prelude (
   CurrySym0, CurrySym1, CurrySym2, CurrySym3,
   UncurrySym0, UncurrySym1, UncurrySym2,
 
-  ErrorSym0, ErrorSym1, UndefinedSym0,
+  ErrorSym0, ErrorSym1,
+  ErrorWithoutStackTraceSym0, ErrorWithoutStackTraceSym1,
+  UndefinedSym0,
 
   LTSym0, EQSym0, GTSym0,
   CompareSym0, CompareSym1, CompareSym2,

--- a/src/Data/Singletons/Prelude.hs
+++ b/src/Data/Singletons/Prelude.hs
@@ -37,6 +37,7 @@ module Data.Singletons.Prelude (
 
   -- * Error reporting
   Error, sError,
+  ErrorWithoutStackTrace, sErrorWithoutStackTrace,
   Undefined, sUndefined,
 
   -- * Singleton equality
@@ -128,7 +129,9 @@ module Data.Singletons.Prelude (
   CurrySym0, CurrySym1, CurrySym2, CurrySym3,
   UncurrySym0, UncurrySym1, UncurrySym2,
 
-  ErrorSym0, ErrorSym1, UndefinedSym0,
+  ErrorSym0, ErrorSym1,
+  ErrorWithoutStackTraceSym0, ErrorWithoutStackTraceSym1,
+  UndefinedSym0,
 
   LTSym0, EQSym0, GTSym0,
   CompareSym0, CompareSym1, CompareSym2,

--- a/src/Data/Singletons/TypeError.hs
+++ b/src/Data/Singletons/TypeError.hs
@@ -42,6 +42,7 @@ import Data.Kind
 import Data.Singletons.TH
 import qualified Data.Text as Text
 import qualified GHC.TypeLits as TL (ErrorMessage(..), TypeError)
+import GHC.Stack (HasCallStack)
 import GHC.TypeLits hiding (ErrorMessage(..), TypeError)
 import Prelude hiding ((<>))
 import Text.PrettyPrint (Doc, text, (<>), ($$))
@@ -128,7 +129,7 @@ showErrorMessage = show . go
 -- Note that this is not quite as expressive as 'TypeError', as it is unable
 -- to print the contents of 'ShowType' constructors (it will simply print
 -- @\"\<type\>\"@ in their place).
-typeError :: ErrorMessage -> a
+typeError :: HasCallStack => ErrorMessage -> a
 typeError = error . showErrorMessage
 
 -- | Convert a 'PErrorMessage' to a 'TL.ErrorMessage' from "GHC.TypeLits".
@@ -148,7 +149,7 @@ type family TypeError (a :: PErrorMessage) :: b where
 --
 -- Note that this is not quite as expressive as 'TypeError', as it is unable
 -- to handle 'ShowType' constructors at all.
-sTypeError :: Sing err -> Sing (TypeError err)
+sTypeError :: HasCallStack => Sing err -> Sing (TypeError err)
 sTypeError = typeError . fromSing
 
 $(genDefunSymbols [''ErrorMessage', ''TypeError])

--- a/src/Data/Singletons/TypeLits.hs
+++ b/src/Data/Singletons/TypeLits.hs
@@ -21,6 +21,7 @@ module Data.Singletons.TypeLits (
   Sing(SNat, SSym),
   SNat, SSymbol, withKnownNat, withKnownSymbol,
   Error, sError,
+  ErrorWithoutStackTrace, sErrorWithoutStackTrace,
   Undefined, sUndefined,
   KnownNat, natVal,
   KnownSymbol, symbolVal,
@@ -33,7 +34,9 @@ module Data.Singletons.TypeLits (
   Quot, sQuot, Rem, sRem, QuotRem, sQuotRem,
 
   -- * Defunctionalization symbols
-  ErrorSym0, ErrorSym1, UndefinedSym0,
+  ErrorSym0, ErrorSym1,
+  ErrorWithoutStackTraceSym0, ErrorWithoutStackTraceSym1,
+  UndefinedSym0,
   KnownNatSym0, KnownNatSym1,
   KnownSymbolSym0, KnownSymbolSym1,
   type (^@#@$), type (^@#@$$), type (^@#@$$$),

--- a/src/Data/Singletons/TypeLits/Internal.hs
+++ b/src/Data/Singletons/TypeLits/Internal.hs
@@ -26,13 +26,16 @@ module Data.Singletons.TypeLits.Internal (
   Nat, Symbol,
   SNat, SSymbol, withKnownNat, withKnownSymbol,
   Error, sError,
+  ErrorWithoutStackTrace, sErrorWithoutStackTrace,
   Undefined, sUndefined,
   KnownNat, TN.natVal, KnownSymbol, symbolVal,
   type (^), (%^),
   type (<=?), (%<=?),
 
   -- * Defunctionalization symbols
-  ErrorSym0, ErrorSym1, UndefinedSym0,
+  ErrorSym0, ErrorSym1,
+  ErrorWithoutStackTraceSym0, ErrorWithoutStackTraceSym1,
+  UndefinedSym0,
   type (^@#@$),  type (^@#@$$),  type (^@#@$$$),
   type (<=?@#@$),  type (<=?@#@$$),  type (<=?@#@$$$)
   ) where
@@ -43,6 +46,7 @@ import Data.Singletons.Prelude.Eq
 import Data.Singletons.Prelude.Ord as O
 import Data.Singletons.Decide
 import Data.Singletons.Prelude.Bool
+import GHC.Stack (HasCallStack)
 import GHC.TypeLits as TL
 import qualified GHC.TypeNats as TN
 import qualified Data.Type.Equality as DTE
@@ -158,15 +162,24 @@ type family Error (str :: k0) :: k where {}
 $(genDefunSymbols [''Error])
 
 -- | The singleton for 'error'
-sError :: Sing (str :: Symbol) -> a
+sError :: HasCallStack => Sing (str :: Symbol) -> a
 sError sstr = error (T.unpack (fromSing sstr))
+
+-- | The promotion of 'errorWithoutStackTrace'. This version is more
+-- poly-kinded for easier use.
+type family ErrorWithoutStackTrace (str :: k0) :: k where {}
+$(genDefunSymbols [''ErrorWithoutStackTrace])
+
+-- | The singleton for 'errorWithoutStackTrace'.
+sErrorWithoutStackTrace :: Sing (str :: Symbol) -> a
+sErrorWithoutStackTrace sstr = errorWithoutStackTrace (T.unpack (fromSing sstr))
 
 -- | The promotion of 'undefined'.
 type family Undefined :: k where {}
 $(genDefunSymbols [''Undefined])
 
 -- | The singleton for 'undefined'.
-sUndefined :: a
+sUndefined :: HasCallStack => a
 sUndefined = undefined
 
 -- | The singleton analogue of '(TN.^)' for 'Nat's.

--- a/tests/compile-and-dump/Singletons/T160.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T160.ghc84.template
@@ -45,11 +45,29 @@ Singletons/T160.hs:(0,0)-(0,0): Splicing declarations
         in  case sScrutinee_0123456789876543210 of
               STrue -> sFromInteger (sing :: Sing 1)
               SFalse
-                -> (applySing
-                      ((applySing ((singFun2 @($@#@$)) (%$)))
-                         ((singFun1 @TypeErrorSym0) sTypeError)))
+                -> (applySing ((applySing ((singFun2 @($@#@$)) (%$))) sTypeError))
                      ((applySing ((singFun1 @ShowTypeSym0) SShowType)) sX) ::
               Sing (Case_0123456789876543210 x (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x) :: a)
+
+Singletons/T160.hs:0:0: error:
+    • t
+    • In the expression:
+        (applySing ((applySing ((singFun2 @($@#@$)) (%$))) sTypeError))
+          ((applySing ((singFun1 @ShowTypeSym0) SShowType)) sX)
+      In a case alternative:
+          SFalse
+            -> (applySing ((applySing ((singFun2 @($@#@$)) (%$))) sTypeError))
+                 ((applySing ((singFun1 @ShowTypeSym0) SShowType)) sX)
+      In the expression:
+          case sScrutinee_0123456789876543210 of
+            STrue -> sFromInteger (sing :: Sing 1)
+            SFalse
+              -> (applySing ((applySing ((singFun2 @($@#@$)) (%$))) sTypeError))
+                   ((applySing ((singFun1 @ShowTypeSym0) SShowType)) sX) ::
+            Sing (Case_0123456789876543210 x (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x) :: a)
+  |
+7 | $(singletons
+  |   ^^^^^^^^^^...
 
 Singletons/T160.hs:0:0: error:
     • 1


### PR DESCRIPTION
In GHC 8.0, `base` added `HasCallStack` constraints to `error` and `undefined`, but these never found their ways into their singled counterparts in `singletons`. Let's do so.

GHC 8.0 also added an `errorWithoutStackTrace` function to the `Prelude` which does _not_ have a `HasCallStack` constraint, so for the sake of completeness, I added this too.