### PR TITLE
Fix #216 by making genDefunSymbols TypeInType-aware

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,16 @@ Changelog for singletons project
   through Template Haskell. As a result, you may need to enable
   `FlexibleInstances` in more places.
 
+* `genDefunSymbols` is now more robust with respect to types that use
+  dependent quantification à la `TypeInType`, such as:
+
+  ```haskell
+  type family MyProxy k (a :: k) :: Type where
+    MyProxy k (a :: k) = Proxy a
+  ```
+
+  See the documentation for `genDefunSymbols` for limitations to this.
+
 * Rename `Data.Singletons.TypeRepStar` to `Data.Singletons.TypeRepTYPE`, and
   generalize the `Sing :: Type -> Type` instance to `Sing :: TYPE rep -> Type`,
   allowing it to work over more open kinds. Also rename `SomeTypeRepStar` to

--- a/src/Data/Singletons/Names.hs
+++ b/src/Data/Singletons/Names.hs
@@ -24,7 +24,7 @@ import Control.Monad
 
 boolName, andName, tyEqName, compareName, minBoundName,
   maxBoundName, repName,
-  nilName, consName, listName, tyFunName, tyFunArrowName,
+  nilName, consName, listName, tyFunArrowName,
   applyName, natName, symbolName, typeRepName, stringName,
   eqName, ordName, boundedName, orderingName,
   singFamilyName, singIName, singMethName, demoteName,
@@ -52,7 +52,6 @@ repName = mkName "Rep"   -- this is actually defined in client code!
 nilName = '[]
 consName = '(:)
 listName = ''[]
-tyFunName = ''TyFun
 tyFunArrowName = ''(~>)
 applyName = ''Apply
 symbolName = ''Symbol

--- a/src/Data/Singletons/Promote/Defun.hs
+++ b/src/Data/Singletons/Promote/Defun.hs
@@ -18,7 +18,10 @@ import Language.Haskell.TH.Syntax
 import Data.Singletons.Syntax
 import Data.Singletons.Util
 import Control.Monad
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
 import Data.Maybe
+import qualified Data.Set as Set
 
 defunInfo :: DInfo -> PrM [DDec]
 defunInfo (DTyConI dec _instances) = buildDefunSyms dec
@@ -55,32 +58,33 @@ buildDefunSyms (DOpenTypeFamilyD tf_head) =
 buildDefunSyms (DTySynD name tvbs _type) =
   buildDefunSymsTySynD name tvbs
 buildDefunSyms (DClassD _cxt name tvbs _fundeps _members) = do
-  let arg_m_kinds = map extractTvbKind tvbs
-  defunReifyFixity name arg_m_kinds (Just (DConT constraintName))
+  defunReifyFixity name tvbs (Just (DConT constraintName))
 buildDefunSyms _ = fail $ "Defunctionalization symbols can only be built for " ++
                           "type families and data declarations"
 
 buildDefunSymsClosedTypeFamilyD :: DTypeFamilyHead -> PrM [DDec]
-buildDefunSymsClosedTypeFamilyD = buildDefunSymsTypeFamilyHead id
+buildDefunSymsClosedTypeFamilyD = buildDefunSymsTypeFamilyHead id id
 
 buildDefunSymsOpenTypeFamilyD :: DTypeFamilyHead -> PrM [DDec]
-buildDefunSymsOpenTypeFamilyD = buildDefunSymsTypeFamilyHead default_to_star
+buildDefunSymsOpenTypeFamilyD = buildDefunSymsTypeFamilyHead cuskify default_to_star
   where
     default_to_star :: Maybe DKind -> Maybe DKind
     default_to_star Nothing  = Just $ DConT typeKindName
     default_to_star (Just k) = Just k
 
 buildDefunSymsTypeFamilyHead
-  :: (Maybe DKind -> Maybe DKind) -> DTypeFamilyHead -> PrM [DDec]
-buildDefunSymsTypeFamilyHead default_kind (DTypeFamilyHead name tvbs result_sig _) = do
-  let arg_kinds = map (default_kind . extractTvbKind) tvbs
-      res_kind  = default_kind (resultSigToMaybeKind result_sig)
-  defunReifyFixity name arg_kinds res_kind
+  :: (DTyVarBndr -> DTyVarBndr)
+  -> (Maybe DKind -> Maybe DKind)
+  -> DTypeFamilyHead -> PrM [DDec]
+buildDefunSymsTypeFamilyHead default_tvb default_kind
+    (DTypeFamilyHead name tvbs result_sig _) = do
+  let arg_tvbs = map default_tvb tvbs
+      res_kind = default_kind (resultSigToMaybeKind result_sig)
+  defunReifyFixity name arg_tvbs res_kind
 
 buildDefunSymsTySynD :: Name -> [DTyVarBndr] -> PrM [DDec]
-buildDefunSymsTySynD name tvbs = do
-  let arg_m_kinds = map extractTvbKind tvbs
-  defunReifyFixity name arg_m_kinds Nothing
+buildDefunSymsTySynD name tvbs =
+  defunReifyFixity name tvbs Nothing
 
 buildDefunSymsDataD :: [DCon] -> PrM [DDec]
 buildDefunSymsDataD ctors =
@@ -89,17 +93,19 @@ buildDefunSymsDataD ctors =
     promoteCtor :: DCon -> PrM [DDec]
     promoteCtor ctor@(DCon _ _ _ _ res_ty) = do
       let (name, arg_tys) = extractNameTypes ctor
+      tvb_names <- replicateM (length arg_tys) $ qNewName "t"
       arg_kis <- mapM promoteType arg_tys
+      let arg_tvbs = zipWith DKindedTV tvb_names arg_kis
       res_ki <- promoteType res_ty
-      defunReifyFixity name (map Just arg_kis) (Just res_ki)
+      defunReifyFixity name arg_tvbs (Just res_ki)
 
 -- Generate defunctionalization symbols for a name, using reifyFixityWithLocals
 -- to determine what the fixity of each symbol should be.
 -- See Note [Fixity declarations for defunctionalization symbols]
-defunReifyFixity :: Name -> [Maybe DKind] -> Maybe DKind -> PrM [DDec]
-defunReifyFixity name m_arg_kinds m_res_kind = do
+defunReifyFixity :: Name -> [DTyVarBndr] -> Maybe DKind -> PrM [DDec]
+defunReifyFixity name tvbs m_res_kind = do
   m_fixity <- reifyFixityWithLocals name
-  defunctionalize name m_fixity m_arg_kinds m_res_kind
+  defunctionalize name m_fixity tvbs m_res_kind
 
 -- Generate data declarations and apply instances
 -- required for defunctionalization.
@@ -134,77 +140,250 @@ defunReifyFixity name m_arg_kinds m_res_kind = do
 --
 -- The defunctionalize function takes Maybe DKinds so that the caller can
 -- indicate which kinds are known and which need to be inferred.
+--
+-- See also Note [Defunctionalization and TypeInType]
 defunctionalize :: Name
                 -> Maybe Fixity -- The name's fixity, if one was declared.
-                -> [Maybe DKind] -> Maybe DKind -> PrM [DDec]
-defunctionalize name m_fixity m_arg_kinds' m_res_kind' = do
-  let (m_arg_kinds, m_res_kind) = eta_expand (noExactTyVars m_arg_kinds')
-                                             (noExactTyVars m_res_kind')
-      num_args = length m_arg_kinds
+                -> [DTyVarBndr] -> Maybe DKind -> PrM [DDec]
+defunctionalize name m_fixity m_arg_tvbs' m_res_kind' = do
+  (m_arg_tvbs, m_res_kind) <- eta_expand (noExactTyVars m_arg_tvbs')
+                                         (noExactTyVars m_res_kind')
+
+  let -- Implements part (2)(i) from Note [Defunctionalization and TypeInType]
+      tvb_to_type_map :: Map Name DType
+      tvb_to_type_map = Map.fromList $                   -- (2)(i)(c)
+                        map (\tvb -> (extractTvbName tvb, dTyVarBndrToDType tvb)) $
+                        toposortTyVarsOf $               -- (2)(i)(b)
+                        map dTyVarBndrToDType m_arg_tvbs -- (2)(i)(a)
+
+      go :: Int -> [DTyVarBndr] -> Maybe DKind
+         -> ([DTyVarBndr] -> DType)  -- given the argument tyvar binders,
+                                     -- produce the RHS of the Apply instance
+         -> PrM [DDec]
+      go _ [] _ _ = return []
+      go n (m_arg : m_args) m_result mk_rhs = do
+        extra_name <- qNewName "arg"
+        let tyfun_name  = extractTvbName m_arg
+            data_name   = promoteTySym name n
+            next_name   = promoteTySym name (n+1)
+            con_name    = prefixName "" ":" $ suffixName "KindInference" "###" data_name
+            m_tyfun     = buildTyFunArrow_maybe (extractTvbKind m_arg) m_result
+            arg_params  = reverse m_args
+            tyfun_param = mk_tvb tyfun_name m_tyfun
+            arg_names   = map extractTvbName arg_params
+            params      = arg_params ++ [tyfun_param]
+            con_eq_ct   = DConPr sameKindName `DAppPr` lhs `DAppPr` rhs
+              where
+                lhs = foldType (DConT data_name) (map DVarT arg_names) `apply` (DVarT extra_name)
+                rhs = foldType (DConT next_name) (map DVarT (arg_names ++ [extra_name]))
+            con_decl    = DCon (map dropTvbKind params ++ [DPlainTV extra_name])
+                               [con_eq_ct]
+                               con_name
+                               (DNormalC False [])
+                               (foldTypeTvbs (DConT data_name) params)
+            data_decl   = DDataD Data [] data_name args res_ki [con_decl] []
+              where
+                (args, res_ki)
+                  = case m_tyfun of
+                      Nothing    -> (params, Nothing)
+                                    -- If we cannot infer the return type, don't bother
+                                    -- trying to construct an explicit return kind.
+                      Just tyfun ->
+                        let bound_tvs = Set.fromList (map extractTvbName arg_params) `Set.union`
+                                        foldMap (foldMap fvDType) (map extractTvbKind arg_params)
+                            not_bound tvb = not (extractTvbName tvb `Set.member` bound_tvs)
+                            tvb_to_type tvb_name = fromMaybe (DVarT tvb_name) $
+                                                   Map.lookup tvb_name tvb_to_type_map
+                            -- Implements part (2)(ii) from
+                            -- Note [Defunctionalization and TypeInType]
+                            tyfun_tvbs = filter not_bound $         -- (2)(ii)(d)
+                                         toposortTyVarsOf $         -- (2)(ii)(c)
+                                         map tvb_to_type $          -- (2)(ii)(b)
+                                         Set.toList $ fvDType tyfun -- (2)(ii)(a)
+                        in (arg_params, Just (DForallT tyfun_tvbs [] tyfun))
+            app_data_ty = foldTypeTvbs (DConT data_name) m_args
+            app_eqn     = DTySynEqn [app_data_ty, DVarT tyfun_name]
+                                    (mk_rhs (m_args ++ [DPlainTV tyfun_name]))
+            app_decl    = DTySynInstD applyName app_eqn
+            suppress    = DInstanceD Nothing []
+                            (DConT suppressClassName `DAppT` app_data_ty)
+                            [DLetDec $ DFunD suppressMethodName
+                                             [DClause []
+                                                      ((DVarE 'snd) `DAppE`
+                                                       mkTupleDExp [DConE con_name,
+                                                                    mkTupleDExp []])]]
+
+            mk_rhs'     = foldTypeTvbs (DConT data_name)
+
+            -- See Note [Fixity declarations for defunctionalization symbols]
+            mk_fix_decl f = DLetDec $ DInfixD f data_name
+            fixity_decl   = maybeToList $ fmap mk_fix_decl m_fixity
+
+        decls <- go (n - 1) m_args m_tyfun mk_rhs'
+        return $ suppress : data_decl : app_decl : fixity_decl ++ decls
+
+  let num_args = length m_arg_tvbs
       sat_name = promoteTySym name num_args
-  tvbNames <- replicateM num_args $ qNewName "t"
-  let  mk_rhs ns = foldType (DConT name) (map DVarT ns)
-       sat_dec   = DTySynD sat_name (zipWith mk_tvb tvbNames m_arg_kinds) (mk_rhs tvbNames)
-  other_decs <- go (num_args - 1) (reverse m_arg_kinds) m_res_kind mk_rhs
+      mk_rhs   = foldTypeTvbs (DConT name)
+      sat_dec  = DTySynD sat_name m_arg_tvbs (mk_rhs m_arg_tvbs)
+
+  other_decs <- go (num_args - 1) (reverse m_arg_tvbs) m_res_kind mk_rhs
   return $ sat_dec : other_decs
   where
     mk_tvb :: Name -> Maybe DKind -> DTyVarBndr
     mk_tvb tvb_name Nothing  = DPlainTV tvb_name
     mk_tvb tvb_name (Just k) = DKindedTV tvb_name k
 
-    eta_expand :: [Maybe DKind] -> Maybe DKind -> ([Maybe DKind], Maybe DKind)
-    eta_expand m_arg_kinds Nothing = (m_arg_kinds, Nothing)
-    eta_expand m_arg_kinds (Just res_kind) =
+    eta_expand :: [DTyVarBndr] -> Maybe DKind -> PrM ([DTyVarBndr], Maybe DKind)
+    eta_expand m_arg_tvbs Nothing = pure (m_arg_tvbs, Nothing)
+    eta_expand m_arg_tvbs (Just res_kind) = do
         let (_, _, argKs, resultK) = unravel res_kind
-        in (m_arg_kinds ++ (map Just argKs), Just resultK)
+        tvb_names <- replicateM (length argKs) $ qNewName "e"
+        let res_kind_arg_tvbs = zipWith DKindedTV tvb_names argKs
+        pure (m_arg_tvbs ++ res_kind_arg_tvbs, Just resultK)
 
-    go :: Int -> [Maybe DKind] -> Maybe DKind
-       -> ([Name] -> DType)  -- given the argument names, the RHS of the Apply instance
-       -> PrM [DDec]
-    go _ [] _ _ = return []
-    go n (m_arg : m_args) m_result mk_rhs = do
-      fst_name : rest_names <- replicateM (n + 1) (qNewName "l")
-      extra_name <- qNewName "arg"
-      let data_name   = promoteTySym name n
-          next_name   = promoteTySym name (n+1)
-          con_name    = prefixName "" ":" $ suffixName "KindInference" "###" data_name
-          m_tyfun     = buildTyFun_maybe m_arg m_result
-          arg_params  = zipWith mk_tvb rest_names (reverse m_args)
-          tyfun_param = mk_tvb fst_name m_tyfun
-          arg_names   = map extractTvbName arg_params
-          params      = arg_params ++ [tyfun_param]
-          con_eq_ct   = DConPr sameKindName `DAppPr` lhs `DAppPr` rhs
-            where
-              lhs = foldType (DConT data_name) (map DVarT arg_names) `apply` (DVarT extra_name)
-              rhs = foldType (DConT next_name) (map DVarT (arg_names ++ [extra_name]))
-          con_decl    = DCon (map dropTvbKind params ++ [DPlainTV extra_name])
-                             [con_eq_ct]
-                             con_name
-                             (DNormalC False [])
-                             (foldTypeTvbs (DConT data_name) params)
-          data_decl   = DDataD Data [] data_name params
-                               (Just (DConT typeKindName)) [con_decl] []
-          app_eqn     = DTySynEqn [ foldType (DConT data_name)
-                                             (map DVarT rest_names)
-                                  , DVarT fst_name ]
-                                  (mk_rhs (rest_names ++ [fst_name]))
-          app_decl    = DTySynInstD applyName app_eqn
-          suppress    = DInstanceD Nothing []
-                          (DConT suppressClassName `DAppT` DConT data_name)
-                          [DLetDec $ DFunD suppressMethodName
-                                           [DClause []
-                                                    ((DVarE 'snd) `DAppE`
-                                                     mkTupleDExp [DConE con_name,
-                                                                  mkTupleDExp []])]]
+{-
+Note [Defunctionalization and TypeInType]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The machinery in this module supports defunctionalizing types that use
+dependent quantification à la TypeInType, such as in the following example:
 
-          mk_rhs' ns  = foldType (DConT data_name) (map DVarT ns)
+  type family Symmetry (a :: t) (y :: t) (e :: a :~: y) :: Type where
+    Symmetry a y _ = y :~: a
 
-          -- See Note [Fixity declarations for defunctionalization symbols]
-          mk_fix_decl f = DLetDec $ DInfixD f data_name
-          fixity_decl   = maybeToList $ fmap mk_fix_decl m_fixity
+Here is what is involved in making this happen:
 
-      decls <- go (n - 1) m_args (buildTyFunArrow_maybe m_arg m_result) mk_rhs'
-      return $ suppress : data_decl : app_decl : fixity_decl ++ decls
+1. When defunctionalizing, we must not only know the argument kinds, but rather
+   the argument *kind variable binders*. This is essential since, for instance,
+   Symmetry dependently quantifies `a` and `y` and uses them in the kind of
+   `e`. If we did not track the original kind variable names, then instead of
+   generating this defunctinalization symbol for Symmetry:
+
+     data SymmetrySym2 (a :: t) (y :: t) :: (a :~: y) ~> Type
+
+   We would generate something more general, like this:
+
+     data SymmetrySym2 (abc1 :: t) (abc2 :: t) :: (a :~: y) ~> Type
+
+   Alas, there are times where will have no choice but to write a slightly
+   more general kind than we should. For instance, consider this:
+
+     data SymmetrySym0 :: t ~> t ~> (a :~: y) ~> Type
+
+   This defunctionalization symbol doesn't capture the dependent quantification
+   in the first and second argument kinds. But in order to do that properly,
+   you'd need the ability to write something like:
+
+     data SymmetrySym0 :: forall t ~> forall t ~> (a :~: y) ~> Type
+
+   It is my (RGS's) belief that it is not possible to achieve something like
+   this in today's GHC (see #304), so we'll just have to live with SymmetrySym0
+   being slightly more general than it ought to be. In practice, this is
+   unlikely to bite unless you're writing code that specifically exploits this
+   dependency in just the right way.
+
+2. I pulled a fast one earlier by writing:
+
+     data SymmetrySym0 :: t ~> t ~> (a :~: y) ~> Type
+
+   GHC will actually reject this, because it does not have a CUSK. There are
+   two glaring problems here:
+
+   (a) The kind of `t` is underdetermined.
+   (b) `a` and `y` should have kind `t`, but this is not currently the case.
+
+   Ultimately, the fix is to use explicit kind signatures. A naïve attempt
+   would be something like this:
+
+     data SymmetrySym0 :: (t :: Type) ~> (t :: Type)
+                       ~> ((a :: t) :~: (y :: t)) ~> Type
+
+   While that works, it adds a nontrivial amount of clutter. Plus, it requires
+   figuring out (in Template Haskell) which variables have underdetermined
+   kinds and substituting for them. Blegh. A much cleaner approach is:
+
+     data SymmetrySym0 :: forall (t :: Type) (a :: t) (y :: t).
+                          t ~> t ~> (a :~: y) ~> Type
+
+   This time, all we have to do is put an explicit `forall` in front, and we
+   achieve a CUSK without having to change the body of the type. It also has
+   the benefit of looking much nicer in generated code.
+
+   Let's talk about how to achieve this feat:
+
+   (i) Before we begin defunctionalizing a type, we construct a mapping from
+       variable names to their corresponding types, complete with kinds.
+       For instance, in Symmetry, we would have the following map:
+
+         { t :-> DVarT t                   -- t
+         , a :-> DSigT (DVarT a) (DVarT t) -- (a :: t)
+         , y :-> DSigT (DVarT y) (DVarT y) -- (y :: t)
+         }
+
+       Why do this? Because when constructing the `forall` in the return kind
+       of a defunctionalization symbol, it's convenient to be able to know
+       the kinds of everything being bound at a glance. It's not always
+       possible to recover the kinds of every variable (for instance, if
+       we're just given `t ~> t ~> (a :~: y) ~> Type`), so having this
+       information is handy.
+
+       To construct this map, we:
+
+       (a) Grab the list of type variable binders. (This is given as an input
+           to defunctionalize, as discussed in part (1).)
+       (b) Construct a flat list of all type variables mentioned in this list.
+           This may involve looking in the kinds of type variables binders.
+           (Note that this part is crucial—the the Singletons/PolyKinds test
+           will fail to compile without it!)
+       (c) Take the flat list and insert each variable into the map by
+           mapping its name to its type (as demonstrated above).
+
+       To continue the Symmetry example:
+
+       (a) We grab the list of type variable binders
+           [(a :: t), (y :: t), (e :: a :~: y)] from the Symmetry declaration.
+       (b) We flatten this into [t, (a :: t), (y :: t), (e :: a :~: y)].
+       (c) From this, we construct the map:
+
+             { t :-> DVarT                     -- t
+             , a :-> DSigT (DVarT a) (DVarT t) -- (a :: t)
+             , y :-> DSigT (DVarT y) (DVarT t) -- (y :: t)
+             , e :-> DSigT (DVarT e) (DConT ''(:~:) `DAppT` DVarT a `DAppT` DVarT y)
+                                               -- (e :: a :~: y)
+             }
+
+   (ii) When constructing each defunctionalization symbol, we will end up with
+        some remaining type variable binders and a return kind. For instance:
+
+          data SymmetrySym1 (a :: t) :: forall ???.
+                                        t ~> (a :~: y) ~> Type
+
+        We must fill in the ??? part. Here is how we do so:
+
+        (a) Collect all of the type variables mentioned in the return kind.
+        (b) Look up each type variable's corresponding type in the map (from
+            part (i)) to learn as much kind information as possible.
+        (c) Perform a reverse topological sort on these types to put the
+            types (and kind) variables in proper dependency order.
+        (d) Filter out any variables that are already bound by the type
+            variable binders that precede the return kind.
+
+        After doing these steps, what remains goes in place of ???. Let's
+        explain this with the example above:
+
+          data SymmetrySym1 (a :: t) :: forall ???.
+                                        t ~> (a :~: y) ~> Type
+
+        (a) [t, a, y]
+        (b) [t, (a :: t), (y :: t)]
+        (c) [t, (a :: t), (y :: t)] (Thankfully, this was already sorted)
+        (d) [(y :: t)] (`t` and `a` were already bound)
+
+        Therefore, we end up with:
+
+          data SymmetrySym1 (a :: t) :: forall (y :: t).
+                                        t ~> (a :~: y) ~> Type
+-}
 
 -- This is a small function with large importance. When generating
 -- defunctionalization data types, we often need to fill in the blank in the
@@ -256,20 +435,6 @@ buildTyFunArrow_maybe m_k1 m_k2 = do
   k1 <- m_k1
   k2 <- m_k2
   return $ DConT tyFunArrowName `DAppT` k1 `DAppT` k2
-
--- Shorthand for building (TyFun k1 k2 ~> Type)
---
--- We'd like to replace all uses of this with `buildTyFunArrow`, but we can't
--- do this until https://github.com/goldfirere/th-desugar/issues/68
--- is implemented.
-buildTyFun :: DKind -> DKind -> DKind
-buildTyFun k1 k2 = DConT tyFunName `DAppT` k1 `DAppT` k2
-
-buildTyFun_maybe :: Maybe DKind -> Maybe DKind -> Maybe DKind
-buildTyFun_maybe m_k1 m_k2 = do
-  k1 <- m_k1
-  k2 <- m_k2
-  return $ buildTyFun k1 k2
 
 -- Build (~>) kind from the list of kinds
 ravelTyFun :: [DKind] -> DKind

--- a/src/Data/Singletons/Sigma.hs
+++ b/src/Data/Singletons/Sigma.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeInType #-}
 
@@ -23,10 +25,14 @@ module Data.Singletons.Sigma
     ( Sigma(..), Σ
     , projSigma1, projSigma2
     , mapSigma, zipSigma
+
+      -- * Defunctionalization symbols
+    , ΣSym0, ΣSym1, ΣSym2
     ) where
 
 import Data.Kind (Type)
 import Data.Singletons.Internal
+import Data.Singletons.Promote
 
 -- | A dependent pair.
 data Sigma (s :: Type) :: (s ~> Type) -> Type where
@@ -35,8 +41,6 @@ infixr 4 :&:
 
 -- | Unicode shorthand for 'Sigma'.
 type Σ (s :: Type) (t :: s ~> Type) = Sigma s t
--- We can't define defunctionalization symbols for this at the moment due
--- to #216
 
 -- | Project the first element out of a dependent pair.
 projSigma1 :: forall s t. SingKind s => Sigma s t -> Demote s
@@ -66,3 +70,5 @@ zipSigma :: Sing (f :: a ~> b ~> c)
          -> Sigma a p -> Sigma b q -> Sigma c r
 zipSigma f g ((a :: Sing (fstA :: a)) :&: p) ((b :: Sing (fstB :: b)) :&: q) =
   (f @@ a @@ b) :&: (g @fstA @fstB p q)
+
+$(genDefunSymbols [''Σ])

--- a/src/Data/Singletons/Single/Defun.hs
+++ b/src/Data/Singletons/Single/Defun.hs
@@ -142,11 +142,6 @@ singDefuns n ns ty_ctxt mb_ty_args mb_ty_res =
             tycon_inst_ty = DConT (mkTyConName sing_fun_num) `DAppT`
                             foldType (DConT n) tvb_tys
 
--- | Convert a 'DTyVarBndr' into a 'DType'.
-dTyVarBndrToDType :: DTyVarBndr -> DType
-dTyVarBndrToDType (DPlainTV a)    = DVarT a
-dTyVarBndrToDType (DKindedTV a k) = DVarT a `DSigT` k
-
 {-
 Note [singDefuns and type inference]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/Data/Singletons/Util.hs
+++ b/src/Data/Singletons/Util.hs
@@ -335,6 +335,10 @@ substKindInTvb :: Map Name DKind -> DTyVarBndr -> DTyVarBndr
 substKindInTvb _ tvb@(DPlainTV _) = tvb
 substKindInTvb subst (DKindedTV n ki) = DKindedTV n (substKind subst ki)
 
+cuskify :: DTyVarBndr -> DTyVarBndr
+cuskify (DPlainTV tvname) = DKindedTV tvname $ DConT typeKindName
+cuskify tvb               = tvb
+
 -- apply a type to a list of types
 foldType :: DType -> [DType] -> DType
 foldType = foldl DAppT

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -82,6 +82,7 @@ tests =
     , compileAndDumpStdTest "T200"
     , compileAndDumpStdTest "T206"
     , compileAndDumpStdTest "T209"
+    , compileAndDumpStdTest "T216"
     , compileAndDumpStdTest "T226"
     , compileAndDumpStdTest "T229"
     , compileAndDumpStdTest "T249"

--- a/tests/compile-and-dump/GradingClient/Database.ghc84.template
+++ b/tests/compile-and-dump/GradingClient/Database.ghc84.template
@@ -8,44 +8,49 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       = Zero | Succ Nat
       deriving (Eq, Ord)
     type ZeroSym0 = Zero
-    type SuccSym1 (t :: Nat) = Succ t
+    type SuccSym1 (t0123456789876543210 :: Nat) =
+        Succ t0123456789876543210
     instance SuppressUnusedWarnings SuccSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SuccSym0KindInference) GHC.Tuple.())
-    data SuccSym0 (l :: TyFun Nat Nat) :: Type
+    data SuccSym0 :: (~>) Nat Nat
       where
-        SuccSym0KindInference :: forall l arg.
-                                 SameKind (Apply SuccSym0 arg) (SuccSym1 arg) => SuccSym0 l
-    type instance Apply SuccSym0 l = Succ l
+        SuccSym0KindInference :: forall t0123456789876543210 arg.
+                                 SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
+                                 SuccSym0 t0123456789876543210
+    type instance Apply SuccSym0 t0123456789876543210 = Succ t0123456789876543210
     type family Compare_0123456789876543210 (a :: Nat) (a :: Nat) :: Ordering where
       Compare_0123456789876543210 Zero Zero = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) '[]
       Compare_0123456789876543210 (Succ a_0123456789876543210) (Succ b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) '[])
       Compare_0123456789876543210 Zero (Succ _) = LTSym0
       Compare_0123456789876543210 (Succ _) Zero = GTSym0
-    type Compare_0123456789876543210Sym2 (t :: Nat) (t :: Nat) =
-        Compare_0123456789876543210 t t
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym1 where
+    type Compare_0123456789876543210Sym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) =
+        Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym1 (l :: Nat) (l :: TyFun Nat Ordering) :: Type
+    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Nat) :: (~>) Nat Ordering
       where
-        Compare_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                        SameKind (Apply (Compare_0123456789876543210Sym1 l) arg) (Compare_0123456789876543210Sym2 l arg) =>
-                                                        Compare_0123456789876543210Sym1 l l
-    type instance Apply (Compare_0123456789876543210Sym1 l) l = Compare_0123456789876543210 l l
+        Compare_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                               a0123456789876543210
+                                                               arg.
+                                                        SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym0 (l :: TyFun Nat ((~>) Nat Ordering)) :: Type
+    data Compare_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Ordering)
       where
-        Compare_0123456789876543210Sym0KindInference :: forall l arg.
+        Compare_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                               arg.
                                                         SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 l
-    type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
+                                                        Compare_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
     instance POrd Nat where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type family Equals_0123456789876543210 (a :: Nat) (b :: Nat) :: Bool where
@@ -228,23 +233,28 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     type BOOLSym0 = BOOL
     type STRINGSym0 = STRING
     type NATSym0 = NAT
-    type VECSym2 (t :: U) (t :: Nat) = VEC t t
-    instance SuppressUnusedWarnings VECSym1 where
+    type VECSym2 (t0123456789876543210 :: U) (t0123456789876543210 :: Nat) =
+        VEC t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (VECSym1 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) VECSym1KindInference) GHC.Tuple.())
-    data VECSym1 (l :: U) (l :: TyFun Nat U) :: Type
+    data VECSym1 (t0123456789876543210 :: U) :: (~>) Nat U
       where
-        VECSym1KindInference :: forall l l arg.
-                                SameKind (Apply (VECSym1 l) arg) (VECSym2 l arg) => VECSym1 l l
-    type instance Apply (VECSym1 l) l = VEC l l
+        VECSym1KindInference :: forall t0123456789876543210
+                                       t0123456789876543210
+                                       arg.
+                                SameKind (Apply (VECSym1 t0123456789876543210) arg) (VECSym2 t0123456789876543210 arg) =>
+                                VECSym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (VECSym1 t0123456789876543210) t0123456789876543210 = VEC t0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings VECSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) VECSym0KindInference) GHC.Tuple.())
-    data VECSym0 (l :: TyFun U ((~>) Nat U)) :: Type
+    data VECSym0 :: (~>) U ((~>) Nat U)
       where
-        VECSym0KindInference :: forall l arg.
-                                SameKind (Apply VECSym0 arg) (VECSym1 arg) => VECSym0 l
-    type instance Apply VECSym0 l = VECSym1 l
+        VECSym0KindInference :: forall t0123456789876543210 arg.
+                                SameKind (Apply VECSym0 arg) (VECSym1 arg) =>
+                                VECSym0 t0123456789876543210
+    type instance Apply VECSym0 t0123456789876543210 = VECSym1 t0123456789876543210
     type CASym0 = CA
     type CBSym0 = CB
     type CCSym0 = CC
@@ -271,189 +281,214 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     type CXSym0 = CX
     type CYSym0 = CY
     type CZSym0 = CZ
-    type AttrSym2 (t :: [AChar]) (t :: U) = Attr t t
-    instance SuppressUnusedWarnings AttrSym1 where
+    type AttrSym2 (t0123456789876543210 :: [AChar]) (t0123456789876543210 :: U) =
+        Attr t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (AttrSym1 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) AttrSym1KindInference) GHC.Tuple.())
-    data AttrSym1 (l :: [AChar]) (l :: TyFun U Attribute) :: Type
+    data AttrSym1 (t0123456789876543210 :: [AChar]) :: (~>) U Attribute
       where
-        AttrSym1KindInference :: forall l l arg.
-                                 SameKind (Apply (AttrSym1 l) arg) (AttrSym2 l arg) => AttrSym1 l l
-    type instance Apply (AttrSym1 l) l = Attr l l
+        AttrSym1KindInference :: forall t0123456789876543210
+                                        t0123456789876543210
+                                        arg.
+                                 SameKind (Apply (AttrSym1 t0123456789876543210) arg) (AttrSym2 t0123456789876543210 arg) =>
+                                 AttrSym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (AttrSym1 t0123456789876543210) t0123456789876543210 = Attr t0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings AttrSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) AttrSym0KindInference) GHC.Tuple.())
-    data AttrSym0 (l :: TyFun [AChar] ((~>) U Attribute)) :: Type
+    data AttrSym0 :: (~>) [AChar] ((~>) U Attribute)
       where
-        AttrSym0KindInference :: forall l arg.
-                                 SameKind (Apply AttrSym0 arg) (AttrSym1 arg) => AttrSym0 l
-    type instance Apply AttrSym0 l = AttrSym1 l
-    type SchSym1 (t :: [Attribute]) = Sch t
+        AttrSym0KindInference :: forall t0123456789876543210 arg.
+                                 SameKind (Apply AttrSym0 arg) (AttrSym1 arg) =>
+                                 AttrSym0 t0123456789876543210
+    type instance Apply AttrSym0 t0123456789876543210 = AttrSym1 t0123456789876543210
+    type SchSym1 (t0123456789876543210 :: [Attribute]) =
+        Sch t0123456789876543210
     instance SuppressUnusedWarnings SchSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SchSym0KindInference) GHC.Tuple.())
-    data SchSym0 (l :: TyFun [Attribute] Schema) :: Type
+    data SchSym0 :: (~>) [Attribute] Schema
       where
-        SchSym0KindInference :: forall l arg.
-                                SameKind (Apply SchSym0 arg) (SchSym1 arg) => SchSym0 l
-    type instance Apply SchSym0 l = Sch l
-    type Let0123456789876543210Scrutinee_0123456789876543210Sym4 t t t t =
-        Let0123456789876543210Scrutinee_0123456789876543210 t t t t
-    instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym3 where
+        SchSym0KindInference :: forall t0123456789876543210 arg.
+                                SameKind (Apply SchSym0 arg) (SchSym1 arg) =>
+                                SchSym0 t0123456789876543210
+    type instance Apply SchSym0 t0123456789876543210 = Sch t0123456789876543210
+    type Let0123456789876543210Scrutinee_0123456789876543210Sym4 name0123456789876543210 name'0123456789876543210 u0123456789876543210 attrs0123456789876543210 =
+        Let0123456789876543210Scrutinee_0123456789876543210 name0123456789876543210 name'0123456789876543210 u0123456789876543210 attrs0123456789876543210
+    instance SuppressUnusedWarnings (Let0123456789876543210Scrutinee_0123456789876543210Sym3 u0123456789876543210 name'0123456789876543210 name0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210Scrutinee_0123456789876543210Sym3KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210Scrutinee_0123456789876543210Sym3 l l l l :: Type
+    data Let0123456789876543210Scrutinee_0123456789876543210Sym3 name0123456789876543210 name'0123456789876543210 u0123456789876543210 attrs0123456789876543210
       where
-        Let0123456789876543210Scrutinee_0123456789876543210Sym3KindInference :: forall l
-                                                                                       l
-                                                                                       l
-                                                                                       l
+        Let0123456789876543210Scrutinee_0123456789876543210Sym3KindInference :: forall name0123456789876543210
+                                                                                       name'0123456789876543210
+                                                                                       u0123456789876543210
+                                                                                       attrs0123456789876543210
                                                                                        arg.
-                                                                                SameKind (Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym3 l l l) arg) (Let0123456789876543210Scrutinee_0123456789876543210Sym4 l l l arg) =>
-                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym3 l l l l
-    type instance Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym3 l l l) l = Let0123456789876543210Scrutinee_0123456789876543210 l l l l
-    instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym2 where
+                                                                                SameKind (Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym3 name0123456789876543210 name'0123456789876543210 u0123456789876543210) arg) (Let0123456789876543210Scrutinee_0123456789876543210Sym4 name0123456789876543210 name'0123456789876543210 u0123456789876543210 arg) =>
+                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym3 name0123456789876543210 name'0123456789876543210 u0123456789876543210 attrs0123456789876543210
+    type instance Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym3 u0123456789876543210 name'0123456789876543210 name0123456789876543210) attrs0123456789876543210 = Let0123456789876543210Scrutinee_0123456789876543210 u0123456789876543210 name'0123456789876543210 name0123456789876543210 attrs0123456789876543210
+    instance SuppressUnusedWarnings (Let0123456789876543210Scrutinee_0123456789876543210Sym2 name'0123456789876543210 name0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210Scrutinee_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210Scrutinee_0123456789876543210Sym2 l l l :: Type
+    data Let0123456789876543210Scrutinee_0123456789876543210Sym2 name0123456789876543210 name'0123456789876543210 u0123456789876543210
       where
-        Let0123456789876543210Scrutinee_0123456789876543210Sym2KindInference :: forall l
-                                                                                       l
-                                                                                       l
+        Let0123456789876543210Scrutinee_0123456789876543210Sym2KindInference :: forall name0123456789876543210
+                                                                                       name'0123456789876543210
+                                                                                       u0123456789876543210
                                                                                        arg.
-                                                                                SameKind (Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym2 l l) arg) (Let0123456789876543210Scrutinee_0123456789876543210Sym3 l l arg) =>
-                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym2 l l l
-    type instance Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym2 l l) l = Let0123456789876543210Scrutinee_0123456789876543210Sym3 l l l
-    instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym1 where
+                                                                                SameKind (Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym2 name0123456789876543210 name'0123456789876543210) arg) (Let0123456789876543210Scrutinee_0123456789876543210Sym3 name0123456789876543210 name'0123456789876543210 arg) =>
+                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym2 name0123456789876543210 name'0123456789876543210 u0123456789876543210
+    type instance Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym2 name'0123456789876543210 name0123456789876543210) u0123456789876543210 = Let0123456789876543210Scrutinee_0123456789876543210Sym3 name'0123456789876543210 name0123456789876543210 u0123456789876543210
+    instance SuppressUnusedWarnings (Let0123456789876543210Scrutinee_0123456789876543210Sym1 name0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210Scrutinee_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210Scrutinee_0123456789876543210Sym1 l l :: Type
+    data Let0123456789876543210Scrutinee_0123456789876543210Sym1 name0123456789876543210 name'0123456789876543210
       where
-        Let0123456789876543210Scrutinee_0123456789876543210Sym1KindInference :: forall l
-                                                                                       l
+        Let0123456789876543210Scrutinee_0123456789876543210Sym1KindInference :: forall name0123456789876543210
+                                                                                       name'0123456789876543210
                                                                                        arg.
-                                                                                SameKind (Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym1 l) arg) (Let0123456789876543210Scrutinee_0123456789876543210Sym2 l arg) =>
-                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym1 l l
-    type instance Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym1 l) l = Let0123456789876543210Scrutinee_0123456789876543210Sym2 l l
+                                                                                SameKind (Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym1 name0123456789876543210) arg) (Let0123456789876543210Scrutinee_0123456789876543210Sym2 name0123456789876543210 arg) =>
+                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym1 name0123456789876543210 name'0123456789876543210
+    type instance Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym1 name0123456789876543210) name'0123456789876543210 = Let0123456789876543210Scrutinee_0123456789876543210Sym2 name0123456789876543210 name'0123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210Scrutinee_0123456789876543210Sym0 l :: Type
+    data Let0123456789876543210Scrutinee_0123456789876543210Sym0 name0123456789876543210
       where
-        Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference :: forall l
+        Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference :: forall name0123456789876543210
                                                                                        arg.
                                                                                 SameKind (Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 arg) (Let0123456789876543210Scrutinee_0123456789876543210Sym1 arg) =>
-                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym0 l
-    type instance Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 l = Let0123456789876543210Scrutinee_0123456789876543210Sym1 l
+                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym0 name0123456789876543210
+    type instance Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 name0123456789876543210 = Let0123456789876543210Scrutinee_0123456789876543210Sym1 name0123456789876543210
     type family Let0123456789876543210Scrutinee_0123456789876543210 name name' u attrs where
       Let0123456789876543210Scrutinee_0123456789876543210 name name' u attrs = Apply (Apply (==@#@$) name) name'
     type family Case_0123456789876543210 name name' u attrs t where
       Case_0123456789876543210 name name' u attrs True = u
       Case_0123456789876543210 name name' u attrs False = Apply (Apply LookupSym0 name) (Apply SchSym0 attrs)
-    type LookupSym2 (t :: [AChar]) (t :: Schema) = Lookup t t
-    instance SuppressUnusedWarnings LookupSym1 where
+    type LookupSym2 (a0123456789876543210 :: [AChar]) (a0123456789876543210 :: Schema) =
+        Lookup a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (LookupSym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) LookupSym1KindInference) GHC.Tuple.())
-    data LookupSym1 (l :: [AChar]) (l :: TyFun Schema U) :: Type
+    data LookupSym1 (a0123456789876543210 :: [AChar]) :: (~>) Schema U
       where
-        LookupSym1KindInference :: forall l l arg.
-                                   SameKind (Apply (LookupSym1 l) arg) (LookupSym2 l arg) =>
-                                   LookupSym1 l l
-    type instance Apply (LookupSym1 l) l = Lookup l l
+        LookupSym1KindInference :: forall a0123456789876543210
+                                          a0123456789876543210
+                                          arg.
+                                   SameKind (Apply (LookupSym1 a0123456789876543210) arg) (LookupSym2 a0123456789876543210 arg) =>
+                                   LookupSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (LookupSym1 a0123456789876543210) a0123456789876543210 = Lookup a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings LookupSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) LookupSym0KindInference) GHC.Tuple.())
-    data LookupSym0 (l :: TyFun [AChar] ((~>) Schema U)) :: Type
+    data LookupSym0 :: (~>) [AChar] ((~>) Schema U)
       where
-        LookupSym0KindInference :: forall l arg.
-                                   SameKind (Apply LookupSym0 arg) (LookupSym1 arg) => LookupSym0 l
-    type instance Apply LookupSym0 l = LookupSym1 l
-    type OccursSym2 (t :: [AChar]) (t :: Schema) = Occurs t t
-    instance SuppressUnusedWarnings OccursSym1 where
+        LookupSym0KindInference :: forall a0123456789876543210 arg.
+                                   SameKind (Apply LookupSym0 arg) (LookupSym1 arg) =>
+                                   LookupSym0 a0123456789876543210
+    type instance Apply LookupSym0 a0123456789876543210 = LookupSym1 a0123456789876543210
+    type OccursSym2 (a0123456789876543210 :: [AChar]) (a0123456789876543210 :: Schema) =
+        Occurs a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (OccursSym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) OccursSym1KindInference) GHC.Tuple.())
-    data OccursSym1 (l :: [AChar]) (l :: TyFun Schema Bool) :: Type
+    data OccursSym1 (a0123456789876543210 :: [AChar]) :: (~>) Schema Bool
       where
-        OccursSym1KindInference :: forall l l arg.
-                                   SameKind (Apply (OccursSym1 l) arg) (OccursSym2 l arg) =>
-                                   OccursSym1 l l
-    type instance Apply (OccursSym1 l) l = Occurs l l
+        OccursSym1KindInference :: forall a0123456789876543210
+                                          a0123456789876543210
+                                          arg.
+                                   SameKind (Apply (OccursSym1 a0123456789876543210) arg) (OccursSym2 a0123456789876543210 arg) =>
+                                   OccursSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (OccursSym1 a0123456789876543210) a0123456789876543210 = Occurs a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings OccursSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) OccursSym0KindInference) GHC.Tuple.())
-    data OccursSym0 (l :: TyFun [AChar] ((~>) Schema Bool)) :: Type
+    data OccursSym0 :: (~>) [AChar] ((~>) Schema Bool)
       where
-        OccursSym0KindInference :: forall l arg.
-                                   SameKind (Apply OccursSym0 arg) (OccursSym1 arg) => OccursSym0 l
-    type instance Apply OccursSym0 l = OccursSym1 l
-    type AttrNotInSym2 (t :: Attribute) (t :: Schema) = AttrNotIn t t
-    instance SuppressUnusedWarnings AttrNotInSym1 where
+        OccursSym0KindInference :: forall a0123456789876543210 arg.
+                                   SameKind (Apply OccursSym0 arg) (OccursSym1 arg) =>
+                                   OccursSym0 a0123456789876543210
+    type instance Apply OccursSym0 a0123456789876543210 = OccursSym1 a0123456789876543210
+    type AttrNotInSym2 (a0123456789876543210 :: Attribute) (a0123456789876543210 :: Schema) =
+        AttrNotIn a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (AttrNotInSym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) AttrNotInSym1KindInference) GHC.Tuple.())
-    data AttrNotInSym1 (l :: Attribute) (l :: TyFun Schema Bool) :: Type
+    data AttrNotInSym1 (a0123456789876543210 :: Attribute) :: (~>) Schema Bool
       where
-        AttrNotInSym1KindInference :: forall l l arg.
-                                      SameKind (Apply (AttrNotInSym1 l) arg) (AttrNotInSym2 l arg) =>
-                                      AttrNotInSym1 l l
-    type instance Apply (AttrNotInSym1 l) l = AttrNotIn l l
+        AttrNotInSym1KindInference :: forall a0123456789876543210
+                                             a0123456789876543210
+                                             arg.
+                                      SameKind (Apply (AttrNotInSym1 a0123456789876543210) arg) (AttrNotInSym2 a0123456789876543210 arg) =>
+                                      AttrNotInSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (AttrNotInSym1 a0123456789876543210) a0123456789876543210 = AttrNotIn a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings AttrNotInSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) AttrNotInSym0KindInference) GHC.Tuple.())
-    data AttrNotInSym0 (l :: TyFun Attribute ((~>) Schema Bool)) :: Type
+    data AttrNotInSym0 :: (~>) Attribute ((~>) Schema Bool)
       where
-        AttrNotInSym0KindInference :: forall l arg.
+        AttrNotInSym0KindInference :: forall a0123456789876543210 arg.
                                       SameKind (Apply AttrNotInSym0 arg) (AttrNotInSym1 arg) =>
-                                      AttrNotInSym0 l
-    type instance Apply AttrNotInSym0 l = AttrNotInSym1 l
-    type DisjointSym2 (t :: Schema) (t :: Schema) = Disjoint t t
-    instance SuppressUnusedWarnings DisjointSym1 where
+                                      AttrNotInSym0 a0123456789876543210
+    type instance Apply AttrNotInSym0 a0123456789876543210 = AttrNotInSym1 a0123456789876543210
+    type DisjointSym2 (a0123456789876543210 :: Schema) (a0123456789876543210 :: Schema) =
+        Disjoint a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (DisjointSym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) DisjointSym1KindInference) GHC.Tuple.())
-    data DisjointSym1 (l :: Schema) (l :: TyFun Schema Bool) :: Type
+    data DisjointSym1 (a0123456789876543210 :: Schema) :: (~>) Schema Bool
       where
-        DisjointSym1KindInference :: forall l l arg.
-                                     SameKind (Apply (DisjointSym1 l) arg) (DisjointSym2 l arg) =>
-                                     DisjointSym1 l l
-    type instance Apply (DisjointSym1 l) l = Disjoint l l
+        DisjointSym1KindInference :: forall a0123456789876543210
+                                            a0123456789876543210
+                                            arg.
+                                     SameKind (Apply (DisjointSym1 a0123456789876543210) arg) (DisjointSym2 a0123456789876543210 arg) =>
+                                     DisjointSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (DisjointSym1 a0123456789876543210) a0123456789876543210 = Disjoint a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings DisjointSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) DisjointSym0KindInference) GHC.Tuple.())
-    data DisjointSym0 (l :: TyFun Schema ((~>) Schema Bool)) :: Type
+    data DisjointSym0 :: (~>) Schema ((~>) Schema Bool)
       where
-        DisjointSym0KindInference :: forall l arg.
+        DisjointSym0KindInference :: forall a0123456789876543210 arg.
                                      SameKind (Apply DisjointSym0 arg) (DisjointSym1 arg) =>
-                                     DisjointSym0 l
-    type instance Apply DisjointSym0 l = DisjointSym1 l
-    type AppendSym2 (t :: Schema) (t :: Schema) = Append t t
-    instance SuppressUnusedWarnings AppendSym1 where
+                                     DisjointSym0 a0123456789876543210
+    type instance Apply DisjointSym0 a0123456789876543210 = DisjointSym1 a0123456789876543210
+    type AppendSym2 (a0123456789876543210 :: Schema) (a0123456789876543210 :: Schema) =
+        Append a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (AppendSym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) AppendSym1KindInference) GHC.Tuple.())
-    data AppendSym1 (l :: Schema) (l :: TyFun Schema Schema) :: Type
+    data AppendSym1 (a0123456789876543210 :: Schema) :: (~>) Schema Schema
       where
-        AppendSym1KindInference :: forall l l arg.
-                                   SameKind (Apply (AppendSym1 l) arg) (AppendSym2 l arg) =>
-                                   AppendSym1 l l
-    type instance Apply (AppendSym1 l) l = Append l l
+        AppendSym1KindInference :: forall a0123456789876543210
+                                          a0123456789876543210
+                                          arg.
+                                   SameKind (Apply (AppendSym1 a0123456789876543210) arg) (AppendSym2 a0123456789876543210 arg) =>
+                                   AppendSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (AppendSym1 a0123456789876543210) a0123456789876543210 = Append a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings AppendSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) AppendSym0KindInference) GHC.Tuple.())
-    data AppendSym0 (l :: TyFun Schema ((~>) Schema Schema)) :: Type
+    data AppendSym0 :: (~>) Schema ((~>) Schema Schema)
       where
-        AppendSym0KindInference :: forall l arg.
-                                   SameKind (Apply AppendSym0 arg) (AppendSym1 arg) => AppendSym0 l
-    type instance Apply AppendSym0 l = AppendSym1 l
+        AppendSym0KindInference :: forall a0123456789876543210 arg.
+                                   SameKind (Apply AppendSym0 arg) (AppendSym1 arg) =>
+                                   AppendSym0 a0123456789876543210
+    type instance Apply AppendSym0 a0123456789876543210 = AppendSym1 a0123456789876543210
     type family Lookup (a :: [AChar]) (a :: Schema) :: U where
       Lookup _ (Sch '[]) = UndefinedSym0
       Lookup name (Sch ((:) (Attr name' u) attrs)) = Case_0123456789876543210 name name' u attrs (Let0123456789876543210Scrutinee_0123456789876543210Sym4 name name' u attrs)
@@ -473,41 +508,47 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       ShowsPrec_0123456789876543210 _ STRING a_0123456789876543210 = Apply (Apply ShowStringSym0 "STRING") a_0123456789876543210
       ShowsPrec_0123456789876543210 _ NAT a_0123456789876543210 = Apply (Apply ShowStringSym0 "NAT") a_0123456789876543210
       ShowsPrec_0123456789876543210 p_0123456789876543210 (VEC arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "VEC ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: U) (t :: Symbol) =
-        ShowsPrec_0123456789876543210 t t t
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+    type ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: U) (a0123456789876543210 :: Symbol) =
+        ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym2 (l :: GHC.Types.Nat) (l :: U) (l :: TyFun Symbol Symbol) :: Type
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: U) :: (~>) Symbol Symbol
       where
-        ShowsPrec_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 l l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+        ShowsPrec_0123456789876543210Sym2KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun U ((~>) Symbol Symbol)) :: Type
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: (~>) U ((~>) Symbol Symbol)
       where
-        ShowsPrec_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+        ShowsPrec_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) U ((~>) Symbol Symbol))) :: Type
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) U ((~>) Symbol Symbol))
       where
-        ShowsPrec_0123456789876543210Sym0KindInference :: forall l arg.
+        ShowsPrec_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                 arg.
                                                           SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 l
-    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
     instance PShow U where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: AChar) (a :: Symbol) :: Symbol where
@@ -537,41 +578,47 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       ShowsPrec_0123456789876543210 _ CX a_0123456789876543210 = Apply (Apply ShowStringSym0 "CX") a_0123456789876543210
       ShowsPrec_0123456789876543210 _ CY a_0123456789876543210 = Apply (Apply ShowStringSym0 "CY") a_0123456789876543210
       ShowsPrec_0123456789876543210 _ CZ a_0123456789876543210 = Apply (Apply ShowStringSym0 "CZ") a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: AChar) (t :: Symbol) =
-        ShowsPrec_0123456789876543210 t t t
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+    type ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: AChar) (a0123456789876543210 :: Symbol) =
+        ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym2 (l :: GHC.Types.Nat) (l :: AChar) (l :: TyFun Symbol Symbol) :: Type
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: AChar) :: (~>) Symbol Symbol
       where
-        ShowsPrec_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 l l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+        ShowsPrec_0123456789876543210Sym2KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun AChar ((~>) Symbol Symbol)) :: Type
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: (~>) AChar ((~>) Symbol Symbol)
       where
-        ShowsPrec_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+        ShowsPrec_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) AChar ((~>) Symbol Symbol))) :: Type
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) AChar ((~>) Symbol Symbol))
       where
-        ShowsPrec_0123456789876543210Sym0KindInference :: forall l arg.
+        ShowsPrec_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                 arg.
                                                           SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 l
-    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
     instance PShow AChar where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type family Equals_0123456789876543210 (a :: U) (b :: U) :: Bool where

--- a/tests/compile-and-dump/InsertionSort/InsertionSortImp.ghc84.template
+++ b/tests/compile-and-dump/InsertionSort/InsertionSortImp.ghc84.template
@@ -3,15 +3,17 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
   ======>
     data Nat = Zero | Succ Nat
     type ZeroSym0 = Zero
-    type SuccSym1 (t :: Nat) = Succ t
+    type SuccSym1 (t0123456789876543210 :: Nat) =
+        Succ t0123456789876543210
     instance SuppressUnusedWarnings SuccSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SuccSym0KindInference) GHC.Tuple.())
-    data SuccSym0 (l :: TyFun Nat Nat) :: Type
+    data SuccSym0 :: (~>) Nat Nat
       where
-        SuccSym0KindInference :: forall l arg.
-                                 SameKind (Apply SuccSym0 arg) (SuccSym1 arg) => SuccSym0 l
-    type instance Apply SuccSym0 l = Succ l
+        SuccSym0KindInference :: forall t0123456789876543210 arg.
+                                 SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
+                                 SuccSym0 t0123456789876543210
+    type instance Apply SuccSym0 t0123456789876543210 = Succ t0123456789876543210
     data instance Sing :: Nat -> Type :: Nat -> Type
       where
         SZero :: Sing Zero
@@ -61,100 +63,110 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
     insertionSort :: [Nat] -> [Nat]
     insertionSort GHC.Types.[] = []
     insertionSort (h GHC.Types.: t) = (insert h) (insertionSort t)
-    type Let0123456789876543210Scrutinee_0123456789876543210Sym3 t t t =
-        Let0123456789876543210Scrutinee_0123456789876543210 t t t
-    instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym2 where
+    type Let0123456789876543210Scrutinee_0123456789876543210Sym3 n0123456789876543210 h0123456789876543210 t0123456789876543210 =
+        Let0123456789876543210Scrutinee_0123456789876543210 n0123456789876543210 h0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Let0123456789876543210Scrutinee_0123456789876543210Sym2 h0123456789876543210 n0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210Scrutinee_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210Scrutinee_0123456789876543210Sym2 l l l :: Type
+    data Let0123456789876543210Scrutinee_0123456789876543210Sym2 n0123456789876543210 h0123456789876543210 t0123456789876543210
       where
-        Let0123456789876543210Scrutinee_0123456789876543210Sym2KindInference :: forall l
-                                                                                       l
-                                                                                       l
+        Let0123456789876543210Scrutinee_0123456789876543210Sym2KindInference :: forall n0123456789876543210
+                                                                                       h0123456789876543210
+                                                                                       t0123456789876543210
                                                                                        arg.
-                                                                                SameKind (Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym2 l l) arg) (Let0123456789876543210Scrutinee_0123456789876543210Sym3 l l arg) =>
-                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym2 l l l
-    type instance Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym2 l l) l = Let0123456789876543210Scrutinee_0123456789876543210 l l l
-    instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym1 where
+                                                                                SameKind (Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym2 n0123456789876543210 h0123456789876543210) arg) (Let0123456789876543210Scrutinee_0123456789876543210Sym3 n0123456789876543210 h0123456789876543210 arg) =>
+                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym2 n0123456789876543210 h0123456789876543210 t0123456789876543210
+    type instance Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym2 h0123456789876543210 n0123456789876543210) t0123456789876543210 = Let0123456789876543210Scrutinee_0123456789876543210 h0123456789876543210 n0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Let0123456789876543210Scrutinee_0123456789876543210Sym1 n0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210Scrutinee_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210Scrutinee_0123456789876543210Sym1 l l :: Type
+    data Let0123456789876543210Scrutinee_0123456789876543210Sym1 n0123456789876543210 h0123456789876543210
       where
-        Let0123456789876543210Scrutinee_0123456789876543210Sym1KindInference :: forall l
-                                                                                       l
+        Let0123456789876543210Scrutinee_0123456789876543210Sym1KindInference :: forall n0123456789876543210
+                                                                                       h0123456789876543210
                                                                                        arg.
-                                                                                SameKind (Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym1 l) arg) (Let0123456789876543210Scrutinee_0123456789876543210Sym2 l arg) =>
-                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym1 l l
-    type instance Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym1 l) l = Let0123456789876543210Scrutinee_0123456789876543210Sym2 l l
+                                                                                SameKind (Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym1 n0123456789876543210) arg) (Let0123456789876543210Scrutinee_0123456789876543210Sym2 n0123456789876543210 arg) =>
+                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym1 n0123456789876543210 h0123456789876543210
+    type instance Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym1 n0123456789876543210) h0123456789876543210 = Let0123456789876543210Scrutinee_0123456789876543210Sym2 n0123456789876543210 h0123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210Scrutinee_0123456789876543210Sym0 l :: Type
+    data Let0123456789876543210Scrutinee_0123456789876543210Sym0 n0123456789876543210
       where
-        Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference :: forall l
+        Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference :: forall n0123456789876543210
                                                                                        arg.
                                                                                 SameKind (Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 arg) (Let0123456789876543210Scrutinee_0123456789876543210Sym1 arg) =>
-                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym0 l
-    type instance Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 l = Let0123456789876543210Scrutinee_0123456789876543210Sym1 l
+                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym0 n0123456789876543210
+    type instance Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 n0123456789876543210 = Let0123456789876543210Scrutinee_0123456789876543210Sym1 n0123456789876543210
     type family Let0123456789876543210Scrutinee_0123456789876543210 n h t where
       Let0123456789876543210Scrutinee_0123456789876543210 n h t = Apply (Apply LeqSym0 n) h
     type family Case_0123456789876543210 n h t t where
       Case_0123456789876543210 n h t True = Apply (Apply (:@#@$) n) (Apply (Apply (:@#@$) h) t)
       Case_0123456789876543210 n h t False = Apply (Apply (:@#@$) h) (Apply (Apply InsertSym0 n) t)
-    type LeqSym2 (t :: Nat) (t :: Nat) = Leq t t
-    instance SuppressUnusedWarnings LeqSym1 where
+    type LeqSym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) =
+        Leq a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (LeqSym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) LeqSym1KindInference) GHC.Tuple.())
-    data LeqSym1 (l :: Nat) (l :: TyFun Nat Bool) :: Type
+    data LeqSym1 (a0123456789876543210 :: Nat) :: (~>) Nat Bool
       where
-        LeqSym1KindInference :: forall l l arg.
-                                SameKind (Apply (LeqSym1 l) arg) (LeqSym2 l arg) => LeqSym1 l l
-    type instance Apply (LeqSym1 l) l = Leq l l
+        LeqSym1KindInference :: forall a0123456789876543210
+                                       a0123456789876543210
+                                       arg.
+                                SameKind (Apply (LeqSym1 a0123456789876543210) arg) (LeqSym2 a0123456789876543210 arg) =>
+                                LeqSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (LeqSym1 a0123456789876543210) a0123456789876543210 = Leq a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings LeqSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) LeqSym0KindInference) GHC.Tuple.())
-    data LeqSym0 (l :: TyFun Nat ((~>) Nat Bool)) :: Type
+    data LeqSym0 :: (~>) Nat ((~>) Nat Bool)
       where
-        LeqSym0KindInference :: forall l arg.
-                                SameKind (Apply LeqSym0 arg) (LeqSym1 arg) => LeqSym0 l
-    type instance Apply LeqSym0 l = LeqSym1 l
-    type InsertSym2 (t :: Nat) (t :: [Nat]) = Insert t t
-    instance SuppressUnusedWarnings InsertSym1 where
+        LeqSym0KindInference :: forall a0123456789876543210 arg.
+                                SameKind (Apply LeqSym0 arg) (LeqSym1 arg) =>
+                                LeqSym0 a0123456789876543210
+    type instance Apply LeqSym0 a0123456789876543210 = LeqSym1 a0123456789876543210
+    type InsertSym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: [Nat]) =
+        Insert a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (InsertSym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) InsertSym1KindInference) GHC.Tuple.())
-    data InsertSym1 (l :: Nat) (l :: TyFun [Nat] [Nat]) :: Type
+    data InsertSym1 (a0123456789876543210 :: Nat) :: (~>) [Nat] [Nat]
       where
-        InsertSym1KindInference :: forall l l arg.
-                                   SameKind (Apply (InsertSym1 l) arg) (InsertSym2 l arg) =>
-                                   InsertSym1 l l
-    type instance Apply (InsertSym1 l) l = Insert l l
+        InsertSym1KindInference :: forall a0123456789876543210
+                                          a0123456789876543210
+                                          arg.
+                                   SameKind (Apply (InsertSym1 a0123456789876543210) arg) (InsertSym2 a0123456789876543210 arg) =>
+                                   InsertSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (InsertSym1 a0123456789876543210) a0123456789876543210 = Insert a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings InsertSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) InsertSym0KindInference) GHC.Tuple.())
-    data InsertSym0 (l :: TyFun Nat ((~>) [Nat] [Nat])) :: Type
+    data InsertSym0 :: (~>) Nat ((~>) [Nat] [Nat])
       where
-        InsertSym0KindInference :: forall l arg.
-                                   SameKind (Apply InsertSym0 arg) (InsertSym1 arg) => InsertSym0 l
-    type instance Apply InsertSym0 l = InsertSym1 l
-    type InsertionSortSym1 (t :: [Nat]) = InsertionSort t
+        InsertSym0KindInference :: forall a0123456789876543210 arg.
+                                   SameKind (Apply InsertSym0 arg) (InsertSym1 arg) =>
+                                   InsertSym0 a0123456789876543210
+    type instance Apply InsertSym0 a0123456789876543210 = InsertSym1 a0123456789876543210
+    type InsertionSortSym1 (a0123456789876543210 :: [Nat]) =
+        InsertionSort a0123456789876543210
     instance SuppressUnusedWarnings InsertionSortSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) InsertionSortSym0KindInference) GHC.Tuple.())
-    data InsertionSortSym0 (l :: TyFun [Nat] [Nat]) :: Type
+    data InsertionSortSym0 :: (~>) [Nat] [Nat]
       where
-        InsertionSortSym0KindInference :: forall l arg.
+        InsertionSortSym0KindInference :: forall a0123456789876543210 arg.
                                           SameKind (Apply InsertionSortSym0 arg) (InsertionSortSym1 arg) =>
-                                          InsertionSortSym0 l
-    type instance Apply InsertionSortSym0 l = InsertionSort l
+                                          InsertionSortSym0 a0123456789876543210
+    type instance Apply InsertionSortSym0 a0123456789876543210 = InsertionSort a0123456789876543210
     type family Leq (a :: Nat) (a :: Nat) :: Bool where
       Leq Zero _ = TrueSym0
       Leq (Succ _) Zero = FalseSym0

--- a/tests/compile-and-dump/Promote/Constructors.ghc84.template
+++ b/tests/compile-and-dump/Promote/Constructors.ghc84.template
@@ -6,66 +6,86 @@ Promote/Constructors.hs:(0,0)-(0,0): Splicing declarations
     data Foo = Foo | Foo :+ Foo
     data Bar = Bar Bar Bar Bar Bar Foo
     type FooSym0 = Foo
-    type (:+@#@$$$) (t :: Foo) (t :: Foo) = (:+) t t
-    instance SuppressUnusedWarnings (:+@#@$$) where
+    type (:+@#@$$$) (t0123456789876543210 :: Foo) (t0123456789876543210 :: Foo) =
+        (:+) t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings ((:+@#@$$) t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::+@#@$$###)) GHC.Tuple.())
-    data (:+@#@$$) (l :: Foo) (l :: TyFun Foo Foo) :: GHC.Types.Type
+    data (:+@#@$$) (t0123456789876543210 :: Foo) :: (~>) Foo Foo
       where
-        (::+@#@$$###) :: forall l l arg.
-                         SameKind (Apply ((:+@#@$$) l) arg) ((:+@#@$$$) l arg) =>
-                         (:+@#@$$) l l
-    type instance Apply ((:+@#@$$) l) l = (:+) l l
+        (::+@#@$$###) :: forall t0123456789876543210
+                                t0123456789876543210
+                                arg.
+                         SameKind (Apply ((:+@#@$$) t0123456789876543210) arg) ((:+@#@$$$) t0123456789876543210 arg) =>
+                         (:+@#@$$) t0123456789876543210 t0123456789876543210
+    type instance Apply ((:+@#@$$) t0123456789876543210) t0123456789876543210 = (:+) t0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings (:+@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::+@#@$###)) GHC.Tuple.())
-    data (:+@#@$) (l :: TyFun Foo ((~>) Foo Foo)) :: GHC.Types.Type
+    data :+@#@$ :: (~>) Foo ((~>) Foo Foo)
       where
-        (::+@#@$###) :: forall l arg.
-                        SameKind (Apply (:+@#@$) arg) ((:+@#@$$) arg) => (:+@#@$) l
-    type instance Apply (:+@#@$) l = (:+@#@$$) l
-    type BarSym5 (t :: Bar) (t :: Bar) (t :: Bar) (t :: Bar) (t :: Foo) =
-        Bar t t t t t
-    instance SuppressUnusedWarnings BarSym4 where
+        (::+@#@$###) :: forall t0123456789876543210 arg.
+                        SameKind (Apply (:+@#@$) arg) ((:+@#@$$) arg) =>
+                        (:+@#@$) t0123456789876543210
+    type instance Apply (:+@#@$) t0123456789876543210 = (:+@#@$$) t0123456789876543210
+    type BarSym5 (t0123456789876543210 :: Bar) (t0123456789876543210 :: Bar) (t0123456789876543210 :: Bar) (t0123456789876543210 :: Bar) (t0123456789876543210 :: Foo) =
+        Bar t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (BarSym4 t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BarSym4KindInference) GHC.Tuple.())
-    data BarSym4 (l :: Bar) (l :: Bar) (l :: Bar) (l :: Bar) (l :: TyFun Foo Bar) :: GHC.Types.Type
+    data BarSym4 (t0123456789876543210 :: Bar) (t0123456789876543210 :: Bar) (t0123456789876543210 :: Bar) (t0123456789876543210 :: Bar) :: (~>) Foo Bar
       where
-        BarSym4KindInference :: forall l l l l l arg.
-                                SameKind (Apply (BarSym4 l l l l) arg) (BarSym5 l l l l arg) =>
-                                BarSym4 l l l l l
-    type instance Apply (BarSym4 l l l l) l = Bar l l l l l
-    instance SuppressUnusedWarnings BarSym3 where
+        BarSym4KindInference :: forall t0123456789876543210
+                                       t0123456789876543210
+                                       t0123456789876543210
+                                       t0123456789876543210
+                                       t0123456789876543210
+                                       arg.
+                                SameKind (Apply (BarSym4 t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210) arg) (BarSym5 t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210 arg) =>
+                                BarSym4 t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    type instance Apply (BarSym4 t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210) t0123456789876543210 = Bar t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (BarSym3 t0123456789876543210 t0123456789876543210 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BarSym3KindInference) GHC.Tuple.())
-    data BarSym3 (l :: Bar) (l :: Bar) (l :: Bar) (l :: TyFun Bar ((~>) Foo Bar)) :: GHC.Types.Type
+    data BarSym3 (t0123456789876543210 :: Bar) (t0123456789876543210 :: Bar) (t0123456789876543210 :: Bar) :: (~>) Bar ((~>) Foo Bar)
       where
-        BarSym3KindInference :: forall l l l l arg.
-                                SameKind (Apply (BarSym3 l l l) arg) (BarSym4 l l l arg) =>
-                                BarSym3 l l l l
-    type instance Apply (BarSym3 l l l) l = BarSym4 l l l l
-    instance SuppressUnusedWarnings BarSym2 where
+        BarSym3KindInference :: forall t0123456789876543210
+                                       t0123456789876543210
+                                       t0123456789876543210
+                                       t0123456789876543210
+                                       arg.
+                                SameKind (Apply (BarSym3 t0123456789876543210 t0123456789876543210 t0123456789876543210) arg) (BarSym4 t0123456789876543210 t0123456789876543210 t0123456789876543210 arg) =>
+                                BarSym3 t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    type instance Apply (BarSym3 t0123456789876543210 t0123456789876543210 t0123456789876543210) t0123456789876543210 = BarSym4 t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (BarSym2 t0123456789876543210 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BarSym2KindInference) GHC.Tuple.())
-    data BarSym2 (l :: Bar) (l :: Bar) (l :: TyFun Bar ((~>) Bar ((~>) Foo Bar))) :: GHC.Types.Type
+    data BarSym2 (t0123456789876543210 :: Bar) (t0123456789876543210 :: Bar) :: (~>) Bar ((~>) Bar ((~>) Foo Bar))
       where
-        BarSym2KindInference :: forall l l l arg.
-                                SameKind (Apply (BarSym2 l l) arg) (BarSym3 l l arg) =>
-                                BarSym2 l l l
-    type instance Apply (BarSym2 l l) l = BarSym3 l l l
-    instance SuppressUnusedWarnings BarSym1 where
+        BarSym2KindInference :: forall t0123456789876543210
+                                       t0123456789876543210
+                                       t0123456789876543210
+                                       arg.
+                                SameKind (Apply (BarSym2 t0123456789876543210 t0123456789876543210) arg) (BarSym3 t0123456789876543210 t0123456789876543210 arg) =>
+                                BarSym2 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    type instance Apply (BarSym2 t0123456789876543210 t0123456789876543210) t0123456789876543210 = BarSym3 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (BarSym1 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BarSym1KindInference) GHC.Tuple.())
-    data BarSym1 (l :: Bar) (l :: TyFun Bar ((~>) Bar ((~>) Bar ((~>) Foo Bar)))) :: GHC.Types.Type
+    data BarSym1 (t0123456789876543210 :: Bar) :: (~>) Bar ((~>) Bar ((~>) Bar ((~>) Foo Bar)))
       where
-        BarSym1KindInference :: forall l l arg.
-                                SameKind (Apply (BarSym1 l) arg) (BarSym2 l arg) => BarSym1 l l
-    type instance Apply (BarSym1 l) l = BarSym2 l l
+        BarSym1KindInference :: forall t0123456789876543210
+                                       t0123456789876543210
+                                       arg.
+                                SameKind (Apply (BarSym1 t0123456789876543210) arg) (BarSym2 t0123456789876543210 arg) =>
+                                BarSym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (BarSym1 t0123456789876543210) t0123456789876543210 = BarSym2 t0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings BarSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BarSym0KindInference) GHC.Tuple.())
-    data BarSym0 (l :: TyFun Bar ((~>) Bar ((~>) Bar ((~>) Bar ((~>) Foo Bar))))) :: GHC.Types.Type
+    data BarSym0 :: (~>) Bar ((~>) Bar ((~>) Bar ((~>) Bar ((~>) Foo Bar))))
       where
-        BarSym0KindInference :: forall l arg.
-                                SameKind (Apply BarSym0 arg) (BarSym1 arg) => BarSym0 l
-    type instance Apply BarSym0 l = BarSym1 l
+        BarSym0KindInference :: forall t0123456789876543210 arg.
+                                SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
+                                BarSym0 t0123456789876543210
+    type instance Apply BarSym0 t0123456789876543210 = BarSym1 t0123456789876543210

--- a/tests/compile-and-dump/Promote/GenDefunSymbols.ghc84.template
+++ b/tests/compile-and-dump/Promote/GenDefunSymbols.ghc84.template
@@ -1,53 +1,61 @@
 Promote/GenDefunSymbols.hs:0:0:: Splicing declarations
     genDefunSymbols [''LiftMaybe, ''NatT, ''(:+)]
   ======>
-    type LiftMaybeSym2 (t :: (~>) a0123456789876543210 b0123456789876543210) (t :: Maybe a0123456789876543210) =
-        LiftMaybe t t
-    instance SuppressUnusedWarnings LiftMaybeSym1 where
+    type LiftMaybeSym2 (f0123456789876543210 :: (~>) a0123456789876543210 b0123456789876543210) (x0123456789876543210 :: Maybe a0123456789876543210) =
+        LiftMaybe f0123456789876543210 x0123456789876543210
+    instance SuppressUnusedWarnings (LiftMaybeSym1 f0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) LiftMaybeSym1KindInference) GHC.Tuple.())
-    data LiftMaybeSym1 (l :: (~>) a0123456789876543210 b0123456789876543210) (l :: Data.Singletons.Internal.TyFun (Maybe a0123456789876543210) (Maybe b0123456789876543210)) :: Type
+    data LiftMaybeSym1 (f0123456789876543210 :: (~>) a0123456789876543210 b0123456789876543210) :: (~>) (Maybe a0123456789876543210) (Maybe b0123456789876543210)
       where
-        LiftMaybeSym1KindInference :: forall l l arg.
-                                      Data.Singletons.Internal.SameKind (Apply (LiftMaybeSym1 l) arg) (LiftMaybeSym2 l arg) =>
-                                      LiftMaybeSym1 l l
-    type instance Apply (LiftMaybeSym1 l) l = LiftMaybe l l
+        LiftMaybeSym1KindInference :: forall f0123456789876543210
+                                             x0123456789876543210
+                                             arg.
+                                      Data.Singletons.Internal.SameKind (Apply (LiftMaybeSym1 f0123456789876543210) arg) (LiftMaybeSym2 f0123456789876543210 arg) =>
+                                      LiftMaybeSym1 f0123456789876543210 x0123456789876543210
+    type instance Apply (LiftMaybeSym1 f0123456789876543210) x0123456789876543210 = LiftMaybe f0123456789876543210 x0123456789876543210
     instance SuppressUnusedWarnings LiftMaybeSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) LiftMaybeSym0KindInference) GHC.Tuple.())
-    data LiftMaybeSym0 (l :: Data.Singletons.Internal.TyFun ((~>) a0123456789876543210 b0123456789876543210) ((~>) (Maybe a0123456789876543210) (Maybe b0123456789876543210))) :: Type
+    data LiftMaybeSym0 :: forall a0123456789876543210
+                                 b0123456789876543210.
+                          (~>) ((~>) a0123456789876543210 b0123456789876543210) ((~>) (Maybe a0123456789876543210) (Maybe b0123456789876543210))
       where
-        LiftMaybeSym0KindInference :: forall l arg.
+        LiftMaybeSym0KindInference :: forall f0123456789876543210 arg.
                                       Data.Singletons.Internal.SameKind (Apply LiftMaybeSym0 arg) (LiftMaybeSym1 arg) =>
-                                      LiftMaybeSym0 l
-    type instance Apply LiftMaybeSym0 l = LiftMaybeSym1 l
+                                      LiftMaybeSym0 f0123456789876543210
+    type instance Apply LiftMaybeSym0 f0123456789876543210 = LiftMaybeSym1 f0123456789876543210
     type ZeroSym0 = Zero
-    type SuccSym1 (t :: NatT) = Succ t
+    type SuccSym1 (t0123456789876543210 :: NatT) =
+        Succ t0123456789876543210
     instance SuppressUnusedWarnings SuccSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SuccSym0KindInference) GHC.Tuple.())
-    data SuccSym0 (l :: Data.Singletons.Internal.TyFun NatT NatT) :: Type
+    data SuccSym0 :: (~>) NatT NatT
       where
-        SuccSym0KindInference :: forall l arg.
+        SuccSym0KindInference :: forall t0123456789876543210 arg.
                                  Data.Singletons.Internal.SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
-                                 SuccSym0 l
-    type instance Apply SuccSym0 l = Succ l
-    type (:+@#@$$$) (t :: Nat) (t :: Nat) = (:+) t t
-    instance SuppressUnusedWarnings (:+@#@$$) where
+                                 SuccSym0 t0123456789876543210
+    type instance Apply SuccSym0 t0123456789876543210 = Succ t0123456789876543210
+    type (:+@#@$$$) (a0123456789876543210 :: Nat) (b0123456789876543210 :: Nat) =
+        (:+) a0123456789876543210 b0123456789876543210
+    instance SuppressUnusedWarnings ((:+@#@$$) a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::+@#@$$###)) GHC.Tuple.())
-    data (:+@#@$$) (l :: Nat) l :: Type
+    data (:+@#@$$) (a0123456789876543210 :: Nat) b0123456789876543210
       where
-        (::+@#@$$###) :: forall l l arg.
-                         Data.Singletons.Internal.SameKind (Apply ((:+@#@$$) l) arg) ((:+@#@$$$) l arg) =>
-                         (:+@#@$$) l l
-    type instance Apply ((:+@#@$$) l) l = (:+) l l
+        (::+@#@$$###) :: forall a0123456789876543210
+                                b0123456789876543210
+                                arg.
+                         Data.Singletons.Internal.SameKind (Apply ((:+@#@$$) a0123456789876543210) arg) ((:+@#@$$$) a0123456789876543210 arg) =>
+                         (:+@#@$$) a0123456789876543210 b0123456789876543210
+    type instance Apply ((:+@#@$$) a0123456789876543210) b0123456789876543210 = (:+) a0123456789876543210 b0123456789876543210
     instance SuppressUnusedWarnings (:+@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::+@#@$###)) GHC.Tuple.())
-    data (:+@#@$) l :: Type
+    data (:+@#@$) a0123456789876543210
       where
-        (::+@#@$###) :: forall l arg.
+        (::+@#@$###) :: forall a0123456789876543210 arg.
                         Data.Singletons.Internal.SameKind (Apply (:+@#@$) arg) ((:+@#@$$) arg) =>
-                        (:+@#@$) l
-    type instance Apply (:+@#@$) l = (:+@#@$$) l
+                        (:+@#@$) a0123456789876543210
+    type instance Apply (:+@#@$) a0123456789876543210 = (:+@#@$$) a0123456789876543210

--- a/tests/compile-and-dump/Promote/Newtypes.ghc84.template
+++ b/tests/compile-and-dump/Promote/Newtypes.ghc84.template
@@ -14,32 +14,38 @@ Promote/Newtypes.hs:(0,0)-(0,0): Splicing declarations
       Equals_0123456789876543210 (_ :: Foo) (_ :: Foo) = FalseSym0
     instance PEq Foo where
       type (==) a b = Equals_0123456789876543210 a b
-    type UnBarSym1 (t :: Bar) = UnBar t
+    type UnBarSym1 (a0123456789876543210 :: Bar) =
+        UnBar a0123456789876543210
     instance SuppressUnusedWarnings UnBarSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) UnBarSym0KindInference) GHC.Tuple.())
-    data UnBarSym0 (l :: TyFun Bar Nat) :: GHC.Types.Type
+    data UnBarSym0 :: (~>) Bar Nat
       where
-        UnBarSym0KindInference :: forall l arg.
-                                  SameKind (Apply UnBarSym0 arg) (UnBarSym1 arg) => UnBarSym0 l
-    type instance Apply UnBarSym0 l = UnBar l
+        UnBarSym0KindInference :: forall a0123456789876543210 arg.
+                                  SameKind (Apply UnBarSym0 arg) (UnBarSym1 arg) =>
+                                  UnBarSym0 a0123456789876543210
+    type instance Apply UnBarSym0 a0123456789876543210 = UnBar a0123456789876543210
     type family UnBar (a :: Bar) :: Nat where
       UnBar (Bar field) = field
-    type FooSym1 (t :: Nat) = Foo t
+    type FooSym1 (t0123456789876543210 :: Nat) =
+        Foo t0123456789876543210
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym0KindInference) GHC.Tuple.())
-    data FooSym0 (l :: TyFun Nat Foo) :: GHC.Types.Type
+    data FooSym0 :: (~>) Nat Foo
       where
-        FooSym0KindInference :: forall l arg.
-                                SameKind (Apply FooSym0 arg) (FooSym1 arg) => FooSym0 l
-    type instance Apply FooSym0 l = Foo l
-    type BarSym1 (t :: Nat) = Bar t
+        FooSym0KindInference :: forall t0123456789876543210 arg.
+                                SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
+                                FooSym0 t0123456789876543210
+    type instance Apply FooSym0 t0123456789876543210 = Foo t0123456789876543210
+    type BarSym1 (t0123456789876543210 :: Nat) =
+        Bar t0123456789876543210
     instance SuppressUnusedWarnings BarSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BarSym0KindInference) GHC.Tuple.())
-    data BarSym0 (l :: TyFun Nat Bar) :: GHC.Types.Type
+    data BarSym0 :: (~>) Nat Bar
       where
-        BarSym0KindInference :: forall l arg.
-                                SameKind (Apply BarSym0 arg) (BarSym1 arg) => BarSym0 l
-    type instance Apply BarSym0 l = Bar l
+        BarSym0KindInference :: forall t0123456789876543210 arg.
+                                SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
+                                BarSym0 t0123456789876543210
+    type instance Apply BarSym0 t0123456789876543210 = Bar t0123456789876543210

--- a/tests/compile-and-dump/Promote/Prelude.ghc84.template
+++ b/tests/compile-and-dump/Promote/Prelude.ghc84.template
@@ -4,16 +4,17 @@ Promote/Prelude.hs:(0,0)-(0,0): Splicing declarations
           odd 0 = False
           odd n = not . odd $ n - 1 |]
   ======>
-    type OddSym1 (t :: Nat) = Odd t
+    type OddSym1 (a0123456789876543210 :: Nat) =
+        Odd a0123456789876543210
     instance SuppressUnusedWarnings OddSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) OddSym0KindInference) GHC.Tuple.())
-    data OddSym0 (l :: TyFun Nat Bool) :: GHC.Types.Type
+    data OddSym0 :: (Data.Singletons.Internal.~>) Nat Bool
       where
-        OddSym0KindInference :: forall l arg.
+        OddSym0KindInference :: forall a0123456789876543210 arg.
                                 Data.Singletons.Internal.SameKind (Apply OddSym0 arg) (OddSym1 arg) =>
-                                OddSym0 l
-    type instance Apply OddSym0 l = Odd l
+                                OddSym0 a0123456789876543210
+    type instance Apply OddSym0 a0123456789876543210 = Odd a0123456789876543210
     type family Odd (a :: Nat) :: Bool where
       Odd 0 = FalseSym0
       Odd n = Apply (Apply ($@#@$) (Apply (Apply (.@#@$) NotSym0) OddSym0)) (Apply (Apply (-@#@$) n) (FromInteger 1))

--- a/tests/compile-and-dump/Promote/T180.ghc84.template
+++ b/tests/compile-and-dump/Promote/T180.ghc84.template
@@ -8,45 +8,51 @@ Promote/T180.hs:(0,0)-(0,0): Splicing declarations
     data X = X1 {y :: Symbol} | X2 {y :: Symbol}
     z (X1 x) = x
     z (X2 x) = x
-    type ZSym1 t = Z t
+    type ZSym1 a0123456789876543210 = Z a0123456789876543210
     instance SuppressUnusedWarnings ZSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ZSym0KindInference) GHC.Tuple.())
-    data ZSym0 l :: GHC.Types.Type
+    data ZSym0 a0123456789876543210
       where
-        ZSym0KindInference :: forall l arg.
-                              SameKind (Apply ZSym0 arg) (ZSym1 arg) => ZSym0 l
-    type instance Apply ZSym0 l = Z l
+        ZSym0KindInference :: forall a0123456789876543210 arg.
+                              SameKind (Apply ZSym0 arg) (ZSym1 arg) =>
+                              ZSym0 a0123456789876543210
+    type instance Apply ZSym0 a0123456789876543210 = Z a0123456789876543210
     type family Z a where
       Z (X1 x) = x
       Z (X2 x) = x
-    type YSym1 (t :: X) = Y t
+    type YSym1 (a0123456789876543210 :: X) = Y a0123456789876543210
     instance SuppressUnusedWarnings YSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) YSym0KindInference) GHC.Tuple.())
-    data YSym0 (l :: TyFun X Symbol) :: GHC.Types.Type
+    data YSym0 :: (~>) X Symbol
       where
-        YSym0KindInference :: forall l arg.
-                              SameKind (Apply YSym0 arg) (YSym1 arg) => YSym0 l
-    type instance Apply YSym0 l = Y l
+        YSym0KindInference :: forall a0123456789876543210 arg.
+                              SameKind (Apply YSym0 arg) (YSym1 arg) =>
+                              YSym0 a0123456789876543210
+    type instance Apply YSym0 a0123456789876543210 = Y a0123456789876543210
     type family Y (a :: X) :: Symbol where
       Y (X1 field) = field
       Y (X2 field) = field
-    type X1Sym1 (t :: Symbol) = X1 t
+    type X1Sym1 (t0123456789876543210 :: Symbol) =
+        X1 t0123456789876543210
     instance SuppressUnusedWarnings X1Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) X1Sym0KindInference) GHC.Tuple.())
-    data X1Sym0 (l :: TyFun Symbol X) :: GHC.Types.Type
+    data X1Sym0 :: (~>) Symbol X
       where
-        X1Sym0KindInference :: forall l arg.
-                               SameKind (Apply X1Sym0 arg) (X1Sym1 arg) => X1Sym0 l
-    type instance Apply X1Sym0 l = X1 l
-    type X2Sym1 (t :: Symbol) = X2 t
+        X1Sym0KindInference :: forall t0123456789876543210 arg.
+                               SameKind (Apply X1Sym0 arg) (X1Sym1 arg) =>
+                               X1Sym0 t0123456789876543210
+    type instance Apply X1Sym0 t0123456789876543210 = X1 t0123456789876543210
+    type X2Sym1 (t0123456789876543210 :: Symbol) =
+        X2 t0123456789876543210
     instance SuppressUnusedWarnings X2Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) X2Sym0KindInference) GHC.Tuple.())
-    data X2Sym0 (l :: TyFun Symbol X) :: GHC.Types.Type
+    data X2Sym0 :: (~>) Symbol X
       where
-        X2Sym0KindInference :: forall l arg.
-                               SameKind (Apply X2Sym0 arg) (X2Sym1 arg) => X2Sym0 l
-    type instance Apply X2Sym0 l = X2 l
+        X2Sym0KindInference :: forall t0123456789876543210 arg.
+                               SameKind (Apply X2Sym0 arg) (X2Sym1 arg) =>
+                               X2Sym0 t0123456789876543210
+    type instance Apply X2Sym0 t0123456789876543210 = X2 t0123456789876543210

--- a/tests/compile-and-dump/Singletons/AsPattern.ghc84.template
+++ b/tests/compile-and-dump/Singletons/AsPattern.ghc84.template
@@ -34,214 +34,251 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
     foo p@GHC.Types.[] = p
     foo p@[_] = p
     foo p@(_ GHC.Types.: (_ GHC.Types.: _)) = p
-    type BazSym3 (t :: Nat) (t :: Nat) (t :: Nat) = Baz t t t
-    instance SuppressUnusedWarnings BazSym2 where
+    type BazSym3 (t0123456789876543210 :: Nat) (t0123456789876543210 :: Nat) (t0123456789876543210 :: Nat) =
+        Baz t0123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (BazSym2 t0123456789876543210 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BazSym2KindInference) GHC.Tuple.())
-    data BazSym2 (l :: Nat) (l :: Nat) (l :: TyFun Nat Baz) :: GHC.Types.Type
+    data BazSym2 (t0123456789876543210 :: Nat) (t0123456789876543210 :: Nat) :: (~>) Nat Baz
       where
-        BazSym2KindInference :: forall l l l arg.
-                                SameKind (Apply (BazSym2 l l) arg) (BazSym3 l l arg) =>
-                                BazSym2 l l l
-    type instance Apply (BazSym2 l l) l = Baz l l l
-    instance SuppressUnusedWarnings BazSym1 where
+        BazSym2KindInference :: forall t0123456789876543210
+                                       t0123456789876543210
+                                       t0123456789876543210
+                                       arg.
+                                SameKind (Apply (BazSym2 t0123456789876543210 t0123456789876543210) arg) (BazSym3 t0123456789876543210 t0123456789876543210 arg) =>
+                                BazSym2 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    type instance Apply (BazSym2 t0123456789876543210 t0123456789876543210) t0123456789876543210 = Baz t0123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (BazSym1 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BazSym1KindInference) GHC.Tuple.())
-    data BazSym1 (l :: Nat) (l :: TyFun Nat ((~>) Nat Baz)) :: GHC.Types.Type
+    data BazSym1 (t0123456789876543210 :: Nat) :: (~>) Nat ((~>) Nat Baz)
       where
-        BazSym1KindInference :: forall l l arg.
-                                SameKind (Apply (BazSym1 l) arg) (BazSym2 l arg) => BazSym1 l l
-    type instance Apply (BazSym1 l) l = BazSym2 l l
+        BazSym1KindInference :: forall t0123456789876543210
+                                       t0123456789876543210
+                                       arg.
+                                SameKind (Apply (BazSym1 t0123456789876543210) arg) (BazSym2 t0123456789876543210 arg) =>
+                                BazSym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (BazSym1 t0123456789876543210) t0123456789876543210 = BazSym2 t0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings BazSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BazSym0KindInference) GHC.Tuple.())
-    data BazSym0 (l :: TyFun Nat ((~>) Nat ((~>) Nat Baz))) :: GHC.Types.Type
+    data BazSym0 :: (~>) Nat ((~>) Nat ((~>) Nat Baz))
       where
-        BazSym0KindInference :: forall l arg.
-                                SameKind (Apply BazSym0 arg) (BazSym1 arg) => BazSym0 l
-    type instance Apply BazSym0 l = BazSym1 l
+        BazSym0KindInference :: forall t0123456789876543210 arg.
+                                SameKind (Apply BazSym0 arg) (BazSym1 arg) =>
+                                BazSym0 t0123456789876543210
+    type instance Apply BazSym0 t0123456789876543210 = BazSym1 t0123456789876543210
     type Let0123456789876543210PSym0 = Let0123456789876543210P
     type family Let0123456789876543210P where
       Let0123456789876543210P = '[]
-    type Let0123456789876543210PSym1 t = Let0123456789876543210P t
+    type Let0123456789876543210PSym1 wild_01234567898765432100123456789876543210 =
+        Let0123456789876543210P wild_01234567898765432100123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210PSym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210PSym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210PSym0 l :: GHC.Types.Type
+    data Let0123456789876543210PSym0 wild_01234567898765432100123456789876543210
       where
-        Let0123456789876543210PSym0KindInference :: forall l arg.
+        Let0123456789876543210PSym0KindInference :: forall wild_01234567898765432100123456789876543210
+                                                           arg.
                                                     SameKind (Apply Let0123456789876543210PSym0 arg) (Let0123456789876543210PSym1 arg) =>
-                                                    Let0123456789876543210PSym0 l
-    type instance Apply Let0123456789876543210PSym0 l = Let0123456789876543210P l
+                                                    Let0123456789876543210PSym0 wild_01234567898765432100123456789876543210
+    type instance Apply Let0123456789876543210PSym0 wild_01234567898765432100123456789876543210 = Let0123456789876543210P wild_01234567898765432100123456789876543210
     type family Let0123456789876543210P wild_0123456789876543210 where
       Let0123456789876543210P wild_0123456789876543210 = Apply (Apply (:@#@$) wild_0123456789876543210) '[]
-    type Let0123456789876543210PSym3 t t t =
-        Let0123456789876543210P t t t
-    instance SuppressUnusedWarnings Let0123456789876543210PSym2 where
+    type Let0123456789876543210PSym3 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 =
+        Let0123456789876543210P wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210
+    instance SuppressUnusedWarnings (Let0123456789876543210PSym2 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210PSym2KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210PSym2 l l l :: GHC.Types.Type
+    data Let0123456789876543210PSym2 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210
       where
-        Let0123456789876543210PSym2KindInference :: forall l l l arg.
-                                                    SameKind (Apply (Let0123456789876543210PSym2 l l) arg) (Let0123456789876543210PSym3 l l arg) =>
-                                                    Let0123456789876543210PSym2 l l l
-    type instance Apply (Let0123456789876543210PSym2 l l) l = Let0123456789876543210P l l l
-    instance SuppressUnusedWarnings Let0123456789876543210PSym1 where
+        Let0123456789876543210PSym2KindInference :: forall wild_01234567898765432100123456789876543210
+                                                           wild_01234567898765432100123456789876543210
+                                                           wild_01234567898765432100123456789876543210
+                                                           arg.
+                                                    SameKind (Apply (Let0123456789876543210PSym2 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210) arg) (Let0123456789876543210PSym3 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 arg) =>
+                                                    Let0123456789876543210PSym2 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210
+    type instance Apply (Let0123456789876543210PSym2 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210) wild_01234567898765432100123456789876543210 = Let0123456789876543210P wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210
+    instance SuppressUnusedWarnings (Let0123456789876543210PSym1 wild_01234567898765432100123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210PSym1KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210PSym1 l l :: GHC.Types.Type
+    data Let0123456789876543210PSym1 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210
       where
-        Let0123456789876543210PSym1KindInference :: forall l l arg.
-                                                    SameKind (Apply (Let0123456789876543210PSym1 l) arg) (Let0123456789876543210PSym2 l arg) =>
-                                                    Let0123456789876543210PSym1 l l
-    type instance Apply (Let0123456789876543210PSym1 l) l = Let0123456789876543210PSym2 l l
+        Let0123456789876543210PSym1KindInference :: forall wild_01234567898765432100123456789876543210
+                                                           wild_01234567898765432100123456789876543210
+                                                           arg.
+                                                    SameKind (Apply (Let0123456789876543210PSym1 wild_01234567898765432100123456789876543210) arg) (Let0123456789876543210PSym2 wild_01234567898765432100123456789876543210 arg) =>
+                                                    Let0123456789876543210PSym1 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210
+    type instance Apply (Let0123456789876543210PSym1 wild_01234567898765432100123456789876543210) wild_01234567898765432100123456789876543210 = Let0123456789876543210PSym2 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210PSym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210PSym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210PSym0 l :: GHC.Types.Type
+    data Let0123456789876543210PSym0 wild_01234567898765432100123456789876543210
       where
-        Let0123456789876543210PSym0KindInference :: forall l arg.
+        Let0123456789876543210PSym0KindInference :: forall wild_01234567898765432100123456789876543210
+                                                           arg.
                                                     SameKind (Apply Let0123456789876543210PSym0 arg) (Let0123456789876543210PSym1 arg) =>
-                                                    Let0123456789876543210PSym0 l
-    type instance Apply Let0123456789876543210PSym0 l = Let0123456789876543210PSym1 l
+                                                    Let0123456789876543210PSym0 wild_01234567898765432100123456789876543210
+    type instance Apply Let0123456789876543210PSym0 wild_01234567898765432100123456789876543210 = Let0123456789876543210PSym1 wild_01234567898765432100123456789876543210
     type family Let0123456789876543210P wild_0123456789876543210 wild_0123456789876543210 wild_0123456789876543210 where
       Let0123456789876543210P wild_0123456789876543210 wild_0123456789876543210 wild_0123456789876543210 = Apply (Apply (:@#@$) wild_0123456789876543210) (Apply (Apply (:@#@$) wild_0123456789876543210) wild_0123456789876543210)
-    type Let0123456789876543210PSym2 t t = Let0123456789876543210P t t
-    instance SuppressUnusedWarnings Let0123456789876543210PSym1 where
+    type Let0123456789876543210PSym2 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 =
+        Let0123456789876543210P wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210
+    instance SuppressUnusedWarnings (Let0123456789876543210PSym1 wild_01234567898765432100123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210PSym1KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210PSym1 l l :: GHC.Types.Type
+    data Let0123456789876543210PSym1 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210
       where
-        Let0123456789876543210PSym1KindInference :: forall l l arg.
-                                                    SameKind (Apply (Let0123456789876543210PSym1 l) arg) (Let0123456789876543210PSym2 l arg) =>
-                                                    Let0123456789876543210PSym1 l l
-    type instance Apply (Let0123456789876543210PSym1 l) l = Let0123456789876543210P l l
+        Let0123456789876543210PSym1KindInference :: forall wild_01234567898765432100123456789876543210
+                                                           wild_01234567898765432100123456789876543210
+                                                           arg.
+                                                    SameKind (Apply (Let0123456789876543210PSym1 wild_01234567898765432100123456789876543210) arg) (Let0123456789876543210PSym2 wild_01234567898765432100123456789876543210 arg) =>
+                                                    Let0123456789876543210PSym1 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210
+    type instance Apply (Let0123456789876543210PSym1 wild_01234567898765432100123456789876543210) wild_01234567898765432100123456789876543210 = Let0123456789876543210P wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210PSym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210PSym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210PSym0 l :: GHC.Types.Type
+    data Let0123456789876543210PSym0 wild_01234567898765432100123456789876543210
       where
-        Let0123456789876543210PSym0KindInference :: forall l arg.
+        Let0123456789876543210PSym0KindInference :: forall wild_01234567898765432100123456789876543210
+                                                           arg.
                                                     SameKind (Apply Let0123456789876543210PSym0 arg) (Let0123456789876543210PSym1 arg) =>
-                                                    Let0123456789876543210PSym0 l
-    type instance Apply Let0123456789876543210PSym0 l = Let0123456789876543210PSym1 l
+                                                    Let0123456789876543210PSym0 wild_01234567898765432100123456789876543210
+    type instance Apply Let0123456789876543210PSym0 wild_01234567898765432100123456789876543210 = Let0123456789876543210PSym1 wild_01234567898765432100123456789876543210
     type family Let0123456789876543210P wild_0123456789876543210 wild_0123456789876543210 where
       Let0123456789876543210P wild_0123456789876543210 wild_0123456789876543210 = Apply (Apply Tuple2Sym0 wild_0123456789876543210) wild_0123456789876543210
     type Let0123456789876543210PSym0 = Let0123456789876543210P
     type family Let0123456789876543210P where
       Let0123456789876543210P = NothingSym0
-    type Let0123456789876543210PSym3 t t t =
-        Let0123456789876543210P t t t
-    instance SuppressUnusedWarnings Let0123456789876543210PSym2 where
+    type Let0123456789876543210PSym3 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 =
+        Let0123456789876543210P wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210
+    instance SuppressUnusedWarnings (Let0123456789876543210PSym2 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210PSym2KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210PSym2 l l l :: GHC.Types.Type
+    data Let0123456789876543210PSym2 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210
       where
-        Let0123456789876543210PSym2KindInference :: forall l l l arg.
-                                                    SameKind (Apply (Let0123456789876543210PSym2 l l) arg) (Let0123456789876543210PSym3 l l arg) =>
-                                                    Let0123456789876543210PSym2 l l l
-    type instance Apply (Let0123456789876543210PSym2 l l) l = Let0123456789876543210P l l l
-    instance SuppressUnusedWarnings Let0123456789876543210PSym1 where
+        Let0123456789876543210PSym2KindInference :: forall wild_01234567898765432100123456789876543210
+                                                           wild_01234567898765432100123456789876543210
+                                                           wild_01234567898765432100123456789876543210
+                                                           arg.
+                                                    SameKind (Apply (Let0123456789876543210PSym2 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210) arg) (Let0123456789876543210PSym3 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 arg) =>
+                                                    Let0123456789876543210PSym2 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210
+    type instance Apply (Let0123456789876543210PSym2 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210) wild_01234567898765432100123456789876543210 = Let0123456789876543210P wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210
+    instance SuppressUnusedWarnings (Let0123456789876543210PSym1 wild_01234567898765432100123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210PSym1KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210PSym1 l l :: GHC.Types.Type
+    data Let0123456789876543210PSym1 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210
       where
-        Let0123456789876543210PSym1KindInference :: forall l l arg.
-                                                    SameKind (Apply (Let0123456789876543210PSym1 l) arg) (Let0123456789876543210PSym2 l arg) =>
-                                                    Let0123456789876543210PSym1 l l
-    type instance Apply (Let0123456789876543210PSym1 l) l = Let0123456789876543210PSym2 l l
+        Let0123456789876543210PSym1KindInference :: forall wild_01234567898765432100123456789876543210
+                                                           wild_01234567898765432100123456789876543210
+                                                           arg.
+                                                    SameKind (Apply (Let0123456789876543210PSym1 wild_01234567898765432100123456789876543210) arg) (Let0123456789876543210PSym2 wild_01234567898765432100123456789876543210 arg) =>
+                                                    Let0123456789876543210PSym1 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210
+    type instance Apply (Let0123456789876543210PSym1 wild_01234567898765432100123456789876543210) wild_01234567898765432100123456789876543210 = Let0123456789876543210PSym2 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210PSym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210PSym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210PSym0 l :: GHC.Types.Type
+    data Let0123456789876543210PSym0 wild_01234567898765432100123456789876543210
       where
-        Let0123456789876543210PSym0KindInference :: forall l arg.
+        Let0123456789876543210PSym0KindInference :: forall wild_01234567898765432100123456789876543210
+                                                           arg.
                                                     SameKind (Apply Let0123456789876543210PSym0 arg) (Let0123456789876543210PSym1 arg) =>
-                                                    Let0123456789876543210PSym0 l
-    type instance Apply Let0123456789876543210PSym0 l = Let0123456789876543210PSym1 l
+                                                    Let0123456789876543210PSym0 wild_01234567898765432100123456789876543210
+    type instance Apply Let0123456789876543210PSym0 wild_01234567898765432100123456789876543210 = Let0123456789876543210PSym1 wild_01234567898765432100123456789876543210
     type family Let0123456789876543210P wild_0123456789876543210 wild_0123456789876543210 wild_0123456789876543210 where
       Let0123456789876543210P wild_0123456789876543210 wild_0123456789876543210 wild_0123456789876543210 = Apply JustSym0 (Apply (Apply (Apply BazSym0 wild_0123456789876543210) wild_0123456789876543210) wild_0123456789876543210)
-    type Let0123456789876543210XSym1 t = Let0123456789876543210X t
+    type Let0123456789876543210XSym1 wild_01234567898765432100123456789876543210 =
+        Let0123456789876543210X wild_01234567898765432100123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210XSym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210XSym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210XSym0 l :: GHC.Types.Type
+    data Let0123456789876543210XSym0 wild_01234567898765432100123456789876543210
       where
-        Let0123456789876543210XSym0KindInference :: forall l arg.
+        Let0123456789876543210XSym0KindInference :: forall wild_01234567898765432100123456789876543210
+                                                           arg.
                                                     SameKind (Apply Let0123456789876543210XSym0 arg) (Let0123456789876543210XSym1 arg) =>
-                                                    Let0123456789876543210XSym0 l
-    type instance Apply Let0123456789876543210XSym0 l = Let0123456789876543210X l
+                                                    Let0123456789876543210XSym0 wild_01234567898765432100123456789876543210
+    type instance Apply Let0123456789876543210XSym0 wild_01234567898765432100123456789876543210 = Let0123456789876543210X wild_01234567898765432100123456789876543210
     type family Let0123456789876543210X wild_0123456789876543210 where
       Let0123456789876543210X wild_0123456789876543210 = Apply JustSym0 wild_0123456789876543210
     type Let0123456789876543210PSym0 = Let0123456789876543210P
     type family Let0123456789876543210P where
       Let0123456789876543210P = NothingSym0
-    type FooSym1 (t :: [Nat]) = Foo t
+    type FooSym1 (a0123456789876543210 :: [Nat]) =
+        Foo a0123456789876543210
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym0KindInference) GHC.Tuple.())
-    data FooSym0 (l :: TyFun [Nat] [Nat]) :: GHC.Types.Type
+    data FooSym0 :: (~>) [Nat] [Nat]
       where
-        FooSym0KindInference :: forall l arg.
-                                SameKind (Apply FooSym0 arg) (FooSym1 arg) => FooSym0 l
-    type instance Apply FooSym0 l = Foo l
-    type TupSym1 (t :: (Nat, Nat)) = Tup t
+        FooSym0KindInference :: forall a0123456789876543210 arg.
+                                SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
+                                FooSym0 a0123456789876543210
+    type instance Apply FooSym0 a0123456789876543210 = Foo a0123456789876543210
+    type TupSym1 (a0123456789876543210 :: (Nat, Nat)) =
+        Tup a0123456789876543210
     instance SuppressUnusedWarnings TupSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) TupSym0KindInference) GHC.Tuple.())
-    data TupSym0 (l :: TyFun (Nat, Nat) (Nat, Nat)) :: GHC.Types.Type
+    data TupSym0 :: (~>) (Nat, Nat) (Nat, Nat)
       where
-        TupSym0KindInference :: forall l arg.
-                                SameKind (Apply TupSym0 arg) (TupSym1 arg) => TupSym0 l
-    type instance Apply TupSym0 l = Tup l
-    type Baz_Sym1 (t :: Maybe Baz) = Baz_ t
+        TupSym0KindInference :: forall a0123456789876543210 arg.
+                                SameKind (Apply TupSym0 arg) (TupSym1 arg) =>
+                                TupSym0 a0123456789876543210
+    type instance Apply TupSym0 a0123456789876543210 = Tup a0123456789876543210
+    type Baz_Sym1 (a0123456789876543210 :: Maybe Baz) =
+        Baz_ a0123456789876543210
     instance SuppressUnusedWarnings Baz_Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Baz_Sym0KindInference) GHC.Tuple.())
-    data Baz_Sym0 (l :: TyFun (Maybe Baz) (Maybe Baz)) :: GHC.Types.Type
+    data Baz_Sym0 :: (~>) (Maybe Baz) (Maybe Baz)
       where
-        Baz_Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Baz_Sym0 arg) (Baz_Sym1 arg) => Baz_Sym0 l
-    type instance Apply Baz_Sym0 l = Baz_ l
-    type BarSym1 (t :: Maybe Nat) = Bar t
+        Baz_Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Baz_Sym0 arg) (Baz_Sym1 arg) =>
+                                 Baz_Sym0 a0123456789876543210
+    type instance Apply Baz_Sym0 a0123456789876543210 = Baz_ a0123456789876543210
+    type BarSym1 (a0123456789876543210 :: Maybe Nat) =
+        Bar a0123456789876543210
     instance SuppressUnusedWarnings BarSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BarSym0KindInference) GHC.Tuple.())
-    data BarSym0 (l :: TyFun (Maybe Nat) (Maybe Nat)) :: GHC.Types.Type
+    data BarSym0 :: (~>) (Maybe Nat) (Maybe Nat)
       where
-        BarSym0KindInference :: forall l arg.
-                                SameKind (Apply BarSym0 arg) (BarSym1 arg) => BarSym0 l
-    type instance Apply BarSym0 l = Bar l
-    type MaybePlusSym1 (t :: Maybe Nat) = MaybePlus t
+        BarSym0KindInference :: forall a0123456789876543210 arg.
+                                SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
+                                BarSym0 a0123456789876543210
+    type instance Apply BarSym0 a0123456789876543210 = Bar a0123456789876543210
+    type MaybePlusSym1 (a0123456789876543210 :: Maybe Nat) =
+        MaybePlus a0123456789876543210
     instance SuppressUnusedWarnings MaybePlusSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MaybePlusSym0KindInference) GHC.Tuple.())
-    data MaybePlusSym0 (l :: TyFun (Maybe Nat) (Maybe Nat)) :: GHC.Types.Type
+    data MaybePlusSym0 :: (~>) (Maybe Nat) (Maybe Nat)
       where
-        MaybePlusSym0KindInference :: forall l arg.
+        MaybePlusSym0KindInference :: forall a0123456789876543210 arg.
                                       SameKind (Apply MaybePlusSym0 arg) (MaybePlusSym1 arg) =>
-                                      MaybePlusSym0 l
-    type instance Apply MaybePlusSym0 l = MaybePlus l
+                                      MaybePlusSym0 a0123456789876543210
+    type instance Apply MaybePlusSym0 a0123456789876543210 = MaybePlus a0123456789876543210
     type family Foo (a :: [Nat]) :: [Nat] where
       Foo '[] = Let0123456789876543210PSym0
       Foo '[wild_0123456789876543210] = Let0123456789876543210PSym1 wild_0123456789876543210

--- a/tests/compile-and-dump/Singletons/BoundedDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/BoundedDeriving.ghc84.template
@@ -37,34 +37,42 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
     type CSym0 = C
     type DSym0 = D
     type ESym0 = E
-    type Foo3Sym1 (t :: a0123456789876543210) = Foo3 t
+    type Foo3Sym1 (t0123456789876543210 :: a0123456789876543210) =
+        Foo3 t0123456789876543210
     instance SuppressUnusedWarnings Foo3Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo3Sym0KindInference) GHC.Tuple.())
-    data Foo3Sym0 (l :: TyFun a0123456789876543210 (Foo3 a0123456789876543210)) :: Type
+    data Foo3Sym0 :: forall a0123456789876543210.
+                     (~>) a0123456789876543210 (Foo3 a0123456789876543210)
       where
-        Foo3Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) => Foo3Sym0 l
-    type instance Apply Foo3Sym0 l = Foo3 l
+        Foo3Sym0KindInference :: forall t0123456789876543210 arg.
+                                 SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
+                                 Foo3Sym0 t0123456789876543210
+    type instance Apply Foo3Sym0 t0123456789876543210 = Foo3 t0123456789876543210
     type Foo41Sym0 = Foo41
     type Foo42Sym0 = Foo42
-    type PairSym2 (t :: Bool) (t :: Bool) = Pair t t
-    instance SuppressUnusedWarnings PairSym1 where
+    type PairSym2 (t0123456789876543210 :: Bool) (t0123456789876543210 :: Bool) =
+        Pair t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (PairSym1 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) PairSym1KindInference) GHC.Tuple.())
-    data PairSym1 (l :: Bool) (l :: TyFun Bool Pair) :: Type
+    data PairSym1 (t0123456789876543210 :: Bool) :: (~>) Bool Pair
       where
-        PairSym1KindInference :: forall l l arg.
-                                 SameKind (Apply (PairSym1 l) arg) (PairSym2 l arg) => PairSym1 l l
-    type instance Apply (PairSym1 l) l = Pair l l
+        PairSym1KindInference :: forall t0123456789876543210
+                                        t0123456789876543210
+                                        arg.
+                                 SameKind (Apply (PairSym1 t0123456789876543210) arg) (PairSym2 t0123456789876543210 arg) =>
+                                 PairSym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (PairSym1 t0123456789876543210) t0123456789876543210 = Pair t0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings PairSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) PairSym0KindInference) GHC.Tuple.())
-    data PairSym0 (l :: TyFun Bool ((~>) Bool Pair)) :: Type
+    data PairSym0 :: (~>) Bool ((~>) Bool Pair)
       where
-        PairSym0KindInference :: forall l arg.
-                                 SameKind (Apply PairSym0 arg) (PairSym1 arg) => PairSym0 l
-    type instance Apply PairSym0 l = PairSym1 l
+        PairSym0KindInference :: forall t0123456789876543210 arg.
+                                 SameKind (Apply PairSym0 arg) (PairSym1 arg) =>
+                                 PairSym0 t0123456789876543210
+    type instance Apply PairSym0 t0123456789876543210 = PairSym1 t0123456789876543210
     type family MinBound_0123456789876543210 :: Foo1 where
       MinBound_0123456789876543210 = Foo1Sym0
     type MinBound_0123456789876543210Sym0 =

--- a/tests/compile-and-dump/Singletons/BoxUnBox.ghc84.template
+++ b/tests/compile-and-dump/Singletons/BoxUnBox.ghc84.template
@@ -8,24 +8,30 @@ Singletons/BoxUnBox.hs:(0,0)-(0,0): Splicing declarations
     data Box a = FBox a
     unBox :: Box a -> a
     unBox (FBox a) = a
-    type FBoxSym1 (t :: a0123456789876543210) = FBox t
+    type FBoxSym1 (t0123456789876543210 :: a0123456789876543210) =
+        FBox t0123456789876543210
     instance SuppressUnusedWarnings FBoxSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FBoxSym0KindInference) GHC.Tuple.())
-    data FBoxSym0 (l :: TyFun a0123456789876543210 (Box a0123456789876543210)) :: GHC.Types.Type
+    data FBoxSym0 :: forall a0123456789876543210.
+                     (~>) a0123456789876543210 (Box a0123456789876543210)
       where
-        FBoxSym0KindInference :: forall l arg.
-                                 SameKind (Apply FBoxSym0 arg) (FBoxSym1 arg) => FBoxSym0 l
-    type instance Apply FBoxSym0 l = FBox l
-    type UnBoxSym1 (t :: Box a0123456789876543210) = UnBox t
+        FBoxSym0KindInference :: forall t0123456789876543210 arg.
+                                 SameKind (Apply FBoxSym0 arg) (FBoxSym1 arg) =>
+                                 FBoxSym0 t0123456789876543210
+    type instance Apply FBoxSym0 t0123456789876543210 = FBox t0123456789876543210
+    type UnBoxSym1 (a0123456789876543210 :: Box a0123456789876543210) =
+        UnBox a0123456789876543210
     instance SuppressUnusedWarnings UnBoxSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) UnBoxSym0KindInference) GHC.Tuple.())
-    data UnBoxSym0 (l :: TyFun (Box a0123456789876543210) a0123456789876543210) :: GHC.Types.Type
+    data UnBoxSym0 :: forall a0123456789876543210.
+                      (~>) (Box a0123456789876543210) a0123456789876543210
       where
-        UnBoxSym0KindInference :: forall l arg.
-                                  SameKind (Apply UnBoxSym0 arg) (UnBoxSym1 arg) => UnBoxSym0 l
-    type instance Apply UnBoxSym0 l = UnBox l
+        UnBoxSym0KindInference :: forall a0123456789876543210 arg.
+                                  SameKind (Apply UnBoxSym0 arg) (UnBoxSym1 arg) =>
+                                  UnBoxSym0 a0123456789876543210
+    type instance Apply UnBoxSym0 a0123456789876543210 = UnBox a0123456789876543210
     type family UnBox (a :: Box a) :: a where
       UnBox (FBox a) = a
     sUnBox ::

--- a/tests/compile-and-dump/Singletons/CaseExpressions.ghc84.template
+++ b/tests/compile-and-dump/Singletons/CaseExpressions.ghc84.template
@@ -41,118 +41,128 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
       Case_0123456789876543210 x y arg_0123456789876543210 _ = x
     type family Lambda_0123456789876543210 x y t where
       Lambda_0123456789876543210 x y arg_0123456789876543210 = Case_0123456789876543210 x y arg_0123456789876543210 arg_0123456789876543210
-    type Lambda_0123456789876543210Sym3 t t t =
-        Lambda_0123456789876543210 t t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+    type Lambda_0123456789876543210Sym3 x0123456789876543210 y0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 x0123456789876543210 y0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym2 y0123456789876543210 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
-                                                       Lambda_0123456789876543210Sym2 l l l
-    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+        Lambda_0123456789876543210Sym2KindInference :: forall x0123456789876543210
+                                                              y0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210) arg) (Lambda_0123456789876543210Sym3 x0123456789876543210 y0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym2 y0123456789876543210 x0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 y0123456789876543210 x0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall x0123456789876543210
+                                                              y0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) arg) (Lambda_0123456789876543210Sym2 x0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) y0123456789876543210 = Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 x0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall x0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+                                                       Lambda_0123456789876543210Sym0 x0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 x0123456789876543210 = Lambda_0123456789876543210Sym1 x0123456789876543210
     type family Case_0123456789876543210 x t where
       Case_0123456789876543210 x y = Apply (Apply (Apply Lambda_0123456789876543210Sym0 x) y) y
-    type Let0123456789876543210ZSym2 t t = Let0123456789876543210Z t t
-    instance SuppressUnusedWarnings Let0123456789876543210ZSym1 where
+    type Let0123456789876543210ZSym2 x0123456789876543210 y0123456789876543210 =
+        Let0123456789876543210Z x0123456789876543210 y0123456789876543210
+    instance SuppressUnusedWarnings (Let0123456789876543210ZSym1 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210ZSym1KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210ZSym1 l l :: GHC.Types.Type
+    data Let0123456789876543210ZSym1 x0123456789876543210 y0123456789876543210
       where
-        Let0123456789876543210ZSym1KindInference :: forall l l arg.
-                                                    SameKind (Apply (Let0123456789876543210ZSym1 l) arg) (Let0123456789876543210ZSym2 l arg) =>
-                                                    Let0123456789876543210ZSym1 l l
-    type instance Apply (Let0123456789876543210ZSym1 l) l = Let0123456789876543210Z l l
+        Let0123456789876543210ZSym1KindInference :: forall x0123456789876543210
+                                                           y0123456789876543210
+                                                           arg.
+                                                    SameKind (Apply (Let0123456789876543210ZSym1 x0123456789876543210) arg) (Let0123456789876543210ZSym2 x0123456789876543210 arg) =>
+                                                    Let0123456789876543210ZSym1 x0123456789876543210 y0123456789876543210
+    type instance Apply (Let0123456789876543210ZSym1 x0123456789876543210) y0123456789876543210 = Let0123456789876543210Z x0123456789876543210 y0123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210ZSym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210ZSym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210ZSym0 l :: GHC.Types.Type
+    data Let0123456789876543210ZSym0 x0123456789876543210
       where
-        Let0123456789876543210ZSym0KindInference :: forall l arg.
+        Let0123456789876543210ZSym0KindInference :: forall x0123456789876543210
+                                                           arg.
                                                     SameKind (Apply Let0123456789876543210ZSym0 arg) (Let0123456789876543210ZSym1 arg) =>
-                                                    Let0123456789876543210ZSym0 l
-    type instance Apply Let0123456789876543210ZSym0 l = Let0123456789876543210ZSym1 l
+                                                    Let0123456789876543210ZSym0 x0123456789876543210
+    type instance Apply Let0123456789876543210ZSym0 x0123456789876543210 = Let0123456789876543210ZSym1 x0123456789876543210
     type family Let0123456789876543210Z x y :: a where
       Let0123456789876543210Z x y = y
     type family Case_0123456789876543210 x t where
       Case_0123456789876543210 x y = Let0123456789876543210ZSym2 x y
-    type Let0123456789876543210Scrutinee_0123456789876543210Sym2 t t =
-        Let0123456789876543210Scrutinee_0123456789876543210 t t
-    instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym1 where
+    type Let0123456789876543210Scrutinee_0123456789876543210Sym2 a0123456789876543210 b0123456789876543210 =
+        Let0123456789876543210Scrutinee_0123456789876543210 a0123456789876543210 b0123456789876543210
+    instance SuppressUnusedWarnings (Let0123456789876543210Scrutinee_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210Scrutinee_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210Scrutinee_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Let0123456789876543210Scrutinee_0123456789876543210Sym1 a0123456789876543210 b0123456789876543210
       where
-        Let0123456789876543210Scrutinee_0123456789876543210Sym1KindInference :: forall l
-                                                                                       l
+        Let0123456789876543210Scrutinee_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                                                       b0123456789876543210
                                                                                        arg.
-                                                                                SameKind (Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym1 l) arg) (Let0123456789876543210Scrutinee_0123456789876543210Sym2 l arg) =>
-                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym1 l l
-    type instance Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym1 l) l = Let0123456789876543210Scrutinee_0123456789876543210 l l
+                                                                                SameKind (Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym1 a0123456789876543210) arg) (Let0123456789876543210Scrutinee_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym1 a0123456789876543210 b0123456789876543210
+    type instance Apply (Let0123456789876543210Scrutinee_0123456789876543210Sym1 a0123456789876543210) b0123456789876543210 = Let0123456789876543210Scrutinee_0123456789876543210 a0123456789876543210 b0123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210Scrutinee_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Let0123456789876543210Scrutinee_0123456789876543210Sym0 a0123456789876543210
       where
-        Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference :: forall l
+        Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference :: forall a0123456789876543210
                                                                                        arg.
                                                                                 SameKind (Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 arg) (Let0123456789876543210Scrutinee_0123456789876543210Sym1 arg) =>
-                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym0 l
-    type instance Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 l = Let0123456789876543210Scrutinee_0123456789876543210Sym1 l
+                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 a0123456789876543210 = Let0123456789876543210Scrutinee_0123456789876543210Sym1 a0123456789876543210
     type family Let0123456789876543210Scrutinee_0123456789876543210 a b where
       Let0123456789876543210Scrutinee_0123456789876543210 a b = Apply (Apply Tuple2Sym0 a) b
     type family Case_0123456789876543210 a b t where
       Case_0123456789876543210 a b (GHC.Tuple.(,) p _) = p
-    type Let0123456789876543210Scrutinee_0123456789876543210Sym1 t =
-        Let0123456789876543210Scrutinee_0123456789876543210 t
+    type Let0123456789876543210Scrutinee_0123456789876543210Sym1 d0123456789876543210 =
+        Let0123456789876543210Scrutinee_0123456789876543210 d0123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210Scrutinee_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Let0123456789876543210Scrutinee_0123456789876543210Sym0 d0123456789876543210
       where
-        Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference :: forall l
+        Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference :: forall d0123456789876543210
                                                                                        arg.
                                                                                 SameKind (Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 arg) (Let0123456789876543210Scrutinee_0123456789876543210Sym1 arg) =>
-                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym0 l
-    type instance Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 l = Let0123456789876543210Scrutinee_0123456789876543210 l
+                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym0 d0123456789876543210
+    type instance Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 d0123456789876543210 = Let0123456789876543210Scrutinee_0123456789876543210 d0123456789876543210
     type family Let0123456789876543210Scrutinee_0123456789876543210 d where
       Let0123456789876543210Scrutinee_0123456789876543210 d = Apply JustSym0 d
     type family Case_0123456789876543210 d t where
@@ -160,78 +170,100 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
     type family Case_0123456789876543210 d x t where
       Case_0123456789876543210 d x (Just y) = y
       Case_0123456789876543210 d x Nothing = d
-    type Foo5Sym1 (t :: a0123456789876543210) = Foo5 t
+    type Foo5Sym1 (a0123456789876543210 :: a0123456789876543210) =
+        Foo5 a0123456789876543210
     instance SuppressUnusedWarnings Foo5Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo5Sym0KindInference) GHC.Tuple.())
-    data Foo5Sym0 (l :: TyFun a0123456789876543210 a0123456789876543210) :: GHC.Types.Type
+    data Foo5Sym0 :: forall a0123456789876543210.
+                     (~>) a0123456789876543210 a0123456789876543210
       where
-        Foo5Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo5Sym0 arg) (Foo5Sym1 arg) => Foo5Sym0 l
-    type instance Apply Foo5Sym0 l = Foo5 l
-    type Foo4Sym1 (t :: a0123456789876543210) = Foo4 t
+        Foo5Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo5Sym0 arg) (Foo5Sym1 arg) =>
+                                 Foo5Sym0 a0123456789876543210
+    type instance Apply Foo5Sym0 a0123456789876543210 = Foo5 a0123456789876543210
+    type Foo4Sym1 (a0123456789876543210 :: a0123456789876543210) =
+        Foo4 a0123456789876543210
     instance SuppressUnusedWarnings Foo4Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo4Sym0KindInference) GHC.Tuple.())
-    data Foo4Sym0 (l :: TyFun a0123456789876543210 a0123456789876543210) :: GHC.Types.Type
+    data Foo4Sym0 :: forall a0123456789876543210.
+                     (~>) a0123456789876543210 a0123456789876543210
       where
-        Foo4Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo4Sym0 arg) (Foo4Sym1 arg) => Foo4Sym0 l
-    type instance Apply Foo4Sym0 l = Foo4 l
-    type Foo3Sym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
-        Foo3 t t
-    instance SuppressUnusedWarnings Foo3Sym1 where
+        Foo4Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo4Sym0 arg) (Foo4Sym1 arg) =>
+                                 Foo4Sym0 a0123456789876543210
+    type instance Apply Foo4Sym0 a0123456789876543210 = Foo4 a0123456789876543210
+    type Foo3Sym2 (a0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: b0123456789876543210) =
+        Foo3 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Foo3Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo3Sym1KindInference) GHC.Tuple.())
-    data Foo3Sym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 a0123456789876543210) :: GHC.Types.Type
+    data Foo3Sym1 (a0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210.
+                                                                    (~>) b0123456789876543210 a0123456789876543210
       where
-        Foo3Sym1KindInference :: forall l l arg.
-                                 SameKind (Apply (Foo3Sym1 l) arg) (Foo3Sym2 l arg) => Foo3Sym1 l l
-    type instance Apply (Foo3Sym1 l) l = Foo3 l l
+        Foo3Sym1KindInference :: forall a0123456789876543210
+                                        a0123456789876543210
+                                        arg.
+                                 SameKind (Apply (Foo3Sym1 a0123456789876543210) arg) (Foo3Sym2 a0123456789876543210 arg) =>
+                                 Foo3Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Foo3Sym1 a0123456789876543210) a0123456789876543210 = Foo3 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Foo3Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo3Sym0KindInference) GHC.Tuple.())
-    data Foo3Sym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 a0123456789876543210)) :: GHC.Types.Type
+    data Foo3Sym0 :: forall a0123456789876543210 b0123456789876543210.
+                     (~>) a0123456789876543210 ((~>) b0123456789876543210 a0123456789876543210)
       where
-        Foo3Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) => Foo3Sym0 l
-    type instance Apply Foo3Sym0 l = Foo3Sym1 l
-    type Foo2Sym2 (t :: a0123456789876543210) (t :: Maybe a0123456789876543210) =
-        Foo2 t t
-    instance SuppressUnusedWarnings Foo2Sym1 where
+        Foo3Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
+                                 Foo3Sym0 a0123456789876543210
+    type instance Apply Foo3Sym0 a0123456789876543210 = Foo3Sym1 a0123456789876543210
+    type Foo2Sym2 (a0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: Maybe a0123456789876543210) =
+        Foo2 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Foo2Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo2Sym1KindInference) GHC.Tuple.())
-    data Foo2Sym1 (l :: a0123456789876543210) (l :: TyFun (Maybe a0123456789876543210) a0123456789876543210) :: GHC.Types.Type
+    data Foo2Sym1 (a0123456789876543210 :: a0123456789876543210) :: (~>) (Maybe a0123456789876543210) a0123456789876543210
       where
-        Foo2Sym1KindInference :: forall l l arg.
-                                 SameKind (Apply (Foo2Sym1 l) arg) (Foo2Sym2 l arg) => Foo2Sym1 l l
-    type instance Apply (Foo2Sym1 l) l = Foo2 l l
+        Foo2Sym1KindInference :: forall a0123456789876543210
+                                        a0123456789876543210
+                                        arg.
+                                 SameKind (Apply (Foo2Sym1 a0123456789876543210) arg) (Foo2Sym2 a0123456789876543210 arg) =>
+                                 Foo2Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Foo2Sym1 a0123456789876543210) a0123456789876543210 = Foo2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Foo2Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo2Sym0KindInference) GHC.Tuple.())
-    data Foo2Sym0 (l :: TyFun a0123456789876543210 ((~>) (Maybe a0123456789876543210) a0123456789876543210)) :: GHC.Types.Type
+    data Foo2Sym0 :: forall a0123456789876543210.
+                     (~>) a0123456789876543210 ((~>) (Maybe a0123456789876543210) a0123456789876543210)
       where
-        Foo2Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) => Foo2Sym0 l
-    type instance Apply Foo2Sym0 l = Foo2Sym1 l
-    type Foo1Sym2 (t :: a0123456789876543210) (t :: Maybe a0123456789876543210) =
-        Foo1 t t
-    instance SuppressUnusedWarnings Foo1Sym1 where
+        Foo2Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) =>
+                                 Foo2Sym0 a0123456789876543210
+    type instance Apply Foo2Sym0 a0123456789876543210 = Foo2Sym1 a0123456789876543210
+    type Foo1Sym2 (a0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: Maybe a0123456789876543210) =
+        Foo1 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Foo1Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo1Sym1KindInference) GHC.Tuple.())
-    data Foo1Sym1 (l :: a0123456789876543210) (l :: TyFun (Maybe a0123456789876543210) a0123456789876543210) :: GHC.Types.Type
+    data Foo1Sym1 (a0123456789876543210 :: a0123456789876543210) :: (~>) (Maybe a0123456789876543210) a0123456789876543210
       where
-        Foo1Sym1KindInference :: forall l l arg.
-                                 SameKind (Apply (Foo1Sym1 l) arg) (Foo1Sym2 l arg) => Foo1Sym1 l l
-    type instance Apply (Foo1Sym1 l) l = Foo1 l l
+        Foo1Sym1KindInference :: forall a0123456789876543210
+                                        a0123456789876543210
+                                        arg.
+                                 SameKind (Apply (Foo1Sym1 a0123456789876543210) arg) (Foo1Sym2 a0123456789876543210 arg) =>
+                                 Foo1Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Foo1Sym1 a0123456789876543210) a0123456789876543210 = Foo1 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Foo1Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo1Sym0KindInference) GHC.Tuple.())
-    data Foo1Sym0 (l :: TyFun a0123456789876543210 ((~>) (Maybe a0123456789876543210) a0123456789876543210)) :: GHC.Types.Type
+    data Foo1Sym0 :: forall a0123456789876543210.
+                     (~>) a0123456789876543210 ((~>) (Maybe a0123456789876543210) a0123456789876543210)
       where
-        Foo1Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) => Foo1Sym0 l
-    type instance Apply Foo1Sym0 l = Foo1Sym1 l
+        Foo1Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
+                                 Foo1Sym0 a0123456789876543210
+    type instance Apply Foo1Sym0 a0123456789876543210 = Foo1Sym1 a0123456789876543210
     type family Foo5 (a :: a) :: a where
       Foo5 x = Case_0123456789876543210 x x
     type family Foo4 (a :: a) :: a where

--- a/tests/compile-and-dump/Singletons/Classes.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Classes.ghc84.template
@@ -65,44 +65,52 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     type BSym0 = B
     type FSym0 = F
     type GSym0 = G
-    type FooCompareSym2 (t :: Foo) (t :: Foo) = FooCompare t t
-    instance SuppressUnusedWarnings FooCompareSym1 where
+    type FooCompareSym2 (a0123456789876543210 :: Foo) (a0123456789876543210 :: Foo) =
+        FooCompare a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (FooCompareSym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooCompareSym1KindInference) GHC.Tuple.())
-    data FooCompareSym1 (l :: Foo) (l :: TyFun Foo Ordering) :: GHC.Types.Type
+    data FooCompareSym1 (a0123456789876543210 :: Foo) :: (~>) Foo Ordering
       where
-        FooCompareSym1KindInference :: forall l l arg.
-                                       SameKind (Apply (FooCompareSym1 l) arg) (FooCompareSym2 l arg) =>
-                                       FooCompareSym1 l l
-    type instance Apply (FooCompareSym1 l) l = FooCompare l l
+        FooCompareSym1KindInference :: forall a0123456789876543210
+                                              a0123456789876543210
+                                              arg.
+                                       SameKind (Apply (FooCompareSym1 a0123456789876543210) arg) (FooCompareSym2 a0123456789876543210 arg) =>
+                                       FooCompareSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (FooCompareSym1 a0123456789876543210) a0123456789876543210 = FooCompare a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings FooCompareSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooCompareSym0KindInference) GHC.Tuple.())
-    data FooCompareSym0 (l :: TyFun Foo ((~>) Foo Ordering)) :: GHC.Types.Type
+    data FooCompareSym0 :: (~>) Foo ((~>) Foo Ordering)
       where
-        FooCompareSym0KindInference :: forall l arg.
+        FooCompareSym0KindInference :: forall a0123456789876543210 arg.
                                        SameKind (Apply FooCompareSym0 arg) (FooCompareSym1 arg) =>
-                                       FooCompareSym0 l
-    type instance Apply FooCompareSym0 l = FooCompareSym1 l
-    type ConstSym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
-        Const t t
-    instance SuppressUnusedWarnings ConstSym1 where
+                                       FooCompareSym0 a0123456789876543210
+    type instance Apply FooCompareSym0 a0123456789876543210 = FooCompareSym1 a0123456789876543210
+    type ConstSym2 (a0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: b0123456789876543210) =
+        Const a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ConstSym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ConstSym1KindInference) GHC.Tuple.())
-    data ConstSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 a0123456789876543210) :: GHC.Types.Type
+    data ConstSym1 (a0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210.
+                                                                     (~>) b0123456789876543210 a0123456789876543210
       where
-        ConstSym1KindInference :: forall l l arg.
-                                  SameKind (Apply (ConstSym1 l) arg) (ConstSym2 l arg) =>
-                                  ConstSym1 l l
-    type instance Apply (ConstSym1 l) l = Const l l
+        ConstSym1KindInference :: forall a0123456789876543210
+                                         a0123456789876543210
+                                         arg.
+                                  SameKind (Apply (ConstSym1 a0123456789876543210) arg) (ConstSym2 a0123456789876543210 arg) =>
+                                  ConstSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (ConstSym1 a0123456789876543210) a0123456789876543210 = Const a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ConstSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ConstSym0KindInference) GHC.Tuple.())
-    data ConstSym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 a0123456789876543210)) :: GHC.Types.Type
+    data ConstSym0 :: forall a0123456789876543210 b0123456789876543210.
+                      (~>) a0123456789876543210 ((~>) b0123456789876543210 a0123456789876543210)
       where
-        ConstSym0KindInference :: forall l arg.
-                                  SameKind (Apply ConstSym0 arg) (ConstSym1 arg) => ConstSym0 l
-    type instance Apply ConstSym0 l = ConstSym1 l
+        ConstSym0KindInference :: forall a0123456789876543210 arg.
+                                  SameKind (Apply ConstSym0 arg) (ConstSym1 arg) =>
+                                  ConstSym0 a0123456789876543210
+    type instance Apply ConstSym0 a0123456789876543210 = ConstSym1 a0123456789876543210
     type family FooCompare (a :: Foo) (a :: Foo) :: Ordering where
       FooCompare A A = EQSym0
       FooCompare A B = LTSym0
@@ -110,73 +118,84 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       FooCompare B A = EQSym0
     type family Const (a :: a) (a :: b) :: a where
       Const x _ = x
-    type MycompareSym2 (t :: a0123456789876543210) (t :: a0123456789876543210) =
-        Mycompare t t
-    instance SuppressUnusedWarnings MycompareSym1 where
+    type MycompareSym2 (arg0123456789876543210 :: a0123456789876543210) (arg0123456789876543210 :: a0123456789876543210) =
+        Mycompare arg0123456789876543210 arg0123456789876543210
+    instance SuppressUnusedWarnings (MycompareSym1 arg0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MycompareSym1KindInference) GHC.Tuple.())
-    data MycompareSym1 (l :: a0123456789876543210) (l :: TyFun a0123456789876543210 Ordering) :: GHC.Types.Type
+    data MycompareSym1 (arg0123456789876543210 :: a0123456789876543210) :: (~>) a0123456789876543210 Ordering
       where
-        MycompareSym1KindInference :: forall l l arg.
-                                      SameKind (Apply (MycompareSym1 l) arg) (MycompareSym2 l arg) =>
-                                      MycompareSym1 l l
-    type instance Apply (MycompareSym1 l) l = Mycompare l l
+        MycompareSym1KindInference :: forall arg0123456789876543210
+                                             arg0123456789876543210
+                                             arg.
+                                      SameKind (Apply (MycompareSym1 arg0123456789876543210) arg) (MycompareSym2 arg0123456789876543210 arg) =>
+                                      MycompareSym1 arg0123456789876543210 arg0123456789876543210
+    type instance Apply (MycompareSym1 arg0123456789876543210) arg0123456789876543210 = Mycompare arg0123456789876543210 arg0123456789876543210
     instance SuppressUnusedWarnings MycompareSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MycompareSym0KindInference) GHC.Tuple.())
-    data MycompareSym0 (l :: TyFun a0123456789876543210 ((~>) a0123456789876543210 Ordering)) :: GHC.Types.Type
+    data MycompareSym0 :: forall a0123456789876543210.
+                          (~>) a0123456789876543210 ((~>) a0123456789876543210 Ordering)
       where
-        MycompareSym0KindInference :: forall l arg.
+        MycompareSym0KindInference :: forall arg0123456789876543210 arg.
                                       SameKind (Apply MycompareSym0 arg) (MycompareSym1 arg) =>
-                                      MycompareSym0 l
-    type instance Apply MycompareSym0 l = MycompareSym1 l
-    type (<=>@#@$$$) (t :: a0123456789876543210) (t :: a0123456789876543210) =
-        (<=>) t t
-    instance SuppressUnusedWarnings (<=>@#@$$) where
+                                      MycompareSym0 arg0123456789876543210
+    type instance Apply MycompareSym0 arg0123456789876543210 = MycompareSym1 arg0123456789876543210
+    type (<=>@#@$$$) (arg0123456789876543210 :: a0123456789876543210) (arg0123456789876543210 :: a0123456789876543210) =
+        (<=>) arg0123456789876543210 arg0123456789876543210
+    instance SuppressUnusedWarnings ((<=>@#@$$) arg0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:<=>@#@$$###)) GHC.Tuple.())
-    data (<=>@#@$$) (l :: a0123456789876543210) (l :: TyFun a0123456789876543210 Ordering) :: GHC.Types.Type
+    data (<=>@#@$$) (arg0123456789876543210 :: a0123456789876543210) :: (~>) a0123456789876543210 Ordering
       where
-        (:<=>@#@$$###) :: forall l l arg.
-                          SameKind (Apply ((<=>@#@$$) l) arg) ((<=>@#@$$$) l arg) =>
-                          (<=>@#@$$) l l
-    type instance Apply ((<=>@#@$$) l) l = (<=>) l l
+        (:<=>@#@$$###) :: forall arg0123456789876543210
+                                 arg0123456789876543210
+                                 arg.
+                          SameKind (Apply ((<=>@#@$$) arg0123456789876543210) arg) ((<=>@#@$$$) arg0123456789876543210 arg) =>
+                          (<=>@#@$$) arg0123456789876543210 arg0123456789876543210
+    type instance Apply ((<=>@#@$$) arg0123456789876543210) arg0123456789876543210 = (<=>) arg0123456789876543210 arg0123456789876543210
     infix 4 <=>@#@$$
     instance SuppressUnusedWarnings (<=>@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:<=>@#@$###)) GHC.Tuple.())
-    data (<=>@#@$) (l :: TyFun a0123456789876543210 ((~>) a0123456789876543210 Ordering)) :: GHC.Types.Type
+    data <=>@#@$ :: forall a0123456789876543210.
+                    (~>) a0123456789876543210 ((~>) a0123456789876543210 Ordering)
       where
-        (:<=>@#@$###) :: forall l arg.
-                         SameKind (Apply (<=>@#@$) arg) ((<=>@#@$$) arg) => (<=>@#@$) l
-    type instance Apply (<=>@#@$) l = (<=>@#@$$) l
+        (:<=>@#@$###) :: forall arg0123456789876543210 arg.
+                         SameKind (Apply (<=>@#@$) arg) ((<=>@#@$$) arg) =>
+                         (<=>@#@$) arg0123456789876543210
+    type instance Apply (<=>@#@$) arg0123456789876543210 = (<=>@#@$$) arg0123456789876543210
     infix 4 <=>@#@$
     type family TFHelper_0123456789876543210 (a :: a) (a :: a) :: Ordering where
       TFHelper_0123456789876543210 a_0123456789876543210 a_0123456789876543210 = Apply (Apply MycompareSym0 a_0123456789876543210) a_0123456789876543210
-    type TFHelper_0123456789876543210Sym2 (t :: a0123456789876543210) (t :: a0123456789876543210) =
-        TFHelper_0123456789876543210 t t
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym1 where
+    type TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: a0123456789876543210) =
+        TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) TFHelper_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data TFHelper_0123456789876543210Sym1 (l :: a0123456789876543210) (l :: TyFun a0123456789876543210 Ordering) :: GHC.Types.Type
+    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: a0123456789876543210) :: (~>) a0123456789876543210 Ordering
       where
-        TFHelper_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                         SameKind (Apply (TFHelper_0123456789876543210Sym1 l) arg) (TFHelper_0123456789876543210Sym2 l arg) =>
-                                                         TFHelper_0123456789876543210Sym1 l l
-    type instance Apply (TFHelper_0123456789876543210Sym1 l) l = TFHelper_0123456789876543210 l l
+        TFHelper_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                                a0123456789876543210
+                                                                arg.
+                                                         SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) TFHelper_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data TFHelper_0123456789876543210Sym0 (l :: TyFun a0123456789876543210 ((~>) a0123456789876543210 Ordering)) :: GHC.Types.Type
+    data TFHelper_0123456789876543210Sym0 :: forall a0123456789876543210.
+                                             (~>) a0123456789876543210 ((~>) a0123456789876543210 Ordering)
       where
-        TFHelper_0123456789876543210Sym0KindInference :: forall l arg.
+        TFHelper_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                arg.
                                                          SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 l
-    type instance Apply TFHelper_0123456789876543210Sym0 l = TFHelper_0123456789876543210Sym1 l
+                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
     class PMyOrd (a :: GHC.Types.Type) where
       type Mycompare (arg :: a) (arg :: a) :: Ordering
       type (<=>) (arg :: a) (arg :: a) :: Ordering
@@ -186,86 +205,95 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       Mycompare_0123456789876543210 Zero (Succ _) = LTSym0
       Mycompare_0123456789876543210 (Succ _) Zero = GTSym0
       Mycompare_0123456789876543210 (Succ n) (Succ m) = Apply (Apply MycompareSym0 m) n
-    type Mycompare_0123456789876543210Sym2 (t :: Nat) (t :: Nat) =
-        Mycompare_0123456789876543210 t t
-    instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym1 where
+    type Mycompare_0123456789876543210Sym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) =
+        Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Mycompare_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Mycompare_0123456789876543210Sym1 (l :: Nat) (l :: TyFun Nat Ordering) :: GHC.Types.Type
+    data Mycompare_0123456789876543210Sym1 (a0123456789876543210 :: Nat) :: (~>) Nat Ordering
       where
-        Mycompare_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                          SameKind (Apply (Mycompare_0123456789876543210Sym1 l) arg) (Mycompare_0123456789876543210Sym2 l arg) =>
-                                                          Mycompare_0123456789876543210Sym1 l l
-    type instance Apply (Mycompare_0123456789876543210Sym1 l) l = Mycompare_0123456789876543210 l l
+        Mycompare_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (Mycompare_0123456789876543210Sym1 a0123456789876543210) arg) (Mycompare_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                          Mycompare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Mycompare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Mycompare_0123456789876543210Sym0 (l :: TyFun Nat ((~>) Nat Ordering)) :: GHC.Types.Type
+    data Mycompare_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Ordering)
       where
-        Mycompare_0123456789876543210Sym0KindInference :: forall l arg.
+        Mycompare_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                 arg.
                                                           SameKind (Apply Mycompare_0123456789876543210Sym0 arg) (Mycompare_0123456789876543210Sym1 arg) =>
-                                                          Mycompare_0123456789876543210Sym0 l
-    type instance Apply Mycompare_0123456789876543210Sym0 l = Mycompare_0123456789876543210Sym1 l
+                                                          Mycompare_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Mycompare_0123456789876543210Sym0 a0123456789876543210 = Mycompare_0123456789876543210Sym1 a0123456789876543210
     instance PMyOrd Nat where
       type Mycompare a a = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
     type family Mycompare_0123456789876543210 (a :: ()) (a :: ()) :: Ordering where
       Mycompare_0123456789876543210 _ a_0123456789876543210 = Apply (Apply ConstSym0 EQSym0) a_0123456789876543210
-    type Mycompare_0123456789876543210Sym2 (t :: ()) (t :: ()) =
-        Mycompare_0123456789876543210 t t
-    instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym1 where
+    type Mycompare_0123456789876543210Sym2 (a0123456789876543210 :: ()) (a0123456789876543210 :: ()) =
+        Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Mycompare_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Mycompare_0123456789876543210Sym1 (l :: ()) (l :: TyFun () Ordering) :: GHC.Types.Type
+    data Mycompare_0123456789876543210Sym1 (a0123456789876543210 :: ()) :: (~>) () Ordering
       where
-        Mycompare_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                          SameKind (Apply (Mycompare_0123456789876543210Sym1 l) arg) (Mycompare_0123456789876543210Sym2 l arg) =>
-                                                          Mycompare_0123456789876543210Sym1 l l
-    type instance Apply (Mycompare_0123456789876543210Sym1 l) l = Mycompare_0123456789876543210 l l
+        Mycompare_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (Mycompare_0123456789876543210Sym1 a0123456789876543210) arg) (Mycompare_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                          Mycompare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Mycompare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Mycompare_0123456789876543210Sym0 (l :: TyFun () ((~>) () Ordering)) :: GHC.Types.Type
+    data Mycompare_0123456789876543210Sym0 :: (~>) () ((~>) () Ordering)
       where
-        Mycompare_0123456789876543210Sym0KindInference :: forall l arg.
+        Mycompare_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                 arg.
                                                           SameKind (Apply Mycompare_0123456789876543210Sym0 arg) (Mycompare_0123456789876543210Sym1 arg) =>
-                                                          Mycompare_0123456789876543210Sym0 l
-    type instance Apply Mycompare_0123456789876543210Sym0 l = Mycompare_0123456789876543210Sym1 l
+                                                          Mycompare_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Mycompare_0123456789876543210Sym0 a0123456789876543210 = Mycompare_0123456789876543210Sym1 a0123456789876543210
     instance PMyOrd () where
       type Mycompare a a = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
     type family Mycompare_0123456789876543210 (a :: Foo) (a :: Foo) :: Ordering where
       Mycompare_0123456789876543210 a_0123456789876543210 a_0123456789876543210 = Apply (Apply FooCompareSym0 a_0123456789876543210) a_0123456789876543210
-    type Mycompare_0123456789876543210Sym2 (t :: Foo) (t :: Foo) =
-        Mycompare_0123456789876543210 t t
-    instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym1 where
+    type Mycompare_0123456789876543210Sym2 (a0123456789876543210 :: Foo) (a0123456789876543210 :: Foo) =
+        Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Mycompare_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Mycompare_0123456789876543210Sym1 (l :: Foo) (l :: TyFun Foo Ordering) :: GHC.Types.Type
+    data Mycompare_0123456789876543210Sym1 (a0123456789876543210 :: Foo) :: (~>) Foo Ordering
       where
-        Mycompare_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                          SameKind (Apply (Mycompare_0123456789876543210Sym1 l) arg) (Mycompare_0123456789876543210Sym2 l arg) =>
-                                                          Mycompare_0123456789876543210Sym1 l l
-    type instance Apply (Mycompare_0123456789876543210Sym1 l) l = Mycompare_0123456789876543210 l l
+        Mycompare_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (Mycompare_0123456789876543210Sym1 a0123456789876543210) arg) (Mycompare_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                          Mycompare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Mycompare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Mycompare_0123456789876543210Sym0 (l :: TyFun Foo ((~>) Foo Ordering)) :: GHC.Types.Type
+    data Mycompare_0123456789876543210Sym0 :: (~>) Foo ((~>) Foo Ordering)
       where
-        Mycompare_0123456789876543210Sym0KindInference :: forall l arg.
+        Mycompare_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                 arg.
                                                           SameKind (Apply Mycompare_0123456789876543210Sym0 arg) (Mycompare_0123456789876543210Sym1 arg) =>
-                                                          Mycompare_0123456789876543210Sym0 l
-    type instance Apply Mycompare_0123456789876543210Sym0 l = Mycompare_0123456789876543210Sym1 l
+                                                          Mycompare_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Mycompare_0123456789876543210Sym0 a0123456789876543210 = Mycompare_0123456789876543210Sym1 a0123456789876543210
     instance PMyOrd Foo where
       type Mycompare a a = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
     type family TFHelper_0123456789876543210 (a :: Foo2) (a :: Foo2) :: Bool where
@@ -273,30 +301,33 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       TFHelper_0123456789876543210 G G = TrueSym0
       TFHelper_0123456789876543210 F G = FalseSym0
       TFHelper_0123456789876543210 G F = FalseSym0
-    type TFHelper_0123456789876543210Sym2 (t :: Foo2) (t :: Foo2) =
-        TFHelper_0123456789876543210 t t
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym1 where
+    type TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: Foo2) (a0123456789876543210 :: Foo2) =
+        TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) TFHelper_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data TFHelper_0123456789876543210Sym1 (l :: Foo2) (l :: TyFun Foo2 Bool) :: GHC.Types.Type
+    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Foo2) :: (~>) Foo2 Bool
       where
-        TFHelper_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                         SameKind (Apply (TFHelper_0123456789876543210Sym1 l) arg) (TFHelper_0123456789876543210Sym2 l arg) =>
-                                                         TFHelper_0123456789876543210Sym1 l l
-    type instance Apply (TFHelper_0123456789876543210Sym1 l) l = TFHelper_0123456789876543210 l l
+        TFHelper_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                                a0123456789876543210
+                                                                arg.
+                                                         SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) TFHelper_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data TFHelper_0123456789876543210Sym0 (l :: TyFun Foo2 ((~>) Foo2 Bool)) :: GHC.Types.Type
+    data TFHelper_0123456789876543210Sym0 :: (~>) Foo2 ((~>) Foo2 Bool)
       where
-        TFHelper_0123456789876543210Sym0KindInference :: forall l arg.
+        TFHelper_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                arg.
                                                          SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 l
-    type instance Apply TFHelper_0123456789876543210Sym0 l = TFHelper_0123456789876543210Sym1 l
+                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
     instance PEq Foo2 where
       type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
     infix 4 %<=>
@@ -447,60 +478,66 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       Mycompare_0123456789876543210 F F = EQSym0
       Mycompare_0123456789876543210 F _ = LTSym0
       Mycompare_0123456789876543210 _ _ = GTSym0
-    type Mycompare_0123456789876543210Sym2 (t :: Foo2) (t :: Foo2) =
-        Mycompare_0123456789876543210 t t
-    instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym1 where
+    type Mycompare_0123456789876543210Sym2 (a0123456789876543210 :: Foo2) (a0123456789876543210 :: Foo2) =
+        Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Mycompare_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Mycompare_0123456789876543210Sym1 (l :: Foo2) (l :: TyFun Foo2 Ordering) :: GHC.Types.Type
+    data Mycompare_0123456789876543210Sym1 (a0123456789876543210 :: Foo2) :: (~>) Foo2 Ordering
       where
-        Mycompare_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                          SameKind (Apply (Mycompare_0123456789876543210Sym1 l) arg) (Mycompare_0123456789876543210Sym2 l arg) =>
-                                                          Mycompare_0123456789876543210Sym1 l l
-    type instance Apply (Mycompare_0123456789876543210Sym1 l) l = Mycompare_0123456789876543210 l l
+        Mycompare_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (Mycompare_0123456789876543210Sym1 a0123456789876543210) arg) (Mycompare_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                          Mycompare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Mycompare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Mycompare_0123456789876543210Sym0 (l :: TyFun Foo2 ((~>) Foo2 Ordering)) :: GHC.Types.Type
+    data Mycompare_0123456789876543210Sym0 :: (~>) Foo2 ((~>) Foo2 Ordering)
       where
-        Mycompare_0123456789876543210Sym0KindInference :: forall l arg.
+        Mycompare_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                 arg.
                                                           SameKind (Apply Mycompare_0123456789876543210Sym0 arg) (Mycompare_0123456789876543210Sym1 arg) =>
-                                                          Mycompare_0123456789876543210Sym0 l
-    type instance Apply Mycompare_0123456789876543210Sym0 l = Mycompare_0123456789876543210Sym1 l
+                                                          Mycompare_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Mycompare_0123456789876543210Sym0 a0123456789876543210 = Mycompare_0123456789876543210Sym1 a0123456789876543210
     instance PMyOrd Foo2 where
       type Mycompare a a = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
     type family Compare_0123456789876543210 (a :: Foo2) (a :: Foo2) :: Ordering where
       Compare_0123456789876543210 F F = EQSym0
       Compare_0123456789876543210 F _ = LTSym0
       Compare_0123456789876543210 _ _ = GTSym0
-    type Compare_0123456789876543210Sym2 (t :: Foo2) (t :: Foo2) =
-        Compare_0123456789876543210 t t
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym1 where
+    type Compare_0123456789876543210Sym2 (a0123456789876543210 :: Foo2) (a0123456789876543210 :: Foo2) =
+        Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym1 (l :: Foo2) (l :: TyFun Foo2 Ordering) :: GHC.Types.Type
+    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Foo2) :: (~>) Foo2 Ordering
       where
-        Compare_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                        SameKind (Apply (Compare_0123456789876543210Sym1 l) arg) (Compare_0123456789876543210Sym2 l arg) =>
-                                                        Compare_0123456789876543210Sym1 l l
-    type instance Apply (Compare_0123456789876543210Sym1 l) l = Compare_0123456789876543210 l l
+        Compare_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                               a0123456789876543210
+                                                               arg.
+                                                        SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym0 (l :: TyFun Foo2 ((~>) Foo2 Ordering)) :: GHC.Types.Type
+    data Compare_0123456789876543210Sym0 :: (~>) Foo2 ((~>) Foo2 Ordering)
       where
-        Compare_0123456789876543210Sym0KindInference :: forall l arg.
+        Compare_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                               arg.
                                                         SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 l
-    type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
+                                                        Compare_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
     instance POrd Foo2 where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
 Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
@@ -520,44 +557,49 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       mycompare (Succ' _) Zero' = GT
       mycompare (Succ' n) (Succ' m) = (m `mycompare` n)
     type Zero'Sym0 = Zero'
-    type Succ'Sym1 (t :: Nat') = Succ' t
+    type Succ'Sym1 (t0123456789876543210 :: Nat') =
+        Succ' t0123456789876543210
     instance SuppressUnusedWarnings Succ'Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Succ'Sym0KindInference) GHC.Tuple.())
-    data Succ'Sym0 (l :: TyFun Nat' Nat') :: GHC.Types.Type
+    data Succ'Sym0 :: (~>) Nat' Nat'
       where
-        Succ'Sym0KindInference :: forall l arg.
-                                  SameKind (Apply Succ'Sym0 arg) (Succ'Sym1 arg) => Succ'Sym0 l
-    type instance Apply Succ'Sym0 l = Succ' l
+        Succ'Sym0KindInference :: forall t0123456789876543210 arg.
+                                  SameKind (Apply Succ'Sym0 arg) (Succ'Sym1 arg) =>
+                                  Succ'Sym0 t0123456789876543210
+    type instance Apply Succ'Sym0 t0123456789876543210 = Succ' t0123456789876543210
     type family Mycompare_0123456789876543210 (a :: Nat') (a :: Nat') :: Ordering where
       Mycompare_0123456789876543210 Zero' Zero' = EQSym0
       Mycompare_0123456789876543210 Zero' (Succ' _) = LTSym0
       Mycompare_0123456789876543210 (Succ' _) Zero' = GTSym0
       Mycompare_0123456789876543210 (Succ' n) (Succ' m) = Apply (Apply MycompareSym0 m) n
-    type Mycompare_0123456789876543210Sym2 (t :: Nat') (t :: Nat') =
-        Mycompare_0123456789876543210 t t
-    instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym1 where
+    type Mycompare_0123456789876543210Sym2 (a0123456789876543210 :: Nat') (a0123456789876543210 :: Nat') =
+        Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Mycompare_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Mycompare_0123456789876543210Sym1 (l :: Nat') (l :: TyFun Nat' Ordering) :: GHC.Types.Type
+    data Mycompare_0123456789876543210Sym1 (a0123456789876543210 :: Nat') :: (~>) Nat' Ordering
       where
-        Mycompare_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                          SameKind (Apply (Mycompare_0123456789876543210Sym1 l) arg) (Mycompare_0123456789876543210Sym2 l arg) =>
-                                                          Mycompare_0123456789876543210Sym1 l l
-    type instance Apply (Mycompare_0123456789876543210Sym1 l) l = Mycompare_0123456789876543210 l l
+        Mycompare_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (Mycompare_0123456789876543210Sym1 a0123456789876543210) arg) (Mycompare_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                          Mycompare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Mycompare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Mycompare_0123456789876543210Sym0 (l :: TyFun Nat' ((~>) Nat' Ordering)) :: GHC.Types.Type
+    data Mycompare_0123456789876543210Sym0 :: (~>) Nat' ((~>) Nat' Ordering)
       where
-        Mycompare_0123456789876543210Sym0KindInference :: forall l arg.
+        Mycompare_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                 arg.
                                                           SameKind (Apply Mycompare_0123456789876543210Sym0 arg) (Mycompare_0123456789876543210Sym1 arg) =>
-                                                          Mycompare_0123456789876543210Sym0 l
-    type instance Apply Mycompare_0123456789876543210Sym0 l = Mycompare_0123456789876543210Sym1 l
+                                                          Mycompare_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Mycompare_0123456789876543210Sym0 a0123456789876543210 = Mycompare_0123456789876543210Sym1 a0123456789876543210
     instance PMyOrd Nat' where
       type Mycompare a a = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
     data instance Sing :: Nat' -> GHC.Types.Type :: Nat'

--- a/tests/compile-and-dump/Singletons/Classes2.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Classes2.ghc84.template
@@ -15,45 +15,49 @@ Singletons/Classes2.hs:(0,0)-(0,0): Splicing declarations
       mycompare (SuccFoo _) ZeroFoo = GT
       mycompare (SuccFoo n) (SuccFoo m) = (m `mycompare` n)
     type ZeroFooSym0 = ZeroFoo
-    type SuccFooSym1 (t :: NatFoo) = SuccFoo t
+    type SuccFooSym1 (t0123456789876543210 :: NatFoo) =
+        SuccFoo t0123456789876543210
     instance SuppressUnusedWarnings SuccFooSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SuccFooSym0KindInference) GHC.Tuple.())
-    data SuccFooSym0 (l :: TyFun NatFoo NatFoo) :: GHC.Types.Type
+    data SuccFooSym0 :: (~>) NatFoo NatFoo
       where
-        SuccFooSym0KindInference :: forall l arg.
+        SuccFooSym0KindInference :: forall t0123456789876543210 arg.
                                     SameKind (Apply SuccFooSym0 arg) (SuccFooSym1 arg) =>
-                                    SuccFooSym0 l
-    type instance Apply SuccFooSym0 l = SuccFoo l
+                                    SuccFooSym0 t0123456789876543210
+    type instance Apply SuccFooSym0 t0123456789876543210 = SuccFoo t0123456789876543210
     type family Mycompare_0123456789876543210 (a :: NatFoo) (a :: NatFoo) :: Ordering where
       Mycompare_0123456789876543210 ZeroFoo ZeroFoo = EQSym0
       Mycompare_0123456789876543210 ZeroFoo (SuccFoo _) = LTSym0
       Mycompare_0123456789876543210 (SuccFoo _) ZeroFoo = GTSym0
       Mycompare_0123456789876543210 (SuccFoo n) (SuccFoo m) = Apply (Apply MycompareSym0 m) n
-    type Mycompare_0123456789876543210Sym2 (t :: NatFoo) (t :: NatFoo) =
-        Mycompare_0123456789876543210 t t
-    instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym1 where
+    type Mycompare_0123456789876543210Sym2 (a0123456789876543210 :: NatFoo) (a0123456789876543210 :: NatFoo) =
+        Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Mycompare_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Mycompare_0123456789876543210Sym1 (l :: NatFoo) (l :: TyFun NatFoo Ordering) :: GHC.Types.Type
+    data Mycompare_0123456789876543210Sym1 (a0123456789876543210 :: NatFoo) :: (~>) NatFoo Ordering
       where
-        Mycompare_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                          SameKind (Apply (Mycompare_0123456789876543210Sym1 l) arg) (Mycompare_0123456789876543210Sym2 l arg) =>
-                                                          Mycompare_0123456789876543210Sym1 l l
-    type instance Apply (Mycompare_0123456789876543210Sym1 l) l = Mycompare_0123456789876543210 l l
+        Mycompare_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (Mycompare_0123456789876543210Sym1 a0123456789876543210) arg) (Mycompare_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                          Mycompare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Mycompare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Mycompare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Mycompare_0123456789876543210Sym0 (l :: TyFun NatFoo ((~>) NatFoo Ordering)) :: GHC.Types.Type
+    data Mycompare_0123456789876543210Sym0 :: (~>) NatFoo ((~>) NatFoo Ordering)
       where
-        Mycompare_0123456789876543210Sym0KindInference :: forall l arg.
+        Mycompare_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                 arg.
                                                           SameKind (Apply Mycompare_0123456789876543210Sym0 arg) (Mycompare_0123456789876543210Sym1 arg) =>
-                                                          Mycompare_0123456789876543210Sym0 l
-    type instance Apply Mycompare_0123456789876543210Sym0 l = Mycompare_0123456789876543210Sym1 l
+                                                          Mycompare_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Mycompare_0123456789876543210Sym0 a0123456789876543210 = Mycompare_0123456789876543210Sym1 a0123456789876543210
     instance PMyOrd NatFoo where
       type Mycompare a a = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
     data instance Sing :: NatFoo -> GHC.Types.Type :: NatFoo

--- a/tests/compile-and-dump/Singletons/Contains.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Contains.ghc84.template
@@ -7,26 +7,29 @@ Singletons/Contains.hs:(0,0)-(0,0): Splicing declarations
     contains :: Eq a => a -> [a] -> Bool
     contains _ GHC.Types.[] = False
     contains elt (h GHC.Types.: t) = ((elt == h) || ((contains elt) t))
-    type ContainsSym2 (t :: a0123456789876543210) (t :: [a0123456789876543210]) =
-        Contains t t
-    instance SuppressUnusedWarnings ContainsSym1 where
+    type ContainsSym2 (a0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: [a0123456789876543210]) =
+        Contains a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ContainsSym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ContainsSym1KindInference) GHC.Tuple.())
-    data ContainsSym1 (l :: a0123456789876543210) (l :: TyFun [a0123456789876543210] Bool) :: GHC.Types.Type
+    data ContainsSym1 (a0123456789876543210 :: a0123456789876543210) :: (~>) [a0123456789876543210] Bool
       where
-        ContainsSym1KindInference :: forall l l arg.
-                                     SameKind (Apply (ContainsSym1 l) arg) (ContainsSym2 l arg) =>
-                                     ContainsSym1 l l
-    type instance Apply (ContainsSym1 l) l = Contains l l
+        ContainsSym1KindInference :: forall a0123456789876543210
+                                            a0123456789876543210
+                                            arg.
+                                     SameKind (Apply (ContainsSym1 a0123456789876543210) arg) (ContainsSym2 a0123456789876543210 arg) =>
+                                     ContainsSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (ContainsSym1 a0123456789876543210) a0123456789876543210 = Contains a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ContainsSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ContainsSym0KindInference) GHC.Tuple.())
-    data ContainsSym0 (l :: TyFun a0123456789876543210 ((~>) [a0123456789876543210] Bool)) :: GHC.Types.Type
+    data ContainsSym0 :: forall a0123456789876543210.
+                         (~>) a0123456789876543210 ((~>) [a0123456789876543210] Bool)
       where
-        ContainsSym0KindInference :: forall l arg.
+        ContainsSym0KindInference :: forall a0123456789876543210 arg.
                                      SameKind (Apply ContainsSym0 arg) (ContainsSym1 arg) =>
-                                     ContainsSym0 l
-    type instance Apply ContainsSym0 l = ContainsSym1 l
+                                     ContainsSym0 a0123456789876543210
+    type instance Apply ContainsSym0 a0123456789876543210 = ContainsSym1 a0123456789876543210
     type family Contains (a :: a) (a :: [a]) :: Bool where
       Contains _ '[] = FalseSym0
       Contains elt ((:) h t) = Apply (Apply (||@#@$) (Apply (Apply (==@#@$) elt) h)) (Apply (Apply ContainsSym0 elt) t)

--- a/tests/compile-and-dump/Singletons/DataValues.ghc84.template
+++ b/tests/compile-and-dump/Singletons/DataValues.ghc84.template
@@ -16,24 +16,30 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
     complex = (Pair ((Pair (Just Zero)) Zero)) False
     tuple = (False, Just Zero, True)
     aList = [Zero, Succ Zero, Succ (Succ Zero)]
-    type PairSym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
-        Pair t t
-    instance SuppressUnusedWarnings PairSym1 where
+    type PairSym2 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: b0123456789876543210) =
+        Pair t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (PairSym1 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) PairSym1KindInference) GHC.Tuple.())
-    data PairSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 (Pair a0123456789876543210 b0123456789876543210)) :: GHC.Types.Type
+    data PairSym1 (t0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210.
+                                                                    (~>) b0123456789876543210 (Pair a0123456789876543210 b0123456789876543210)
       where
-        PairSym1KindInference :: forall l l arg.
-                                 SameKind (Apply (PairSym1 l) arg) (PairSym2 l arg) => PairSym1 l l
-    type instance Apply (PairSym1 l) l = Pair l l
+        PairSym1KindInference :: forall t0123456789876543210
+                                        t0123456789876543210
+                                        arg.
+                                 SameKind (Apply (PairSym1 t0123456789876543210) arg) (PairSym2 t0123456789876543210 arg) =>
+                                 PairSym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (PairSym1 t0123456789876543210) t0123456789876543210 = Pair t0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings PairSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) PairSym0KindInference) GHC.Tuple.())
-    data PairSym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 (Pair a0123456789876543210 b0123456789876543210))) :: GHC.Types.Type
+    data PairSym0 :: forall a0123456789876543210 b0123456789876543210.
+                     (~>) a0123456789876543210 ((~>) b0123456789876543210 (Pair a0123456789876543210 b0123456789876543210))
       where
-        PairSym0KindInference :: forall l arg.
-                                 SameKind (Apply PairSym0 arg) (PairSym1 arg) => PairSym0 l
-    type instance Apply PairSym0 l = PairSym1 l
+        PairSym0KindInference :: forall t0123456789876543210 arg.
+                                 SameKind (Apply PairSym0 arg) (PairSym1 arg) =>
+                                 PairSym0 t0123456789876543210
+    type instance Apply PairSym0 t0123456789876543210 = PairSym1 t0123456789876543210
     type AListSym0 = AList
     type TupleSym0 = Tuple
     type ComplexSym0 = Complex
@@ -48,41 +54,51 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
       Pr = Apply (Apply PairSym0 (Apply SuccSym0 ZeroSym0)) (Apply (Apply (:@#@$) ZeroSym0) '[])
     type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Pair a b) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 p_0123456789876543210 (Pair arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Pair ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: Pair a0123456789876543210 b0123456789876543210) (t :: Symbol) =
-        ShowsPrec_0123456789876543210 t t t
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+    type ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Pair a0123456789876543210 b0123456789876543210) (a0123456789876543210 :: Symbol) =
+        ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym2 (l :: GHC.Types.Nat) (l :: Pair a0123456789876543210 b0123456789876543210) (l :: TyFun Symbol Symbol) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Pair a0123456789876543210 b0123456789876543210) :: (~>) Symbol Symbol
       where
-        ShowsPrec_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 l l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+        ShowsPrec_0123456789876543210Sym2KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun (Pair a0123456789876543210 b0123456789876543210) ((~>) Symbol Symbol)) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: forall a0123456789876543210
+                                                                                             b0123456789876543210.
+                                                                                      (~>) (Pair a0123456789876543210 b0123456789876543210) ((~>) Symbol Symbol)
       where
-        ShowsPrec_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+        ShowsPrec_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) (Pair a0123456789876543210 b0123456789876543210) ((~>) Symbol Symbol))) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym0 :: forall a0123456789876543210
+                                                     b0123456789876543210.
+                                              (~>) GHC.Types.Nat ((~>) (Pair a0123456789876543210 b0123456789876543210) ((~>) Symbol Symbol))
       where
-        ShowsPrec_0123456789876543210Sym0KindInference :: forall l arg.
+        ShowsPrec_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                 arg.
                                                           SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 l
-    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
     instance PShow (Pair a b) where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     sAList :: Sing AListSym0

--- a/tests/compile-and-dump/Singletons/EmptyShowDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/EmptyShowDeriving.ghc84.template
@@ -9,41 +9,47 @@ Singletons/EmptyShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     type family Case_0123456789876543210 v_0123456789876543210 a_0123456789876543210 t where
     type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Foo) (a :: GHC.Types.Symbol) :: GHC.Types.Symbol where
       ShowsPrec_0123456789876543210 _ v_0123456789876543210 a_0123456789876543210 = Apply (Case_0123456789876543210 v_0123456789876543210 a_0123456789876543210 v_0123456789876543210) a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: Foo) (t :: GHC.Types.Symbol) =
-        ShowsPrec_0123456789876543210 t t t
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+    type ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Foo) (a0123456789876543210 :: GHC.Types.Symbol) =
+        ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym2 (l :: GHC.Types.Nat) (l :: Foo) (l :: TyFun GHC.Types.Symbol GHC.Types.Symbol) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Foo) :: (~>) GHC.Types.Symbol GHC.Types.Symbol
       where
-        ShowsPrec_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 l l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+        ShowsPrec_0123456789876543210Sym2KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun Foo ((~>) GHC.Types.Symbol GHC.Types.Symbol)) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: (~>) Foo ((~>) GHC.Types.Symbol GHC.Types.Symbol)
       where
-        ShowsPrec_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+        ShowsPrec_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) Foo ((~>) GHC.Types.Symbol GHC.Types.Symbol))) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) Foo ((~>) GHC.Types.Symbol GHC.Types.Symbol))
       where
-        ShowsPrec_0123456789876543210Sym0KindInference :: forall l arg.
+        ShowsPrec_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                 arg.
                                                           SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 l
-    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
     instance PShow Foo where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     data instance Sing :: Foo -> GHC.Types.Type :: Foo

--- a/tests/compile-and-dump/Singletons/EnumDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/EnumDeriving.ghc84.template
@@ -25,36 +25,38 @@ Singletons/EnumDeriving.hs:(0,0)-(0,0): Splicing declarations
       Case_0123456789876543210 n False = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (Data.Singletons.Prelude.Num.FromInteger 1))
     type family ToEnum_0123456789876543210 (a :: GHC.Types.Nat) :: Foo where
       ToEnum_0123456789876543210 n = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (Data.Singletons.Prelude.Num.FromInteger 0))
-    type ToEnum_0123456789876543210Sym1 (t :: GHC.Types.Nat) =
-        ToEnum_0123456789876543210 t
+    type ToEnum_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) =
+        ToEnum_0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ToEnum_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ToEnum_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ToEnum_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat Foo) :: GHC.Types.Type
+    data ToEnum_0123456789876543210Sym0 :: (~>) GHC.Types.Nat Foo
       where
-        ToEnum_0123456789876543210Sym0KindInference :: forall l arg.
+        ToEnum_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                              arg.
                                                        SameKind (Apply ToEnum_0123456789876543210Sym0 arg) (ToEnum_0123456789876543210Sym1 arg) =>
-                                                       ToEnum_0123456789876543210Sym0 l
-    type instance Apply ToEnum_0123456789876543210Sym0 l = ToEnum_0123456789876543210 l
+                                                       ToEnum_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply ToEnum_0123456789876543210Sym0 a0123456789876543210 = ToEnum_0123456789876543210 a0123456789876543210
     type family FromEnum_0123456789876543210 (a :: Foo) :: GHC.Types.Nat where
       FromEnum_0123456789876543210 Bar = Data.Singletons.Prelude.Num.FromInteger 0
       FromEnum_0123456789876543210 Baz = Data.Singletons.Prelude.Num.FromInteger 1
       FromEnum_0123456789876543210 Bum = Data.Singletons.Prelude.Num.FromInteger 2
-    type FromEnum_0123456789876543210Sym1 (t :: Foo) =
-        FromEnum_0123456789876543210 t
+    type FromEnum_0123456789876543210Sym1 (a0123456789876543210 :: Foo) =
+        FromEnum_0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings FromEnum_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) FromEnum_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data FromEnum_0123456789876543210Sym0 (l :: TyFun Foo GHC.Types.Nat) :: GHC.Types.Type
+    data FromEnum_0123456789876543210Sym0 :: (~>) Foo GHC.Types.Nat
       where
-        FromEnum_0123456789876543210Sym0KindInference :: forall l arg.
+        FromEnum_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                arg.
                                                          SameKind (Apply FromEnum_0123456789876543210Sym0 arg) (FromEnum_0123456789876543210Sym1 arg) =>
-                                                         FromEnum_0123456789876543210Sym0 l
-    type instance Apply FromEnum_0123456789876543210Sym0 l = FromEnum_0123456789876543210 l
+                                                         FromEnum_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply FromEnum_0123456789876543210Sym0 a0123456789876543210 = FromEnum_0123456789876543210 a0123456789876543210
     instance PEnum Foo where
       type ToEnum a = Apply ToEnum_0123456789876543210Sym0 a
       type FromEnum a = Apply FromEnum_0123456789876543210Sym0 a
@@ -145,35 +147,37 @@ Singletons/EnumDeriving.hs:0:0:: Splicing declarations
       Case_0123456789876543210 n False = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (Data.Singletons.Prelude.Num.FromInteger 1))
     type family ToEnum_0123456789876543210 (a :: GHC.Types.Nat) :: Quux where
       ToEnum_0123456789876543210 n = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (Data.Singletons.Prelude.Num.FromInteger 0))
-    type ToEnum_0123456789876543210Sym1 (t :: GHC.Types.Nat) =
-        ToEnum_0123456789876543210 t
+    type ToEnum_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) =
+        ToEnum_0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ToEnum_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ToEnum_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ToEnum_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat Quux) :: GHC.Types.Type
+    data ToEnum_0123456789876543210Sym0 :: (~>) GHC.Types.Nat Quux
       where
-        ToEnum_0123456789876543210Sym0KindInference :: forall l arg.
+        ToEnum_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                              arg.
                                                        SameKind (Apply ToEnum_0123456789876543210Sym0 arg) (ToEnum_0123456789876543210Sym1 arg) =>
-                                                       ToEnum_0123456789876543210Sym0 l
-    type instance Apply ToEnum_0123456789876543210Sym0 l = ToEnum_0123456789876543210 l
+                                                       ToEnum_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply ToEnum_0123456789876543210Sym0 a0123456789876543210 = ToEnum_0123456789876543210 a0123456789876543210
     type family FromEnum_0123456789876543210 (a :: Quux) :: GHC.Types.Nat where
       FromEnum_0123456789876543210 Q1 = Data.Singletons.Prelude.Num.FromInteger 0
       FromEnum_0123456789876543210 Q2 = Data.Singletons.Prelude.Num.FromInteger 1
-    type FromEnum_0123456789876543210Sym1 (t :: Quux) =
-        FromEnum_0123456789876543210 t
+    type FromEnum_0123456789876543210Sym1 (a0123456789876543210 :: Quux) =
+        FromEnum_0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings FromEnum_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) FromEnum_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data FromEnum_0123456789876543210Sym0 (l :: TyFun Quux GHC.Types.Nat) :: GHC.Types.Type
+    data FromEnum_0123456789876543210Sym0 :: (~>) Quux GHC.Types.Nat
       where
-        FromEnum_0123456789876543210Sym0KindInference :: forall l arg.
+        FromEnum_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                arg.
                                                          SameKind (Apply FromEnum_0123456789876543210Sym0 arg) (FromEnum_0123456789876543210Sym1 arg) =>
-                                                         FromEnum_0123456789876543210Sym0 l
-    type instance Apply FromEnum_0123456789876543210Sym0 l = FromEnum_0123456789876543210 l
+                                                         FromEnum_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply FromEnum_0123456789876543210Sym0 a0123456789876543210 = FromEnum_0123456789876543210 a0123456789876543210
     instance PEnum Quux where
       type ToEnum a = Apply ToEnum_0123456789876543210Sym0 a
       type FromEnum a = Apply FromEnum_0123456789876543210Sym0 a

--- a/tests/compile-and-dump/Singletons/Error.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Error.ghc84.template
@@ -7,15 +7,18 @@ Singletons/Error.hs:(0,0)-(0,0): Splicing declarations
     head :: [a] -> a
     head (a GHC.Types.: _) = a
     head GHC.Types.[] = error "Data.Singletons.List.head: empty list"
-    type HeadSym1 (t :: [a0123456789876543210]) = Head t
+    type HeadSym1 (a0123456789876543210 :: [a0123456789876543210]) =
+        Head a0123456789876543210
     instance SuppressUnusedWarnings HeadSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) HeadSym0KindInference) GHC.Tuple.())
-    data HeadSym0 (l :: TyFun [a0123456789876543210] a0123456789876543210) :: GHC.Types.Type
+    data HeadSym0 :: forall a0123456789876543210.
+                     (~>) [a0123456789876543210] a0123456789876543210
       where
-        HeadSym0KindInference :: forall l arg.
-                                 SameKind (Apply HeadSym0 arg) (HeadSym1 arg) => HeadSym0 l
-    type instance Apply HeadSym0 l = Head l
+        HeadSym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply HeadSym0 arg) (HeadSym1 arg) =>
+                                 HeadSym0 a0123456789876543210
+    type instance Apply HeadSym0 a0123456789876543210 = Head a0123456789876543210
     type family Head (a :: [a]) :: a where
       Head ((:) a _) = a
       Head '[] = Apply ErrorSym0 "Data.Singletons.List.head: empty list"

--- a/tests/compile-and-dump/Singletons/Fixity.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Fixity.ghc84.template
@@ -16,49 +16,57 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
     (====) :: a -> a -> a
     (====) a _ = a
     infix 4 ====
-    type (====@#@$$$) (t :: a0123456789876543210) (t :: a0123456789876543210) =
-        (====) t t
-    instance SuppressUnusedWarnings (====@#@$$) where
+    type (====@#@$$$) (a0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: a0123456789876543210) =
+        (====) a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings ((====@#@$$) a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:====@#@$$###)) GHC.Tuple.())
-    data (====@#@$$) (l :: a0123456789876543210) (l :: TyFun a0123456789876543210 a0123456789876543210) :: GHC.Types.Type
+    data (====@#@$$) (a0123456789876543210 :: a0123456789876543210) :: (~>) a0123456789876543210 a0123456789876543210
       where
-        (:====@#@$$###) :: forall l l arg.
-                           SameKind (Apply ((====@#@$$) l) arg) ((====@#@$$$) l arg) =>
-                           (====@#@$$) l l
-    type instance Apply ((====@#@$$) l) l = (====) l l
+        (:====@#@$$###) :: forall a0123456789876543210
+                                  a0123456789876543210
+                                  arg.
+                           SameKind (Apply ((====@#@$$) a0123456789876543210) arg) ((====@#@$$$) a0123456789876543210 arg) =>
+                           (====@#@$$) a0123456789876543210 a0123456789876543210
+    type instance Apply ((====@#@$$) a0123456789876543210) a0123456789876543210 = (====) a0123456789876543210 a0123456789876543210
     infix 4 ====@#@$$
     instance SuppressUnusedWarnings (====@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:====@#@$###)) GHC.Tuple.())
-    data (====@#@$) (l :: TyFun a0123456789876543210 ((~>) a0123456789876543210 a0123456789876543210)) :: GHC.Types.Type
+    data ====@#@$ :: forall a0123456789876543210.
+                     (~>) a0123456789876543210 ((~>) a0123456789876543210 a0123456789876543210)
       where
-        (:====@#@$###) :: forall l arg.
-                          SameKind (Apply (====@#@$) arg) ((====@#@$$) arg) => (====@#@$) l
-    type instance Apply (====@#@$) l = (====@#@$$) l
+        (:====@#@$###) :: forall a0123456789876543210 arg.
+                          SameKind (Apply (====@#@$) arg) ((====@#@$$) arg) =>
+                          (====@#@$) a0123456789876543210
+    type instance Apply (====@#@$) a0123456789876543210 = (====@#@$$) a0123456789876543210
     infix 4 ====@#@$
     type family (====) (a :: a) (a :: a) :: a where
       (====) a _ = a
-    type (<=>@#@$$$) (t :: a0123456789876543210) (t :: a0123456789876543210) =
-        (<=>) t t
-    instance SuppressUnusedWarnings (<=>@#@$$) where
+    type (<=>@#@$$$) (arg0123456789876543210 :: a0123456789876543210) (arg0123456789876543210 :: a0123456789876543210) =
+        (<=>) arg0123456789876543210 arg0123456789876543210
+    instance SuppressUnusedWarnings ((<=>@#@$$) arg0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:<=>@#@$$###)) GHC.Tuple.())
-    data (<=>@#@$$) (l :: a0123456789876543210) (l :: TyFun a0123456789876543210 Ordering) :: GHC.Types.Type
+    data (<=>@#@$$) (arg0123456789876543210 :: a0123456789876543210) :: (~>) a0123456789876543210 Ordering
       where
-        (:<=>@#@$$###) :: forall l l arg.
-                          SameKind (Apply ((<=>@#@$$) l) arg) ((<=>@#@$$$) l arg) =>
-                          (<=>@#@$$) l l
-    type instance Apply ((<=>@#@$$) l) l = (<=>) l l
+        (:<=>@#@$$###) :: forall arg0123456789876543210
+                                 arg0123456789876543210
+                                 arg.
+                          SameKind (Apply ((<=>@#@$$) arg0123456789876543210) arg) ((<=>@#@$$$) arg0123456789876543210 arg) =>
+                          (<=>@#@$$) arg0123456789876543210 arg0123456789876543210
+    type instance Apply ((<=>@#@$$) arg0123456789876543210) arg0123456789876543210 = (<=>) arg0123456789876543210 arg0123456789876543210
     infix 4 <=>@#@$$
     instance SuppressUnusedWarnings (<=>@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:<=>@#@$###)) GHC.Tuple.())
-    data (<=>@#@$) (l :: TyFun a0123456789876543210 ((~>) a0123456789876543210 Ordering)) :: GHC.Types.Type
+    data <=>@#@$ :: forall a0123456789876543210.
+                    (~>) a0123456789876543210 ((~>) a0123456789876543210 Ordering)
       where
-        (:<=>@#@$###) :: forall l arg.
-                         SameKind (Apply (<=>@#@$) arg) ((<=>@#@$$) arg) => (<=>@#@$) l
-    type instance Apply (<=>@#@$) l = (<=>@#@$$) l
+        (:<=>@#@$###) :: forall arg0123456789876543210 arg.
+                         SameKind (Apply (<=>@#@$) arg) ((<=>@#@$$) arg) =>
+                         (<=>@#@$) arg0123456789876543210
+    type instance Apply (<=>@#@$) arg0123456789876543210 = (<=>@#@$$) arg0123456789876543210
     infix 4 <=>@#@$
     class PMyOrd (a :: GHC.Types.Type) where
       type (<=>) (arg :: a) (arg :: a) :: Ordering

--- a/tests/compile-and-dump/Singletons/FunDeps.ghc84.template
+++ b/tests/compile-and-dump/Singletons/FunDeps.ghc84.template
@@ -22,58 +22,66 @@ Singletons/FunDeps.hs:(0,0)-(0,0): Splicing declarations
     type T1Sym0 = T1
     type family T1 where
       T1 = Apply MethSym0 TrueSym0
-    type MethSym1 (t :: a0123456789876543210) = Meth t
+    type MethSym1 (arg0123456789876543210 :: a0123456789876543210) =
+        Meth arg0123456789876543210
     instance SuppressUnusedWarnings MethSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MethSym0KindInference) GHC.Tuple.())
-    data MethSym0 (l :: TyFun a0123456789876543210 a0123456789876543210) :: GHC.Types.Type
+    data MethSym0 :: forall a0123456789876543210.
+                     (~>) a0123456789876543210 a0123456789876543210
       where
-        MethSym0KindInference :: forall l arg.
-                                 SameKind (Apply MethSym0 arg) (MethSym1 arg) => MethSym0 l
-    type instance Apply MethSym0 l = Meth l
-    type L2rSym1 (t :: a0123456789876543210) = L2r t
+        MethSym0KindInference :: forall arg0123456789876543210 arg.
+                                 SameKind (Apply MethSym0 arg) (MethSym1 arg) =>
+                                 MethSym0 arg0123456789876543210
+    type instance Apply MethSym0 arg0123456789876543210 = Meth arg0123456789876543210
+    type L2rSym1 (arg0123456789876543210 :: a0123456789876543210) =
+        L2r arg0123456789876543210
     instance SuppressUnusedWarnings L2rSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) L2rSym0KindInference) GHC.Tuple.())
-    data L2rSym0 (l :: TyFun a0123456789876543210 b0123456789876543210) :: GHC.Types.Type
+    data L2rSym0 :: forall a0123456789876543210 b0123456789876543210.
+                    (~>) a0123456789876543210 b0123456789876543210
       where
-        L2rSym0KindInference :: forall l arg.
-                                SameKind (Apply L2rSym0 arg) (L2rSym1 arg) => L2rSym0 l
-    type instance Apply L2rSym0 l = L2r l
+        L2rSym0KindInference :: forall arg0123456789876543210 arg.
+                                SameKind (Apply L2rSym0 arg) (L2rSym1 arg) =>
+                                L2rSym0 arg0123456789876543210
+    type instance Apply L2rSym0 arg0123456789876543210 = L2r arg0123456789876543210
     class PFD (a :: GHC.Types.Type) (b :: GHC.Types.Type) | a -> b where
       type Meth (arg :: a) :: a
       type L2r (arg :: a) :: b
     type family Meth_0123456789876543210 (a :: Bool) :: Bool where
       Meth_0123456789876543210 a_0123456789876543210 = Apply NotSym0 a_0123456789876543210
-    type Meth_0123456789876543210Sym1 (t :: Bool) =
-        Meth_0123456789876543210 t
+    type Meth_0123456789876543210Sym1 (a0123456789876543210 :: Bool) =
+        Meth_0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Meth_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Meth_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Meth_0123456789876543210Sym0 (l :: TyFun Bool Bool) :: GHC.Types.Type
+    data Meth_0123456789876543210Sym0 :: (~>) Bool Bool
       where
-        Meth_0123456789876543210Sym0KindInference :: forall l arg.
+        Meth_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                            arg.
                                                      SameKind (Apply Meth_0123456789876543210Sym0 arg) (Meth_0123456789876543210Sym1 arg) =>
-                                                     Meth_0123456789876543210Sym0 l
-    type instance Apply Meth_0123456789876543210Sym0 l = Meth_0123456789876543210 l
+                                                     Meth_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Meth_0123456789876543210Sym0 a0123456789876543210 = Meth_0123456789876543210 a0123456789876543210
     type family L2r_0123456789876543210 (a :: Bool) :: Nat where
       L2r_0123456789876543210 False = FromInteger 0
       L2r_0123456789876543210 True = FromInteger 1
-    type L2r_0123456789876543210Sym1 (t :: Bool) =
-        L2r_0123456789876543210 t
+    type L2r_0123456789876543210Sym1 (a0123456789876543210 :: Bool) =
+        L2r_0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings L2r_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) L2r_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data L2r_0123456789876543210Sym0 (l :: TyFun Bool Nat) :: GHC.Types.Type
+    data L2r_0123456789876543210Sym0 :: (~>) Bool Nat
       where
-        L2r_0123456789876543210Sym0KindInference :: forall l arg.
+        L2r_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                           arg.
                                                     SameKind (Apply L2r_0123456789876543210Sym0 arg) (L2r_0123456789876543210Sym1 arg) =>
-                                                    L2r_0123456789876543210Sym0 l
-    type instance Apply L2r_0123456789876543210Sym0 l = L2r_0123456789876543210 l
+                                                    L2r_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply L2r_0123456789876543210Sym0 a0123456789876543210 = L2r_0123456789876543210 a0123456789876543210
     instance PFD Bool Nat where
       type Meth a = Apply Meth_0123456789876543210Sym0 a
       type L2r a = Apply L2r_0123456789876543210Sym0 a

--- a/tests/compile-and-dump/Singletons/HigherOrder.ghc84.template
+++ b/tests/compile-and-dump/Singletons/HigherOrder.ghc84.template
@@ -41,256 +41,315 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
       = ((zipWith (\ n b -> if b then Succ (Succ n) else n)) ns) bs
     etad :: [Nat] -> [Bool] -> [Nat]
     etad = zipWith (\ n b -> if b then Succ (Succ n) else n)
-    type LeftSym1 (t :: a0123456789876543210) = Left t
+    type LeftSym1 (t0123456789876543210 :: a0123456789876543210) =
+        Left t0123456789876543210
     instance SuppressUnusedWarnings LeftSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) LeftSym0KindInference) GHC.Tuple.())
-    data LeftSym0 (l :: TyFun a0123456789876543210 (Either a0123456789876543210 b0123456789876543210)) :: GHC.Types.Type
+    data LeftSym0 :: forall a0123456789876543210 b0123456789876543210.
+                     (~>) a0123456789876543210 (Either a0123456789876543210 b0123456789876543210)
       where
-        LeftSym0KindInference :: forall l arg.
-                                 SameKind (Apply LeftSym0 arg) (LeftSym1 arg) => LeftSym0 l
-    type instance Apply LeftSym0 l = Left l
-    type RightSym1 (t :: b0123456789876543210) = Right t
+        LeftSym0KindInference :: forall t0123456789876543210 arg.
+                                 SameKind (Apply LeftSym0 arg) (LeftSym1 arg) =>
+                                 LeftSym0 t0123456789876543210
+    type instance Apply LeftSym0 t0123456789876543210 = Left t0123456789876543210
+    type RightSym1 (t0123456789876543210 :: b0123456789876543210) =
+        Right t0123456789876543210
     instance SuppressUnusedWarnings RightSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) RightSym0KindInference) GHC.Tuple.())
-    data RightSym0 (l :: TyFun b0123456789876543210 (Either a0123456789876543210 b0123456789876543210)) :: GHC.Types.Type
+    data RightSym0 :: forall a0123456789876543210 b0123456789876543210.
+                      (~>) b0123456789876543210 (Either a0123456789876543210 b0123456789876543210)
       where
-        RightSym0KindInference :: forall l arg.
-                                  SameKind (Apply RightSym0 arg) (RightSym1 arg) => RightSym0 l
-    type instance Apply RightSym0 l = Right l
+        RightSym0KindInference :: forall t0123456789876543210 arg.
+                                  SameKind (Apply RightSym0 arg) (RightSym1 arg) =>
+                                  RightSym0 t0123456789876543210
+    type instance Apply RightSym0 t0123456789876543210 = Right t0123456789876543210
     type family Case_0123456789876543210 ns bs n b t where
       Case_0123456789876543210 ns bs n b True = Apply SuccSym0 (Apply SuccSym0 n)
       Case_0123456789876543210 ns bs n b False = n
     type family Lambda_0123456789876543210 ns bs t t where
       Lambda_0123456789876543210 ns bs n b = Case_0123456789876543210 ns bs n b b
-    type Lambda_0123456789876543210Sym4 t t t t =
-        Lambda_0123456789876543210 t t t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym3 where
+    type Lambda_0123456789876543210Sym4 ns0123456789876543210 bs0123456789876543210 t0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 ns0123456789876543210 bs0123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym3 t0123456789876543210 bs0123456789876543210 ns0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym3KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym3 l l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym3 ns0123456789876543210 bs0123456789876543210 t0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym3KindInference :: forall l l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym3 l l l) arg) (Lambda_0123456789876543210Sym4 l l l arg) =>
-                                                       Lambda_0123456789876543210Sym3 l l l l
-    type instance Apply (Lambda_0123456789876543210Sym3 l l l) l = Lambda_0123456789876543210 l l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+        Lambda_0123456789876543210Sym3KindInference :: forall ns0123456789876543210
+                                                              bs0123456789876543210
+                                                              t0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym3 ns0123456789876543210 bs0123456789876543210 t0123456789876543210) arg) (Lambda_0123456789876543210Sym4 ns0123456789876543210 bs0123456789876543210 t0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym3 ns0123456789876543210 bs0123456789876543210 t0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym3 t0123456789876543210 bs0123456789876543210 ns0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 t0123456789876543210 bs0123456789876543210 ns0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym2 bs0123456789876543210 ns0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym2 ns0123456789876543210 bs0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
-                                                       Lambda_0123456789876543210Sym2 l l l
-    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210Sym3 l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+        Lambda_0123456789876543210Sym2KindInference :: forall ns0123456789876543210
+                                                              bs0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 ns0123456789876543210 bs0123456789876543210) arg) (Lambda_0123456789876543210Sym3 ns0123456789876543210 bs0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym2 ns0123456789876543210 bs0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym2 bs0123456789876543210 ns0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210Sym3 bs0123456789876543210 ns0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 ns0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 ns0123456789876543210 bs0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall ns0123456789876543210
+                                                              bs0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 ns0123456789876543210) arg) (Lambda_0123456789876543210Sym2 ns0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 ns0123456789876543210 bs0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 ns0123456789876543210) bs0123456789876543210 = Lambda_0123456789876543210Sym2 ns0123456789876543210 bs0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 ns0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall ns0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+                                                       Lambda_0123456789876543210Sym0 ns0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 ns0123456789876543210 = Lambda_0123456789876543210Sym1 ns0123456789876543210
     type family Case_0123456789876543210 n b a_0123456789876543210 a_0123456789876543210 t where
       Case_0123456789876543210 n b a_0123456789876543210 a_0123456789876543210 True = Apply SuccSym0 (Apply SuccSym0 n)
       Case_0123456789876543210 n b a_0123456789876543210 a_0123456789876543210 False = n
     type family Lambda_0123456789876543210 a_0123456789876543210 a_0123456789876543210 t t where
       Lambda_0123456789876543210 a_0123456789876543210 a_0123456789876543210 n b = Case_0123456789876543210 n b a_0123456789876543210 a_0123456789876543210 b
-    type Lambda_0123456789876543210Sym4 t t t t =
-        Lambda_0123456789876543210 t t t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym3 where
+    type Lambda_0123456789876543210Sym4 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym3 t0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym3KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym3 l l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym3 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym3KindInference :: forall l l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym3 l l l) arg) (Lambda_0123456789876543210Sym4 l l l arg) =>
-                                                       Lambda_0123456789876543210Sym3 l l l l
-    type instance Apply (Lambda_0123456789876543210Sym3 l l l) l = Lambda_0123456789876543210 l l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+        Lambda_0123456789876543210Sym3KindInference :: forall a_01234567898765432100123456789876543210
+                                                              a_01234567898765432100123456789876543210
+                                                              t0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym3 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210) arg) (Lambda_0123456789876543210Sym4 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym3 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym3 t0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 t0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym2 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym2 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
-                                                       Lambda_0123456789876543210Sym2 l l l
-    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210Sym3 l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+        Lambda_0123456789876543210Sym2KindInference :: forall a_01234567898765432100123456789876543210
+                                                              a_01234567898765432100123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (Lambda_0123456789876543210Sym3 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym2 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym2 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) t0123456789876543210 = Lambda_0123456789876543210Sym3 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 a_01234567898765432100123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall a_01234567898765432100123456789876543210
+                                                              a_01234567898765432100123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 a_01234567898765432100123456789876543210) arg) (Lambda_0123456789876543210Sym2 a_01234567898765432100123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = Lambda_0123456789876543210Sym2 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 a_01234567898765432100123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall a_01234567898765432100123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
-    type FooSym3 (t :: (~>) ((~>) a0123456789876543210 b0123456789876543210) ((~>) a0123456789876543210 b0123456789876543210)) (t :: (~>) a0123456789876543210 b0123456789876543210) (t :: a0123456789876543210) =
-        Foo t t t
-    instance SuppressUnusedWarnings FooSym2 where
+                                                       Lambda_0123456789876543210Sym0 a_01234567898765432100123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 a_01234567898765432100123456789876543210 = Lambda_0123456789876543210Sym1 a_01234567898765432100123456789876543210
+    type FooSym3 (a0123456789876543210 :: (~>) ((~>) a0123456789876543210 b0123456789876543210) ((~>) a0123456789876543210 b0123456789876543210)) (a0123456789876543210 :: (~>) a0123456789876543210 b0123456789876543210) (a0123456789876543210 :: a0123456789876543210) =
+        Foo a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (FooSym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym2KindInference) GHC.Tuple.())
-    data FooSym2 (l :: (~>) ((~>) a0123456789876543210 b0123456789876543210) ((~>) a0123456789876543210 b0123456789876543210)) (l :: (~>) a0123456789876543210 b0123456789876543210) (l :: TyFun a0123456789876543210 b0123456789876543210) :: GHC.Types.Type
+    data FooSym2 (a0123456789876543210 :: (~>) ((~>) a0123456789876543210 b0123456789876543210) ((~>) a0123456789876543210 b0123456789876543210)) (a0123456789876543210 :: (~>) a0123456789876543210 b0123456789876543210) :: (~>) a0123456789876543210 b0123456789876543210
       where
-        FooSym2KindInference :: forall l l l arg.
-                                SameKind (Apply (FooSym2 l l) arg) (FooSym3 l l arg) =>
-                                FooSym2 l l l
-    type instance Apply (FooSym2 l l) l = Foo l l l
-    instance SuppressUnusedWarnings FooSym1 where
+        FooSym2KindInference :: forall a0123456789876543210
+                                       a0123456789876543210
+                                       a0123456789876543210
+                                       arg.
+                                SameKind (Apply (FooSym2 a0123456789876543210 a0123456789876543210) arg) (FooSym3 a0123456789876543210 a0123456789876543210 arg) =>
+                                FooSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type instance Apply (FooSym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = Foo a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (FooSym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym1KindInference) GHC.Tuple.())
-    data FooSym1 (l :: (~>) ((~>) a0123456789876543210 b0123456789876543210) ((~>) a0123456789876543210 b0123456789876543210)) (l :: TyFun ((~>) a0123456789876543210 b0123456789876543210) ((~>) a0123456789876543210 b0123456789876543210)) :: GHC.Types.Type
+    data FooSym1 (a0123456789876543210 :: (~>) ((~>) a0123456789876543210 b0123456789876543210) ((~>) a0123456789876543210 b0123456789876543210)) :: (~>) ((~>) a0123456789876543210 b0123456789876543210) ((~>) a0123456789876543210 b0123456789876543210)
       where
-        FooSym1KindInference :: forall l l arg.
-                                SameKind (Apply (FooSym1 l) arg) (FooSym2 l arg) => FooSym1 l l
-    type instance Apply (FooSym1 l) l = FooSym2 l l
+        FooSym1KindInference :: forall a0123456789876543210
+                                       a0123456789876543210
+                                       arg.
+                                SameKind (Apply (FooSym1 a0123456789876543210) arg) (FooSym2 a0123456789876543210 arg) =>
+                                FooSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (FooSym1 a0123456789876543210) a0123456789876543210 = FooSym2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym0KindInference) GHC.Tuple.())
-    data FooSym0 (l :: TyFun ((~>) ((~>) a0123456789876543210 b0123456789876543210) ((~>) a0123456789876543210 b0123456789876543210)) ((~>) ((~>) a0123456789876543210 b0123456789876543210) ((~>) a0123456789876543210 b0123456789876543210))) :: GHC.Types.Type
+    data FooSym0 :: forall a0123456789876543210 b0123456789876543210.
+                    (~>) ((~>) ((~>) a0123456789876543210 b0123456789876543210) ((~>) a0123456789876543210 b0123456789876543210)) ((~>) ((~>) a0123456789876543210 b0123456789876543210) ((~>) a0123456789876543210 b0123456789876543210))
       where
-        FooSym0KindInference :: forall l arg.
-                                SameKind (Apply FooSym0 arg) (FooSym1 arg) => FooSym0 l
-    type instance Apply FooSym0 l = FooSym1 l
-    type ZipWithSym3 (t :: (~>) a0123456789876543210 ((~>) b0123456789876543210 c0123456789876543210)) (t :: [a0123456789876543210]) (t :: [b0123456789876543210]) =
-        ZipWith t t t
-    instance SuppressUnusedWarnings ZipWithSym2 where
+        FooSym0KindInference :: forall a0123456789876543210 arg.
+                                SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
+                                FooSym0 a0123456789876543210
+    type instance Apply FooSym0 a0123456789876543210 = FooSym1 a0123456789876543210
+    type ZipWithSym3 (a0123456789876543210 :: (~>) a0123456789876543210 ((~>) b0123456789876543210 c0123456789876543210)) (a0123456789876543210 :: [a0123456789876543210]) (a0123456789876543210 :: [b0123456789876543210]) =
+        ZipWith a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ZipWithSym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ZipWithSym2KindInference) GHC.Tuple.())
-    data ZipWithSym2 (l :: (~>) a0123456789876543210 ((~>) b0123456789876543210 c0123456789876543210)) (l :: [a0123456789876543210]) (l :: TyFun [b0123456789876543210] [c0123456789876543210]) :: GHC.Types.Type
+    data ZipWithSym2 (a0123456789876543210 :: (~>) a0123456789876543210 ((~>) b0123456789876543210 c0123456789876543210)) (a0123456789876543210 :: [a0123456789876543210]) :: (~>) [b0123456789876543210] [c0123456789876543210]
       where
-        ZipWithSym2KindInference :: forall l l l arg.
-                                    SameKind (Apply (ZipWithSym2 l l) arg) (ZipWithSym3 l l arg) =>
-                                    ZipWithSym2 l l l
-    type instance Apply (ZipWithSym2 l l) l = ZipWith l l l
-    instance SuppressUnusedWarnings ZipWithSym1 where
+        ZipWithSym2KindInference :: forall a0123456789876543210
+                                           a0123456789876543210
+                                           a0123456789876543210
+                                           arg.
+                                    SameKind (Apply (ZipWithSym2 a0123456789876543210 a0123456789876543210) arg) (ZipWithSym3 a0123456789876543210 a0123456789876543210 arg) =>
+                                    ZipWithSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type instance Apply (ZipWithSym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ZipWith a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ZipWithSym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ZipWithSym1KindInference) GHC.Tuple.())
-    data ZipWithSym1 (l :: (~>) a0123456789876543210 ((~>) b0123456789876543210 c0123456789876543210)) (l :: TyFun [a0123456789876543210] ((~>) [b0123456789876543210] [c0123456789876543210])) :: GHC.Types.Type
+    data ZipWithSym1 (a0123456789876543210 :: (~>) a0123456789876543210 ((~>) b0123456789876543210 c0123456789876543210)) :: (~>) [a0123456789876543210] ((~>) [b0123456789876543210] [c0123456789876543210])
       where
-        ZipWithSym1KindInference :: forall l l arg.
-                                    SameKind (Apply (ZipWithSym1 l) arg) (ZipWithSym2 l arg) =>
-                                    ZipWithSym1 l l
-    type instance Apply (ZipWithSym1 l) l = ZipWithSym2 l l
+        ZipWithSym1KindInference :: forall a0123456789876543210
+                                           a0123456789876543210
+                                           arg.
+                                    SameKind (Apply (ZipWithSym1 a0123456789876543210) arg) (ZipWithSym2 a0123456789876543210 arg) =>
+                                    ZipWithSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (ZipWithSym1 a0123456789876543210) a0123456789876543210 = ZipWithSym2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ZipWithSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ZipWithSym0KindInference) GHC.Tuple.())
-    data ZipWithSym0 (l :: TyFun ((~>) a0123456789876543210 ((~>) b0123456789876543210 c0123456789876543210)) ((~>) [a0123456789876543210] ((~>) [b0123456789876543210] [c0123456789876543210]))) :: GHC.Types.Type
+    data ZipWithSym0 :: forall a0123456789876543210
+                               b0123456789876543210
+                               c0123456789876543210.
+                        (~>) ((~>) a0123456789876543210 ((~>) b0123456789876543210 c0123456789876543210)) ((~>) [a0123456789876543210] ((~>) [b0123456789876543210] [c0123456789876543210]))
       where
-        ZipWithSym0KindInference :: forall l arg.
+        ZipWithSym0KindInference :: forall a0123456789876543210 arg.
                                     SameKind (Apply ZipWithSym0 arg) (ZipWithSym1 arg) =>
-                                    ZipWithSym0 l
-    type instance Apply ZipWithSym0 l = ZipWithSym1 l
-    type SplungeSym2 (t :: [Nat]) (t :: [Bool]) = Splunge t t
-    instance SuppressUnusedWarnings SplungeSym1 where
+                                    ZipWithSym0 a0123456789876543210
+    type instance Apply ZipWithSym0 a0123456789876543210 = ZipWithSym1 a0123456789876543210
+    type SplungeSym2 (a0123456789876543210 :: [Nat]) (a0123456789876543210 :: [Bool]) =
+        Splunge a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (SplungeSym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SplungeSym1KindInference) GHC.Tuple.())
-    data SplungeSym1 (l :: [Nat]) (l :: TyFun [Bool] [Nat]) :: GHC.Types.Type
+    data SplungeSym1 (a0123456789876543210 :: [Nat]) :: (~>) [Bool] [Nat]
       where
-        SplungeSym1KindInference :: forall l l arg.
-                                    SameKind (Apply (SplungeSym1 l) arg) (SplungeSym2 l arg) =>
-                                    SplungeSym1 l l
-    type instance Apply (SplungeSym1 l) l = Splunge l l
+        SplungeSym1KindInference :: forall a0123456789876543210
+                                           a0123456789876543210
+                                           arg.
+                                    SameKind (Apply (SplungeSym1 a0123456789876543210) arg) (SplungeSym2 a0123456789876543210 arg) =>
+                                    SplungeSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (SplungeSym1 a0123456789876543210) a0123456789876543210 = Splunge a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings SplungeSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SplungeSym0KindInference) GHC.Tuple.())
-    data SplungeSym0 (l :: TyFun [Nat] ((~>) [Bool] [Nat])) :: GHC.Types.Type
+    data SplungeSym0 :: (~>) [Nat] ((~>) [Bool] [Nat])
       where
-        SplungeSym0KindInference :: forall l arg.
+        SplungeSym0KindInference :: forall a0123456789876543210 arg.
                                     SameKind (Apply SplungeSym0 arg) (SplungeSym1 arg) =>
-                                    SplungeSym0 l
-    type instance Apply SplungeSym0 l = SplungeSym1 l
-    type EtadSym2 (t :: [Nat]) (t :: [Bool]) = Etad t t
-    instance SuppressUnusedWarnings EtadSym1 where
+                                    SplungeSym0 a0123456789876543210
+    type instance Apply SplungeSym0 a0123456789876543210 = SplungeSym1 a0123456789876543210
+    type EtadSym2 (a0123456789876543210 :: [Nat]) (a0123456789876543210 :: [Bool]) =
+        Etad a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (EtadSym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) EtadSym1KindInference) GHC.Tuple.())
-    data EtadSym1 (l :: [Nat]) (l :: TyFun [Bool] [Nat]) :: GHC.Types.Type
+    data EtadSym1 (a0123456789876543210 :: [Nat]) :: (~>) [Bool] [Nat]
       where
-        EtadSym1KindInference :: forall l l arg.
-                                 SameKind (Apply (EtadSym1 l) arg) (EtadSym2 l arg) => EtadSym1 l l
-    type instance Apply (EtadSym1 l) l = Etad l l
+        EtadSym1KindInference :: forall a0123456789876543210
+                                        a0123456789876543210
+                                        arg.
+                                 SameKind (Apply (EtadSym1 a0123456789876543210) arg) (EtadSym2 a0123456789876543210 arg) =>
+                                 EtadSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (EtadSym1 a0123456789876543210) a0123456789876543210 = Etad a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings EtadSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) EtadSym0KindInference) GHC.Tuple.())
-    data EtadSym0 (l :: TyFun [Nat] ((~>) [Bool] [Nat])) :: GHC.Types.Type
+    data EtadSym0 :: (~>) [Nat] ((~>) [Bool] [Nat])
       where
-        EtadSym0KindInference :: forall l arg.
-                                 SameKind (Apply EtadSym0 arg) (EtadSym1 arg) => EtadSym0 l
-    type instance Apply EtadSym0 l = EtadSym1 l
-    type LiftMaybeSym2 (t :: (~>) a0123456789876543210 b0123456789876543210) (t :: Maybe a0123456789876543210) =
-        LiftMaybe t t
-    instance SuppressUnusedWarnings LiftMaybeSym1 where
+        EtadSym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply EtadSym0 arg) (EtadSym1 arg) =>
+                                 EtadSym0 a0123456789876543210
+    type instance Apply EtadSym0 a0123456789876543210 = EtadSym1 a0123456789876543210
+    type LiftMaybeSym2 (a0123456789876543210 :: (~>) a0123456789876543210 b0123456789876543210) (a0123456789876543210 :: Maybe a0123456789876543210) =
+        LiftMaybe a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (LiftMaybeSym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) LiftMaybeSym1KindInference) GHC.Tuple.())
-    data LiftMaybeSym1 (l :: (~>) a0123456789876543210 b0123456789876543210) (l :: TyFun (Maybe a0123456789876543210) (Maybe b0123456789876543210)) :: GHC.Types.Type
+    data LiftMaybeSym1 (a0123456789876543210 :: (~>) a0123456789876543210 b0123456789876543210) :: (~>) (Maybe a0123456789876543210) (Maybe b0123456789876543210)
       where
-        LiftMaybeSym1KindInference :: forall l l arg.
-                                      SameKind (Apply (LiftMaybeSym1 l) arg) (LiftMaybeSym2 l arg) =>
-                                      LiftMaybeSym1 l l
-    type instance Apply (LiftMaybeSym1 l) l = LiftMaybe l l
+        LiftMaybeSym1KindInference :: forall a0123456789876543210
+                                             a0123456789876543210
+                                             arg.
+                                      SameKind (Apply (LiftMaybeSym1 a0123456789876543210) arg) (LiftMaybeSym2 a0123456789876543210 arg) =>
+                                      LiftMaybeSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (LiftMaybeSym1 a0123456789876543210) a0123456789876543210 = LiftMaybe a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings LiftMaybeSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) LiftMaybeSym0KindInference) GHC.Tuple.())
-    data LiftMaybeSym0 (l :: TyFun ((~>) a0123456789876543210 b0123456789876543210) ((~>) (Maybe a0123456789876543210) (Maybe b0123456789876543210))) :: GHC.Types.Type
+    data LiftMaybeSym0 :: forall a0123456789876543210
+                                 b0123456789876543210.
+                          (~>) ((~>) a0123456789876543210 b0123456789876543210) ((~>) (Maybe a0123456789876543210) (Maybe b0123456789876543210))
       where
-        LiftMaybeSym0KindInference :: forall l arg.
+        LiftMaybeSym0KindInference :: forall a0123456789876543210 arg.
                                       SameKind (Apply LiftMaybeSym0 arg) (LiftMaybeSym1 arg) =>
-                                      LiftMaybeSym0 l
-    type instance Apply LiftMaybeSym0 l = LiftMaybeSym1 l
-    type MapSym2 (t :: (~>) a0123456789876543210 b0123456789876543210) (t :: [a0123456789876543210]) =
-        Map t t
-    instance SuppressUnusedWarnings MapSym1 where
+                                      LiftMaybeSym0 a0123456789876543210
+    type instance Apply LiftMaybeSym0 a0123456789876543210 = LiftMaybeSym1 a0123456789876543210
+    type MapSym2 (a0123456789876543210 :: (~>) a0123456789876543210 b0123456789876543210) (a0123456789876543210 :: [a0123456789876543210]) =
+        Map a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (MapSym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MapSym1KindInference) GHC.Tuple.())
-    data MapSym1 (l :: (~>) a0123456789876543210 b0123456789876543210) (l :: TyFun [a0123456789876543210] [b0123456789876543210]) :: GHC.Types.Type
+    data MapSym1 (a0123456789876543210 :: (~>) a0123456789876543210 b0123456789876543210) :: (~>) [a0123456789876543210] [b0123456789876543210]
       where
-        MapSym1KindInference :: forall l l arg.
-                                SameKind (Apply (MapSym1 l) arg) (MapSym2 l arg) => MapSym1 l l
-    type instance Apply (MapSym1 l) l = Map l l
+        MapSym1KindInference :: forall a0123456789876543210
+                                       a0123456789876543210
+                                       arg.
+                                SameKind (Apply (MapSym1 a0123456789876543210) arg) (MapSym2 a0123456789876543210 arg) =>
+                                MapSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (MapSym1 a0123456789876543210) a0123456789876543210 = Map a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings MapSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MapSym0KindInference) GHC.Tuple.())
-    data MapSym0 (l :: TyFun ((~>) a0123456789876543210 b0123456789876543210) ((~>) [a0123456789876543210] [b0123456789876543210])) :: GHC.Types.Type
+    data MapSym0 :: forall a0123456789876543210 b0123456789876543210.
+                    (~>) ((~>) a0123456789876543210 b0123456789876543210) ((~>) [a0123456789876543210] [b0123456789876543210])
       where
-        MapSym0KindInference :: forall l arg.
-                                SameKind (Apply MapSym0 arg) (MapSym1 arg) => MapSym0 l
-    type instance Apply MapSym0 l = MapSym1 l
+        MapSym0KindInference :: forall a0123456789876543210 arg.
+                                SameKind (Apply MapSym0 arg) (MapSym1 arg) =>
+                                MapSym0 a0123456789876543210
+    type instance Apply MapSym0 a0123456789876543210 = MapSym1 a0123456789876543210
     type family Foo (a :: (~>) ((~>) a b) ((~>) a b)) (a :: (~>) a b) (a :: a) :: b where
       Foo f g a = Apply (Apply f g) a
     type family ZipWith (a :: (~>) a ((~>) b c)) (a :: [a]) (a :: [b]) :: [c] where

--- a/tests/compile-and-dump/Singletons/LambdaCase.ghc84.template
+++ b/tests/compile-and-dump/Singletons/LambdaCase.ghc84.template
@@ -33,164 +33,195 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
       Case_0123456789876543210 a b x_0123456789876543210 (GHC.Tuple.(,) p _) = p
     type family Lambda_0123456789876543210 a b t where
       Lambda_0123456789876543210 a b x_0123456789876543210 = Case_0123456789876543210 a b x_0123456789876543210 x_0123456789876543210
-    type Lambda_0123456789876543210Sym3 t t t =
-        Lambda_0123456789876543210 t t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+    type Lambda_0123456789876543210Sym3 a0123456789876543210 b0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 a0123456789876543210 b0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym2 b0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym2 a0123456789876543210 b0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
-                                                       Lambda_0123456789876543210Sym2 l l l
-    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+        Lambda_0123456789876543210Sym2KindInference :: forall a0123456789876543210
+                                                              b0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 a0123456789876543210 b0123456789876543210) arg) (Lambda_0123456789876543210Sym3 a0123456789876543210 b0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym2 a0123456789876543210 b0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym2 b0123456789876543210 a0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 b0123456789876543210 a0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 a0123456789876543210 b0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                              b0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 a0123456789876543210) arg) (Lambda_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 a0123456789876543210 b0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 a0123456789876543210) b0123456789876543210 = Lambda_0123456789876543210Sym2 a0123456789876543210 b0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 a0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+                                                       Lambda_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 a0123456789876543210 = Lambda_0123456789876543210Sym1 a0123456789876543210
     type family Case_0123456789876543210 d x_0123456789876543210 t where
       Case_0123456789876543210 d x_0123456789876543210 (Just y) = y
       Case_0123456789876543210 d x_0123456789876543210 Nothing = d
     type family Lambda_0123456789876543210 d t where
       Lambda_0123456789876543210 d x_0123456789876543210 = Case_0123456789876543210 d x_0123456789876543210 x_0123456789876543210
-    type Lambda_0123456789876543210Sym2 t t =
-        Lambda_0123456789876543210 t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+    type Lambda_0123456789876543210Sym2 d0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 d0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 d0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 d0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall d0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 d0123456789876543210) arg) (Lambda_0123456789876543210Sym2 d0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 d0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 d0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 d0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 d0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall d0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+                                                       Lambda_0123456789876543210Sym0 d0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 d0123456789876543210 = Lambda_0123456789876543210Sym1 d0123456789876543210
     type family Case_0123456789876543210 d x x_0123456789876543210 t where
       Case_0123456789876543210 d x x_0123456789876543210 (Just y) = y
       Case_0123456789876543210 d x x_0123456789876543210 Nothing = d
     type family Lambda_0123456789876543210 d x t where
       Lambda_0123456789876543210 d x x_0123456789876543210 = Case_0123456789876543210 d x x_0123456789876543210 x_0123456789876543210
-    type Lambda_0123456789876543210Sym3 t t t =
-        Lambda_0123456789876543210 t t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+    type Lambda_0123456789876543210Sym3 d0123456789876543210 x0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 d0123456789876543210 x0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym2 x0123456789876543210 d0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym2 d0123456789876543210 x0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
-                                                       Lambda_0123456789876543210Sym2 l l l
-    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+        Lambda_0123456789876543210Sym2KindInference :: forall d0123456789876543210
+                                                              x0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 d0123456789876543210 x0123456789876543210) arg) (Lambda_0123456789876543210Sym3 d0123456789876543210 x0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym2 d0123456789876543210 x0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym2 x0123456789876543210 d0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 x0123456789876543210 d0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 d0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 d0123456789876543210 x0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall d0123456789876543210
+                                                              x0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 d0123456789876543210) arg) (Lambda_0123456789876543210Sym2 d0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 d0123456789876543210 x0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 d0123456789876543210) x0123456789876543210 = Lambda_0123456789876543210Sym2 d0123456789876543210 x0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 d0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall d0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
-    type Foo3Sym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
-        Foo3 t t
-    instance SuppressUnusedWarnings Foo3Sym1 where
+                                                       Lambda_0123456789876543210Sym0 d0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 d0123456789876543210 = Lambda_0123456789876543210Sym1 d0123456789876543210
+    type Foo3Sym2 (a0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: b0123456789876543210) =
+        Foo3 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Foo3Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo3Sym1KindInference) GHC.Tuple.())
-    data Foo3Sym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 a0123456789876543210) :: GHC.Types.Type
+    data Foo3Sym1 (a0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210.
+                                                                    (~>) b0123456789876543210 a0123456789876543210
       where
-        Foo3Sym1KindInference :: forall l l arg.
-                                 SameKind (Apply (Foo3Sym1 l) arg) (Foo3Sym2 l arg) => Foo3Sym1 l l
-    type instance Apply (Foo3Sym1 l) l = Foo3 l l
+        Foo3Sym1KindInference :: forall a0123456789876543210
+                                        a0123456789876543210
+                                        arg.
+                                 SameKind (Apply (Foo3Sym1 a0123456789876543210) arg) (Foo3Sym2 a0123456789876543210 arg) =>
+                                 Foo3Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Foo3Sym1 a0123456789876543210) a0123456789876543210 = Foo3 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Foo3Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo3Sym0KindInference) GHC.Tuple.())
-    data Foo3Sym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 a0123456789876543210)) :: GHC.Types.Type
+    data Foo3Sym0 :: forall a0123456789876543210 b0123456789876543210.
+                     (~>) a0123456789876543210 ((~>) b0123456789876543210 a0123456789876543210)
       where
-        Foo3Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) => Foo3Sym0 l
-    type instance Apply Foo3Sym0 l = Foo3Sym1 l
-    type Foo2Sym2 (t :: a0123456789876543210) (t :: Maybe a0123456789876543210) =
-        Foo2 t t
-    instance SuppressUnusedWarnings Foo2Sym1 where
+        Foo3Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
+                                 Foo3Sym0 a0123456789876543210
+    type instance Apply Foo3Sym0 a0123456789876543210 = Foo3Sym1 a0123456789876543210
+    type Foo2Sym2 (a0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: Maybe a0123456789876543210) =
+        Foo2 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Foo2Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo2Sym1KindInference) GHC.Tuple.())
-    data Foo2Sym1 (l :: a0123456789876543210) (l :: TyFun (Maybe a0123456789876543210) a0123456789876543210) :: GHC.Types.Type
+    data Foo2Sym1 (a0123456789876543210 :: a0123456789876543210) :: (~>) (Maybe a0123456789876543210) a0123456789876543210
       where
-        Foo2Sym1KindInference :: forall l l arg.
-                                 SameKind (Apply (Foo2Sym1 l) arg) (Foo2Sym2 l arg) => Foo2Sym1 l l
-    type instance Apply (Foo2Sym1 l) l = Foo2 l l
+        Foo2Sym1KindInference :: forall a0123456789876543210
+                                        a0123456789876543210
+                                        arg.
+                                 SameKind (Apply (Foo2Sym1 a0123456789876543210) arg) (Foo2Sym2 a0123456789876543210 arg) =>
+                                 Foo2Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Foo2Sym1 a0123456789876543210) a0123456789876543210 = Foo2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Foo2Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo2Sym0KindInference) GHC.Tuple.())
-    data Foo2Sym0 (l :: TyFun a0123456789876543210 ((~>) (Maybe a0123456789876543210) a0123456789876543210)) :: GHC.Types.Type
+    data Foo2Sym0 :: forall a0123456789876543210.
+                     (~>) a0123456789876543210 ((~>) (Maybe a0123456789876543210) a0123456789876543210)
       where
-        Foo2Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) => Foo2Sym0 l
-    type instance Apply Foo2Sym0 l = Foo2Sym1 l
-    type Foo1Sym2 (t :: a0123456789876543210) (t :: Maybe a0123456789876543210) =
-        Foo1 t t
-    instance SuppressUnusedWarnings Foo1Sym1 where
+        Foo2Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) =>
+                                 Foo2Sym0 a0123456789876543210
+    type instance Apply Foo2Sym0 a0123456789876543210 = Foo2Sym1 a0123456789876543210
+    type Foo1Sym2 (a0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: Maybe a0123456789876543210) =
+        Foo1 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Foo1Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo1Sym1KindInference) GHC.Tuple.())
-    data Foo1Sym1 (l :: a0123456789876543210) (l :: TyFun (Maybe a0123456789876543210) a0123456789876543210) :: GHC.Types.Type
+    data Foo1Sym1 (a0123456789876543210 :: a0123456789876543210) :: (~>) (Maybe a0123456789876543210) a0123456789876543210
       where
-        Foo1Sym1KindInference :: forall l l arg.
-                                 SameKind (Apply (Foo1Sym1 l) arg) (Foo1Sym2 l arg) => Foo1Sym1 l l
-    type instance Apply (Foo1Sym1 l) l = Foo1 l l
+        Foo1Sym1KindInference :: forall a0123456789876543210
+                                        a0123456789876543210
+                                        arg.
+                                 SameKind (Apply (Foo1Sym1 a0123456789876543210) arg) (Foo1Sym2 a0123456789876543210 arg) =>
+                                 Foo1Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Foo1Sym1 a0123456789876543210) a0123456789876543210 = Foo1 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Foo1Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo1Sym0KindInference) GHC.Tuple.())
-    data Foo1Sym0 (l :: TyFun a0123456789876543210 ((~>) (Maybe a0123456789876543210) a0123456789876543210)) :: GHC.Types.Type
+    data Foo1Sym0 :: forall a0123456789876543210.
+                     (~>) a0123456789876543210 ((~>) (Maybe a0123456789876543210) a0123456789876543210)
       where
-        Foo1Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) => Foo1Sym0 l
-    type instance Apply Foo1Sym0 l = Foo1Sym1 l
+        Foo1Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
+                                 Foo1Sym0 a0123456789876543210
+    type instance Apply Foo1Sym0 a0123456789876543210 = Foo1Sym1 a0123456789876543210
     type family Foo3 (a :: a) (a :: b) :: a where
       Foo3 a b = Apply (Apply (Apply Lambda_0123456789876543210Sym0 a) b) (Apply (Apply Tuple2Sym0 a) b)
     type family Foo2 (a :: a) (a :: Maybe a) :: a where

--- a/tests/compile-and-dump/Singletons/Lambdas.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Lambdas.ghc84.template
@@ -40,587 +40,713 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     data Foo a b = Foo a b
     foo8 :: Foo a b -> a
     foo8 x = (\ (Foo a _) -> a) x
-    type FooSym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
-        Foo t t
-    instance SuppressUnusedWarnings FooSym1 where
+    type FooSym2 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: b0123456789876543210) =
+        Foo t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (FooSym1 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym1KindInference) GHC.Tuple.())
-    data FooSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 (Foo a0123456789876543210 b0123456789876543210)) :: GHC.Types.Type
+    data FooSym1 (t0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210.
+                                                                   (~>) b0123456789876543210 (Foo a0123456789876543210 b0123456789876543210)
       where
-        FooSym1KindInference :: forall l l arg.
-                                SameKind (Apply (FooSym1 l) arg) (FooSym2 l arg) => FooSym1 l l
-    type instance Apply (FooSym1 l) l = Foo l l
+        FooSym1KindInference :: forall t0123456789876543210
+                                       t0123456789876543210
+                                       arg.
+                                SameKind (Apply (FooSym1 t0123456789876543210) arg) (FooSym2 t0123456789876543210 arg) =>
+                                FooSym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (FooSym1 t0123456789876543210) t0123456789876543210 = Foo t0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym0KindInference) GHC.Tuple.())
-    data FooSym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 (Foo a0123456789876543210 b0123456789876543210))) :: GHC.Types.Type
+    data FooSym0 :: forall a0123456789876543210 b0123456789876543210.
+                    (~>) a0123456789876543210 ((~>) b0123456789876543210 (Foo a0123456789876543210 b0123456789876543210))
       where
-        FooSym0KindInference :: forall l arg.
-                                SameKind (Apply FooSym0 arg) (FooSym1 arg) => FooSym0 l
-    type instance Apply FooSym0 l = FooSym1 l
+        FooSym0KindInference :: forall t0123456789876543210 arg.
+                                SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
+                                FooSym0 t0123456789876543210
+    type instance Apply FooSym0 t0123456789876543210 = FooSym1 t0123456789876543210
     type family Case_0123456789876543210 x arg_0123456789876543210 t where
       Case_0123456789876543210 x arg_0123456789876543210 (Foo a _) = a
     type family Lambda_0123456789876543210 x t where
       Lambda_0123456789876543210 x arg_0123456789876543210 = Case_0123456789876543210 x arg_0123456789876543210 arg_0123456789876543210
-    type Lambda_0123456789876543210Sym2 t t =
-        Lambda_0123456789876543210 t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+    type Lambda_0123456789876543210Sym2 x0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 x0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 x0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall x0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) arg) (Lambda_0123456789876543210Sym2 x0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 x0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 x0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 x0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall x0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+                                                       Lambda_0123456789876543210Sym0 x0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 x0123456789876543210 = Lambda_0123456789876543210Sym1 x0123456789876543210
     type family Case_0123456789876543210 x y arg_0123456789876543210 t where
       Case_0123456789876543210 x y arg_0123456789876543210 (GHC.Tuple.(,) _ b) = b
     type family Lambda_0123456789876543210 x y t where
       Lambda_0123456789876543210 x y arg_0123456789876543210 = Case_0123456789876543210 x y arg_0123456789876543210 arg_0123456789876543210
-    type Lambda_0123456789876543210Sym3 t t t =
-        Lambda_0123456789876543210 t t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+    type Lambda_0123456789876543210Sym3 x0123456789876543210 y0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 x0123456789876543210 y0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym2 y0123456789876543210 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
-                                                       Lambda_0123456789876543210Sym2 l l l
-    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+        Lambda_0123456789876543210Sym2KindInference :: forall x0123456789876543210
+                                                              y0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210) arg) (Lambda_0123456789876543210Sym3 x0123456789876543210 y0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym2 y0123456789876543210 x0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 y0123456789876543210 x0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall x0123456789876543210
+                                                              y0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) arg) (Lambda_0123456789876543210Sym2 x0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) y0123456789876543210 = Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 x0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall x0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+                                                       Lambda_0123456789876543210Sym0 x0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 x0123456789876543210 = Lambda_0123456789876543210Sym1 x0123456789876543210
     type family Case_0123456789876543210 a b x arg_0123456789876543210 t where
       Case_0123456789876543210 a b x arg_0123456789876543210 _ = x
     type family Lambda_0123456789876543210 a b x t where
       Lambda_0123456789876543210 a b x arg_0123456789876543210 = Case_0123456789876543210 a b x arg_0123456789876543210 arg_0123456789876543210
-    type Lambda_0123456789876543210Sym4 t t t t =
-        Lambda_0123456789876543210 t t t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym3 where
+    type Lambda_0123456789876543210Sym4 a0123456789876543210 b0123456789876543210 x0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 a0123456789876543210 b0123456789876543210 x0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym3 x0123456789876543210 b0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym3KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym3 l l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym3 a0123456789876543210 b0123456789876543210 x0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym3KindInference :: forall l l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym3 l l l) arg) (Lambda_0123456789876543210Sym4 l l l arg) =>
-                                                       Lambda_0123456789876543210Sym3 l l l l
-    type instance Apply (Lambda_0123456789876543210Sym3 l l l) l = Lambda_0123456789876543210 l l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+        Lambda_0123456789876543210Sym3KindInference :: forall a0123456789876543210
+                                                              b0123456789876543210
+                                                              x0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym3 a0123456789876543210 b0123456789876543210 x0123456789876543210) arg) (Lambda_0123456789876543210Sym4 a0123456789876543210 b0123456789876543210 x0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym3 a0123456789876543210 b0123456789876543210 x0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym3 x0123456789876543210 b0123456789876543210 a0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 x0123456789876543210 b0123456789876543210 a0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym2 b0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym2 a0123456789876543210 b0123456789876543210 x0123456789876543210
       where
-        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
-                                                       Lambda_0123456789876543210Sym2 l l l
-    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210Sym3 l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+        Lambda_0123456789876543210Sym2KindInference :: forall a0123456789876543210
+                                                              b0123456789876543210
+                                                              x0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 a0123456789876543210 b0123456789876543210) arg) (Lambda_0123456789876543210Sym3 a0123456789876543210 b0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym2 a0123456789876543210 b0123456789876543210 x0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym2 b0123456789876543210 a0123456789876543210) x0123456789876543210 = Lambda_0123456789876543210Sym3 b0123456789876543210 a0123456789876543210 x0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 a0123456789876543210 b0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                              b0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 a0123456789876543210) arg) (Lambda_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 a0123456789876543210 b0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 a0123456789876543210) b0123456789876543210 = Lambda_0123456789876543210Sym2 a0123456789876543210 b0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 a0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+                                                       Lambda_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 a0123456789876543210 = Lambda_0123456789876543210Sym1 a0123456789876543210
     type family Lambda_0123456789876543210 a b t where
       Lambda_0123456789876543210 a b x = Apply (Apply (Apply Lambda_0123456789876543210Sym0 a) b) x
-    type Lambda_0123456789876543210Sym3 t t t =
-        Lambda_0123456789876543210 t t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+    type Lambda_0123456789876543210Sym3 a0123456789876543210 b0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 a0123456789876543210 b0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym2 b0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym2 a0123456789876543210 b0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
-                                                       Lambda_0123456789876543210Sym2 l l l
-    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+        Lambda_0123456789876543210Sym2KindInference :: forall a0123456789876543210
+                                                              b0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 a0123456789876543210 b0123456789876543210) arg) (Lambda_0123456789876543210Sym3 a0123456789876543210 b0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym2 a0123456789876543210 b0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym2 b0123456789876543210 a0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 b0123456789876543210 a0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 a0123456789876543210 b0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                              b0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 a0123456789876543210) arg) (Lambda_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 a0123456789876543210 b0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 a0123456789876543210) b0123456789876543210 = Lambda_0123456789876543210Sym2 a0123456789876543210 b0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 a0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+                                                       Lambda_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 a0123456789876543210 = Lambda_0123456789876543210Sym1 a0123456789876543210
     type family Lambda_0123456789876543210 x y t where
       Lambda_0123456789876543210 x y x = x
-    type Lambda_0123456789876543210Sym3 t t t =
-        Lambda_0123456789876543210 t t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+    type Lambda_0123456789876543210Sym3 x0123456789876543210 y0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 x0123456789876543210 y0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym2 y0123456789876543210 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
-                                                       Lambda_0123456789876543210Sym2 l l l
-    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+        Lambda_0123456789876543210Sym2KindInference :: forall x0123456789876543210
+                                                              y0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210) arg) (Lambda_0123456789876543210Sym3 x0123456789876543210 y0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym2 y0123456789876543210 x0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 y0123456789876543210 x0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall x0123456789876543210
+                                                              y0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) arg) (Lambda_0123456789876543210Sym2 x0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) y0123456789876543210 = Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 x0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall x0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+                                                       Lambda_0123456789876543210Sym0 x0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 x0123456789876543210 = Lambda_0123456789876543210Sym1 x0123456789876543210
     type family Case_0123456789876543210 x y z arg_0123456789876543210 arg_0123456789876543210 t where
       Case_0123456789876543210 x y z arg_0123456789876543210 arg_0123456789876543210 (GHC.Tuple.(,) _ _) = x
     type family Lambda_0123456789876543210 x y z t t where
       Lambda_0123456789876543210 x y z arg_0123456789876543210 arg_0123456789876543210 = Case_0123456789876543210 x y z arg_0123456789876543210 arg_0123456789876543210 (Apply (Apply Tuple2Sym0 arg_0123456789876543210) arg_0123456789876543210)
-    type Lambda_0123456789876543210Sym5 t t t t t =
-        Lambda_0123456789876543210 t t t t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym4 where
+    type Lambda_0123456789876543210Sym5 x0123456789876543210 y0123456789876543210 z0123456789876543210 t0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 x0123456789876543210 y0123456789876543210 z0123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym4 t0123456789876543210 z0123456789876543210 y0123456789876543210 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym4KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym4 l l l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym4 x0123456789876543210 y0123456789876543210 z0123456789876543210 t0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym4KindInference :: forall l
-                                                              l
-                                                              l
-                                                              l
-                                                              l
+        Lambda_0123456789876543210Sym4KindInference :: forall x0123456789876543210
+                                                              y0123456789876543210
+                                                              z0123456789876543210
+                                                              t0123456789876543210
+                                                              t0123456789876543210
                                                               arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym4 l l l l) arg) (Lambda_0123456789876543210Sym5 l l l l arg) =>
-                                                       Lambda_0123456789876543210Sym4 l l l l l
-    type instance Apply (Lambda_0123456789876543210Sym4 l l l l) l = Lambda_0123456789876543210 l l l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym3 where
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym4 x0123456789876543210 y0123456789876543210 z0123456789876543210 t0123456789876543210) arg) (Lambda_0123456789876543210Sym5 x0123456789876543210 y0123456789876543210 z0123456789876543210 t0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym4 x0123456789876543210 y0123456789876543210 z0123456789876543210 t0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym4 t0123456789876543210 z0123456789876543210 y0123456789876543210 x0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 t0123456789876543210 z0123456789876543210 y0123456789876543210 x0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym3 z0123456789876543210 y0123456789876543210 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym3KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym3 l l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym3 x0123456789876543210 y0123456789876543210 z0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym3KindInference :: forall l l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym3 l l l) arg) (Lambda_0123456789876543210Sym4 l l l arg) =>
-                                                       Lambda_0123456789876543210Sym3 l l l l
-    type instance Apply (Lambda_0123456789876543210Sym3 l l l) l = Lambda_0123456789876543210Sym4 l l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+        Lambda_0123456789876543210Sym3KindInference :: forall x0123456789876543210
+                                                              y0123456789876543210
+                                                              z0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym3 x0123456789876543210 y0123456789876543210 z0123456789876543210) arg) (Lambda_0123456789876543210Sym4 x0123456789876543210 y0123456789876543210 z0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym3 x0123456789876543210 y0123456789876543210 z0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym3 z0123456789876543210 y0123456789876543210 x0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210Sym4 z0123456789876543210 y0123456789876543210 x0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym2 y0123456789876543210 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210 z0123456789876543210
       where
-        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
-                                                       Lambda_0123456789876543210Sym2 l l l
-    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210Sym3 l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+        Lambda_0123456789876543210Sym2KindInference :: forall x0123456789876543210
+                                                              y0123456789876543210
+                                                              z0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210) arg) (Lambda_0123456789876543210Sym3 x0123456789876543210 y0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210 z0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym2 y0123456789876543210 x0123456789876543210) z0123456789876543210 = Lambda_0123456789876543210Sym3 y0123456789876543210 x0123456789876543210 z0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall x0123456789876543210
+                                                              y0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) arg) (Lambda_0123456789876543210Sym2 x0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) y0123456789876543210 = Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 x0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall x0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+                                                       Lambda_0123456789876543210Sym0 x0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 x0123456789876543210 = Lambda_0123456789876543210Sym1 x0123456789876543210
     type family Lambda_0123456789876543210 x t where
       Lambda_0123456789876543210 x y = y
-    type Lambda_0123456789876543210Sym2 t t =
-        Lambda_0123456789876543210 t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+    type Lambda_0123456789876543210Sym2 x0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 x0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 x0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall x0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) arg) (Lambda_0123456789876543210Sym2 x0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 x0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 x0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 x0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall x0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+                                                       Lambda_0123456789876543210Sym0 x0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 x0123456789876543210 = Lambda_0123456789876543210Sym1 x0123456789876543210
     type family Case_0123456789876543210 x y arg_0123456789876543210 t where
       Case_0123456789876543210 x y arg_0123456789876543210 _ = x
     type family Lambda_0123456789876543210 x y t where
       Lambda_0123456789876543210 x y arg_0123456789876543210 = Case_0123456789876543210 x y arg_0123456789876543210 arg_0123456789876543210
-    type Lambda_0123456789876543210Sym3 t t t =
-        Lambda_0123456789876543210 t t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+    type Lambda_0123456789876543210Sym3 x0123456789876543210 y0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 x0123456789876543210 y0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym2 y0123456789876543210 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
-                                                       Lambda_0123456789876543210Sym2 l l l
-    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+        Lambda_0123456789876543210Sym2KindInference :: forall x0123456789876543210
+                                                              y0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210) arg) (Lambda_0123456789876543210Sym3 x0123456789876543210 y0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym2 y0123456789876543210 x0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 y0123456789876543210 x0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall x0123456789876543210
+                                                              y0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) arg) (Lambda_0123456789876543210Sym2 x0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) y0123456789876543210 = Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 x0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall x0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+                                                       Lambda_0123456789876543210Sym0 x0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 x0123456789876543210 = Lambda_0123456789876543210Sym1 x0123456789876543210
     type family Case_0123456789876543210 x arg_0123456789876543210 a_0123456789876543210 t where
       Case_0123456789876543210 x arg_0123456789876543210 a_0123456789876543210 _ = x
     type family Lambda_0123456789876543210 x a_0123456789876543210 t where
       Lambda_0123456789876543210 x a_0123456789876543210 arg_0123456789876543210 = Case_0123456789876543210 x arg_0123456789876543210 a_0123456789876543210 arg_0123456789876543210
-    type Lambda_0123456789876543210Sym3 t t t =
-        Lambda_0123456789876543210 t t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+    type Lambda_0123456789876543210Sym3 x0123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym2 a_01234567898765432100123456789876543210 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym2 x0123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
-                                                       Lambda_0123456789876543210Sym2 l l l
-    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+        Lambda_0123456789876543210Sym2KindInference :: forall x0123456789876543210
+                                                              a_01234567898765432100123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 x0123456789876543210 a_01234567898765432100123456789876543210) arg) (Lambda_0123456789876543210Sym3 x0123456789876543210 a_01234567898765432100123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym2 x0123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym2 a_01234567898765432100123456789876543210 x0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 a_01234567898765432100123456789876543210 x0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 x0123456789876543210 a_01234567898765432100123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall x0123456789876543210
+                                                              a_01234567898765432100123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) arg) (Lambda_0123456789876543210Sym2 x0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 x0123456789876543210 a_01234567898765432100123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) a_01234567898765432100123456789876543210 = Lambda_0123456789876543210Sym2 x0123456789876543210 a_01234567898765432100123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 x0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall x0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+                                                       Lambda_0123456789876543210Sym0 x0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 x0123456789876543210 = Lambda_0123456789876543210Sym1 x0123456789876543210
     type family Lambda_0123456789876543210 a_0123456789876543210 a_0123456789876543210 t t where
       Lambda_0123456789876543210 a_0123456789876543210 a_0123456789876543210 x y = x
-    type Lambda_0123456789876543210Sym4 t t t t =
-        Lambda_0123456789876543210 t t t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym3 where
+    type Lambda_0123456789876543210Sym4 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym3 t0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym3KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym3 l l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym3 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym3KindInference :: forall l l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym3 l l l) arg) (Lambda_0123456789876543210Sym4 l l l arg) =>
-                                                       Lambda_0123456789876543210Sym3 l l l l
-    type instance Apply (Lambda_0123456789876543210Sym3 l l l) l = Lambda_0123456789876543210 l l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+        Lambda_0123456789876543210Sym3KindInference :: forall a_01234567898765432100123456789876543210
+                                                              a_01234567898765432100123456789876543210
+                                                              t0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym3 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210) arg) (Lambda_0123456789876543210Sym4 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym3 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym3 t0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 t0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym2 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym2 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
-                                                       Lambda_0123456789876543210Sym2 l l l
-    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210Sym3 l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+        Lambda_0123456789876543210Sym2KindInference :: forall a_01234567898765432100123456789876543210
+                                                              a_01234567898765432100123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (Lambda_0123456789876543210Sym3 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym2 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym2 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) t0123456789876543210 = Lambda_0123456789876543210Sym3 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 a_01234567898765432100123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall a_01234567898765432100123456789876543210
+                                                              a_01234567898765432100123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 a_01234567898765432100123456789876543210) arg) (Lambda_0123456789876543210Sym2 a_01234567898765432100123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = Lambda_0123456789876543210Sym2 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 a_01234567898765432100123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall a_01234567898765432100123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
-    type Foo8Sym1 (t :: Foo a0123456789876543210 b0123456789876543210) =
-        Foo8 t
+                                                       Lambda_0123456789876543210Sym0 a_01234567898765432100123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 a_01234567898765432100123456789876543210 = Lambda_0123456789876543210Sym1 a_01234567898765432100123456789876543210
+    type Foo8Sym1 (a0123456789876543210 :: Foo a0123456789876543210 b0123456789876543210) =
+        Foo8 a0123456789876543210
     instance SuppressUnusedWarnings Foo8Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo8Sym0KindInference) GHC.Tuple.())
-    data Foo8Sym0 (l :: TyFun (Foo a0123456789876543210 b0123456789876543210) a0123456789876543210) :: GHC.Types.Type
+    data Foo8Sym0 :: forall a0123456789876543210 b0123456789876543210.
+                     (~>) (Foo a0123456789876543210 b0123456789876543210) a0123456789876543210
       where
-        Foo8Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo8Sym0 arg) (Foo8Sym1 arg) => Foo8Sym0 l
-    type instance Apply Foo8Sym0 l = Foo8 l
-    type Foo7Sym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
-        Foo7 t t
-    instance SuppressUnusedWarnings Foo7Sym1 where
+        Foo8Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo8Sym0 arg) (Foo8Sym1 arg) =>
+                                 Foo8Sym0 a0123456789876543210
+    type instance Apply Foo8Sym0 a0123456789876543210 = Foo8 a0123456789876543210
+    type Foo7Sym2 (a0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: b0123456789876543210) =
+        Foo7 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Foo7Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo7Sym1KindInference) GHC.Tuple.())
-    data Foo7Sym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 b0123456789876543210) :: GHC.Types.Type
+    data Foo7Sym1 (a0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210.
+                                                                    (~>) b0123456789876543210 b0123456789876543210
       where
-        Foo7Sym1KindInference :: forall l l arg.
-                                 SameKind (Apply (Foo7Sym1 l) arg) (Foo7Sym2 l arg) => Foo7Sym1 l l
-    type instance Apply (Foo7Sym1 l) l = Foo7 l l
+        Foo7Sym1KindInference :: forall a0123456789876543210
+                                        a0123456789876543210
+                                        arg.
+                                 SameKind (Apply (Foo7Sym1 a0123456789876543210) arg) (Foo7Sym2 a0123456789876543210 arg) =>
+                                 Foo7Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Foo7Sym1 a0123456789876543210) a0123456789876543210 = Foo7 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Foo7Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo7Sym0KindInference) GHC.Tuple.())
-    data Foo7Sym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)) :: GHC.Types.Type
+    data Foo7Sym0 :: forall a0123456789876543210 b0123456789876543210.
+                     (~>) a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)
       where
-        Foo7Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo7Sym0 arg) (Foo7Sym1 arg) => Foo7Sym0 l
-    type instance Apply Foo7Sym0 l = Foo7Sym1 l
-    type Foo6Sym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
-        Foo6 t t
-    instance SuppressUnusedWarnings Foo6Sym1 where
+        Foo7Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo7Sym0 arg) (Foo7Sym1 arg) =>
+                                 Foo7Sym0 a0123456789876543210
+    type instance Apply Foo7Sym0 a0123456789876543210 = Foo7Sym1 a0123456789876543210
+    type Foo6Sym2 (a0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: b0123456789876543210) =
+        Foo6 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Foo6Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo6Sym1KindInference) GHC.Tuple.())
-    data Foo6Sym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 a0123456789876543210) :: GHC.Types.Type
+    data Foo6Sym1 (a0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210.
+                                                                    (~>) b0123456789876543210 a0123456789876543210
       where
-        Foo6Sym1KindInference :: forall l l arg.
-                                 SameKind (Apply (Foo6Sym1 l) arg) (Foo6Sym2 l arg) => Foo6Sym1 l l
-    type instance Apply (Foo6Sym1 l) l = Foo6 l l
+        Foo6Sym1KindInference :: forall a0123456789876543210
+                                        a0123456789876543210
+                                        arg.
+                                 SameKind (Apply (Foo6Sym1 a0123456789876543210) arg) (Foo6Sym2 a0123456789876543210 arg) =>
+                                 Foo6Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Foo6Sym1 a0123456789876543210) a0123456789876543210 = Foo6 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Foo6Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo6Sym0KindInference) GHC.Tuple.())
-    data Foo6Sym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 a0123456789876543210)) :: GHC.Types.Type
+    data Foo6Sym0 :: forall a0123456789876543210 b0123456789876543210.
+                     (~>) a0123456789876543210 ((~>) b0123456789876543210 a0123456789876543210)
       where
-        Foo6Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo6Sym0 arg) (Foo6Sym1 arg) => Foo6Sym0 l
-    type instance Apply Foo6Sym0 l = Foo6Sym1 l
-    type Foo5Sym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
-        Foo5 t t
-    instance SuppressUnusedWarnings Foo5Sym1 where
+        Foo6Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo6Sym0 arg) (Foo6Sym1 arg) =>
+                                 Foo6Sym0 a0123456789876543210
+    type instance Apply Foo6Sym0 a0123456789876543210 = Foo6Sym1 a0123456789876543210
+    type Foo5Sym2 (a0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: b0123456789876543210) =
+        Foo5 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Foo5Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo5Sym1KindInference) GHC.Tuple.())
-    data Foo5Sym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 b0123456789876543210) :: GHC.Types.Type
+    data Foo5Sym1 (a0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210.
+                                                                    (~>) b0123456789876543210 b0123456789876543210
       where
-        Foo5Sym1KindInference :: forall l l arg.
-                                 SameKind (Apply (Foo5Sym1 l) arg) (Foo5Sym2 l arg) => Foo5Sym1 l l
-    type instance Apply (Foo5Sym1 l) l = Foo5 l l
+        Foo5Sym1KindInference :: forall a0123456789876543210
+                                        a0123456789876543210
+                                        arg.
+                                 SameKind (Apply (Foo5Sym1 a0123456789876543210) arg) (Foo5Sym2 a0123456789876543210 arg) =>
+                                 Foo5Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Foo5Sym1 a0123456789876543210) a0123456789876543210 = Foo5 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Foo5Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo5Sym0KindInference) GHC.Tuple.())
-    data Foo5Sym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)) :: GHC.Types.Type
+    data Foo5Sym0 :: forall a0123456789876543210 b0123456789876543210.
+                     (~>) a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)
       where
-        Foo5Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo5Sym0 arg) (Foo5Sym1 arg) => Foo5Sym0 l
-    type instance Apply Foo5Sym0 l = Foo5Sym1 l
-    type Foo4Sym3 (t :: a0123456789876543210) (t :: b0123456789876543210) (t :: c0123456789876543210) =
-        Foo4 t t t
-    instance SuppressUnusedWarnings Foo4Sym2 where
+        Foo5Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo5Sym0 arg) (Foo5Sym1 arg) =>
+                                 Foo5Sym0 a0123456789876543210
+    type instance Apply Foo5Sym0 a0123456789876543210 = Foo5Sym1 a0123456789876543210
+    type Foo4Sym3 (a0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: b0123456789876543210) (a0123456789876543210 :: c0123456789876543210) =
+        Foo4 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Foo4Sym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo4Sym2KindInference) GHC.Tuple.())
-    data Foo4Sym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun c0123456789876543210 a0123456789876543210) :: GHC.Types.Type
+    data Foo4Sym2 (a0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: b0123456789876543210) :: forall c0123456789876543210.
+                                                                                                                   (~>) c0123456789876543210 a0123456789876543210
       where
-        Foo4Sym2KindInference :: forall l l l arg.
-                                 SameKind (Apply (Foo4Sym2 l l) arg) (Foo4Sym3 l l arg) =>
-                                 Foo4Sym2 l l l
-    type instance Apply (Foo4Sym2 l l) l = Foo4 l l l
-    instance SuppressUnusedWarnings Foo4Sym1 where
+        Foo4Sym2KindInference :: forall a0123456789876543210
+                                        a0123456789876543210
+                                        a0123456789876543210
+                                        arg.
+                                 SameKind (Apply (Foo4Sym2 a0123456789876543210 a0123456789876543210) arg) (Foo4Sym3 a0123456789876543210 a0123456789876543210 arg) =>
+                                 Foo4Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type instance Apply (Foo4Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = Foo4 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Foo4Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo4Sym1KindInference) GHC.Tuple.())
-    data Foo4Sym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 ((~>) c0123456789876543210 a0123456789876543210)) :: GHC.Types.Type
+    data Foo4Sym1 (a0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210
+                                                                           c0123456789876543210.
+                                                                    (~>) b0123456789876543210 ((~>) c0123456789876543210 a0123456789876543210)
       where
-        Foo4Sym1KindInference :: forall l l arg.
-                                 SameKind (Apply (Foo4Sym1 l) arg) (Foo4Sym2 l arg) => Foo4Sym1 l l
-    type instance Apply (Foo4Sym1 l) l = Foo4Sym2 l l
+        Foo4Sym1KindInference :: forall a0123456789876543210
+                                        a0123456789876543210
+                                        arg.
+                                 SameKind (Apply (Foo4Sym1 a0123456789876543210) arg) (Foo4Sym2 a0123456789876543210 arg) =>
+                                 Foo4Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Foo4Sym1 a0123456789876543210) a0123456789876543210 = Foo4Sym2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Foo4Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo4Sym0KindInference) GHC.Tuple.())
-    data Foo4Sym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 ((~>) c0123456789876543210 a0123456789876543210))) :: GHC.Types.Type
+    data Foo4Sym0 :: forall a0123456789876543210
+                            b0123456789876543210
+                            c0123456789876543210.
+                     (~>) a0123456789876543210 ((~>) b0123456789876543210 ((~>) c0123456789876543210 a0123456789876543210))
       where
-        Foo4Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo4Sym0 arg) (Foo4Sym1 arg) => Foo4Sym0 l
-    type instance Apply Foo4Sym0 l = Foo4Sym1 l
-    type Foo3Sym1 (t :: a0123456789876543210) = Foo3 t
+        Foo4Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo4Sym0 arg) (Foo4Sym1 arg) =>
+                                 Foo4Sym0 a0123456789876543210
+    type instance Apply Foo4Sym0 a0123456789876543210 = Foo4Sym1 a0123456789876543210
+    type Foo3Sym1 (a0123456789876543210 :: a0123456789876543210) =
+        Foo3 a0123456789876543210
     instance SuppressUnusedWarnings Foo3Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo3Sym0KindInference) GHC.Tuple.())
-    data Foo3Sym0 (l :: TyFun a0123456789876543210 a0123456789876543210) :: GHC.Types.Type
+    data Foo3Sym0 :: forall a0123456789876543210.
+                     (~>) a0123456789876543210 a0123456789876543210
       where
-        Foo3Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) => Foo3Sym0 l
-    type instance Apply Foo3Sym0 l = Foo3 l
-    type Foo2Sym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
-        Foo2 t t
-    instance SuppressUnusedWarnings Foo2Sym1 where
+        Foo3Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
+                                 Foo3Sym0 a0123456789876543210
+    type instance Apply Foo3Sym0 a0123456789876543210 = Foo3 a0123456789876543210
+    type Foo2Sym2 (a0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: b0123456789876543210) =
+        Foo2 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Foo2Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo2Sym1KindInference) GHC.Tuple.())
-    data Foo2Sym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 a0123456789876543210) :: GHC.Types.Type
+    data Foo2Sym1 (a0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210.
+                                                                    (~>) b0123456789876543210 a0123456789876543210
       where
-        Foo2Sym1KindInference :: forall l l arg.
-                                 SameKind (Apply (Foo2Sym1 l) arg) (Foo2Sym2 l arg) => Foo2Sym1 l l
-    type instance Apply (Foo2Sym1 l) l = Foo2 l l
+        Foo2Sym1KindInference :: forall a0123456789876543210
+                                        a0123456789876543210
+                                        arg.
+                                 SameKind (Apply (Foo2Sym1 a0123456789876543210) arg) (Foo2Sym2 a0123456789876543210 arg) =>
+                                 Foo2Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Foo2Sym1 a0123456789876543210) a0123456789876543210 = Foo2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Foo2Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo2Sym0KindInference) GHC.Tuple.())
-    data Foo2Sym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 a0123456789876543210)) :: GHC.Types.Type
+    data Foo2Sym0 :: forall a0123456789876543210 b0123456789876543210.
+                     (~>) a0123456789876543210 ((~>) b0123456789876543210 a0123456789876543210)
       where
-        Foo2Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) => Foo2Sym0 l
-    type instance Apply Foo2Sym0 l = Foo2Sym1 l
-    type Foo1Sym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
-        Foo1 t t
-    instance SuppressUnusedWarnings Foo1Sym1 where
+        Foo2Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) =>
+                                 Foo2Sym0 a0123456789876543210
+    type instance Apply Foo2Sym0 a0123456789876543210 = Foo2Sym1 a0123456789876543210
+    type Foo1Sym2 (a0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: b0123456789876543210) =
+        Foo1 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Foo1Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo1Sym1KindInference) GHC.Tuple.())
-    data Foo1Sym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 a0123456789876543210) :: GHC.Types.Type
+    data Foo1Sym1 (a0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210.
+                                                                    (~>) b0123456789876543210 a0123456789876543210
       where
-        Foo1Sym1KindInference :: forall l l arg.
-                                 SameKind (Apply (Foo1Sym1 l) arg) (Foo1Sym2 l arg) => Foo1Sym1 l l
-    type instance Apply (Foo1Sym1 l) l = Foo1 l l
+        Foo1Sym1KindInference :: forall a0123456789876543210
+                                        a0123456789876543210
+                                        arg.
+                                 SameKind (Apply (Foo1Sym1 a0123456789876543210) arg) (Foo1Sym2 a0123456789876543210 arg) =>
+                                 Foo1Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Foo1Sym1 a0123456789876543210) a0123456789876543210 = Foo1 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Foo1Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo1Sym0KindInference) GHC.Tuple.())
-    data Foo1Sym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 a0123456789876543210)) :: GHC.Types.Type
+    data Foo1Sym0 :: forall a0123456789876543210 b0123456789876543210.
+                     (~>) a0123456789876543210 ((~>) b0123456789876543210 a0123456789876543210)
       where
-        Foo1Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) => Foo1Sym0 l
-    type instance Apply Foo1Sym0 l = Foo1Sym1 l
-    type Foo0Sym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
-        Foo0 t t
-    instance SuppressUnusedWarnings Foo0Sym1 where
+        Foo1Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
+                                 Foo1Sym0 a0123456789876543210
+    type instance Apply Foo1Sym0 a0123456789876543210 = Foo1Sym1 a0123456789876543210
+    type Foo0Sym2 (a0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: b0123456789876543210) =
+        Foo0 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Foo0Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo0Sym1KindInference) GHC.Tuple.())
-    data Foo0Sym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 a0123456789876543210) :: GHC.Types.Type
+    data Foo0Sym1 (a0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210.
+                                                                    (~>) b0123456789876543210 a0123456789876543210
       where
-        Foo0Sym1KindInference :: forall l l arg.
-                                 SameKind (Apply (Foo0Sym1 l) arg) (Foo0Sym2 l arg) => Foo0Sym1 l l
-    type instance Apply (Foo0Sym1 l) l = Foo0 l l
+        Foo0Sym1KindInference :: forall a0123456789876543210
+                                        a0123456789876543210
+                                        arg.
+                                 SameKind (Apply (Foo0Sym1 a0123456789876543210) arg) (Foo0Sym2 a0123456789876543210 arg) =>
+                                 Foo0Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Foo0Sym1 a0123456789876543210) a0123456789876543210 = Foo0 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Foo0Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo0Sym0KindInference) GHC.Tuple.())
-    data Foo0Sym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 a0123456789876543210)) :: GHC.Types.Type
+    data Foo0Sym0 :: forall a0123456789876543210 b0123456789876543210.
+                     (~>) a0123456789876543210 ((~>) b0123456789876543210 a0123456789876543210)
       where
-        Foo0Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo0Sym0 arg) (Foo0Sym1 arg) => Foo0Sym0 l
-    type instance Apply Foo0Sym0 l = Foo0Sym1 l
+        Foo0Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo0Sym0 arg) (Foo0Sym1 arg) =>
+                                 Foo0Sym0 a0123456789876543210
+    type instance Apply Foo0Sym0 a0123456789876543210 = Foo0Sym1 a0123456789876543210
     type family Foo8 (a :: Foo a b) :: a where
       Foo8 x = Apply (Apply Lambda_0123456789876543210Sym0 x) x
     type family Foo7 (a :: a) (a :: b) :: b where

--- a/tests/compile-and-dump/Singletons/LambdasComprehensive.ghc84.template
+++ b/tests/compile-and-dump/Singletons/LambdasComprehensive.ghc84.template
@@ -14,19 +14,20 @@ Singletons/LambdasComprehensive.hs:(0,0)-(0,0): Splicing declarations
     bar = (map ((either_ pred) Succ)) [Left Zero, Right (Succ Zero)]
     type family Lambda_0123456789876543210 t where
       Lambda_0123456789876543210 x = Apply (Apply (Apply Either_Sym0 PredSym0) SuccSym0) x
-    type Lambda_0123456789876543210Sym1 t =
-        Lambda_0123456789876543210 t
+    type Lambda_0123456789876543210Sym1 t0123456789876543210 =
+        Lambda_0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall t0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210 l
+                                                       Lambda_0123456789876543210Sym0 t0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 t0123456789876543210 = Lambda_0123456789876543210 t0123456789876543210
     type BarSym0 = Bar
     type FooSym0 = Foo
     type family Bar :: [Nat] where

--- a/tests/compile-and-dump/Singletons/LetStatements.ghc84.template
+++ b/tests/compile-and-dump/Singletons/LetStatements.ghc84.template
@@ -193,430 +193,489 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       Case_0123456789876543210 x (GHC.Tuple.(,) y_0123456789876543210 _) = y_0123456789876543210
     type family Case_0123456789876543210 x t where
       Case_0123456789876543210 x (GHC.Tuple.(,) _ y_0123456789876543210) = y_0123456789876543210
-    type Let0123456789876543210YSym1 t = Let0123456789876543210Y t
+    type Let0123456789876543210YSym1 x0123456789876543210 =
+        Let0123456789876543210Y x0123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210YSym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210YSym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210YSym0 l :: GHC.Types.Type
+    data Let0123456789876543210YSym0 x0123456789876543210
       where
-        Let0123456789876543210YSym0KindInference :: forall l arg.
+        Let0123456789876543210YSym0KindInference :: forall x0123456789876543210
+                                                           arg.
                                                     SameKind (Apply Let0123456789876543210YSym0 arg) (Let0123456789876543210YSym1 arg) =>
-                                                    Let0123456789876543210YSym0 l
-    type instance Apply Let0123456789876543210YSym0 l = Let0123456789876543210Y l
-    type Let0123456789876543210ZSym1 t = Let0123456789876543210Z t
+                                                    Let0123456789876543210YSym0 x0123456789876543210
+    type instance Apply Let0123456789876543210YSym0 x0123456789876543210 = Let0123456789876543210Y x0123456789876543210
+    type Let0123456789876543210ZSym1 x0123456789876543210 =
+        Let0123456789876543210Z x0123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210ZSym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210ZSym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210ZSym0 l :: GHC.Types.Type
+    data Let0123456789876543210ZSym0 x0123456789876543210
       where
-        Let0123456789876543210ZSym0KindInference :: forall l arg.
+        Let0123456789876543210ZSym0KindInference :: forall x0123456789876543210
+                                                           arg.
                                                     SameKind (Apply Let0123456789876543210ZSym0 arg) (Let0123456789876543210ZSym1 arg) =>
-                                                    Let0123456789876543210ZSym0 l
-    type instance Apply Let0123456789876543210ZSym0 l = Let0123456789876543210Z l
-    type Let0123456789876543210X_0123456789876543210Sym1 t =
-        Let0123456789876543210X_0123456789876543210 t
+                                                    Let0123456789876543210ZSym0 x0123456789876543210
+    type instance Apply Let0123456789876543210ZSym0 x0123456789876543210 = Let0123456789876543210Z x0123456789876543210
+    type Let0123456789876543210X_0123456789876543210Sym1 x0123456789876543210 =
+        Let0123456789876543210X_0123456789876543210 x0123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210X_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210X_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210X_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Let0123456789876543210X_0123456789876543210Sym0 x0123456789876543210
       where
-        Let0123456789876543210X_0123456789876543210Sym0KindInference :: forall l
+        Let0123456789876543210X_0123456789876543210Sym0KindInference :: forall x0123456789876543210
                                                                                arg.
                                                                         SameKind (Apply Let0123456789876543210X_0123456789876543210Sym0 arg) (Let0123456789876543210X_0123456789876543210Sym1 arg) =>
-                                                                        Let0123456789876543210X_0123456789876543210Sym0 l
-    type instance Apply Let0123456789876543210X_0123456789876543210Sym0 l = Let0123456789876543210X_0123456789876543210 l
+                                                                        Let0123456789876543210X_0123456789876543210Sym0 x0123456789876543210
+    type instance Apply Let0123456789876543210X_0123456789876543210Sym0 x0123456789876543210 = Let0123456789876543210X_0123456789876543210 x0123456789876543210
     type family Let0123456789876543210Y x where
       Let0123456789876543210Y x = Case_0123456789876543210 x (Let0123456789876543210X_0123456789876543210Sym1 x)
     type family Let0123456789876543210Z x where
       Let0123456789876543210Z x = Case_0123456789876543210 x (Let0123456789876543210X_0123456789876543210Sym1 x)
     type family Let0123456789876543210X_0123456789876543210 x where
       Let0123456789876543210X_0123456789876543210 x = Apply (Apply Tuple2Sym0 (Apply SuccSym0 x)) x
-    type Let0123456789876543210BarSym1 t = Let0123456789876543210Bar t
+    type Let0123456789876543210BarSym1 x0123456789876543210 =
+        Let0123456789876543210Bar x0123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210BarSym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210BarSym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210BarSym0 l :: GHC.Types.Type
+    data Let0123456789876543210BarSym0 x0123456789876543210
       where
-        Let0123456789876543210BarSym0KindInference :: forall l arg.
+        Let0123456789876543210BarSym0KindInference :: forall x0123456789876543210
+                                                             arg.
                                                       SameKind (Apply Let0123456789876543210BarSym0 arg) (Let0123456789876543210BarSym1 arg) =>
-                                                      Let0123456789876543210BarSym0 l
-    type instance Apply Let0123456789876543210BarSym0 l = Let0123456789876543210Bar l
+                                                      Let0123456789876543210BarSym0 x0123456789876543210
+    type instance Apply Let0123456789876543210BarSym0 x0123456789876543210 = Let0123456789876543210Bar x0123456789876543210
     type family Let0123456789876543210Bar x :: a where
       Let0123456789876543210Bar x = x
-    type (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$$) t (t :: Nat) (t :: Nat) =
-        (<<<%%%%%%%%%%%%%%%%%%%%) t t t
-    instance SuppressUnusedWarnings (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) where
+    type (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$$) x0123456789876543210 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) =
+        (<<<%%%%%%%%%%%%%%%%%%%%) x0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) a0123456789876543210 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$$###)) GHC.Tuple.())
-    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) l (l :: Nat) (l :: TyFun Nat Nat) :: GHC.Types.Type
+    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) x0123456789876543210 (a0123456789876543210 :: Nat) :: (~>) Nat Nat
       where
-        (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$$###) :: forall l l l arg.
-                                               SameKind (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) l l) arg) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$$) l l arg) =>
-                                               (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) l l l
-    type instance Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) l l) l = (<<<%%%%%%%%%%%%%%%%%%%%) l l l
-    instance SuppressUnusedWarnings (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) where
+        (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$$###) :: forall x0123456789876543210
+                                                      a0123456789876543210
+                                                      a0123456789876543210
+                                                      arg.
+                                               SameKind (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) x0123456789876543210 a0123456789876543210) arg) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$$) x0123456789876543210 a0123456789876543210 arg) =>
+                                               (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) x0123456789876543210 a0123456789876543210 a0123456789876543210
+    type instance Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) a0123456789876543210 x0123456789876543210) a0123456789876543210 = (<<<%%%%%%%%%%%%%%%%%%%%) a0123456789876543210 x0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$###)) GHC.Tuple.())
-    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l (l :: TyFun Nat ((~>) Nat Nat)) :: GHC.Types.Type
+    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210 :: (~>) Nat ((~>) Nat Nat)
       where
-        (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$###) :: forall l l arg.
-                                              SameKind (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l) arg) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) l arg) =>
-                                              (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l l
-    type instance Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l) l = (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) l l
+        (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$###) :: forall x0123456789876543210
+                                                     a0123456789876543210
+                                                     arg.
+                                              SameKind (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210) arg) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) x0123456789876543210 arg) =>
+                                              (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210 a0123456789876543210
+    type instance Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210) a0123456789876543210 = (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) x0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings (<<<%%%%%%%%%%%%%%%%%%%%@#@$) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) (:<<<%%%%%%%%%%%%%%%%%%%%@#@$###)) GHC.Tuple.())
-    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$) l :: GHC.Types.Type
+    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$) x0123456789876543210
       where
-        (:<<<%%%%%%%%%%%%%%%%%%%%@#@$###) :: forall l arg.
+        (:<<<%%%%%%%%%%%%%%%%%%%%@#@$###) :: forall x0123456789876543210
+                                                    arg.
                                              SameKind (Apply (<<<%%%%%%%%%%%%%%%%%%%%@#@$) arg) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) arg) =>
-                                             (<<<%%%%%%%%%%%%%%%%%%%%@#@$) l
-    type instance Apply (<<<%%%%%%%%%%%%%%%%%%%%@#@$) l = (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l
+                                             (<<<%%%%%%%%%%%%%%%%%%%%@#@$) x0123456789876543210
+    type instance Apply (<<<%%%%%%%%%%%%%%%%%%%%@#@$) x0123456789876543210 = (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210
     type family (<<<%%%%%%%%%%%%%%%%%%%%) x (a :: Nat) (a :: Nat) :: Nat where
       (<<<%%%%%%%%%%%%%%%%%%%%) x Zero m = m
       (<<<%%%%%%%%%%%%%%%%%%%%) x (Succ n) m = Apply SuccSym0 (Apply (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x) n) x)
-    type Let0123456789876543210ZSym1 t = Let0123456789876543210Z t
+    type Let0123456789876543210ZSym1 x0123456789876543210 =
+        Let0123456789876543210Z x0123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210ZSym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210ZSym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210ZSym0 l :: GHC.Types.Type
+    data Let0123456789876543210ZSym0 x0123456789876543210
       where
-        Let0123456789876543210ZSym0KindInference :: forall l arg.
+        Let0123456789876543210ZSym0KindInference :: forall x0123456789876543210
+                                                           arg.
                                                     SameKind (Apply Let0123456789876543210ZSym0 arg) (Let0123456789876543210ZSym1 arg) =>
-                                                    Let0123456789876543210ZSym0 l
-    type instance Apply Let0123456789876543210ZSym0 l = Let0123456789876543210Z l
-    type (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$$) t (t :: Nat) (t :: Nat) =
-        (<<<%%%%%%%%%%%%%%%%%%%%) t t t
-    instance SuppressUnusedWarnings (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) where
+                                                    Let0123456789876543210ZSym0 x0123456789876543210
+    type instance Apply Let0123456789876543210ZSym0 x0123456789876543210 = Let0123456789876543210Z x0123456789876543210
+    type (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$$) x0123456789876543210 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) =
+        (<<<%%%%%%%%%%%%%%%%%%%%) x0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) a0123456789876543210 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$$###)) GHC.Tuple.())
-    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) l (l :: Nat) (l :: TyFun Nat Nat) :: GHC.Types.Type
+    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) x0123456789876543210 (a0123456789876543210 :: Nat) :: (~>) Nat Nat
       where
-        (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$$###) :: forall l l l arg.
-                                               SameKind (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) l l) arg) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$$) l l arg) =>
-                                               (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) l l l
-    type instance Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) l l) l = (<<<%%%%%%%%%%%%%%%%%%%%) l l l
-    instance SuppressUnusedWarnings (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) where
+        (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$$###) :: forall x0123456789876543210
+                                                      a0123456789876543210
+                                                      a0123456789876543210
+                                                      arg.
+                                               SameKind (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) x0123456789876543210 a0123456789876543210) arg) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$$) x0123456789876543210 a0123456789876543210 arg) =>
+                                               (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) x0123456789876543210 a0123456789876543210 a0123456789876543210
+    type instance Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) a0123456789876543210 x0123456789876543210) a0123456789876543210 = (<<<%%%%%%%%%%%%%%%%%%%%) a0123456789876543210 x0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$###)) GHC.Tuple.())
-    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l (l :: TyFun Nat ((~>) Nat Nat)) :: GHC.Types.Type
+    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210 :: (~>) Nat ((~>) Nat Nat)
       where
-        (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$###) :: forall l l arg.
-                                              SameKind (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l) arg) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) l arg) =>
-                                              (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l l
-    type instance Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l) l = (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) l l
+        (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$###) :: forall x0123456789876543210
+                                                     a0123456789876543210
+                                                     arg.
+                                              SameKind (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210) arg) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) x0123456789876543210 arg) =>
+                                              (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210 a0123456789876543210
+    type instance Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210) a0123456789876543210 = (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) x0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings (<<<%%%%%%%%%%%%%%%%%%%%@#@$) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) (:<<<%%%%%%%%%%%%%%%%%%%%@#@$###)) GHC.Tuple.())
-    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$) l :: GHC.Types.Type
+    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$) x0123456789876543210
       where
-        (:<<<%%%%%%%%%%%%%%%%%%%%@#@$###) :: forall l arg.
+        (:<<<%%%%%%%%%%%%%%%%%%%%@#@$###) :: forall x0123456789876543210
+                                                    arg.
                                              SameKind (Apply (<<<%%%%%%%%%%%%%%%%%%%%@#@$) arg) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) arg) =>
-                                             (<<<%%%%%%%%%%%%%%%%%%%%@#@$) l
-    type instance Apply (<<<%%%%%%%%%%%%%%%%%%%%@#@$) l = (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l
+                                             (<<<%%%%%%%%%%%%%%%%%%%%@#@$) x0123456789876543210
+    type instance Apply (<<<%%%%%%%%%%%%%%%%%%%%@#@$) x0123456789876543210 = (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210
     type family Let0123456789876543210Z x :: Nat where
       Let0123456789876543210Z x = x
     type family (<<<%%%%%%%%%%%%%%%%%%%%) x (a :: Nat) (a :: Nat) :: Nat where
       (<<<%%%%%%%%%%%%%%%%%%%%) x Zero m = m
       (<<<%%%%%%%%%%%%%%%%%%%%) x (Succ n) m = Apply SuccSym0 (Apply (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x) n) m)
-    type (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$$) t (t :: Nat) (t :: Nat) =
-        (<<<%%%%%%%%%%%%%%%%%%%%) t t t
-    instance SuppressUnusedWarnings (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) where
+    type (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$$) x0123456789876543210 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) =
+        (<<<%%%%%%%%%%%%%%%%%%%%) x0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) a0123456789876543210 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$$###)) GHC.Tuple.())
-    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) l (l :: Nat) (l :: TyFun Nat Nat) :: GHC.Types.Type
+    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) x0123456789876543210 (a0123456789876543210 :: Nat) :: (~>) Nat Nat
       where
-        (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$$###) :: forall l l l arg.
-                                               SameKind (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) l l) arg) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$$) l l arg) =>
-                                               (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) l l l
-    type instance Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) l l) l = (<<<%%%%%%%%%%%%%%%%%%%%) l l l
-    instance SuppressUnusedWarnings (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) where
+        (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$$###) :: forall x0123456789876543210
+                                                      a0123456789876543210
+                                                      a0123456789876543210
+                                                      arg.
+                                               SameKind (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) x0123456789876543210 a0123456789876543210) arg) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$$) x0123456789876543210 a0123456789876543210 arg) =>
+                                               (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) x0123456789876543210 a0123456789876543210 a0123456789876543210
+    type instance Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) a0123456789876543210 x0123456789876543210) a0123456789876543210 = (<<<%%%%%%%%%%%%%%%%%%%%) a0123456789876543210 x0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$###)) GHC.Tuple.())
-    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l (l :: TyFun Nat ((~>) Nat Nat)) :: GHC.Types.Type
+    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210 :: (~>) Nat ((~>) Nat Nat)
       where
-        (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$###) :: forall l l arg.
-                                              SameKind (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l) arg) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) l arg) =>
-                                              (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l l
-    type instance Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l) l = (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) l l
+        (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$###) :: forall x0123456789876543210
+                                                     a0123456789876543210
+                                                     arg.
+                                              SameKind (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210) arg) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) x0123456789876543210 arg) =>
+                                              (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210 a0123456789876543210
+    type instance Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210) a0123456789876543210 = (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) x0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings (<<<%%%%%%%%%%%%%%%%%%%%@#@$) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) (:<<<%%%%%%%%%%%%%%%%%%%%@#@$###)) GHC.Tuple.())
-    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$) l :: GHC.Types.Type
+    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$) x0123456789876543210
       where
-        (:<<<%%%%%%%%%%%%%%%%%%%%@#@$###) :: forall l arg.
+        (:<<<%%%%%%%%%%%%%%%%%%%%@#@$###) :: forall x0123456789876543210
+                                                    arg.
                                              SameKind (Apply (<<<%%%%%%%%%%%%%%%%%%%%@#@$) arg) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) arg) =>
-                                             (<<<%%%%%%%%%%%%%%%%%%%%@#@$) l
-    type instance Apply (<<<%%%%%%%%%%%%%%%%%%%%@#@$) l = (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) l
+                                             (<<<%%%%%%%%%%%%%%%%%%%%@#@$) x0123456789876543210
+    type instance Apply (<<<%%%%%%%%%%%%%%%%%%%%@#@$) x0123456789876543210 = (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210
     type family (<<<%%%%%%%%%%%%%%%%%%%%) x (a :: Nat) (a :: Nat) :: Nat where
       (<<<%%%%%%%%%%%%%%%%%%%%) x Zero m = m
       (<<<%%%%%%%%%%%%%%%%%%%%) x (Succ n) m = Apply SuccSym0 (Apply (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x) n) m)
     type family Lambda_0123456789876543210 x a_0123456789876543210 t where
       Lambda_0123456789876543210 x a_0123456789876543210 x = x
-    type Lambda_0123456789876543210Sym3 t t t =
-        Lambda_0123456789876543210 t t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+    type Lambda_0123456789876543210Sym3 x0123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym2 a_01234567898765432100123456789876543210 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym2 x0123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
-                                                       Lambda_0123456789876543210Sym2 l l l
-    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+        Lambda_0123456789876543210Sym2KindInference :: forall x0123456789876543210
+                                                              a_01234567898765432100123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 x0123456789876543210 a_01234567898765432100123456789876543210) arg) (Lambda_0123456789876543210Sym3 x0123456789876543210 a_01234567898765432100123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym2 x0123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym2 a_01234567898765432100123456789876543210 x0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 a_01234567898765432100123456789876543210 x0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 x0123456789876543210 a_01234567898765432100123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall x0123456789876543210
+                                                              a_01234567898765432100123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) arg) (Lambda_0123456789876543210Sym2 x0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 x0123456789876543210 a_01234567898765432100123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) a_01234567898765432100123456789876543210 = Lambda_0123456789876543210Sym2 x0123456789876543210 a_01234567898765432100123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 x0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall x0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
-    type Let0123456789876543210ZSym2 t (t :: Nat) =
-        Let0123456789876543210Z t t
-    instance SuppressUnusedWarnings Let0123456789876543210ZSym1 where
+                                                       Lambda_0123456789876543210Sym0 x0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 x0123456789876543210 = Lambda_0123456789876543210Sym1 x0123456789876543210
+    type Let0123456789876543210ZSym2 x0123456789876543210 (a0123456789876543210 :: Nat) =
+        Let0123456789876543210Z x0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Let0123456789876543210ZSym1 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210ZSym1KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210ZSym1 l (l :: TyFun Nat Nat) :: GHC.Types.Type
+    data Let0123456789876543210ZSym1 x0123456789876543210 :: (~>) Nat Nat
       where
-        Let0123456789876543210ZSym1KindInference :: forall l l arg.
-                                                    SameKind (Apply (Let0123456789876543210ZSym1 l) arg) (Let0123456789876543210ZSym2 l arg) =>
-                                                    Let0123456789876543210ZSym1 l l
-    type instance Apply (Let0123456789876543210ZSym1 l) l = Let0123456789876543210Z l l
+        Let0123456789876543210ZSym1KindInference :: forall x0123456789876543210
+                                                           a0123456789876543210
+                                                           arg.
+                                                    SameKind (Apply (Let0123456789876543210ZSym1 x0123456789876543210) arg) (Let0123456789876543210ZSym2 x0123456789876543210 arg) =>
+                                                    Let0123456789876543210ZSym1 x0123456789876543210 a0123456789876543210
+    type instance Apply (Let0123456789876543210ZSym1 x0123456789876543210) a0123456789876543210 = Let0123456789876543210Z x0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210ZSym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210ZSym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210ZSym0 l :: GHC.Types.Type
+    data Let0123456789876543210ZSym0 x0123456789876543210
       where
-        Let0123456789876543210ZSym0KindInference :: forall l arg.
+        Let0123456789876543210ZSym0KindInference :: forall x0123456789876543210
+                                                           arg.
                                                     SameKind (Apply Let0123456789876543210ZSym0 arg) (Let0123456789876543210ZSym1 arg) =>
-                                                    Let0123456789876543210ZSym0 l
-    type instance Apply Let0123456789876543210ZSym0 l = Let0123456789876543210ZSym1 l
+                                                    Let0123456789876543210ZSym0 x0123456789876543210
+    type instance Apply Let0123456789876543210ZSym0 x0123456789876543210 = Let0123456789876543210ZSym1 x0123456789876543210
     type family Let0123456789876543210Z x (a :: Nat) :: Nat where
       Let0123456789876543210Z x a_0123456789876543210 = Apply (Apply (Apply Lambda_0123456789876543210Sym0 x) a_0123456789876543210) a_0123456789876543210
     type family Lambda_0123456789876543210 x t where
       Lambda_0123456789876543210 x x = x
-    type Lambda_0123456789876543210Sym2 t t =
-        Lambda_0123456789876543210 t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+    type Lambda_0123456789876543210Sym2 x0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 x0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 x0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall x0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) arg) (Lambda_0123456789876543210Sym2 x0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 x0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 x0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 x0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall x0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
-    type Let0123456789876543210ZSym1 t = Let0123456789876543210Z t
+                                                       Lambda_0123456789876543210Sym0 x0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 x0123456789876543210 = Lambda_0123456789876543210Sym1 x0123456789876543210
+    type Let0123456789876543210ZSym1 x0123456789876543210 =
+        Let0123456789876543210Z x0123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210ZSym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210ZSym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210ZSym0 l :: GHC.Types.Type
+    data Let0123456789876543210ZSym0 x0123456789876543210
       where
-        Let0123456789876543210ZSym0KindInference :: forall l arg.
+        Let0123456789876543210ZSym0KindInference :: forall x0123456789876543210
+                                                           arg.
                                                     SameKind (Apply Let0123456789876543210ZSym0 arg) (Let0123456789876543210ZSym1 arg) =>
-                                                    Let0123456789876543210ZSym0 l
-    type instance Apply Let0123456789876543210ZSym0 l = Let0123456789876543210Z l
+                                                    Let0123456789876543210ZSym0 x0123456789876543210
+    type instance Apply Let0123456789876543210ZSym0 x0123456789876543210 = Let0123456789876543210Z x0123456789876543210
     type family Let0123456789876543210Z x :: Nat where
       Let0123456789876543210Z x = Apply (Apply Lambda_0123456789876543210Sym0 x) ZeroSym0
-    type Let0123456789876543210XSym1 t = Let0123456789876543210X t
+    type Let0123456789876543210XSym1 x0123456789876543210 =
+        Let0123456789876543210X x0123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210XSym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210XSym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210XSym0 l :: GHC.Types.Type
+    data Let0123456789876543210XSym0 x0123456789876543210
       where
-        Let0123456789876543210XSym0KindInference :: forall l arg.
+        Let0123456789876543210XSym0KindInference :: forall x0123456789876543210
+                                                           arg.
                                                     SameKind (Apply Let0123456789876543210XSym0 arg) (Let0123456789876543210XSym1 arg) =>
-                                                    Let0123456789876543210XSym0 l
-    type instance Apply Let0123456789876543210XSym0 l = Let0123456789876543210X l
+                                                    Let0123456789876543210XSym0 x0123456789876543210
+    type instance Apply Let0123456789876543210XSym0 x0123456789876543210 = Let0123456789876543210X x0123456789876543210
     type family Let0123456789876543210X x :: Nat where
       Let0123456789876543210X x = ZeroSym0
-    type Let0123456789876543210FSym2 t (t :: Nat) =
-        Let0123456789876543210F t t
-    instance SuppressUnusedWarnings Let0123456789876543210FSym1 where
+    type Let0123456789876543210FSym2 x0123456789876543210 (a0123456789876543210 :: Nat) =
+        Let0123456789876543210F x0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Let0123456789876543210FSym1 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210FSym1KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210FSym1 l (l :: TyFun Nat Nat) :: GHC.Types.Type
+    data Let0123456789876543210FSym1 x0123456789876543210 :: (~>) Nat Nat
       where
-        Let0123456789876543210FSym1KindInference :: forall l l arg.
-                                                    SameKind (Apply (Let0123456789876543210FSym1 l) arg) (Let0123456789876543210FSym2 l arg) =>
-                                                    Let0123456789876543210FSym1 l l
-    type instance Apply (Let0123456789876543210FSym1 l) l = Let0123456789876543210F l l
+        Let0123456789876543210FSym1KindInference :: forall x0123456789876543210
+                                                           a0123456789876543210
+                                                           arg.
+                                                    SameKind (Apply (Let0123456789876543210FSym1 x0123456789876543210) arg) (Let0123456789876543210FSym2 x0123456789876543210 arg) =>
+                                                    Let0123456789876543210FSym1 x0123456789876543210 a0123456789876543210
+    type instance Apply (Let0123456789876543210FSym1 x0123456789876543210) a0123456789876543210 = Let0123456789876543210F x0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210FSym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210FSym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210FSym0 l :: GHC.Types.Type
+    data Let0123456789876543210FSym0 x0123456789876543210
       where
-        Let0123456789876543210FSym0KindInference :: forall l arg.
+        Let0123456789876543210FSym0KindInference :: forall x0123456789876543210
+                                                           arg.
                                                     SameKind (Apply Let0123456789876543210FSym0 arg) (Let0123456789876543210FSym1 arg) =>
-                                                    Let0123456789876543210FSym0 l
-    type instance Apply Let0123456789876543210FSym0 l = Let0123456789876543210FSym1 l
+                                                    Let0123456789876543210FSym0 x0123456789876543210
+    type instance Apply Let0123456789876543210FSym0 x0123456789876543210 = Let0123456789876543210FSym1 x0123456789876543210
     type family Let0123456789876543210F x (a :: Nat) :: Nat where
       Let0123456789876543210F x y = Apply SuccSym0 y
-    type Let0123456789876543210ZSym1 t = Let0123456789876543210Z t
+    type Let0123456789876543210ZSym1 x0123456789876543210 =
+        Let0123456789876543210Z x0123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210ZSym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210ZSym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210ZSym0 l :: GHC.Types.Type
+    data Let0123456789876543210ZSym0 x0123456789876543210
       where
-        Let0123456789876543210ZSym0KindInference :: forall l arg.
+        Let0123456789876543210ZSym0KindInference :: forall x0123456789876543210
+                                                           arg.
                                                     SameKind (Apply Let0123456789876543210ZSym0 arg) (Let0123456789876543210ZSym1 arg) =>
-                                                    Let0123456789876543210ZSym0 l
-    type instance Apply Let0123456789876543210ZSym0 l = Let0123456789876543210Z l
+                                                    Let0123456789876543210ZSym0 x0123456789876543210
+    type instance Apply Let0123456789876543210ZSym0 x0123456789876543210 = Let0123456789876543210Z x0123456789876543210
     type family Let0123456789876543210Z x :: Nat where
       Let0123456789876543210Z x = Apply (Let0123456789876543210FSym1 x) x
-    type Let0123456789876543210ZSym2 t t = Let0123456789876543210Z t t
-    instance SuppressUnusedWarnings Let0123456789876543210ZSym1 where
+    type Let0123456789876543210ZSym2 x0123456789876543210 y0123456789876543210 =
+        Let0123456789876543210Z x0123456789876543210 y0123456789876543210
+    instance SuppressUnusedWarnings (Let0123456789876543210ZSym1 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210ZSym1KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210ZSym1 l l :: GHC.Types.Type
+    data Let0123456789876543210ZSym1 x0123456789876543210 y0123456789876543210
       where
-        Let0123456789876543210ZSym1KindInference :: forall l l arg.
-                                                    SameKind (Apply (Let0123456789876543210ZSym1 l) arg) (Let0123456789876543210ZSym2 l arg) =>
-                                                    Let0123456789876543210ZSym1 l l
-    type instance Apply (Let0123456789876543210ZSym1 l) l = Let0123456789876543210Z l l
+        Let0123456789876543210ZSym1KindInference :: forall x0123456789876543210
+                                                           y0123456789876543210
+                                                           arg.
+                                                    SameKind (Apply (Let0123456789876543210ZSym1 x0123456789876543210) arg) (Let0123456789876543210ZSym2 x0123456789876543210 arg) =>
+                                                    Let0123456789876543210ZSym1 x0123456789876543210 y0123456789876543210
+    type instance Apply (Let0123456789876543210ZSym1 x0123456789876543210) y0123456789876543210 = Let0123456789876543210Z x0123456789876543210 y0123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210ZSym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210ZSym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210ZSym0 l :: GHC.Types.Type
+    data Let0123456789876543210ZSym0 x0123456789876543210
       where
-        Let0123456789876543210ZSym0KindInference :: forall l arg.
+        Let0123456789876543210ZSym0KindInference :: forall x0123456789876543210
+                                                           arg.
                                                     SameKind (Apply Let0123456789876543210ZSym0 arg) (Let0123456789876543210ZSym1 arg) =>
-                                                    Let0123456789876543210ZSym0 l
-    type instance Apply Let0123456789876543210ZSym0 l = Let0123456789876543210ZSym1 l
+                                                    Let0123456789876543210ZSym0 x0123456789876543210
+    type instance Apply Let0123456789876543210ZSym0 x0123456789876543210 = Let0123456789876543210ZSym1 x0123456789876543210
     type family Let0123456789876543210Z x y :: Nat where
       Let0123456789876543210Z x y = Apply SuccSym0 y
-    type Let0123456789876543210FSym2 t (t :: Nat) =
-        Let0123456789876543210F t t
-    instance SuppressUnusedWarnings Let0123456789876543210FSym1 where
+    type Let0123456789876543210FSym2 x0123456789876543210 (a0123456789876543210 :: Nat) =
+        Let0123456789876543210F x0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Let0123456789876543210FSym1 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210FSym1KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210FSym1 l (l :: TyFun Nat Nat) :: GHC.Types.Type
+    data Let0123456789876543210FSym1 x0123456789876543210 :: (~>) Nat Nat
       where
-        Let0123456789876543210FSym1KindInference :: forall l l arg.
-                                                    SameKind (Apply (Let0123456789876543210FSym1 l) arg) (Let0123456789876543210FSym2 l arg) =>
-                                                    Let0123456789876543210FSym1 l l
-    type instance Apply (Let0123456789876543210FSym1 l) l = Let0123456789876543210F l l
+        Let0123456789876543210FSym1KindInference :: forall x0123456789876543210
+                                                           a0123456789876543210
+                                                           arg.
+                                                    SameKind (Apply (Let0123456789876543210FSym1 x0123456789876543210) arg) (Let0123456789876543210FSym2 x0123456789876543210 arg) =>
+                                                    Let0123456789876543210FSym1 x0123456789876543210 a0123456789876543210
+    type instance Apply (Let0123456789876543210FSym1 x0123456789876543210) a0123456789876543210 = Let0123456789876543210F x0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210FSym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210FSym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210FSym0 l :: GHC.Types.Type
+    data Let0123456789876543210FSym0 x0123456789876543210
       where
-        Let0123456789876543210FSym0KindInference :: forall l arg.
+        Let0123456789876543210FSym0KindInference :: forall x0123456789876543210
+                                                           arg.
                                                     SameKind (Apply Let0123456789876543210FSym0 arg) (Let0123456789876543210FSym1 arg) =>
-                                                    Let0123456789876543210FSym0 l
-    type instance Apply Let0123456789876543210FSym0 l = Let0123456789876543210FSym1 l
+                                                    Let0123456789876543210FSym0 x0123456789876543210
+    type instance Apply Let0123456789876543210FSym0 x0123456789876543210 = Let0123456789876543210FSym1 x0123456789876543210
     type family Let0123456789876543210F x (a :: Nat) :: Nat where
       Let0123456789876543210F x y = Apply SuccSym0 (Let0123456789876543210ZSym2 x y)
-    type Let0123456789876543210FSym2 t (t :: Nat) =
-        Let0123456789876543210F t t
-    instance SuppressUnusedWarnings Let0123456789876543210FSym1 where
+    type Let0123456789876543210FSym2 x0123456789876543210 (a0123456789876543210 :: Nat) =
+        Let0123456789876543210F x0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Let0123456789876543210FSym1 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210FSym1KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210FSym1 l (l :: TyFun Nat Nat) :: GHC.Types.Type
+    data Let0123456789876543210FSym1 x0123456789876543210 :: (~>) Nat Nat
       where
-        Let0123456789876543210FSym1KindInference :: forall l l arg.
-                                                    SameKind (Apply (Let0123456789876543210FSym1 l) arg) (Let0123456789876543210FSym2 l arg) =>
-                                                    Let0123456789876543210FSym1 l l
-    type instance Apply (Let0123456789876543210FSym1 l) l = Let0123456789876543210F l l
+        Let0123456789876543210FSym1KindInference :: forall x0123456789876543210
+                                                           a0123456789876543210
+                                                           arg.
+                                                    SameKind (Apply (Let0123456789876543210FSym1 x0123456789876543210) arg) (Let0123456789876543210FSym2 x0123456789876543210 arg) =>
+                                                    Let0123456789876543210FSym1 x0123456789876543210 a0123456789876543210
+    type instance Apply (Let0123456789876543210FSym1 x0123456789876543210) a0123456789876543210 = Let0123456789876543210F x0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210FSym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210FSym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210FSym0 l :: GHC.Types.Type
+    data Let0123456789876543210FSym0 x0123456789876543210
       where
-        Let0123456789876543210FSym0KindInference :: forall l arg.
+        Let0123456789876543210FSym0KindInference :: forall x0123456789876543210
+                                                           arg.
                                                     SameKind (Apply Let0123456789876543210FSym0 arg) (Let0123456789876543210FSym1 arg) =>
-                                                    Let0123456789876543210FSym0 l
-    type instance Apply Let0123456789876543210FSym0 l = Let0123456789876543210FSym1 l
+                                                    Let0123456789876543210FSym0 x0123456789876543210
+    type instance Apply Let0123456789876543210FSym0 x0123456789876543210 = Let0123456789876543210FSym1 x0123456789876543210
     type family Let0123456789876543210F x (a :: Nat) :: Nat where
       Let0123456789876543210F x y = Apply SuccSym0 y
-    type Let0123456789876543210YSym1 t = Let0123456789876543210Y t
+    type Let0123456789876543210YSym1 x0123456789876543210 =
+        Let0123456789876543210Y x0123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210YSym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210YSym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210YSym0 l :: GHC.Types.Type
+    data Let0123456789876543210YSym0 x0123456789876543210
       where
-        Let0123456789876543210YSym0KindInference :: forall l arg.
+        Let0123456789876543210YSym0KindInference :: forall x0123456789876543210
+                                                           arg.
                                                     SameKind (Apply Let0123456789876543210YSym0 arg) (Let0123456789876543210YSym1 arg) =>
-                                                    Let0123456789876543210YSym0 l
-    type instance Apply Let0123456789876543210YSym0 l = Let0123456789876543210Y l
+                                                    Let0123456789876543210YSym0 x0123456789876543210
+    type instance Apply Let0123456789876543210YSym0 x0123456789876543210 = Let0123456789876543210Y x0123456789876543210
     type family Let0123456789876543210Y x :: Nat where
       Let0123456789876543210Y x = Apply SuccSym0 x
     type Let0123456789876543210YSym0 = Let0123456789876543210Y
@@ -625,147 +684,179 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       Let0123456789876543210Y = Apply SuccSym0 ZeroSym0
     type family Let0123456789876543210Z where
       Let0123456789876543210Z = Apply SuccSym0 Let0123456789876543210YSym0
-    type Let0123456789876543210YSym1 t = Let0123456789876543210Y t
+    type Let0123456789876543210YSym1 x0123456789876543210 =
+        Let0123456789876543210Y x0123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210YSym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210YSym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210YSym0 l :: GHC.Types.Type
+    data Let0123456789876543210YSym0 x0123456789876543210
       where
-        Let0123456789876543210YSym0KindInference :: forall l arg.
+        Let0123456789876543210YSym0KindInference :: forall x0123456789876543210
+                                                           arg.
                                                     SameKind (Apply Let0123456789876543210YSym0 arg) (Let0123456789876543210YSym1 arg) =>
-                                                    Let0123456789876543210YSym0 l
-    type instance Apply Let0123456789876543210YSym0 l = Let0123456789876543210Y l
+                                                    Let0123456789876543210YSym0 x0123456789876543210
+    type instance Apply Let0123456789876543210YSym0 x0123456789876543210 = Let0123456789876543210Y x0123456789876543210
     type family Let0123456789876543210Y x :: Nat where
       Let0123456789876543210Y x = Apply SuccSym0 ZeroSym0
-    type Foo14Sym1 (t :: Nat) = Foo14 t
+    type Foo14Sym1 (a0123456789876543210 :: Nat) =
+        Foo14 a0123456789876543210
     instance SuppressUnusedWarnings Foo14Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo14Sym0KindInference) GHC.Tuple.())
-    data Foo14Sym0 (l :: TyFun Nat (Nat, Nat)) :: GHC.Types.Type
+    data Foo14Sym0 :: (~>) Nat (Nat, Nat)
       where
-        Foo14Sym0KindInference :: forall l arg.
-                                  SameKind (Apply Foo14Sym0 arg) (Foo14Sym1 arg) => Foo14Sym0 l
-    type instance Apply Foo14Sym0 l = Foo14 l
-    type Foo13_Sym1 (t :: a0123456789876543210) = Foo13_ t
+        Foo14Sym0KindInference :: forall a0123456789876543210 arg.
+                                  SameKind (Apply Foo14Sym0 arg) (Foo14Sym1 arg) =>
+                                  Foo14Sym0 a0123456789876543210
+    type instance Apply Foo14Sym0 a0123456789876543210 = Foo14 a0123456789876543210
+    type Foo13_Sym1 (a0123456789876543210 :: a0123456789876543210) =
+        Foo13_ a0123456789876543210
     instance SuppressUnusedWarnings Foo13_Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo13_Sym0KindInference) GHC.Tuple.())
-    data Foo13_Sym0 (l :: TyFun a0123456789876543210 a0123456789876543210) :: GHC.Types.Type
+    data Foo13_Sym0 :: forall a0123456789876543210.
+                       (~>) a0123456789876543210 a0123456789876543210
       where
-        Foo13_Sym0KindInference :: forall l arg.
-                                   SameKind (Apply Foo13_Sym0 arg) (Foo13_Sym1 arg) => Foo13_Sym0 l
-    type instance Apply Foo13_Sym0 l = Foo13_ l
-    type Foo13Sym1 (t :: a0123456789876543210) = Foo13 t
+        Foo13_Sym0KindInference :: forall a0123456789876543210 arg.
+                                   SameKind (Apply Foo13_Sym0 arg) (Foo13_Sym1 arg) =>
+                                   Foo13_Sym0 a0123456789876543210
+    type instance Apply Foo13_Sym0 a0123456789876543210 = Foo13_ a0123456789876543210
+    type Foo13Sym1 (a0123456789876543210 :: a0123456789876543210) =
+        Foo13 a0123456789876543210
     instance SuppressUnusedWarnings Foo13Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo13Sym0KindInference) GHC.Tuple.())
-    data Foo13Sym0 (l :: TyFun a0123456789876543210 a0123456789876543210) :: GHC.Types.Type
+    data Foo13Sym0 :: forall a0123456789876543210.
+                      (~>) a0123456789876543210 a0123456789876543210
       where
-        Foo13Sym0KindInference :: forall l arg.
-                                  SameKind (Apply Foo13Sym0 arg) (Foo13Sym1 arg) => Foo13Sym0 l
-    type instance Apply Foo13Sym0 l = Foo13 l
-    type Foo12Sym1 (t :: Nat) = Foo12 t
+        Foo13Sym0KindInference :: forall a0123456789876543210 arg.
+                                  SameKind (Apply Foo13Sym0 arg) (Foo13Sym1 arg) =>
+                                  Foo13Sym0 a0123456789876543210
+    type instance Apply Foo13Sym0 a0123456789876543210 = Foo13 a0123456789876543210
+    type Foo12Sym1 (a0123456789876543210 :: Nat) =
+        Foo12 a0123456789876543210
     instance SuppressUnusedWarnings Foo12Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo12Sym0KindInference) GHC.Tuple.())
-    data Foo12Sym0 (l :: TyFun Nat Nat) :: GHC.Types.Type
+    data Foo12Sym0 :: (~>) Nat Nat
       where
-        Foo12Sym0KindInference :: forall l arg.
-                                  SameKind (Apply Foo12Sym0 arg) (Foo12Sym1 arg) => Foo12Sym0 l
-    type instance Apply Foo12Sym0 l = Foo12 l
-    type Foo11Sym1 (t :: Nat) = Foo11 t
+        Foo12Sym0KindInference :: forall a0123456789876543210 arg.
+                                  SameKind (Apply Foo12Sym0 arg) (Foo12Sym1 arg) =>
+                                  Foo12Sym0 a0123456789876543210
+    type instance Apply Foo12Sym0 a0123456789876543210 = Foo12 a0123456789876543210
+    type Foo11Sym1 (a0123456789876543210 :: Nat) =
+        Foo11 a0123456789876543210
     instance SuppressUnusedWarnings Foo11Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo11Sym0KindInference) GHC.Tuple.())
-    data Foo11Sym0 (l :: TyFun Nat Nat) :: GHC.Types.Type
+    data Foo11Sym0 :: (~>) Nat Nat
       where
-        Foo11Sym0KindInference :: forall l arg.
-                                  SameKind (Apply Foo11Sym0 arg) (Foo11Sym1 arg) => Foo11Sym0 l
-    type instance Apply Foo11Sym0 l = Foo11 l
-    type Foo10Sym1 (t :: Nat) = Foo10 t
+        Foo11Sym0KindInference :: forall a0123456789876543210 arg.
+                                  SameKind (Apply Foo11Sym0 arg) (Foo11Sym1 arg) =>
+                                  Foo11Sym0 a0123456789876543210
+    type instance Apply Foo11Sym0 a0123456789876543210 = Foo11 a0123456789876543210
+    type Foo10Sym1 (a0123456789876543210 :: Nat) =
+        Foo10 a0123456789876543210
     instance SuppressUnusedWarnings Foo10Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo10Sym0KindInference) GHC.Tuple.())
-    data Foo10Sym0 (l :: TyFun Nat Nat) :: GHC.Types.Type
+    data Foo10Sym0 :: (~>) Nat Nat
       where
-        Foo10Sym0KindInference :: forall l arg.
-                                  SameKind (Apply Foo10Sym0 arg) (Foo10Sym1 arg) => Foo10Sym0 l
-    type instance Apply Foo10Sym0 l = Foo10 l
-    type Foo9Sym1 (t :: Nat) = Foo9 t
+        Foo10Sym0KindInference :: forall a0123456789876543210 arg.
+                                  SameKind (Apply Foo10Sym0 arg) (Foo10Sym1 arg) =>
+                                  Foo10Sym0 a0123456789876543210
+    type instance Apply Foo10Sym0 a0123456789876543210 = Foo10 a0123456789876543210
+    type Foo9Sym1 (a0123456789876543210 :: Nat) =
+        Foo9 a0123456789876543210
     instance SuppressUnusedWarnings Foo9Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo9Sym0KindInference) GHC.Tuple.())
-    data Foo9Sym0 (l :: TyFun Nat Nat) :: GHC.Types.Type
+    data Foo9Sym0 :: (~>) Nat Nat
       where
-        Foo9Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo9Sym0 arg) (Foo9Sym1 arg) => Foo9Sym0 l
-    type instance Apply Foo9Sym0 l = Foo9 l
-    type Foo8Sym1 (t :: Nat) = Foo8 t
+        Foo9Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo9Sym0 arg) (Foo9Sym1 arg) =>
+                                 Foo9Sym0 a0123456789876543210
+    type instance Apply Foo9Sym0 a0123456789876543210 = Foo9 a0123456789876543210
+    type Foo8Sym1 (a0123456789876543210 :: Nat) =
+        Foo8 a0123456789876543210
     instance SuppressUnusedWarnings Foo8Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo8Sym0KindInference) GHC.Tuple.())
-    data Foo8Sym0 (l :: TyFun Nat Nat) :: GHC.Types.Type
+    data Foo8Sym0 :: (~>) Nat Nat
       where
-        Foo8Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo8Sym0 arg) (Foo8Sym1 arg) => Foo8Sym0 l
-    type instance Apply Foo8Sym0 l = Foo8 l
-    type Foo7Sym1 (t :: Nat) = Foo7 t
+        Foo8Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo8Sym0 arg) (Foo8Sym1 arg) =>
+                                 Foo8Sym0 a0123456789876543210
+    type instance Apply Foo8Sym0 a0123456789876543210 = Foo8 a0123456789876543210
+    type Foo7Sym1 (a0123456789876543210 :: Nat) =
+        Foo7 a0123456789876543210
     instance SuppressUnusedWarnings Foo7Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo7Sym0KindInference) GHC.Tuple.())
-    data Foo7Sym0 (l :: TyFun Nat Nat) :: GHC.Types.Type
+    data Foo7Sym0 :: (~>) Nat Nat
       where
-        Foo7Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo7Sym0 arg) (Foo7Sym1 arg) => Foo7Sym0 l
-    type instance Apply Foo7Sym0 l = Foo7 l
-    type Foo6Sym1 (t :: Nat) = Foo6 t
+        Foo7Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo7Sym0 arg) (Foo7Sym1 arg) =>
+                                 Foo7Sym0 a0123456789876543210
+    type instance Apply Foo7Sym0 a0123456789876543210 = Foo7 a0123456789876543210
+    type Foo6Sym1 (a0123456789876543210 :: Nat) =
+        Foo6 a0123456789876543210
     instance SuppressUnusedWarnings Foo6Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo6Sym0KindInference) GHC.Tuple.())
-    data Foo6Sym0 (l :: TyFun Nat Nat) :: GHC.Types.Type
+    data Foo6Sym0 :: (~>) Nat Nat
       where
-        Foo6Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo6Sym0 arg) (Foo6Sym1 arg) => Foo6Sym0 l
-    type instance Apply Foo6Sym0 l = Foo6 l
-    type Foo5Sym1 (t :: Nat) = Foo5 t
+        Foo6Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo6Sym0 arg) (Foo6Sym1 arg) =>
+                                 Foo6Sym0 a0123456789876543210
+    type instance Apply Foo6Sym0 a0123456789876543210 = Foo6 a0123456789876543210
+    type Foo5Sym1 (a0123456789876543210 :: Nat) =
+        Foo5 a0123456789876543210
     instance SuppressUnusedWarnings Foo5Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo5Sym0KindInference) GHC.Tuple.())
-    data Foo5Sym0 (l :: TyFun Nat Nat) :: GHC.Types.Type
+    data Foo5Sym0 :: (~>) Nat Nat
       where
-        Foo5Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo5Sym0 arg) (Foo5Sym1 arg) => Foo5Sym0 l
-    type instance Apply Foo5Sym0 l = Foo5 l
-    type Foo4Sym1 (t :: Nat) = Foo4 t
+        Foo5Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo5Sym0 arg) (Foo5Sym1 arg) =>
+                                 Foo5Sym0 a0123456789876543210
+    type instance Apply Foo5Sym0 a0123456789876543210 = Foo5 a0123456789876543210
+    type Foo4Sym1 (a0123456789876543210 :: Nat) =
+        Foo4 a0123456789876543210
     instance SuppressUnusedWarnings Foo4Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo4Sym0KindInference) GHC.Tuple.())
-    data Foo4Sym0 (l :: TyFun Nat Nat) :: GHC.Types.Type
+    data Foo4Sym0 :: (~>) Nat Nat
       where
-        Foo4Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo4Sym0 arg) (Foo4Sym1 arg) => Foo4Sym0 l
-    type instance Apply Foo4Sym0 l = Foo4 l
-    type Foo3Sym1 (t :: Nat) = Foo3 t
+        Foo4Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo4Sym0 arg) (Foo4Sym1 arg) =>
+                                 Foo4Sym0 a0123456789876543210
+    type instance Apply Foo4Sym0 a0123456789876543210 = Foo4 a0123456789876543210
+    type Foo3Sym1 (a0123456789876543210 :: Nat) =
+        Foo3 a0123456789876543210
     instance SuppressUnusedWarnings Foo3Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo3Sym0KindInference) GHC.Tuple.())
-    data Foo3Sym0 (l :: TyFun Nat Nat) :: GHC.Types.Type
+    data Foo3Sym0 :: (~>) Nat Nat
       where
-        Foo3Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) => Foo3Sym0 l
-    type instance Apply Foo3Sym0 l = Foo3 l
+        Foo3Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
+                                 Foo3Sym0 a0123456789876543210
+    type instance Apply Foo3Sym0 a0123456789876543210 = Foo3 a0123456789876543210
     type Foo2Sym0 = Foo2
-    type Foo1Sym1 (t :: Nat) = Foo1 t
+    type Foo1Sym1 (a0123456789876543210 :: Nat) =
+        Foo1 a0123456789876543210
     instance SuppressUnusedWarnings Foo1Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo1Sym0KindInference) GHC.Tuple.())
-    data Foo1Sym0 (l :: TyFun Nat Nat) :: GHC.Types.Type
+    data Foo1Sym0 :: (~>) Nat Nat
       where
-        Foo1Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) => Foo1Sym0 l
-    type instance Apply Foo1Sym0 l = Foo1 l
+        Foo1Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
+                                 Foo1Sym0 a0123456789876543210
+    type instance Apply Foo1Sym0 a0123456789876543210 = Foo1 a0123456789876543210
     type family Foo14 (a :: Nat) :: (Nat, Nat) where
       Foo14 x = Apply (Apply Tuple2Sym0 (Let0123456789876543210ZSym1 x)) (Let0123456789876543210YSym1 x)
     type family Foo13_ (a :: a) :: a where

--- a/tests/compile-and-dump/Singletons/Maybe.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Maybe.ghc84.template
@@ -8,53 +8,64 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
       = Nothing | Just a
       deriving (Eq, Show)
     type NothingSym0 = Nothing
-    type JustSym1 (t :: a0123456789876543210) = Just t
+    type JustSym1 (t0123456789876543210 :: a0123456789876543210) =
+        Just t0123456789876543210
     instance SuppressUnusedWarnings JustSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) JustSym0KindInference) GHC.Tuple.())
-    data JustSym0 (l :: TyFun a0123456789876543210 (Maybe a0123456789876543210)) :: GHC.Types.Type
+    data JustSym0 :: forall a0123456789876543210.
+                     (~>) a0123456789876543210 (Maybe a0123456789876543210)
       where
-        JustSym0KindInference :: forall l arg.
-                                 SameKind (Apply JustSym0 arg) (JustSym1 arg) => JustSym0 l
-    type instance Apply JustSym0 l = Just l
+        JustSym0KindInference :: forall t0123456789876543210 arg.
+                                 SameKind (Apply JustSym0 arg) (JustSym1 arg) =>
+                                 JustSym0 t0123456789876543210
+    type instance Apply JustSym0 t0123456789876543210 = Just t0123456789876543210
     type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Maybe a) (a :: GHC.Types.Symbol) :: GHC.Types.Symbol where
       ShowsPrec_0123456789876543210 _ Nothing a_0123456789876543210 = Apply (Apply ShowStringSym0 "Nothing") a_0123456789876543210
       ShowsPrec_0123456789876543210 p_0123456789876543210 (Just arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (Data.Singletons.Prelude.Num.FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Just ")) (Apply (Apply ShowsPrecSym0 (Data.Singletons.Prelude.Num.FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: Maybe a0123456789876543210) (t :: GHC.Types.Symbol) =
-        ShowsPrec_0123456789876543210 t t t
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+    type ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Maybe a0123456789876543210) (a0123456789876543210 :: GHC.Types.Symbol) =
+        ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym2 (l :: GHC.Types.Nat) (l :: Maybe a0123456789876543210) (l :: TyFun GHC.Types.Symbol GHC.Types.Symbol) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Maybe a0123456789876543210) :: (~>) GHC.Types.Symbol GHC.Types.Symbol
       where
-        ShowsPrec_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 l l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+        ShowsPrec_0123456789876543210Sym2KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun (Maybe a0123456789876543210) ((~>) GHC.Types.Symbol GHC.Types.Symbol)) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: forall a0123456789876543210.
+                                                                                      (~>) (Maybe a0123456789876543210) ((~>) GHC.Types.Symbol GHC.Types.Symbol)
       where
-        ShowsPrec_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+        ShowsPrec_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) (Maybe a0123456789876543210) ((~>) GHC.Types.Symbol GHC.Types.Symbol))) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym0 :: forall a0123456789876543210.
+                                              (~>) GHC.Types.Nat ((~>) (Maybe a0123456789876543210) ((~>) GHC.Types.Symbol GHC.Types.Symbol))
       where
-        ShowsPrec_0123456789876543210Sym0KindInference :: forall l arg.
+        ShowsPrec_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                 arg.
                                                           SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 l
-    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
     instance PShow (Maybe a) where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type family Equals_0123456789876543210 (a :: Maybe a) (b :: Maybe a) :: Bool where

--- a/tests/compile-and-dump/Singletons/Nat.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Nat.ghc84.template
@@ -25,41 +25,50 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
     pred Zero = Zero
     pred (Succ n) = n
     type ZeroSym0 = Zero
-    type SuccSym1 (t :: Nat) = Succ t
+    type SuccSym1 (t0123456789876543210 :: Nat) =
+        Succ t0123456789876543210
     instance SuppressUnusedWarnings SuccSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SuccSym0KindInference) GHC.Tuple.())
-    data SuccSym0 (l :: TyFun Nat Nat) :: GHC.Types.Type
+    data SuccSym0 :: (~>) Nat Nat
       where
-        SuccSym0KindInference :: forall l arg.
-                                 SameKind (Apply SuccSym0 arg) (SuccSym1 arg) => SuccSym0 l
-    type instance Apply SuccSym0 l = Succ l
-    type PredSym1 (t :: Nat) = Pred t
+        SuccSym0KindInference :: forall t0123456789876543210 arg.
+                                 SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
+                                 SuccSym0 t0123456789876543210
+    type instance Apply SuccSym0 t0123456789876543210 = Succ t0123456789876543210
+    type PredSym1 (a0123456789876543210 :: Nat) =
+        Pred a0123456789876543210
     instance SuppressUnusedWarnings PredSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) PredSym0KindInference) GHC.Tuple.())
-    data PredSym0 (l :: TyFun Nat Nat) :: GHC.Types.Type
+    data PredSym0 :: (~>) Nat Nat
       where
-        PredSym0KindInference :: forall l arg.
-                                 SameKind (Apply PredSym0 arg) (PredSym1 arg) => PredSym0 l
-    type instance Apply PredSym0 l = Pred l
-    type PlusSym2 (t :: Nat) (t :: Nat) = Plus t t
-    instance SuppressUnusedWarnings PlusSym1 where
+        PredSym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply PredSym0 arg) (PredSym1 arg) =>
+                                 PredSym0 a0123456789876543210
+    type instance Apply PredSym0 a0123456789876543210 = Pred a0123456789876543210
+    type PlusSym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) =
+        Plus a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (PlusSym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) PlusSym1KindInference) GHC.Tuple.())
-    data PlusSym1 (l :: Nat) (l :: TyFun Nat Nat) :: GHC.Types.Type
+    data PlusSym1 (a0123456789876543210 :: Nat) :: (~>) Nat Nat
       where
-        PlusSym1KindInference :: forall l l arg.
-                                 SameKind (Apply (PlusSym1 l) arg) (PlusSym2 l arg) => PlusSym1 l l
-    type instance Apply (PlusSym1 l) l = Plus l l
+        PlusSym1KindInference :: forall a0123456789876543210
+                                        a0123456789876543210
+                                        arg.
+                                 SameKind (Apply (PlusSym1 a0123456789876543210) arg) (PlusSym2 a0123456789876543210 arg) =>
+                                 PlusSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (PlusSym1 a0123456789876543210) a0123456789876543210 = Plus a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings PlusSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) PlusSym0KindInference) GHC.Tuple.())
-    data PlusSym0 (l :: TyFun Nat ((~>) Nat Nat)) :: GHC.Types.Type
+    data PlusSym0 :: (~>) Nat ((~>) Nat Nat)
       where
-        PlusSym0KindInference :: forall l arg.
-                                 SameKind (Apply PlusSym0 arg) (PlusSym1 arg) => PlusSym0 l
-    type instance Apply PlusSym0 l = PlusSym1 l
+        PlusSym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply PlusSym0 arg) (PlusSym1 arg) =>
+                                 PlusSym0 a0123456789876543210
+    type instance Apply PlusSym0 a0123456789876543210 = PlusSym1 a0123456789876543210
     type family Pred (a :: Nat) :: Nat where
       Pred Zero = ZeroSym0
       Pred (Succ n) = n
@@ -69,41 +78,47 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
     type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Nat) (a :: GHC.Types.Symbol) :: GHC.Types.Symbol where
       ShowsPrec_0123456789876543210 _ Zero a_0123456789876543210 = Apply (Apply ShowStringSym0 "Zero") a_0123456789876543210
       ShowsPrec_0123456789876543210 p_0123456789876543210 (Succ arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (Data.Singletons.Prelude.Num.FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Succ ")) (Apply (Apply ShowsPrecSym0 (Data.Singletons.Prelude.Num.FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: Nat) (t :: GHC.Types.Symbol) =
-        ShowsPrec_0123456789876543210 t t t
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+    type ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Nat) (a0123456789876543210 :: GHC.Types.Symbol) =
+        ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym2 (l :: GHC.Types.Nat) (l :: Nat) (l :: TyFun GHC.Types.Symbol GHC.Types.Symbol) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Nat) :: (~>) GHC.Types.Symbol GHC.Types.Symbol
       where
-        ShowsPrec_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 l l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+        ShowsPrec_0123456789876543210Sym2KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun Nat ((~>) GHC.Types.Symbol GHC.Types.Symbol)) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: (~>) Nat ((~>) GHC.Types.Symbol GHC.Types.Symbol)
       where
-        ShowsPrec_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+        ShowsPrec_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) Nat ((~>) GHC.Types.Symbol GHC.Types.Symbol))) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) Nat ((~>) GHC.Types.Symbol GHC.Types.Symbol))
       where
-        ShowsPrec_0123456789876543210Sym0KindInference :: forall l arg.
+        ShowsPrec_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                 arg.
                                                           SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 l
-    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
     instance PShow Nat where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type family Compare_0123456789876543210 (a :: Nat) (a :: Nat) :: Ordering where
@@ -111,30 +126,33 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
       Compare_0123456789876543210 (Succ a_0123456789876543210) (Succ b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) '[])
       Compare_0123456789876543210 Zero (Succ _) = LTSym0
       Compare_0123456789876543210 (Succ _) Zero = GTSym0
-    type Compare_0123456789876543210Sym2 (t :: Nat) (t :: Nat) =
-        Compare_0123456789876543210 t t
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym1 where
+    type Compare_0123456789876543210Sym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) =
+        Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym1 (l :: Nat) (l :: TyFun Nat Ordering) :: GHC.Types.Type
+    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Nat) :: (~>) Nat Ordering
       where
-        Compare_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                        SameKind (Apply (Compare_0123456789876543210Sym1 l) arg) (Compare_0123456789876543210Sym2 l arg) =>
-                                                        Compare_0123456789876543210Sym1 l l
-    type instance Apply (Compare_0123456789876543210Sym1 l) l = Compare_0123456789876543210 l l
+        Compare_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                               a0123456789876543210
+                                                               arg.
+                                                        SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym0 (l :: TyFun Nat ((~>) Nat Ordering)) :: GHC.Types.Type
+    data Compare_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Ordering)
       where
-        Compare_0123456789876543210Sym0KindInference :: forall l arg.
+        Compare_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                               arg.
                                                         SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 l
-    type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
+                                                        Compare_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
     instance POrd Nat where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type family Equals_0123456789876543210 (a :: Nat) (b :: Nat) :: Bool where

--- a/tests/compile-and-dump/Singletons/Operators.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Operators.ghc84.template
@@ -23,50 +23,61 @@ Singletons/Operators.hs:(0,0)-(0,0): Splicing declarations
     (+) Zero m = m
     (+) (Succ n) m = Succ (n + m)
     type FLeafSym0 = FLeaf
-    type (:+:@#@$$$) (t :: Foo) (t :: Foo) = (:+:) t t
-    instance SuppressUnusedWarnings (:+:@#@$$) where
+    type (:+:@#@$$$) (t0123456789876543210 :: Foo) (t0123456789876543210 :: Foo) =
+        (:+:) t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings ((:+:@#@$$) t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::+:@#@$$###)) GHC.Tuple.())
-    data (:+:@#@$$) (l :: Foo) (l :: TyFun Foo Foo) :: GHC.Types.Type
+    data (:+:@#@$$) (t0123456789876543210 :: Foo) :: (~>) Foo Foo
       where
-        (::+:@#@$$###) :: forall l l arg.
-                          SameKind (Apply ((:+:@#@$$) l) arg) ((:+:@#@$$$) l arg) =>
-                          (:+:@#@$$) l l
-    type instance Apply ((:+:@#@$$) l) l = (:+:) l l
+        (::+:@#@$$###) :: forall t0123456789876543210
+                                 t0123456789876543210
+                                 arg.
+                          SameKind (Apply ((:+:@#@$$) t0123456789876543210) arg) ((:+:@#@$$$) t0123456789876543210 arg) =>
+                          (:+:@#@$$) t0123456789876543210 t0123456789876543210
+    type instance Apply ((:+:@#@$$) t0123456789876543210) t0123456789876543210 = (:+:) t0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings (:+:@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::+:@#@$###)) GHC.Tuple.())
-    data (:+:@#@$) (l :: TyFun Foo ((~>) Foo Foo)) :: GHC.Types.Type
+    data :+:@#@$ :: (~>) Foo ((~>) Foo Foo)
       where
-        (::+:@#@$###) :: forall l arg.
-                         SameKind (Apply (:+:@#@$) arg) ((:+:@#@$$) arg) => (:+:@#@$) l
-    type instance Apply (:+:@#@$) l = (:+:@#@$$) l
-    type (+@#@$$$) (t :: Nat) (t :: Nat) = (+) t t
-    instance SuppressUnusedWarnings (+@#@$$) where
+        (::+:@#@$###) :: forall t0123456789876543210 arg.
+                         SameKind (Apply (:+:@#@$) arg) ((:+:@#@$$) arg) =>
+                         (:+:@#@$) t0123456789876543210
+    type instance Apply (:+:@#@$) t0123456789876543210 = (:+:@#@$$) t0123456789876543210
+    type (+@#@$$$) (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) =
+        (+) a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings ((+@#@$$) a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:+@#@$$###)) GHC.Tuple.())
-    data (+@#@$$) (l :: Nat) (l :: TyFun Nat Nat) :: GHC.Types.Type
+    data (+@#@$$) (a0123456789876543210 :: Nat) :: (~>) Nat Nat
       where
-        (:+@#@$$###) :: forall l l arg.
-                        SameKind (Apply ((+@#@$$) l) arg) ((+@#@$$$) l arg) => (+@#@$$) l l
-    type instance Apply ((+@#@$$) l) l = (+) l l
+        (:+@#@$$###) :: forall a0123456789876543210
+                               a0123456789876543210
+                               arg.
+                        SameKind (Apply ((+@#@$$) a0123456789876543210) arg) ((+@#@$$$) a0123456789876543210 arg) =>
+                        (+@#@$$) a0123456789876543210 a0123456789876543210
+    type instance Apply ((+@#@$$) a0123456789876543210) a0123456789876543210 = (+) a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings (+@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:+@#@$###)) GHC.Tuple.())
-    data (+@#@$) (l :: TyFun Nat ((~>) Nat Nat)) :: GHC.Types.Type
+    data +@#@$ :: (~>) Nat ((~>) Nat Nat)
       where
-        (:+@#@$###) :: forall l arg.
-                       SameKind (Apply (+@#@$) arg) ((+@#@$$) arg) => (+@#@$) l
-    type instance Apply (+@#@$) l = (+@#@$$) l
-    type ChildSym1 (t :: Foo) = Child t
+        (:+@#@$###) :: forall a0123456789876543210 arg.
+                       SameKind (Apply (+@#@$) arg) ((+@#@$$) arg) =>
+                       (+@#@$) a0123456789876543210
+    type instance Apply (+@#@$) a0123456789876543210 = (+@#@$$) a0123456789876543210
+    type ChildSym1 (a0123456789876543210 :: Foo) =
+        Child a0123456789876543210
     instance SuppressUnusedWarnings ChildSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ChildSym0KindInference) GHC.Tuple.())
-    data ChildSym0 (l :: TyFun Foo Foo) :: GHC.Types.Type
+    data ChildSym0 :: (~>) Foo Foo
       where
-        ChildSym0KindInference :: forall l arg.
-                                  SameKind (Apply ChildSym0 arg) (ChildSym1 arg) => ChildSym0 l
-    type instance Apply ChildSym0 l = Child l
+        ChildSym0KindInference :: forall a0123456789876543210 arg.
+                                  SameKind (Apply ChildSym0 arg) (ChildSym1 arg) =>
+                                  ChildSym0 a0123456789876543210
+    type instance Apply ChildSym0 a0123456789876543210 = Child a0123456789876543210
     type family (+) (a :: Nat) (a :: Nat) :: Nat where
       (+) Zero m = m
       (+) (Succ n) m = Apply SuccSym0 (Apply (Apply (+@#@$) n) m)

--- a/tests/compile-and-dump/Singletons/OrdDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/OrdDeriving.ghc84.template
@@ -24,254 +24,391 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         F a b c d
       deriving (Eq, Ord)
     type ZeroSym0 = Zero
-    type SuccSym1 (t :: Nat) = Succ t
+    type SuccSym1 (t0123456789876543210 :: Nat) =
+        Succ t0123456789876543210
     instance SuppressUnusedWarnings SuccSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SuccSym0KindInference) GHC.Tuple.())
-    data SuccSym0 (l :: TyFun Nat Nat) :: GHC.Types.Type
+    data SuccSym0 :: (~>) Nat Nat
       where
-        SuccSym0KindInference :: forall l arg.
-                                 SameKind (Apply SuccSym0 arg) (SuccSym1 arg) => SuccSym0 l
-    type instance Apply SuccSym0 l = Succ l
-    type ASym4 (t :: a0123456789876543210) (t :: b0123456789876543210) (t :: c0123456789876543210) (t :: d0123456789876543210) =
-        A t t t t
-    instance SuppressUnusedWarnings ASym3 where
+        SuccSym0KindInference :: forall t0123456789876543210 arg.
+                                 SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
+                                 SuccSym0 t0123456789876543210
+    type instance Apply SuccSym0 t0123456789876543210 = Succ t0123456789876543210
+    type ASym4 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: b0123456789876543210) (t0123456789876543210 :: c0123456789876543210) (t0123456789876543210 :: d0123456789876543210) =
+        A t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (ASym3 t0123456789876543210 t0123456789876543210 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ASym3KindInference) GHC.Tuple.())
-    data ASym3 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: c0123456789876543210) (l :: TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)) :: GHC.Types.Type
+    data ASym3 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: b0123456789876543210) (t0123456789876543210 :: c0123456789876543210) :: forall d0123456789876543210.
+                                                                                                                                                               (~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
       where
-        ASym3KindInference :: forall l l l l arg.
-                              SameKind (Apply (ASym3 l l l) arg) (ASym4 l l l arg) =>
-                              ASym3 l l l l
-    type instance Apply (ASym3 l l l) l = A l l l l
-    instance SuppressUnusedWarnings ASym2 where
+        ASym3KindInference :: forall t0123456789876543210
+                                     t0123456789876543210
+                                     t0123456789876543210
+                                     t0123456789876543210
+                                     arg.
+                              SameKind (Apply (ASym3 t0123456789876543210 t0123456789876543210 t0123456789876543210) arg) (ASym4 t0123456789876543210 t0123456789876543210 t0123456789876543210 arg) =>
+                              ASym3 t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    type instance Apply (ASym3 t0123456789876543210 t0123456789876543210 t0123456789876543210) t0123456789876543210 = A t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (ASym2 t0123456789876543210 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ASym2KindInference) GHC.Tuple.())
-    data ASym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))) :: GHC.Types.Type
+    data ASym2 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: b0123456789876543210) :: forall c0123456789876543210
+                                                                                                                       d0123456789876543210.
+                                                                                                                (~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))
       where
-        ASym2KindInference :: forall l l l arg.
-                              SameKind (Apply (ASym2 l l) arg) (ASym3 l l arg) => ASym2 l l l
-    type instance Apply (ASym2 l l) l = ASym3 l l l
-    instance SuppressUnusedWarnings ASym1 where
+        ASym2KindInference :: forall t0123456789876543210
+                                     t0123456789876543210
+                                     t0123456789876543210
+                                     arg.
+                              SameKind (Apply (ASym2 t0123456789876543210 t0123456789876543210) arg) (ASym3 t0123456789876543210 t0123456789876543210 arg) =>
+                              ASym2 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    type instance Apply (ASym2 t0123456789876543210 t0123456789876543210) t0123456789876543210 = ASym3 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (ASym1 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ASym1KindInference) GHC.Tuple.())
-    data ASym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)))) :: GHC.Types.Type
+    data ASym1 (t0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210
+                                                                        c0123456789876543210
+                                                                        d0123456789876543210.
+                                                                 (~>) b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)))
       where
-        ASym1KindInference :: forall l l arg.
-                              SameKind (Apply (ASym1 l) arg) (ASym2 l arg) => ASym1 l l
-    type instance Apply (ASym1 l) l = ASym2 l l
+        ASym1KindInference :: forall t0123456789876543210
+                                     t0123456789876543210
+                                     arg.
+                              SameKind (Apply (ASym1 t0123456789876543210) arg) (ASym2 t0123456789876543210 arg) =>
+                              ASym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (ASym1 t0123456789876543210) t0123456789876543210 = ASym2 t0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings ASym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ASym0KindInference) GHC.Tuple.())
-    data ASym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))))) :: GHC.Types.Type
+    data ASym0 :: forall a0123456789876543210
+                         b0123456789876543210
+                         c0123456789876543210
+                         d0123456789876543210.
+                  (~>) a0123456789876543210 ((~>) b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))))
       where
-        ASym0KindInference :: forall l arg.
-                              SameKind (Apply ASym0 arg) (ASym1 arg) => ASym0 l
-    type instance Apply ASym0 l = ASym1 l
-    type BSym4 (t :: a0123456789876543210) (t :: b0123456789876543210) (t :: c0123456789876543210) (t :: d0123456789876543210) =
-        B t t t t
-    instance SuppressUnusedWarnings BSym3 where
+        ASym0KindInference :: forall t0123456789876543210 arg.
+                              SameKind (Apply ASym0 arg) (ASym1 arg) =>
+                              ASym0 t0123456789876543210
+    type instance Apply ASym0 t0123456789876543210 = ASym1 t0123456789876543210
+    type BSym4 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: b0123456789876543210) (t0123456789876543210 :: c0123456789876543210) (t0123456789876543210 :: d0123456789876543210) =
+        B t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (BSym3 t0123456789876543210 t0123456789876543210 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BSym3KindInference) GHC.Tuple.())
-    data BSym3 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: c0123456789876543210) (l :: TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)) :: GHC.Types.Type
+    data BSym3 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: b0123456789876543210) (t0123456789876543210 :: c0123456789876543210) :: forall d0123456789876543210.
+                                                                                                                                                               (~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
       where
-        BSym3KindInference :: forall l l l l arg.
-                              SameKind (Apply (BSym3 l l l) arg) (BSym4 l l l arg) =>
-                              BSym3 l l l l
-    type instance Apply (BSym3 l l l) l = B l l l l
-    instance SuppressUnusedWarnings BSym2 where
+        BSym3KindInference :: forall t0123456789876543210
+                                     t0123456789876543210
+                                     t0123456789876543210
+                                     t0123456789876543210
+                                     arg.
+                              SameKind (Apply (BSym3 t0123456789876543210 t0123456789876543210 t0123456789876543210) arg) (BSym4 t0123456789876543210 t0123456789876543210 t0123456789876543210 arg) =>
+                              BSym3 t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    type instance Apply (BSym3 t0123456789876543210 t0123456789876543210 t0123456789876543210) t0123456789876543210 = B t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (BSym2 t0123456789876543210 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BSym2KindInference) GHC.Tuple.())
-    data BSym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))) :: GHC.Types.Type
+    data BSym2 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: b0123456789876543210) :: forall c0123456789876543210
+                                                                                                                       d0123456789876543210.
+                                                                                                                (~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))
       where
-        BSym2KindInference :: forall l l l arg.
-                              SameKind (Apply (BSym2 l l) arg) (BSym3 l l arg) => BSym2 l l l
-    type instance Apply (BSym2 l l) l = BSym3 l l l
-    instance SuppressUnusedWarnings BSym1 where
+        BSym2KindInference :: forall t0123456789876543210
+                                     t0123456789876543210
+                                     t0123456789876543210
+                                     arg.
+                              SameKind (Apply (BSym2 t0123456789876543210 t0123456789876543210) arg) (BSym3 t0123456789876543210 t0123456789876543210 arg) =>
+                              BSym2 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    type instance Apply (BSym2 t0123456789876543210 t0123456789876543210) t0123456789876543210 = BSym3 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (BSym1 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BSym1KindInference) GHC.Tuple.())
-    data BSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)))) :: GHC.Types.Type
+    data BSym1 (t0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210
+                                                                        c0123456789876543210
+                                                                        d0123456789876543210.
+                                                                 (~>) b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)))
       where
-        BSym1KindInference :: forall l l arg.
-                              SameKind (Apply (BSym1 l) arg) (BSym2 l arg) => BSym1 l l
-    type instance Apply (BSym1 l) l = BSym2 l l
+        BSym1KindInference :: forall t0123456789876543210
+                                     t0123456789876543210
+                                     arg.
+                              SameKind (Apply (BSym1 t0123456789876543210) arg) (BSym2 t0123456789876543210 arg) =>
+                              BSym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (BSym1 t0123456789876543210) t0123456789876543210 = BSym2 t0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings BSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BSym0KindInference) GHC.Tuple.())
-    data BSym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))))) :: GHC.Types.Type
+    data BSym0 :: forall a0123456789876543210
+                         b0123456789876543210
+                         c0123456789876543210
+                         d0123456789876543210.
+                  (~>) a0123456789876543210 ((~>) b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))))
       where
-        BSym0KindInference :: forall l arg.
-                              SameKind (Apply BSym0 arg) (BSym1 arg) => BSym0 l
-    type instance Apply BSym0 l = BSym1 l
-    type CSym4 (t :: a0123456789876543210) (t :: b0123456789876543210) (t :: c0123456789876543210) (t :: d0123456789876543210) =
-        C t t t t
-    instance SuppressUnusedWarnings CSym3 where
+        BSym0KindInference :: forall t0123456789876543210 arg.
+                              SameKind (Apply BSym0 arg) (BSym1 arg) =>
+                              BSym0 t0123456789876543210
+    type instance Apply BSym0 t0123456789876543210 = BSym1 t0123456789876543210
+    type CSym4 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: b0123456789876543210) (t0123456789876543210 :: c0123456789876543210) (t0123456789876543210 :: d0123456789876543210) =
+        C t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (CSym3 t0123456789876543210 t0123456789876543210 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) CSym3KindInference) GHC.Tuple.())
-    data CSym3 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: c0123456789876543210) (l :: TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)) :: GHC.Types.Type
+    data CSym3 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: b0123456789876543210) (t0123456789876543210 :: c0123456789876543210) :: forall d0123456789876543210.
+                                                                                                                                                               (~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
       where
-        CSym3KindInference :: forall l l l l arg.
-                              SameKind (Apply (CSym3 l l l) arg) (CSym4 l l l arg) =>
-                              CSym3 l l l l
-    type instance Apply (CSym3 l l l) l = C l l l l
-    instance SuppressUnusedWarnings CSym2 where
+        CSym3KindInference :: forall t0123456789876543210
+                                     t0123456789876543210
+                                     t0123456789876543210
+                                     t0123456789876543210
+                                     arg.
+                              SameKind (Apply (CSym3 t0123456789876543210 t0123456789876543210 t0123456789876543210) arg) (CSym4 t0123456789876543210 t0123456789876543210 t0123456789876543210 arg) =>
+                              CSym3 t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    type instance Apply (CSym3 t0123456789876543210 t0123456789876543210 t0123456789876543210) t0123456789876543210 = C t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (CSym2 t0123456789876543210 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) CSym2KindInference) GHC.Tuple.())
-    data CSym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))) :: GHC.Types.Type
+    data CSym2 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: b0123456789876543210) :: forall c0123456789876543210
+                                                                                                                       d0123456789876543210.
+                                                                                                                (~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))
       where
-        CSym2KindInference :: forall l l l arg.
-                              SameKind (Apply (CSym2 l l) arg) (CSym3 l l arg) => CSym2 l l l
-    type instance Apply (CSym2 l l) l = CSym3 l l l
-    instance SuppressUnusedWarnings CSym1 where
+        CSym2KindInference :: forall t0123456789876543210
+                                     t0123456789876543210
+                                     t0123456789876543210
+                                     arg.
+                              SameKind (Apply (CSym2 t0123456789876543210 t0123456789876543210) arg) (CSym3 t0123456789876543210 t0123456789876543210 arg) =>
+                              CSym2 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    type instance Apply (CSym2 t0123456789876543210 t0123456789876543210) t0123456789876543210 = CSym3 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (CSym1 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) CSym1KindInference) GHC.Tuple.())
-    data CSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)))) :: GHC.Types.Type
+    data CSym1 (t0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210
+                                                                        c0123456789876543210
+                                                                        d0123456789876543210.
+                                                                 (~>) b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)))
       where
-        CSym1KindInference :: forall l l arg.
-                              SameKind (Apply (CSym1 l) arg) (CSym2 l arg) => CSym1 l l
-    type instance Apply (CSym1 l) l = CSym2 l l
+        CSym1KindInference :: forall t0123456789876543210
+                                     t0123456789876543210
+                                     arg.
+                              SameKind (Apply (CSym1 t0123456789876543210) arg) (CSym2 t0123456789876543210 arg) =>
+                              CSym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (CSym1 t0123456789876543210) t0123456789876543210 = CSym2 t0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings CSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) CSym0KindInference) GHC.Tuple.())
-    data CSym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))))) :: GHC.Types.Type
+    data CSym0 :: forall a0123456789876543210
+                         b0123456789876543210
+                         c0123456789876543210
+                         d0123456789876543210.
+                  (~>) a0123456789876543210 ((~>) b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))))
       where
-        CSym0KindInference :: forall l arg.
-                              SameKind (Apply CSym0 arg) (CSym1 arg) => CSym0 l
-    type instance Apply CSym0 l = CSym1 l
-    type DSym4 (t :: a0123456789876543210) (t :: b0123456789876543210) (t :: c0123456789876543210) (t :: d0123456789876543210) =
-        D t t t t
-    instance SuppressUnusedWarnings DSym3 where
+        CSym0KindInference :: forall t0123456789876543210 arg.
+                              SameKind (Apply CSym0 arg) (CSym1 arg) =>
+                              CSym0 t0123456789876543210
+    type instance Apply CSym0 t0123456789876543210 = CSym1 t0123456789876543210
+    type DSym4 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: b0123456789876543210) (t0123456789876543210 :: c0123456789876543210) (t0123456789876543210 :: d0123456789876543210) =
+        D t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (DSym3 t0123456789876543210 t0123456789876543210 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) DSym3KindInference) GHC.Tuple.())
-    data DSym3 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: c0123456789876543210) (l :: TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)) :: GHC.Types.Type
+    data DSym3 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: b0123456789876543210) (t0123456789876543210 :: c0123456789876543210) :: forall d0123456789876543210.
+                                                                                                                                                               (~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
       where
-        DSym3KindInference :: forall l l l l arg.
-                              SameKind (Apply (DSym3 l l l) arg) (DSym4 l l l arg) =>
-                              DSym3 l l l l
-    type instance Apply (DSym3 l l l) l = D l l l l
-    instance SuppressUnusedWarnings DSym2 where
+        DSym3KindInference :: forall t0123456789876543210
+                                     t0123456789876543210
+                                     t0123456789876543210
+                                     t0123456789876543210
+                                     arg.
+                              SameKind (Apply (DSym3 t0123456789876543210 t0123456789876543210 t0123456789876543210) arg) (DSym4 t0123456789876543210 t0123456789876543210 t0123456789876543210 arg) =>
+                              DSym3 t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    type instance Apply (DSym3 t0123456789876543210 t0123456789876543210 t0123456789876543210) t0123456789876543210 = D t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (DSym2 t0123456789876543210 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) DSym2KindInference) GHC.Tuple.())
-    data DSym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))) :: GHC.Types.Type
+    data DSym2 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: b0123456789876543210) :: forall c0123456789876543210
+                                                                                                                       d0123456789876543210.
+                                                                                                                (~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))
       where
-        DSym2KindInference :: forall l l l arg.
-                              SameKind (Apply (DSym2 l l) arg) (DSym3 l l arg) => DSym2 l l l
-    type instance Apply (DSym2 l l) l = DSym3 l l l
-    instance SuppressUnusedWarnings DSym1 where
+        DSym2KindInference :: forall t0123456789876543210
+                                     t0123456789876543210
+                                     t0123456789876543210
+                                     arg.
+                              SameKind (Apply (DSym2 t0123456789876543210 t0123456789876543210) arg) (DSym3 t0123456789876543210 t0123456789876543210 arg) =>
+                              DSym2 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    type instance Apply (DSym2 t0123456789876543210 t0123456789876543210) t0123456789876543210 = DSym3 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (DSym1 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) DSym1KindInference) GHC.Tuple.())
-    data DSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)))) :: GHC.Types.Type
+    data DSym1 (t0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210
+                                                                        c0123456789876543210
+                                                                        d0123456789876543210.
+                                                                 (~>) b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)))
       where
-        DSym1KindInference :: forall l l arg.
-                              SameKind (Apply (DSym1 l) arg) (DSym2 l arg) => DSym1 l l
-    type instance Apply (DSym1 l) l = DSym2 l l
+        DSym1KindInference :: forall t0123456789876543210
+                                     t0123456789876543210
+                                     arg.
+                              SameKind (Apply (DSym1 t0123456789876543210) arg) (DSym2 t0123456789876543210 arg) =>
+                              DSym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (DSym1 t0123456789876543210) t0123456789876543210 = DSym2 t0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings DSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) DSym0KindInference) GHC.Tuple.())
-    data DSym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))))) :: GHC.Types.Type
+    data DSym0 :: forall a0123456789876543210
+                         b0123456789876543210
+                         c0123456789876543210
+                         d0123456789876543210.
+                  (~>) a0123456789876543210 ((~>) b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))))
       where
-        DSym0KindInference :: forall l arg.
-                              SameKind (Apply DSym0 arg) (DSym1 arg) => DSym0 l
-    type instance Apply DSym0 l = DSym1 l
-    type ESym4 (t :: a0123456789876543210) (t :: b0123456789876543210) (t :: c0123456789876543210) (t :: d0123456789876543210) =
-        E t t t t
-    instance SuppressUnusedWarnings ESym3 where
+        DSym0KindInference :: forall t0123456789876543210 arg.
+                              SameKind (Apply DSym0 arg) (DSym1 arg) =>
+                              DSym0 t0123456789876543210
+    type instance Apply DSym0 t0123456789876543210 = DSym1 t0123456789876543210
+    type ESym4 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: b0123456789876543210) (t0123456789876543210 :: c0123456789876543210) (t0123456789876543210 :: d0123456789876543210) =
+        E t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (ESym3 t0123456789876543210 t0123456789876543210 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ESym3KindInference) GHC.Tuple.())
-    data ESym3 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: c0123456789876543210) (l :: TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)) :: GHC.Types.Type
+    data ESym3 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: b0123456789876543210) (t0123456789876543210 :: c0123456789876543210) :: forall d0123456789876543210.
+                                                                                                                                                               (~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
       where
-        ESym3KindInference :: forall l l l l arg.
-                              SameKind (Apply (ESym3 l l l) arg) (ESym4 l l l arg) =>
-                              ESym3 l l l l
-    type instance Apply (ESym3 l l l) l = E l l l l
-    instance SuppressUnusedWarnings ESym2 where
+        ESym3KindInference :: forall t0123456789876543210
+                                     t0123456789876543210
+                                     t0123456789876543210
+                                     t0123456789876543210
+                                     arg.
+                              SameKind (Apply (ESym3 t0123456789876543210 t0123456789876543210 t0123456789876543210) arg) (ESym4 t0123456789876543210 t0123456789876543210 t0123456789876543210 arg) =>
+                              ESym3 t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    type instance Apply (ESym3 t0123456789876543210 t0123456789876543210 t0123456789876543210) t0123456789876543210 = E t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (ESym2 t0123456789876543210 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ESym2KindInference) GHC.Tuple.())
-    data ESym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))) :: GHC.Types.Type
+    data ESym2 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: b0123456789876543210) :: forall c0123456789876543210
+                                                                                                                       d0123456789876543210.
+                                                                                                                (~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))
       where
-        ESym2KindInference :: forall l l l arg.
-                              SameKind (Apply (ESym2 l l) arg) (ESym3 l l arg) => ESym2 l l l
-    type instance Apply (ESym2 l l) l = ESym3 l l l
-    instance SuppressUnusedWarnings ESym1 where
+        ESym2KindInference :: forall t0123456789876543210
+                                     t0123456789876543210
+                                     t0123456789876543210
+                                     arg.
+                              SameKind (Apply (ESym2 t0123456789876543210 t0123456789876543210) arg) (ESym3 t0123456789876543210 t0123456789876543210 arg) =>
+                              ESym2 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    type instance Apply (ESym2 t0123456789876543210 t0123456789876543210) t0123456789876543210 = ESym3 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (ESym1 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ESym1KindInference) GHC.Tuple.())
-    data ESym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)))) :: GHC.Types.Type
+    data ESym1 (t0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210
+                                                                        c0123456789876543210
+                                                                        d0123456789876543210.
+                                                                 (~>) b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)))
       where
-        ESym1KindInference :: forall l l arg.
-                              SameKind (Apply (ESym1 l) arg) (ESym2 l arg) => ESym1 l l
-    type instance Apply (ESym1 l) l = ESym2 l l
+        ESym1KindInference :: forall t0123456789876543210
+                                     t0123456789876543210
+                                     arg.
+                              SameKind (Apply (ESym1 t0123456789876543210) arg) (ESym2 t0123456789876543210 arg) =>
+                              ESym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (ESym1 t0123456789876543210) t0123456789876543210 = ESym2 t0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings ESym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ESym0KindInference) GHC.Tuple.())
-    data ESym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))))) :: GHC.Types.Type
+    data ESym0 :: forall a0123456789876543210
+                         b0123456789876543210
+                         c0123456789876543210
+                         d0123456789876543210.
+                  (~>) a0123456789876543210 ((~>) b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))))
       where
-        ESym0KindInference :: forall l arg.
-                              SameKind (Apply ESym0 arg) (ESym1 arg) => ESym0 l
-    type instance Apply ESym0 l = ESym1 l
-    type FSym4 (t :: a0123456789876543210) (t :: b0123456789876543210) (t :: c0123456789876543210) (t :: d0123456789876543210) =
-        F t t t t
-    instance SuppressUnusedWarnings FSym3 where
+        ESym0KindInference :: forall t0123456789876543210 arg.
+                              SameKind (Apply ESym0 arg) (ESym1 arg) =>
+                              ESym0 t0123456789876543210
+    type instance Apply ESym0 t0123456789876543210 = ESym1 t0123456789876543210
+    type FSym4 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: b0123456789876543210) (t0123456789876543210 :: c0123456789876543210) (t0123456789876543210 :: d0123456789876543210) =
+        F t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (FSym3 t0123456789876543210 t0123456789876543210 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FSym3KindInference) GHC.Tuple.())
-    data FSym3 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: c0123456789876543210) (l :: TyFun d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)) :: GHC.Types.Type
+    data FSym3 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: b0123456789876543210) (t0123456789876543210 :: c0123456789876543210) :: forall d0123456789876543210.
+                                                                                                                                                               (~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)
       where
-        FSym3KindInference :: forall l l l l arg.
-                              SameKind (Apply (FSym3 l l l) arg) (FSym4 l l l arg) =>
-                              FSym3 l l l l
-    type instance Apply (FSym3 l l l) l = F l l l l
-    instance SuppressUnusedWarnings FSym2 where
+        FSym3KindInference :: forall t0123456789876543210
+                                     t0123456789876543210
+                                     t0123456789876543210
+                                     t0123456789876543210
+                                     arg.
+                              SameKind (Apply (FSym3 t0123456789876543210 t0123456789876543210 t0123456789876543210) arg) (FSym4 t0123456789876543210 t0123456789876543210 t0123456789876543210 arg) =>
+                              FSym3 t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    type instance Apply (FSym3 t0123456789876543210 t0123456789876543210 t0123456789876543210) t0123456789876543210 = F t0123456789876543210 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (FSym2 t0123456789876543210 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FSym2KindInference) GHC.Tuple.())
-    data FSym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))) :: GHC.Types.Type
+    data FSym2 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: b0123456789876543210) :: forall c0123456789876543210
+                                                                                                                       d0123456789876543210.
+                                                                                                                (~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))
       where
-        FSym2KindInference :: forall l l l arg.
-                              SameKind (Apply (FSym2 l l) arg) (FSym3 l l arg) => FSym2 l l l
-    type instance Apply (FSym2 l l) l = FSym3 l l l
-    instance SuppressUnusedWarnings FSym1 where
+        FSym2KindInference :: forall t0123456789876543210
+                                     t0123456789876543210
+                                     t0123456789876543210
+                                     arg.
+                              SameKind (Apply (FSym2 t0123456789876543210 t0123456789876543210) arg) (FSym3 t0123456789876543210 t0123456789876543210 arg) =>
+                              FSym2 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    type instance Apply (FSym2 t0123456789876543210 t0123456789876543210) t0123456789876543210 = FSym3 t0123456789876543210 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (FSym1 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FSym1KindInference) GHC.Tuple.())
-    data FSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)))) :: GHC.Types.Type
+    data FSym1 (t0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210
+                                                                        c0123456789876543210
+                                                                        d0123456789876543210.
+                                                                 (~>) b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210)))
       where
-        FSym1KindInference :: forall l l arg.
-                              SameKind (Apply (FSym1 l) arg) (FSym2 l arg) => FSym1 l l
-    type instance Apply (FSym1 l) l = FSym2 l l
+        FSym1KindInference :: forall t0123456789876543210
+                                     t0123456789876543210
+                                     arg.
+                              SameKind (Apply (FSym1 t0123456789876543210) arg) (FSym2 t0123456789876543210 arg) =>
+                              FSym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (FSym1 t0123456789876543210) t0123456789876543210 = FSym2 t0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings FSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FSym0KindInference) GHC.Tuple.())
-    data FSym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))))) :: GHC.Types.Type
+    data FSym0 :: forall a0123456789876543210
+                         b0123456789876543210
+                         c0123456789876543210
+                         d0123456789876543210.
+                  (~>) a0123456789876543210 ((~>) b0123456789876543210 ((~>) c0123456789876543210 ((~>) d0123456789876543210 (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210))))
       where
-        FSym0KindInference :: forall l arg.
-                              SameKind (Apply FSym0 arg) (FSym1 arg) => FSym0 l
-    type instance Apply FSym0 l = FSym1 l
+        FSym0KindInference :: forall t0123456789876543210 arg.
+                              SameKind (Apply FSym0 arg) (FSym1 arg) =>
+                              FSym0 t0123456789876543210
+    type instance Apply FSym0 t0123456789876543210 = FSym1 t0123456789876543210
     type family Compare_0123456789876543210 (a :: Nat) (a :: Nat) :: Ordering where
       Compare_0123456789876543210 Zero Zero = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) '[]
       Compare_0123456789876543210 (Succ a_0123456789876543210) (Succ b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) '[])
       Compare_0123456789876543210 Zero (Succ _) = LTSym0
       Compare_0123456789876543210 (Succ _) Zero = GTSym0
-    type Compare_0123456789876543210Sym2 (t :: Nat) (t :: Nat) =
-        Compare_0123456789876543210 t t
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym1 where
+    type Compare_0123456789876543210Sym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) =
+        Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym1 (l :: Nat) (l :: TyFun Nat Ordering) :: GHC.Types.Type
+    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Nat) :: (~>) Nat Ordering
       where
-        Compare_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                        SameKind (Apply (Compare_0123456789876543210Sym1 l) arg) (Compare_0123456789876543210Sym2 l arg) =>
-                                                        Compare_0123456789876543210Sym1 l l
-    type instance Apply (Compare_0123456789876543210Sym1 l) l = Compare_0123456789876543210 l l
+        Compare_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                               a0123456789876543210
+                                                               arg.
+                                                        SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym0 (l :: TyFun Nat ((~>) Nat Ordering)) :: GHC.Types.Type
+    data Compare_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Ordering)
       where
-        Compare_0123456789876543210Sym0KindInference :: forall l arg.
+        Compare_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                               arg.
                                                         SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 l
-    type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
+                                                        Compare_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
     instance POrd Nat where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type family Compare_0123456789876543210 (a :: Foo a b c d) (a :: Foo a b c d) :: Ordering where
@@ -311,30 +448,37 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       Compare_0123456789876543210 (F _ _ _ _) (C _ _ _ _) = GTSym0
       Compare_0123456789876543210 (F _ _ _ _) (D _ _ _ _) = GTSym0
       Compare_0123456789876543210 (F _ _ _ _) (E _ _ _ _) = GTSym0
-    type Compare_0123456789876543210Sym2 (t :: Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210) (t :: Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210) =
-        Compare_0123456789876543210 t t
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym1 where
+    type Compare_0123456789876543210Sym2 (a0123456789876543210 :: Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210) (a0123456789876543210 :: Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210) =
+        Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym1 (l :: Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210) (l :: TyFun (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210) Ordering) :: GHC.Types.Type
+    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210) :: (~>) (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210) Ordering
       where
-        Compare_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                        SameKind (Apply (Compare_0123456789876543210Sym1 l) arg) (Compare_0123456789876543210Sym2 l arg) =>
-                                                        Compare_0123456789876543210Sym1 l l
-    type instance Apply (Compare_0123456789876543210Sym1 l) l = Compare_0123456789876543210 l l
+        Compare_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                               a0123456789876543210
+                                                               arg.
+                                                        SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym0 (l :: TyFun (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210) ((~>) (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210) Ordering)) :: GHC.Types.Type
+    data Compare_0123456789876543210Sym0 :: forall a0123456789876543210
+                                                   b0123456789876543210
+                                                   c0123456789876543210
+                                                   d0123456789876543210.
+                                            (~>) (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210) ((~>) (Foo a0123456789876543210 b0123456789876543210 c0123456789876543210 d0123456789876543210) Ordering)
       where
-        Compare_0123456789876543210Sym0KindInference :: forall l arg.
+        Compare_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                               arg.
                                                         SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 l
-    type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
+                                                        Compare_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
     instance POrd (Foo a b c d) where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type family Equals_0123456789876543210 (a :: Nat) (b :: Nat) :: Bool where

--- a/tests/compile-and-dump/Singletons/OverloadedStrings.ghc84.template
+++ b/tests/compile-and-dump/Singletons/OverloadedStrings.ghc84.template
@@ -9,15 +9,17 @@ Singletons/OverloadedStrings.hs:(0,0)-(0,0): Splicing declarations
     symId x = x
     foo :: Symbol
     foo = symId "foo"
-    type SymIdSym1 (t :: Symbol) = SymId t
+    type SymIdSym1 (a0123456789876543210 :: Symbol) =
+        SymId a0123456789876543210
     instance SuppressUnusedWarnings SymIdSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SymIdSym0KindInference) GHC.Tuple.())
-    data SymIdSym0 (l :: TyFun Symbol Symbol) :: GHC.Types.Type
+    data SymIdSym0 :: (~>) Symbol Symbol
       where
-        SymIdSym0KindInference :: forall l arg.
-                                  SameKind (Apply SymIdSym0 arg) (SymIdSym1 arg) => SymIdSym0 l
-    type instance Apply SymIdSym0 l = SymId l
+        SymIdSym0KindInference :: forall a0123456789876543210 arg.
+                                  SameKind (Apply SymIdSym0 arg) (SymIdSym1 arg) =>
+                                  SymIdSym0 a0123456789876543210
+    type instance Apply SymIdSym0 a0123456789876543210 = SymId a0123456789876543210
     type FooSym0 = Foo
     type family SymId (a :: Symbol) :: Symbol where
       SymId x = x

--- a/tests/compile-and-dump/Singletons/PatternMatching.ghc84.template
+++ b/tests/compile-and-dump/Singletons/PatternMatching.ghc84.template
@@ -16,24 +16,30 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     complex = (Pair ((Pair (Just Zero)) Zero)) False
     tuple = (False, Just Zero, True)
     aList = [Zero, Succ Zero, Succ (Succ Zero)]
-    type PairSym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
-        Pair t t
-    instance SuppressUnusedWarnings PairSym1 where
+    type PairSym2 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: b0123456789876543210) =
+        Pair t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (PairSym1 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) PairSym1KindInference) GHC.Tuple.())
-    data PairSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 (Pair a0123456789876543210 b0123456789876543210)) :: GHC.Types.Type
+    data PairSym1 (t0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210.
+                                                                    (~>) b0123456789876543210 (Pair a0123456789876543210 b0123456789876543210)
       where
-        PairSym1KindInference :: forall l l arg.
-                                 SameKind (Apply (PairSym1 l) arg) (PairSym2 l arg) => PairSym1 l l
-    type instance Apply (PairSym1 l) l = Pair l l
+        PairSym1KindInference :: forall t0123456789876543210
+                                        t0123456789876543210
+                                        arg.
+                                 SameKind (Apply (PairSym1 t0123456789876543210) arg) (PairSym2 t0123456789876543210 arg) =>
+                                 PairSym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (PairSym1 t0123456789876543210) t0123456789876543210 = Pair t0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings PairSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) PairSym0KindInference) GHC.Tuple.())
-    data PairSym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 (Pair a0123456789876543210 b0123456789876543210))) :: GHC.Types.Type
+    data PairSym0 :: forall a0123456789876543210 b0123456789876543210.
+                     (~>) a0123456789876543210 ((~>) b0123456789876543210 (Pair a0123456789876543210 b0123456789876543210))
       where
-        PairSym0KindInference :: forall l arg.
-                                 SameKind (Apply PairSym0 arg) (PairSym1 arg) => PairSym0 l
-    type instance Apply PairSym0 l = PairSym1 l
+        PairSym0KindInference :: forall t0123456789876543210 arg.
+                                 SameKind (Apply PairSym0 arg) (PairSym1 arg) =>
+                                 PairSym0 t0123456789876543210
+    type instance Apply PairSym0 t0123456789876543210 = PairSym1 t0123456789876543210
     type AListSym0 = AList
     type TupleSym0 = Tuple
     type ComplexSym0 = Complex
@@ -48,41 +54,51 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
       Pr = Apply (Apply PairSym0 (Apply SuccSym0 ZeroSym0)) (Apply (Apply (:@#@$) ZeroSym0) '[])
     type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Pair a b) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 p_0123456789876543210 (Pair arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Pair ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: Pair a0123456789876543210 b0123456789876543210) (t :: Symbol) =
-        ShowsPrec_0123456789876543210 t t t
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+    type ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Pair a0123456789876543210 b0123456789876543210) (a0123456789876543210 :: Symbol) =
+        ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym2 (l :: GHC.Types.Nat) (l :: Pair a0123456789876543210 b0123456789876543210) (l :: TyFun Symbol Symbol) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Pair a0123456789876543210 b0123456789876543210) :: (~>) Symbol Symbol
       where
-        ShowsPrec_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 l l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+        ShowsPrec_0123456789876543210Sym2KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun (Pair a0123456789876543210 b0123456789876543210) ((~>) Symbol Symbol)) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: forall a0123456789876543210
+                                                                                             b0123456789876543210.
+                                                                                      (~>) (Pair a0123456789876543210 b0123456789876543210) ((~>) Symbol Symbol)
       where
-        ShowsPrec_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+        ShowsPrec_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) (Pair a0123456789876543210 b0123456789876543210) ((~>) Symbol Symbol))) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym0 :: forall a0123456789876543210
+                                                     b0123456789876543210.
+                                              (~>) GHC.Types.Nat ((~>) (Pair a0123456789876543210 b0123456789876543210) ((~>) Symbol Symbol))
       where
-        ShowsPrec_0123456789876543210Sym0KindInference :: forall l arg.
+        ShowsPrec_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                 arg.
                                                           SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 l
-    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
     instance PShow (Pair a b) where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     sAList :: Sing AListSym0
@@ -227,138 +243,158 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     silly x = case x of { _ -> GHC.Tuple.() }
     type family Case_0123456789876543210 x t where
       Case_0123456789876543210 x _ = Tuple0Sym0
-    type Let0123456789876543210TSym2 t t = Let0123456789876543210T t t
-    instance SuppressUnusedWarnings Let0123456789876543210TSym1 where
+    type Let0123456789876543210TSym2 x0123456789876543210 y0123456789876543210 =
+        Let0123456789876543210T x0123456789876543210 y0123456789876543210
+    instance SuppressUnusedWarnings (Let0123456789876543210TSym1 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210TSym1KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210TSym1 l l :: GHC.Types.Type
+    data Let0123456789876543210TSym1 x0123456789876543210 y0123456789876543210
       where
-        Let0123456789876543210TSym1KindInference :: forall l l arg.
-                                                    SameKind (Apply (Let0123456789876543210TSym1 l) arg) (Let0123456789876543210TSym2 l arg) =>
-                                                    Let0123456789876543210TSym1 l l
-    type instance Apply (Let0123456789876543210TSym1 l) l = Let0123456789876543210T l l
+        Let0123456789876543210TSym1KindInference :: forall x0123456789876543210
+                                                           y0123456789876543210
+                                                           arg.
+                                                    SameKind (Apply (Let0123456789876543210TSym1 x0123456789876543210) arg) (Let0123456789876543210TSym2 x0123456789876543210 arg) =>
+                                                    Let0123456789876543210TSym1 x0123456789876543210 y0123456789876543210
+    type instance Apply (Let0123456789876543210TSym1 x0123456789876543210) y0123456789876543210 = Let0123456789876543210T x0123456789876543210 y0123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210TSym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210TSym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210TSym0 l :: GHC.Types.Type
+    data Let0123456789876543210TSym0 x0123456789876543210
       where
-        Let0123456789876543210TSym0KindInference :: forall l arg.
+        Let0123456789876543210TSym0KindInference :: forall x0123456789876543210
+                                                           arg.
                                                     SameKind (Apply Let0123456789876543210TSym0 arg) (Let0123456789876543210TSym1 arg) =>
-                                                    Let0123456789876543210TSym0 l
-    type instance Apply Let0123456789876543210TSym0 l = Let0123456789876543210TSym1 l
+                                                    Let0123456789876543210TSym0 x0123456789876543210
+    type instance Apply Let0123456789876543210TSym0 x0123456789876543210 = Let0123456789876543210TSym1 x0123456789876543210
     type family Let0123456789876543210T x y where
       Let0123456789876543210T x y = Apply (Apply Tuple2Sym0 x) y
     type family Case_0123456789876543210 x y a b arg_0123456789876543210 t where
       Case_0123456789876543210 x y a b arg_0123456789876543210 _ = a
     type family Lambda_0123456789876543210 x y a b t where
       Lambda_0123456789876543210 x y a b arg_0123456789876543210 = Case_0123456789876543210 x y a b arg_0123456789876543210 arg_0123456789876543210
-    type Lambda_0123456789876543210Sym5 t t t t t =
-        Lambda_0123456789876543210 t t t t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym4 where
+    type Lambda_0123456789876543210Sym5 x0123456789876543210 y0123456789876543210 a0123456789876543210 b0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 x0123456789876543210 y0123456789876543210 a0123456789876543210 b0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym4 b0123456789876543210 a0123456789876543210 y0123456789876543210 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym4KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym4 l l l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym4 x0123456789876543210 y0123456789876543210 a0123456789876543210 b0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym4KindInference :: forall l
-                                                              l
-                                                              l
-                                                              l
-                                                              l
+        Lambda_0123456789876543210Sym4KindInference :: forall x0123456789876543210
+                                                              y0123456789876543210
+                                                              a0123456789876543210
+                                                              b0123456789876543210
+                                                              t0123456789876543210
                                                               arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym4 l l l l) arg) (Lambda_0123456789876543210Sym5 l l l l arg) =>
-                                                       Lambda_0123456789876543210Sym4 l l l l l
-    type instance Apply (Lambda_0123456789876543210Sym4 l l l l) l = Lambda_0123456789876543210 l l l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym3 where
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym4 x0123456789876543210 y0123456789876543210 a0123456789876543210 b0123456789876543210) arg) (Lambda_0123456789876543210Sym5 x0123456789876543210 y0123456789876543210 a0123456789876543210 b0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym4 x0123456789876543210 y0123456789876543210 a0123456789876543210 b0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym4 b0123456789876543210 a0123456789876543210 y0123456789876543210 x0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 b0123456789876543210 a0123456789876543210 y0123456789876543210 x0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym3 a0123456789876543210 y0123456789876543210 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym3KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym3 l l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym3 x0123456789876543210 y0123456789876543210 a0123456789876543210 b0123456789876543210
       where
-        Lambda_0123456789876543210Sym3KindInference :: forall l l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym3 l l l) arg) (Lambda_0123456789876543210Sym4 l l l arg) =>
-                                                       Lambda_0123456789876543210Sym3 l l l l
-    type instance Apply (Lambda_0123456789876543210Sym3 l l l) l = Lambda_0123456789876543210Sym4 l l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+        Lambda_0123456789876543210Sym3KindInference :: forall x0123456789876543210
+                                                              y0123456789876543210
+                                                              a0123456789876543210
+                                                              b0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym3 x0123456789876543210 y0123456789876543210 a0123456789876543210) arg) (Lambda_0123456789876543210Sym4 x0123456789876543210 y0123456789876543210 a0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym3 x0123456789876543210 y0123456789876543210 a0123456789876543210 b0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym3 a0123456789876543210 y0123456789876543210 x0123456789876543210) b0123456789876543210 = Lambda_0123456789876543210Sym4 a0123456789876543210 y0123456789876543210 x0123456789876543210 b0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym2 y0123456789876543210 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210 a0123456789876543210
       where
-        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
-                                                       Lambda_0123456789876543210Sym2 l l l
-    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210Sym3 l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+        Lambda_0123456789876543210Sym2KindInference :: forall x0123456789876543210
+                                                              y0123456789876543210
+                                                              a0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210) arg) (Lambda_0123456789876543210Sym3 x0123456789876543210 y0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210 a0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym2 y0123456789876543210 x0123456789876543210) a0123456789876543210 = Lambda_0123456789876543210Sym3 y0123456789876543210 x0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall x0123456789876543210
+                                                              y0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) arg) (Lambda_0123456789876543210Sym2 x0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) y0123456789876543210 = Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 x0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall x0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+                                                       Lambda_0123456789876543210Sym0 x0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 x0123456789876543210 = Lambda_0123456789876543210Sym1 x0123456789876543210
     type family Case_0123456789876543210 x y t where
       Case_0123456789876543210 x y (GHC.Tuple.(,) a b) = Apply (Apply (Apply (Apply (Apply Lambda_0123456789876543210Sym0 x) y) a) b) b
     type family Case_0123456789876543210 x y arg_0123456789876543210 t where
       Case_0123456789876543210 x y arg_0123456789876543210 _ = x
     type family Lambda_0123456789876543210 x y t where
       Lambda_0123456789876543210 x y arg_0123456789876543210 = Case_0123456789876543210 x y arg_0123456789876543210 arg_0123456789876543210
-    type Lambda_0123456789876543210Sym3 t t t =
-        Lambda_0123456789876543210 t t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+    type Lambda_0123456789876543210Sym3 x0123456789876543210 y0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 x0123456789876543210 y0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym2 y0123456789876543210 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
-                                                       Lambda_0123456789876543210Sym2 l l l
-    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+        Lambda_0123456789876543210Sym2KindInference :: forall x0123456789876543210
+                                                              y0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210) arg) (Lambda_0123456789876543210Sym3 x0123456789876543210 y0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym2 y0123456789876543210 x0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 y0123456789876543210 x0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall x0123456789876543210
+                                                              y0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) arg) (Lambda_0123456789876543210Sym2 x0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) y0123456789876543210 = Lambda_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 x0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall x0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+                                                       Lambda_0123456789876543210Sym0 x0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 x0123456789876543210 = Lambda_0123456789876543210Sym1 x0123456789876543210
     type family Case_0123456789876543210 t where
       Case_0123456789876543210 '[_,
                                  y_0123456789876543210,
@@ -383,37 +419,46 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
       Case_0123456789876543210 (Pair y_0123456789876543210 _) = y_0123456789876543210
     type family Case_0123456789876543210 t where
       Case_0123456789876543210 (Pair _ y_0123456789876543210) = y_0123456789876543210
-    type SillySym1 (t :: a0123456789876543210) = Silly t
+    type SillySym1 (a0123456789876543210 :: a0123456789876543210) =
+        Silly a0123456789876543210
     instance SuppressUnusedWarnings SillySym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SillySym0KindInference) GHC.Tuple.())
-    data SillySym0 (l :: TyFun a0123456789876543210 ()) :: GHC.Types.Type
+    data SillySym0 :: forall a0123456789876543210.
+                      (~>) a0123456789876543210 ()
       where
-        SillySym0KindInference :: forall l arg.
-                                  SameKind (Apply SillySym0 arg) (SillySym1 arg) => SillySym0 l
-    type instance Apply SillySym0 l = Silly l
-    type Foo2Sym1 (t :: (a0123456789876543210, b0123456789876543210)) =
-        Foo2 t
+        SillySym0KindInference :: forall a0123456789876543210 arg.
+                                  SameKind (Apply SillySym0 arg) (SillySym1 arg) =>
+                                  SillySym0 a0123456789876543210
+    type instance Apply SillySym0 a0123456789876543210 = Silly a0123456789876543210
+    type Foo2Sym1 (a0123456789876543210 :: (a0123456789876543210,
+                                            b0123456789876543210)) =
+        Foo2 a0123456789876543210
     instance SuppressUnusedWarnings Foo2Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo2Sym0KindInference) GHC.Tuple.())
-    data Foo2Sym0 (l :: TyFun (a0123456789876543210,
-                               b0123456789876543210) a0123456789876543210) :: GHC.Types.Type
+    data Foo2Sym0 :: forall a0123456789876543210 b0123456789876543210.
+                     (~>) (a0123456789876543210,
+                           b0123456789876543210) a0123456789876543210
       where
-        Foo2Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) => Foo2Sym0 l
-    type instance Apply Foo2Sym0 l = Foo2 l
-    type Foo1Sym1 (t :: (a0123456789876543210, b0123456789876543210)) =
-        Foo1 t
+        Foo2Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) =>
+                                 Foo2Sym0 a0123456789876543210
+    type instance Apply Foo2Sym0 a0123456789876543210 = Foo2 a0123456789876543210
+    type Foo1Sym1 (a0123456789876543210 :: (a0123456789876543210,
+                                            b0123456789876543210)) =
+        Foo1 a0123456789876543210
     instance SuppressUnusedWarnings Foo1Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo1Sym0KindInference) GHC.Tuple.())
-    data Foo1Sym0 (l :: TyFun (a0123456789876543210,
-                               b0123456789876543210) a0123456789876543210) :: GHC.Types.Type
+    data Foo1Sym0 :: forall a0123456789876543210 b0123456789876543210.
+                     (~>) (a0123456789876543210,
+                           b0123456789876543210) a0123456789876543210
       where
-        Foo1Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) => Foo1Sym0 l
-    type instance Apply Foo1Sym0 l = Foo1 l
+        Foo1Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
+                                 Foo1Sym0 a0123456789876543210
+    type instance Apply Foo1Sym0 a0123456789876543210 = Foo1 a0123456789876543210
     type LszSym0 = Lsz
     type BlimySym0 = Blimy
     type TfSym0 = Tf

--- a/tests/compile-and-dump/Singletons/PolyKinds.ghc84.template
+++ b/tests/compile-and-dump/Singletons/PolyKinds.ghc84.template
@@ -5,16 +5,19 @@ Singletons/PolyKinds.hs:(0,0)-(0,0): Splicing declarations
   ======>
     class Cls (a :: k) where
       fff :: Proxy (a :: k) -> ()
-    type FffSym1 (t :: Proxy (a0123456789876543210 :: k0123456789876543210)) =
-        Fff t
+    type FffSym1 (arg0123456789876543210 :: Proxy (a0123456789876543210 :: k0123456789876543210)) =
+        Fff arg0123456789876543210
     instance SuppressUnusedWarnings FffSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FffSym0KindInference) GHC.Tuple.())
-    data FffSym0 (l :: TyFun (Proxy (a0123456789876543210 :: k0123456789876543210)) ()) :: GHC.Types.Type
+    data FffSym0 :: forall k0123456789876543210
+                           (a0123456789876543210 :: k0123456789876543210).
+                    (~>) (Proxy (a0123456789876543210 :: k0123456789876543210)) ()
       where
-        FffSym0KindInference :: forall l arg.
-                                SameKind (Apply FffSym0 arg) (FffSym1 arg) => FffSym0 l
-    type instance Apply FffSym0 l = Fff l
+        FffSym0KindInference :: forall arg0123456789876543210 arg.
+                                SameKind (Apply FffSym0 arg) (FffSym1 arg) =>
+                                FffSym0 arg0123456789876543210
+    type instance Apply FffSym0 arg0123456789876543210 = Fff arg0123456789876543210
     class PCls (a :: k) where
       type Fff (arg :: Proxy (a :: k)) :: ()
     class SCls (a :: k) where

--- a/tests/compile-and-dump/Singletons/Records.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Records.ghc84.template
@@ -3,48 +3,57 @@ Singletons/Records.hs:(0,0)-(0,0): Splicing declarations
       [d| data Record a = MkRecord {field1 :: a, field2 :: Bool} |]
   ======>
     data Record a = MkRecord {field1 :: a, field2 :: Bool}
-    type Field1Sym1 (t :: Record a0123456789876543210) = Field1 t
+    type Field1Sym1 (a0123456789876543210 :: Record a0123456789876543210) =
+        Field1 a0123456789876543210
     instance SuppressUnusedWarnings Field1Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Field1Sym0KindInference) GHC.Tuple.())
-    data Field1Sym0 (l :: TyFun (Record a0123456789876543210) a0123456789876543210) :: GHC.Types.Type
+    data Field1Sym0 :: forall a0123456789876543210.
+                       (~>) (Record a0123456789876543210) a0123456789876543210
       where
-        Field1Sym0KindInference :: forall l arg.
-                                   SameKind (Apply Field1Sym0 arg) (Field1Sym1 arg) => Field1Sym0 l
-    type instance Apply Field1Sym0 l = Field1 l
-    type Field2Sym1 (t :: Record a0123456789876543210) = Field2 t
+        Field1Sym0KindInference :: forall a0123456789876543210 arg.
+                                   SameKind (Apply Field1Sym0 arg) (Field1Sym1 arg) =>
+                                   Field1Sym0 a0123456789876543210
+    type instance Apply Field1Sym0 a0123456789876543210 = Field1 a0123456789876543210
+    type Field2Sym1 (a0123456789876543210 :: Record a0123456789876543210) =
+        Field2 a0123456789876543210
     instance SuppressUnusedWarnings Field2Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Field2Sym0KindInference) GHC.Tuple.())
-    data Field2Sym0 (l :: TyFun (Record a0123456789876543210) Bool) :: GHC.Types.Type
+    data Field2Sym0 :: forall a0123456789876543210.
+                       (~>) (Record a0123456789876543210) Bool
       where
-        Field2Sym0KindInference :: forall l arg.
-                                   SameKind (Apply Field2Sym0 arg) (Field2Sym1 arg) => Field2Sym0 l
-    type instance Apply Field2Sym0 l = Field2 l
+        Field2Sym0KindInference :: forall a0123456789876543210 arg.
+                                   SameKind (Apply Field2Sym0 arg) (Field2Sym1 arg) =>
+                                   Field2Sym0 a0123456789876543210
+    type instance Apply Field2Sym0 a0123456789876543210 = Field2 a0123456789876543210
     type family Field1 (a :: Record a) :: a where
       Field1 (MkRecord field _) = field
     type family Field2 (a :: Record a) :: Bool where
       Field2 (MkRecord _ field) = field
-    type MkRecordSym2 (t :: a0123456789876543210) (t :: Bool) =
-        MkRecord t t
-    instance SuppressUnusedWarnings MkRecordSym1 where
+    type MkRecordSym2 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: Bool) =
+        MkRecord t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (MkRecordSym1 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MkRecordSym1KindInference) GHC.Tuple.())
-    data MkRecordSym1 (l :: a0123456789876543210) (l :: TyFun Bool (Record a0123456789876543210)) :: GHC.Types.Type
+    data MkRecordSym1 (t0123456789876543210 :: a0123456789876543210) :: (~>) Bool (Record a0123456789876543210)
       where
-        MkRecordSym1KindInference :: forall l l arg.
-                                     SameKind (Apply (MkRecordSym1 l) arg) (MkRecordSym2 l arg) =>
-                                     MkRecordSym1 l l
-    type instance Apply (MkRecordSym1 l) l = MkRecord l l
+        MkRecordSym1KindInference :: forall t0123456789876543210
+                                            t0123456789876543210
+                                            arg.
+                                     SameKind (Apply (MkRecordSym1 t0123456789876543210) arg) (MkRecordSym2 t0123456789876543210 arg) =>
+                                     MkRecordSym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (MkRecordSym1 t0123456789876543210) t0123456789876543210 = MkRecord t0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings MkRecordSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MkRecordSym0KindInference) GHC.Tuple.())
-    data MkRecordSym0 (l :: TyFun a0123456789876543210 ((~>) Bool (Record a0123456789876543210))) :: GHC.Types.Type
+    data MkRecordSym0 :: forall a0123456789876543210.
+                         (~>) a0123456789876543210 ((~>) Bool (Record a0123456789876543210))
       where
-        MkRecordSym0KindInference :: forall l arg.
+        MkRecordSym0KindInference :: forall t0123456789876543210 arg.
                                      SameKind (Apply MkRecordSym0 arg) (MkRecordSym1 arg) =>
-                                     MkRecordSym0 l
-    type instance Apply MkRecordSym0 l = MkRecordSym1 l
+                                     MkRecordSym0 t0123456789876543210
+    type instance Apply MkRecordSym0 t0123456789876543210 = MkRecordSym1 t0123456789876543210
     data instance Sing :: Record a -> GHC.Types.Type :: Record a
                                                         -> GHC.Types.Type
       where

--- a/tests/compile-and-dump/Singletons/ReturnFunc.ghc84.template
+++ b/tests/compile-and-dump/Singletons/ReturnFunc.ghc84.template
@@ -13,53 +13,64 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
     id x = x
     idFoo :: c -> a -> a
     idFoo _ = id
-    type IdSym1 (t :: a0123456789876543210) = Id t
+    type IdSym1 (a0123456789876543210 :: a0123456789876543210) =
+        Id a0123456789876543210
     instance SuppressUnusedWarnings IdSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) IdSym0KindInference) GHC.Tuple.())
-    data IdSym0 (l :: TyFun a0123456789876543210 a0123456789876543210) :: GHC.Types.Type
+    data IdSym0 :: forall a0123456789876543210.
+                   (~>) a0123456789876543210 a0123456789876543210
       where
-        IdSym0KindInference :: forall l arg.
-                               SameKind (Apply IdSym0 arg) (IdSym1 arg) => IdSym0 l
-    type instance Apply IdSym0 l = Id l
-    type IdFooSym2 (t :: c0123456789876543210) (t :: a0123456789876543210) =
-        IdFoo t t
-    instance SuppressUnusedWarnings IdFooSym1 where
+        IdSym0KindInference :: forall a0123456789876543210 arg.
+                               SameKind (Apply IdSym0 arg) (IdSym1 arg) =>
+                               IdSym0 a0123456789876543210
+    type instance Apply IdSym0 a0123456789876543210 = Id a0123456789876543210
+    type IdFooSym2 (a0123456789876543210 :: c0123456789876543210) (a0123456789876543210 :: a0123456789876543210) =
+        IdFoo a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (IdFooSym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) IdFooSym1KindInference) GHC.Tuple.())
-    data IdFooSym1 (l :: c0123456789876543210) (l :: TyFun a0123456789876543210 a0123456789876543210) :: GHC.Types.Type
+    data IdFooSym1 (a0123456789876543210 :: c0123456789876543210) :: forall a0123456789876543210.
+                                                                     (~>) a0123456789876543210 a0123456789876543210
       where
-        IdFooSym1KindInference :: forall l l arg.
-                                  SameKind (Apply (IdFooSym1 l) arg) (IdFooSym2 l arg) =>
-                                  IdFooSym1 l l
-    type instance Apply (IdFooSym1 l) l = IdFoo l l
+        IdFooSym1KindInference :: forall a0123456789876543210
+                                         a0123456789876543210
+                                         arg.
+                                  SameKind (Apply (IdFooSym1 a0123456789876543210) arg) (IdFooSym2 a0123456789876543210 arg) =>
+                                  IdFooSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (IdFooSym1 a0123456789876543210) a0123456789876543210 = IdFoo a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings IdFooSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) IdFooSym0KindInference) GHC.Tuple.())
-    data IdFooSym0 (l :: TyFun c0123456789876543210 ((~>) a0123456789876543210 a0123456789876543210)) :: GHC.Types.Type
+    data IdFooSym0 :: forall a0123456789876543210 c0123456789876543210.
+                      (~>) c0123456789876543210 ((~>) a0123456789876543210 a0123456789876543210)
       where
-        IdFooSym0KindInference :: forall l arg.
-                                  SameKind (Apply IdFooSym0 arg) (IdFooSym1 arg) => IdFooSym0 l
-    type instance Apply IdFooSym0 l = IdFooSym1 l
-    type ReturnFuncSym2 (t :: Nat) (t :: Nat) = ReturnFunc t t
-    instance SuppressUnusedWarnings ReturnFuncSym1 where
+        IdFooSym0KindInference :: forall a0123456789876543210 arg.
+                                  SameKind (Apply IdFooSym0 arg) (IdFooSym1 arg) =>
+                                  IdFooSym0 a0123456789876543210
+    type instance Apply IdFooSym0 a0123456789876543210 = IdFooSym1 a0123456789876543210
+    type ReturnFuncSym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) =
+        ReturnFunc a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ReturnFuncSym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ReturnFuncSym1KindInference) GHC.Tuple.())
-    data ReturnFuncSym1 (l :: Nat) (l :: TyFun Nat Nat) :: GHC.Types.Type
+    data ReturnFuncSym1 (a0123456789876543210 :: Nat) :: (~>) Nat Nat
       where
-        ReturnFuncSym1KindInference :: forall l l arg.
-                                       SameKind (Apply (ReturnFuncSym1 l) arg) (ReturnFuncSym2 l arg) =>
-                                       ReturnFuncSym1 l l
-    type instance Apply (ReturnFuncSym1 l) l = ReturnFunc l l
+        ReturnFuncSym1KindInference :: forall a0123456789876543210
+                                              a0123456789876543210
+                                              arg.
+                                       SameKind (Apply (ReturnFuncSym1 a0123456789876543210) arg) (ReturnFuncSym2 a0123456789876543210 arg) =>
+                                       ReturnFuncSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (ReturnFuncSym1 a0123456789876543210) a0123456789876543210 = ReturnFunc a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ReturnFuncSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ReturnFuncSym0KindInference) GHC.Tuple.())
-    data ReturnFuncSym0 (l :: TyFun Nat ((~>) Nat Nat)) :: GHC.Types.Type
+    data ReturnFuncSym0 :: (~>) Nat ((~>) Nat Nat)
       where
-        ReturnFuncSym0KindInference :: forall l arg.
+        ReturnFuncSym0KindInference :: forall a0123456789876543210 arg.
                                        SameKind (Apply ReturnFuncSym0 arg) (ReturnFuncSym1 arg) =>
-                                       ReturnFuncSym0 l
-    type instance Apply ReturnFuncSym0 l = ReturnFuncSym1 l
+                                       ReturnFuncSym0 a0123456789876543210
+    type instance Apply ReturnFuncSym0 a0123456789876543210 = ReturnFuncSym1 a0123456789876543210
     type family Id (a :: a) :: a where
       Id x = x
     type family IdFoo (a :: c) (a :: a) :: a where

--- a/tests/compile-and-dump/Singletons/Sections.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Sections.ghc84.template
@@ -21,36 +21,42 @@ Singletons/Sections.hs:(0,0)-(0,0): Splicing declarations
     foo3 = ((zipWith (+)) [Succ Zero, Succ Zero]) [Zero, Succ Zero]
     type family Lambda_0123456789876543210 t where
       Lambda_0123456789876543210 lhs_0123456789876543210 = Apply (Apply (+@#@$) lhs_0123456789876543210) (Apply SuccSym0 ZeroSym0)
-    type Lambda_0123456789876543210Sym1 t =
-        Lambda_0123456789876543210 t
+    type Lambda_0123456789876543210Sym1 t0123456789876543210 =
+        Lambda_0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall t0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210 l
-    type (+@#@$$$) (t :: Nat) (t :: Nat) = (+) t t
-    instance SuppressUnusedWarnings (+@#@$$) where
+                                                       Lambda_0123456789876543210Sym0 t0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 t0123456789876543210 = Lambda_0123456789876543210 t0123456789876543210
+    type (+@#@$$$) (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) =
+        (+) a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings ((+@#@$$) a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:+@#@$$###)) GHC.Tuple.())
-    data (+@#@$$) (l :: Nat) (l :: TyFun Nat Nat) :: GHC.Types.Type
+    data (+@#@$$) (a0123456789876543210 :: Nat) :: (~>) Nat Nat
       where
-        (:+@#@$$###) :: forall l l arg.
-                        SameKind (Apply ((+@#@$$) l) arg) ((+@#@$$$) l arg) => (+@#@$$) l l
-    type instance Apply ((+@#@$$) l) l = (+) l l
+        (:+@#@$$###) :: forall a0123456789876543210
+                               a0123456789876543210
+                               arg.
+                        SameKind (Apply ((+@#@$$) a0123456789876543210) arg) ((+@#@$$$) a0123456789876543210 arg) =>
+                        (+@#@$$) a0123456789876543210 a0123456789876543210
+    type instance Apply ((+@#@$$) a0123456789876543210) a0123456789876543210 = (+) a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings (+@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:+@#@$###)) GHC.Tuple.())
-    data (+@#@$) (l :: TyFun Nat ((~>) Nat Nat)) :: GHC.Types.Type
+    data +@#@$ :: (~>) Nat ((~>) Nat Nat)
       where
-        (:+@#@$###) :: forall l arg.
-                       SameKind (Apply (+@#@$) arg) ((+@#@$$) arg) => (+@#@$) l
-    type instance Apply (+@#@$) l = (+@#@$$) l
+        (:+@#@$###) :: forall a0123456789876543210 arg.
+                       SameKind (Apply (+@#@$) arg) ((+@#@$$) arg) =>
+                       (+@#@$) a0123456789876543210
+    type instance Apply (+@#@$) a0123456789876543210 = (+@#@$$) a0123456789876543210
     type Foo1Sym0 = Foo1
     type Foo2Sym0 = Foo2
     type Foo3Sym0 = Foo3

--- a/tests/compile-and-dump/Singletons/ShowDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/ShowDeriving.ghc84.template
@@ -24,169 +24,196 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     data Foo3
       = MkFoo3 {getFoo3a :: Bool, *** :: Bool}
       deriving Show
-    type GetFoo3aSym1 (t :: Foo3) = GetFoo3a t
+    type GetFoo3aSym1 (a0123456789876543210 :: Foo3) =
+        GetFoo3a a0123456789876543210
     instance SuppressUnusedWarnings GetFoo3aSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) GetFoo3aSym0KindInference) GHC.Tuple.())
-    data GetFoo3aSym0 (l :: TyFun Foo3 Bool) :: GHC.Types.Type
+    data GetFoo3aSym0 :: (~>) Foo3 Bool
       where
-        GetFoo3aSym0KindInference :: forall l arg.
+        GetFoo3aSym0KindInference :: forall a0123456789876543210 arg.
                                      SameKind (Apply GetFoo3aSym0 arg) (GetFoo3aSym1 arg) =>
-                                     GetFoo3aSym0 l
-    type instance Apply GetFoo3aSym0 l = GetFoo3a l
-    type (***@#@$$) (t :: Foo3) = (***) t
+                                     GetFoo3aSym0 a0123456789876543210
+    type instance Apply GetFoo3aSym0 a0123456789876543210 = GetFoo3a a0123456789876543210
+    type (***@#@$$) (a0123456789876543210 :: Foo3) =
+        (***) a0123456789876543210
     instance SuppressUnusedWarnings (***@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:***@#@$###)) GHC.Tuple.())
-    data (***@#@$) (l :: TyFun Foo3 Bool) :: GHC.Types.Type
+    data ***@#@$ :: (~>) Foo3 Bool
       where
-        (:***@#@$###) :: forall l arg.
-                         SameKind (Apply (***@#@$) arg) ((***@#@$$) arg) => (***@#@$) l
-    type instance Apply (***@#@$) l = (***) l
+        (:***@#@$###) :: forall a0123456789876543210 arg.
+                         SameKind (Apply (***@#@$) arg) ((***@#@$$) arg) =>
+                         (***@#@$) a0123456789876543210
+    type instance Apply (***@#@$) a0123456789876543210 = (***) a0123456789876543210
     type family GetFoo3a (a :: Foo3) :: Bool where
       GetFoo3a (MkFoo3 field _) = field
     type family (***) (a :: Foo3) :: Bool where
       (***) (MkFoo3 _ field) = field
     type MkFoo1Sym0 = MkFoo1
-    type MkFoo2aSym2 (t :: a0123456789876543210) (t :: a0123456789876543210) =
-        MkFoo2a t t
-    instance SuppressUnusedWarnings MkFoo2aSym1 where
+    type MkFoo2aSym2 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: a0123456789876543210) =
+        MkFoo2a t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (MkFoo2aSym1 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MkFoo2aSym1KindInference) GHC.Tuple.())
-    data MkFoo2aSym1 (l :: a0123456789876543210) (l :: TyFun a0123456789876543210 (Foo2 a0123456789876543210)) :: GHC.Types.Type
+    data MkFoo2aSym1 (t0123456789876543210 :: a0123456789876543210) :: (~>) a0123456789876543210 (Foo2 a0123456789876543210)
       where
-        MkFoo2aSym1KindInference :: forall l l arg.
-                                    SameKind (Apply (MkFoo2aSym1 l) arg) (MkFoo2aSym2 l arg) =>
-                                    MkFoo2aSym1 l l
-    type instance Apply (MkFoo2aSym1 l) l = MkFoo2a l l
+        MkFoo2aSym1KindInference :: forall t0123456789876543210
+                                           t0123456789876543210
+                                           arg.
+                                    SameKind (Apply (MkFoo2aSym1 t0123456789876543210) arg) (MkFoo2aSym2 t0123456789876543210 arg) =>
+                                    MkFoo2aSym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (MkFoo2aSym1 t0123456789876543210) t0123456789876543210 = MkFoo2a t0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings MkFoo2aSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MkFoo2aSym0KindInference) GHC.Tuple.())
-    data MkFoo2aSym0 (l :: TyFun a0123456789876543210 ((~>) a0123456789876543210 (Foo2 a0123456789876543210))) :: GHC.Types.Type
+    data MkFoo2aSym0 :: forall a0123456789876543210.
+                        (~>) a0123456789876543210 ((~>) a0123456789876543210 (Foo2 a0123456789876543210))
       where
-        MkFoo2aSym0KindInference :: forall l arg.
+        MkFoo2aSym0KindInference :: forall t0123456789876543210 arg.
                                     SameKind (Apply MkFoo2aSym0 arg) (MkFoo2aSym1 arg) =>
-                                    MkFoo2aSym0 l
-    type instance Apply MkFoo2aSym0 l = MkFoo2aSym1 l
-    type MkFoo2bSym2 (t :: a0123456789876543210) (t :: a0123456789876543210) =
-        MkFoo2b t t
-    instance SuppressUnusedWarnings MkFoo2bSym1 where
+                                    MkFoo2aSym0 t0123456789876543210
+    type instance Apply MkFoo2aSym0 t0123456789876543210 = MkFoo2aSym1 t0123456789876543210
+    type MkFoo2bSym2 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: a0123456789876543210) =
+        MkFoo2b t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (MkFoo2bSym1 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MkFoo2bSym1KindInference) GHC.Tuple.())
-    data MkFoo2bSym1 (l :: a0123456789876543210) (l :: TyFun a0123456789876543210 (Foo2 a0123456789876543210)) :: GHC.Types.Type
+    data MkFoo2bSym1 (t0123456789876543210 :: a0123456789876543210) :: (~>) a0123456789876543210 (Foo2 a0123456789876543210)
       where
-        MkFoo2bSym1KindInference :: forall l l arg.
-                                    SameKind (Apply (MkFoo2bSym1 l) arg) (MkFoo2bSym2 l arg) =>
-                                    MkFoo2bSym1 l l
-    type instance Apply (MkFoo2bSym1 l) l = MkFoo2b l l
+        MkFoo2bSym1KindInference :: forall t0123456789876543210
+                                           t0123456789876543210
+                                           arg.
+                                    SameKind (Apply (MkFoo2bSym1 t0123456789876543210) arg) (MkFoo2bSym2 t0123456789876543210 arg) =>
+                                    MkFoo2bSym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (MkFoo2bSym1 t0123456789876543210) t0123456789876543210 = MkFoo2b t0123456789876543210 t0123456789876543210
     infixl 5 `MkFoo2bSym1`
     instance SuppressUnusedWarnings MkFoo2bSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MkFoo2bSym0KindInference) GHC.Tuple.())
-    data MkFoo2bSym0 (l :: TyFun a0123456789876543210 ((~>) a0123456789876543210 (Foo2 a0123456789876543210))) :: GHC.Types.Type
+    data MkFoo2bSym0 :: forall a0123456789876543210.
+                        (~>) a0123456789876543210 ((~>) a0123456789876543210 (Foo2 a0123456789876543210))
       where
-        MkFoo2bSym0KindInference :: forall l arg.
+        MkFoo2bSym0KindInference :: forall t0123456789876543210 arg.
                                     SameKind (Apply MkFoo2bSym0 arg) (MkFoo2bSym1 arg) =>
-                                    MkFoo2bSym0 l
-    type instance Apply MkFoo2bSym0 l = MkFoo2bSym1 l
+                                    MkFoo2bSym0 t0123456789876543210
+    type instance Apply MkFoo2bSym0 t0123456789876543210 = MkFoo2bSym1 t0123456789876543210
     infixl 5 `MkFoo2bSym0`
-    type (:*:@#@$$$) (t :: a0123456789876543210) (t :: a0123456789876543210) =
-        (:*:) t t
-    instance SuppressUnusedWarnings (:*:@#@$$) where
+    type (:*:@#@$$$) (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: a0123456789876543210) =
+        (:*:) t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings ((:*:@#@$$) t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::*:@#@$$###)) GHC.Tuple.())
-    data (:*:@#@$$) (l :: a0123456789876543210) (l :: TyFun a0123456789876543210 (Foo2 a0123456789876543210)) :: GHC.Types.Type
+    data (:*:@#@$$) (t0123456789876543210 :: a0123456789876543210) :: (~>) a0123456789876543210 (Foo2 a0123456789876543210)
       where
-        (::*:@#@$$###) :: forall l l arg.
-                          SameKind (Apply ((:*:@#@$$) l) arg) ((:*:@#@$$$) l arg) =>
-                          (:*:@#@$$) l l
-    type instance Apply ((:*:@#@$$) l) l = (:*:) l l
+        (::*:@#@$$###) :: forall t0123456789876543210
+                                 t0123456789876543210
+                                 arg.
+                          SameKind (Apply ((:*:@#@$$) t0123456789876543210) arg) ((:*:@#@$$$) t0123456789876543210 arg) =>
+                          (:*:@#@$$) t0123456789876543210 t0123456789876543210
+    type instance Apply ((:*:@#@$$) t0123456789876543210) t0123456789876543210 = (:*:) t0123456789876543210 t0123456789876543210
     infixl 5 :*:@#@$$
     instance SuppressUnusedWarnings (:*:@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::*:@#@$###)) GHC.Tuple.())
-    data (:*:@#@$) (l :: TyFun a0123456789876543210 ((~>) a0123456789876543210 (Foo2 a0123456789876543210))) :: GHC.Types.Type
+    data :*:@#@$ :: forall a0123456789876543210.
+                    (~>) a0123456789876543210 ((~>) a0123456789876543210 (Foo2 a0123456789876543210))
       where
-        (::*:@#@$###) :: forall l arg.
-                         SameKind (Apply (:*:@#@$) arg) ((:*:@#@$$) arg) => (:*:@#@$) l
-    type instance Apply (:*:@#@$) l = (:*:@#@$$) l
+        (::*:@#@$###) :: forall t0123456789876543210 arg.
+                         SameKind (Apply (:*:@#@$) arg) ((:*:@#@$$) arg) =>
+                         (:*:@#@$) t0123456789876543210
+    type instance Apply (:*:@#@$) t0123456789876543210 = (:*:@#@$$) t0123456789876543210
     infixl 5 :*:@#@$
-    type (:&:@#@$$$) (t :: a0123456789876543210) (t :: a0123456789876543210) =
-        (:&:) t t
-    instance SuppressUnusedWarnings (:&:@#@$$) where
+    type (:&:@#@$$$) (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: a0123456789876543210) =
+        (:&:) t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings ((:&:@#@$$) t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::&:@#@$$###)) GHC.Tuple.())
-    data (:&:@#@$$) (l :: a0123456789876543210) (l :: TyFun a0123456789876543210 (Foo2 a0123456789876543210)) :: GHC.Types.Type
+    data (:&:@#@$$) (t0123456789876543210 :: a0123456789876543210) :: (~>) a0123456789876543210 (Foo2 a0123456789876543210)
       where
-        (::&:@#@$$###) :: forall l l arg.
-                          SameKind (Apply ((:&:@#@$$) l) arg) ((:&:@#@$$$) l arg) =>
-                          (:&:@#@$$) l l
-    type instance Apply ((:&:@#@$$) l) l = (:&:) l l
+        (::&:@#@$$###) :: forall t0123456789876543210
+                                 t0123456789876543210
+                                 arg.
+                          SameKind (Apply ((:&:@#@$$) t0123456789876543210) arg) ((:&:@#@$$$) t0123456789876543210 arg) =>
+                          (:&:@#@$$) t0123456789876543210 t0123456789876543210
+    type instance Apply ((:&:@#@$$) t0123456789876543210) t0123456789876543210 = (:&:) t0123456789876543210 t0123456789876543210
     infixl 5 :&:@#@$$
     instance SuppressUnusedWarnings (:&:@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::&:@#@$###)) GHC.Tuple.())
-    data (:&:@#@$) (l :: TyFun a0123456789876543210 ((~>) a0123456789876543210 (Foo2 a0123456789876543210))) :: GHC.Types.Type
+    data :&:@#@$ :: forall a0123456789876543210.
+                    (~>) a0123456789876543210 ((~>) a0123456789876543210 (Foo2 a0123456789876543210))
       where
-        (::&:@#@$###) :: forall l arg.
-                         SameKind (Apply (:&:@#@$) arg) ((:&:@#@$$) arg) => (:&:@#@$) l
-    type instance Apply (:&:@#@$) l = (:&:@#@$$) l
+        (::&:@#@$###) :: forall t0123456789876543210 arg.
+                         SameKind (Apply (:&:@#@$) arg) ((:&:@#@$$) arg) =>
+                         (:&:@#@$) t0123456789876543210
+    type instance Apply (:&:@#@$) t0123456789876543210 = (:&:@#@$$) t0123456789876543210
     infixl 5 :&:@#@$
-    type MkFoo3Sym2 (t :: Bool) (t :: Bool) = MkFoo3 t t
-    instance SuppressUnusedWarnings MkFoo3Sym1 where
+    type MkFoo3Sym2 (t0123456789876543210 :: Bool) (t0123456789876543210 :: Bool) =
+        MkFoo3 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (MkFoo3Sym1 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MkFoo3Sym1KindInference) GHC.Tuple.())
-    data MkFoo3Sym1 (l :: Bool) (l :: TyFun Bool Foo3) :: GHC.Types.Type
+    data MkFoo3Sym1 (t0123456789876543210 :: Bool) :: (~>) Bool Foo3
       where
-        MkFoo3Sym1KindInference :: forall l l arg.
-                                   SameKind (Apply (MkFoo3Sym1 l) arg) (MkFoo3Sym2 l arg) =>
-                                   MkFoo3Sym1 l l
-    type instance Apply (MkFoo3Sym1 l) l = MkFoo3 l l
+        MkFoo3Sym1KindInference :: forall t0123456789876543210
+                                          t0123456789876543210
+                                          arg.
+                                   SameKind (Apply (MkFoo3Sym1 t0123456789876543210) arg) (MkFoo3Sym2 t0123456789876543210 arg) =>
+                                   MkFoo3Sym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (MkFoo3Sym1 t0123456789876543210) t0123456789876543210 = MkFoo3 t0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings MkFoo3Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MkFoo3Sym0KindInference) GHC.Tuple.())
-    data MkFoo3Sym0 (l :: TyFun Bool ((~>) Bool Foo3)) :: GHC.Types.Type
+    data MkFoo3Sym0 :: (~>) Bool ((~>) Bool Foo3)
       where
-        MkFoo3Sym0KindInference :: forall l arg.
-                                   SameKind (Apply MkFoo3Sym0 arg) (MkFoo3Sym1 arg) => MkFoo3Sym0 l
-    type instance Apply MkFoo3Sym0 l = MkFoo3Sym1 l
+        MkFoo3Sym0KindInference :: forall t0123456789876543210 arg.
+                                   SameKind (Apply MkFoo3Sym0 arg) (MkFoo3Sym1 arg) =>
+                                   MkFoo3Sym0 t0123456789876543210
+    type instance Apply MkFoo3Sym0 t0123456789876543210 = MkFoo3Sym1 t0123456789876543210
     type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Foo1) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 _ MkFoo1 a_0123456789876543210 = Apply (Apply ShowStringSym0 "MkFoo1") a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: Foo1) (t :: Symbol) =
-        ShowsPrec_0123456789876543210 t t t
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+    type ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Foo1) (a0123456789876543210 :: Symbol) =
+        ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym2 (l :: GHC.Types.Nat) (l :: Foo1) (l :: TyFun Symbol Symbol) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Foo1) :: (~>) Symbol Symbol
       where
-        ShowsPrec_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 l l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+        ShowsPrec_0123456789876543210Sym2KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun Foo1 ((~>) Symbol Symbol)) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: (~>) Foo1 ((~>) Symbol Symbol)
       where
-        ShowsPrec_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+        ShowsPrec_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) Foo1 ((~>) Symbol Symbol))) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) Foo1 ((~>) Symbol Symbol))
       where
-        ShowsPrec_0123456789876543210Sym0KindInference :: forall l arg.
+        ShowsPrec_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                 arg.
                                                           SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 l
-    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
     instance PShow Foo1 where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Foo2 a) (a :: Symbol) :: Symbol where
@@ -194,80 +221,94 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
       ShowsPrec_0123456789876543210 p_0123456789876543210 (MkFoo2b argL_0123456789876543210 argR_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 5))) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 6)) argL_0123456789876543210)) (Apply (Apply (.@#@$) (Apply ShowStringSym0 " `MkFoo2b` ")) (Apply (Apply ShowsPrecSym0 (FromInteger 6)) argR_0123456789876543210)))) a_0123456789876543210
       ShowsPrec_0123456789876543210 p_0123456789876543210 ((:*:) arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "(:*:) ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
       ShowsPrec_0123456789876543210 p_0123456789876543210 ((:&:) argL_0123456789876543210 argR_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 5))) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 6)) argL_0123456789876543210)) (Apply (Apply (.@#@$) (Apply ShowStringSym0 " :&: ")) (Apply (Apply ShowsPrecSym0 (FromInteger 6)) argR_0123456789876543210)))) a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: Foo2 a0123456789876543210) (t :: Symbol) =
-        ShowsPrec_0123456789876543210 t t t
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+    type ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Foo2 a0123456789876543210) (a0123456789876543210 :: Symbol) =
+        ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym2 (l :: GHC.Types.Nat) (l :: Foo2 a0123456789876543210) (l :: TyFun Symbol Symbol) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Foo2 a0123456789876543210) :: (~>) Symbol Symbol
       where
-        ShowsPrec_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 l l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+        ShowsPrec_0123456789876543210Sym2KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun (Foo2 a0123456789876543210) ((~>) Symbol Symbol)) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: forall a0123456789876543210.
+                                                                                      (~>) (Foo2 a0123456789876543210) ((~>) Symbol Symbol)
       where
-        ShowsPrec_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+        ShowsPrec_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) (Foo2 a0123456789876543210) ((~>) Symbol Symbol))) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym0 :: forall a0123456789876543210.
+                                              (~>) GHC.Types.Nat ((~>) (Foo2 a0123456789876543210) ((~>) Symbol Symbol))
       where
-        ShowsPrec_0123456789876543210Sym0KindInference :: forall l arg.
+        ShowsPrec_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                 arg.
                                                           SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 l
-    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
     instance PShow (Foo2 a) where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Foo3) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 p_0123456789876543210 (MkFoo3 arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "MkFoo3 ")) (Apply (Apply (.@#@$) (Apply ShowCharSym0 "{")) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "getFoo3a = ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 0)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowCommaSpaceSym0) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "(***) = ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 0)) arg_0123456789876543210)) (Apply ShowCharSym0 "}"))))))))) a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: Foo3) (t :: Symbol) =
-        ShowsPrec_0123456789876543210 t t t
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+    type ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Foo3) (a0123456789876543210 :: Symbol) =
+        ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym2 (l :: GHC.Types.Nat) (l :: Foo3) (l :: TyFun Symbol Symbol) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Foo3) :: (~>) Symbol Symbol
       where
-        ShowsPrec_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 l l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+        ShowsPrec_0123456789876543210Sym2KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun Foo3 ((~>) Symbol Symbol)) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: (~>) Foo3 ((~>) Symbol Symbol)
       where
-        ShowsPrec_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+        ShowsPrec_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) Foo3 ((~>) Symbol Symbol))) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) Foo3 ((~>) Symbol Symbol))
       where
-        ShowsPrec_0123456789876543210Sym0KindInference :: forall l arg.
+        ShowsPrec_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                 arg.
                                                           SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 l
-    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
     instance PShow Foo3 where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     infixl 5 `SMkFoo2b`

--- a/tests/compile-and-dump/Singletons/StandaloneDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/StandaloneDeriving.ghc84.template
@@ -25,94 +25,111 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
     deriving instance Show S
     deriving instance Bounded S
     deriving instance Enum S
-    type (:*:@#@$$$) (t :: a0123456789876543210) (t :: b0123456789876543210) =
-        (:*:) t t
-    instance SuppressUnusedWarnings (:*:@#@$$) where
+    type (:*:@#@$$$) (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: b0123456789876543210) =
+        (:*:) t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings ((:*:@#@$$) t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::*:@#@$$###)) GHC.Tuple.())
-    data (:*:@#@$$) (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 (T a0123456789876543210 b0123456789876543210)) :: GHC.Types.Type
+    data (:*:@#@$$) (t0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210.
+                                                                      (~>) b0123456789876543210 (T a0123456789876543210 b0123456789876543210)
       where
-        (::*:@#@$$###) :: forall l l arg.
-                          SameKind (Apply ((:*:@#@$$) l) arg) ((:*:@#@$$$) l arg) =>
-                          (:*:@#@$$) l l
-    type instance Apply ((:*:@#@$$) l) l = (:*:) l l
+        (::*:@#@$$###) :: forall t0123456789876543210
+                                 t0123456789876543210
+                                 arg.
+                          SameKind (Apply ((:*:@#@$$) t0123456789876543210) arg) ((:*:@#@$$$) t0123456789876543210 arg) =>
+                          (:*:@#@$$) t0123456789876543210 t0123456789876543210
+    type instance Apply ((:*:@#@$$) t0123456789876543210) t0123456789876543210 = (:*:) t0123456789876543210 t0123456789876543210
     infixl 6 :*:@#@$$
     instance SuppressUnusedWarnings (:*:@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::*:@#@$###)) GHC.Tuple.())
-    data (:*:@#@$) (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 (T a0123456789876543210 b0123456789876543210))) :: GHC.Types.Type
+    data :*:@#@$ :: forall a0123456789876543210 b0123456789876543210.
+                    (~>) a0123456789876543210 ((~>) b0123456789876543210 (T a0123456789876543210 b0123456789876543210))
       where
-        (::*:@#@$###) :: forall l arg.
-                         SameKind (Apply (:*:@#@$) arg) ((:*:@#@$$) arg) => (:*:@#@$) l
-    type instance Apply (:*:@#@$) l = (:*:@#@$$) l
+        (::*:@#@$###) :: forall t0123456789876543210 arg.
+                         SameKind (Apply (:*:@#@$) arg) ((:*:@#@$$) arg) =>
+                         (:*:@#@$) t0123456789876543210
+    type instance Apply (:*:@#@$) t0123456789876543210 = (:*:@#@$$) t0123456789876543210
     infixl 6 :*:@#@$
     type S1Sym0 = S1
     type S2Sym0 = S2
     type family Compare_0123456789876543210 (a :: T a ()) (a :: T a ()) :: Ordering where
       Compare_0123456789876543210 ((:*:) a_0123456789876543210 a_0123456789876543210) ((:*:) b_0123456789876543210 b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) '[]))
-    type Compare_0123456789876543210Sym2 (t :: T a0123456789876543210 ()) (t :: T a0123456789876543210 ()) =
-        Compare_0123456789876543210 t t
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym1 where
+    type Compare_0123456789876543210Sym2 (a0123456789876543210 :: T a0123456789876543210 ()) (a0123456789876543210 :: T a0123456789876543210 ()) =
+        Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym1 (l :: T a0123456789876543210 ()) (l :: TyFun (T a0123456789876543210 ()) Ordering) :: GHC.Types.Type
+    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: T a0123456789876543210 ()) :: (~>) (T a0123456789876543210 ()) Ordering
       where
-        Compare_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                        SameKind (Apply (Compare_0123456789876543210Sym1 l) arg) (Compare_0123456789876543210Sym2 l arg) =>
-                                                        Compare_0123456789876543210Sym1 l l
-    type instance Apply (Compare_0123456789876543210Sym1 l) l = Compare_0123456789876543210 l l
+        Compare_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                               a0123456789876543210
+                                                               arg.
+                                                        SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym0 (l :: TyFun (T a0123456789876543210 ()) ((~>) (T a0123456789876543210 ()) Ordering)) :: GHC.Types.Type
+    data Compare_0123456789876543210Sym0 :: forall a0123456789876543210.
+                                            (~>) (T a0123456789876543210 ()) ((~>) (T a0123456789876543210 ()) Ordering)
       where
-        Compare_0123456789876543210Sym0KindInference :: forall l arg.
+        Compare_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                               arg.
                                                         SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 l
-    type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
+                                                        Compare_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
     instance POrd (T a ()) where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: T a ()) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 p_0123456789876543210 ((:*:) argL_0123456789876543210 argR_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 6))) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 7)) argL_0123456789876543210)) (Apply (Apply (.@#@$) (Apply ShowStringSym0 " :*: ")) (Apply (Apply ShowsPrecSym0 (FromInteger 7)) argR_0123456789876543210)))) a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: T a0123456789876543210 ()) (t :: Symbol) =
-        ShowsPrec_0123456789876543210 t t t
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+    type ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: T a0123456789876543210 ()) (a0123456789876543210 :: Symbol) =
+        ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym2 (l :: GHC.Types.Nat) (l :: T a0123456789876543210 ()) (l :: TyFun Symbol Symbol) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: T a0123456789876543210 ()) :: (~>) Symbol Symbol
       where
-        ShowsPrec_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 l l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+        ShowsPrec_0123456789876543210Sym2KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun (T a0123456789876543210 ()) ((~>) Symbol Symbol)) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: forall a0123456789876543210.
+                                                                                      (~>) (T a0123456789876543210 ()) ((~>) Symbol Symbol)
       where
-        ShowsPrec_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+        ShowsPrec_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) (T a0123456789876543210 ()) ((~>) Symbol Symbol))) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym0 :: forall a0123456789876543210.
+                                              (~>) GHC.Types.Nat ((~>) (T a0123456789876543210 ()) ((~>) Symbol Symbol))
       where
-        ShowsPrec_0123456789876543210Sym0KindInference :: forall l arg.
+        ShowsPrec_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                 arg.
                                                           SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 l
-    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
     instance PShow (T a ()) where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type family Compare_0123456789876543210 (a :: S) (a :: S) :: Ordering where
@@ -120,70 +137,79 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
       Compare_0123456789876543210 S2 S2 = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) '[]
       Compare_0123456789876543210 S1 S2 = LTSym0
       Compare_0123456789876543210 S2 S1 = GTSym0
-    type Compare_0123456789876543210Sym2 (t :: S) (t :: S) =
-        Compare_0123456789876543210 t t
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym1 where
+    type Compare_0123456789876543210Sym2 (a0123456789876543210 :: S) (a0123456789876543210 :: S) =
+        Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym1 (l :: S) (l :: TyFun S Ordering) :: GHC.Types.Type
+    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: S) :: (~>) S Ordering
       where
-        Compare_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                        SameKind (Apply (Compare_0123456789876543210Sym1 l) arg) (Compare_0123456789876543210Sym2 l arg) =>
-                                                        Compare_0123456789876543210Sym1 l l
-    type instance Apply (Compare_0123456789876543210Sym1 l) l = Compare_0123456789876543210 l l
+        Compare_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                               a0123456789876543210
+                                                               arg.
+                                                        SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym0 (l :: TyFun S ((~>) S Ordering)) :: GHC.Types.Type
+    data Compare_0123456789876543210Sym0 :: (~>) S ((~>) S Ordering)
       where
-        Compare_0123456789876543210Sym0KindInference :: forall l arg.
+        Compare_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                               arg.
                                                         SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 l
-    type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
+                                                        Compare_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
     instance POrd S where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: S) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 _ S1 a_0123456789876543210 = Apply (Apply ShowStringSym0 "S1") a_0123456789876543210
       ShowsPrec_0123456789876543210 _ S2 a_0123456789876543210 = Apply (Apply ShowStringSym0 "S2") a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: S) (t :: Symbol) =
-        ShowsPrec_0123456789876543210 t t t
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+    type ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: S) (a0123456789876543210 :: Symbol) =
+        ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym2 (l :: GHC.Types.Nat) (l :: S) (l :: TyFun Symbol Symbol) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: S) :: (~>) Symbol Symbol
       where
-        ShowsPrec_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 l l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+        ShowsPrec_0123456789876543210Sym2KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun S ((~>) Symbol Symbol)) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: (~>) S ((~>) Symbol Symbol)
       where
-        ShowsPrec_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+        ShowsPrec_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) S ((~>) Symbol Symbol))) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) S ((~>) Symbol Symbol))
       where
-        ShowsPrec_0123456789876543210Sym0KindInference :: forall l arg.
+        ShowsPrec_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                 arg.
                                                           SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 l
-    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
     instance PShow S where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type family MinBound_0123456789876543210 :: S where
@@ -205,35 +231,37 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
       Case_0123456789876543210 n False = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (FromInteger 1))
     type family ToEnum_0123456789876543210 (a :: GHC.Types.Nat) :: S where
       ToEnum_0123456789876543210 n = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (FromInteger 0))
-    type ToEnum_0123456789876543210Sym1 (t :: GHC.Types.Nat) =
-        ToEnum_0123456789876543210 t
+    type ToEnum_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) =
+        ToEnum_0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ToEnum_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ToEnum_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ToEnum_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat S) :: GHC.Types.Type
+    data ToEnum_0123456789876543210Sym0 :: (~>) GHC.Types.Nat S
       where
-        ToEnum_0123456789876543210Sym0KindInference :: forall l arg.
+        ToEnum_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                              arg.
                                                        SameKind (Apply ToEnum_0123456789876543210Sym0 arg) (ToEnum_0123456789876543210Sym1 arg) =>
-                                                       ToEnum_0123456789876543210Sym0 l
-    type instance Apply ToEnum_0123456789876543210Sym0 l = ToEnum_0123456789876543210 l
+                                                       ToEnum_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply ToEnum_0123456789876543210Sym0 a0123456789876543210 = ToEnum_0123456789876543210 a0123456789876543210
     type family FromEnum_0123456789876543210 (a :: S) :: GHC.Types.Nat where
       FromEnum_0123456789876543210 S1 = FromInteger 0
       FromEnum_0123456789876543210 S2 = FromInteger 1
-    type FromEnum_0123456789876543210Sym1 (t :: S) =
-        FromEnum_0123456789876543210 t
+    type FromEnum_0123456789876543210Sym1 (a0123456789876543210 :: S) =
+        FromEnum_0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings FromEnum_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) FromEnum_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data FromEnum_0123456789876543210Sym0 (l :: TyFun S GHC.Types.Nat) :: GHC.Types.Type
+    data FromEnum_0123456789876543210Sym0 :: (~>) S GHC.Types.Nat
       where
-        FromEnum_0123456789876543210Sym0KindInference :: forall l arg.
+        FromEnum_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                arg.
                                                          SameKind (Apply FromEnum_0123456789876543210Sym0 arg) (FromEnum_0123456789876543210Sym1 arg) =>
-                                                         FromEnum_0123456789876543210Sym0 l
-    type instance Apply FromEnum_0123456789876543210Sym0 l = FromEnum_0123456789876543210 l
+                                                         FromEnum_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply FromEnum_0123456789876543210Sym0 a0123456789876543210 = FromEnum_0123456789876543210 a0123456789876543210
     instance PEnum S where
       type ToEnum a = Apply ToEnum_0123456789876543210Sym0 a
       type FromEnum a = Apply FromEnum_0123456789876543210Sym0 a

--- a/tests/compile-and-dump/Singletons/Star.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Star.ghc84.template
@@ -12,32 +12,39 @@ Singletons/Star.hs:0:0:: Splicing declarations
     type NatSym0 = Nat
     type IntSym0 = Int
     type StringSym0 = String
-    type MaybeSym1 (t :: Type) = Maybe t
+    type MaybeSym1 (t0123456789876543210 :: Type) =
+        Maybe t0123456789876543210
     instance SuppressUnusedWarnings MaybeSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MaybeSym0KindInference) GHC.Tuple.())
-    data MaybeSym0 (l :: TyFun Type Type) :: Type
+    data MaybeSym0 :: (~>) Type Type
       where
-        MaybeSym0KindInference :: forall l arg.
-                                  SameKind (Apply MaybeSym0 arg) (MaybeSym1 arg) => MaybeSym0 l
-    type instance Apply MaybeSym0 l = Maybe l
-    type VecSym2 (t :: Type) (t :: Nat) = Vec t t
-    instance SuppressUnusedWarnings VecSym1 where
+        MaybeSym0KindInference :: forall t0123456789876543210 arg.
+                                  SameKind (Apply MaybeSym0 arg) (MaybeSym1 arg) =>
+                                  MaybeSym0 t0123456789876543210
+    type instance Apply MaybeSym0 t0123456789876543210 = Maybe t0123456789876543210
+    type VecSym2 (t0123456789876543210 :: Type) (t0123456789876543210 :: Nat) =
+        Vec t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (VecSym1 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) VecSym1KindInference) GHC.Tuple.())
-    data VecSym1 (l :: Type) (l :: TyFun Nat Type) :: Type
+    data VecSym1 (t0123456789876543210 :: Type) :: (~>) Nat Type
       where
-        VecSym1KindInference :: forall l l arg.
-                                SameKind (Apply (VecSym1 l) arg) (VecSym2 l arg) => VecSym1 l l
-    type instance Apply (VecSym1 l) l = Vec l l
+        VecSym1KindInference :: forall t0123456789876543210
+                                       t0123456789876543210
+                                       arg.
+                                SameKind (Apply (VecSym1 t0123456789876543210) arg) (VecSym2 t0123456789876543210 arg) =>
+                                VecSym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (VecSym1 t0123456789876543210) t0123456789876543210 = Vec t0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings VecSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) VecSym0KindInference) GHC.Tuple.())
-    data VecSym0 (l :: TyFun Type ((~>) Nat Type)) :: Type
+    data VecSym0 :: (~>) Type ((~>) Nat Type)
       where
-        VecSym0KindInference :: forall l arg.
-                                SameKind (Apply VecSym0 arg) (VecSym1 arg) => VecSym0 l
-    type instance Apply VecSym0 l = VecSym1 l
+        VecSym0KindInference :: forall t0123456789876543210 arg.
+                                SameKind (Apply VecSym0 arg) (VecSym1 arg) =>
+                                VecSym0 t0123456789876543210
+    type instance Apply VecSym0 t0123456789876543210 = VecSym1 t0123456789876543210
     type family Equals_0123456789876543210 (a :: Type) (b :: Type) :: Bool where
       Equals_0123456789876543210 Nat Nat = TrueSym0
       Equals_0123456789876543210 Int Int = TrueSym0
@@ -73,30 +80,33 @@ Singletons/Star.hs:0:0:: Splicing declarations
       Compare_0123456789876543210 (Vec _ _) Int = GTSym0
       Compare_0123456789876543210 (Vec _ _) String = GTSym0
       Compare_0123456789876543210 (Vec _ _) (Maybe _) = GTSym0
-    type Compare_0123456789876543210Sym2 (t :: Type) (t :: Type) =
-        Compare_0123456789876543210 t t
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym1 where
+    type Compare_0123456789876543210Sym2 (a0123456789876543210 :: Type) (a0123456789876543210 :: Type) =
+        Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym1 (l :: Type) (l :: TyFun Type Ordering) :: Type
+    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Type) :: (~>) Type Ordering
       where
-        Compare_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                        SameKind (Apply (Compare_0123456789876543210Sym1 l) arg) (Compare_0123456789876543210Sym2 l arg) =>
-                                                        Compare_0123456789876543210Sym1 l l
-    type instance Apply (Compare_0123456789876543210Sym1 l) l = Compare_0123456789876543210 l l
+        Compare_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                               a0123456789876543210
+                                                               arg.
+                                                        SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym0 (l :: TyFun Type ((~>) Type Ordering)) :: Type
+    data Compare_0123456789876543210Sym0 :: (~>) Type ((~>) Type Ordering)
       where
-        Compare_0123456789876543210Sym0KindInference :: forall l arg.
+        Compare_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                               arg.
                                                         SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 l
-    type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
+                                                        Compare_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
     instance POrd Type where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Type) (a :: Symbol) :: Symbol where
@@ -105,41 +115,47 @@ Singletons/Star.hs:0:0:: Splicing declarations
       ShowsPrec_0123456789876543210 _ String a_0123456789876543210 = Apply (Apply ShowStringSym0 "String") a_0123456789876543210
       ShowsPrec_0123456789876543210 p_0123456789876543210 (Maybe arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Maybe ")) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
       ShowsPrec_0123456789876543210 p_0123456789876543210 (Vec arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Vec ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: Type) (t :: Symbol) =
-        ShowsPrec_0123456789876543210 t t t
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+    type ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Type) (a0123456789876543210 :: Symbol) =
+        ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym2 (l :: GHC.Types.Nat) (l :: Type) (l :: TyFun Symbol Symbol) :: Type
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Type) :: (~>) Symbol Symbol
       where
-        ShowsPrec_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 l l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+        ShowsPrec_0123456789876543210Sym2KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun Type ((~>) Symbol Symbol)) :: Type
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: (~>) Type ((~>) Symbol Symbol)
       where
-        ShowsPrec_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+        ShowsPrec_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) Type ((~>) Symbol Symbol))) :: Type
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) Type ((~>) Symbol Symbol))
       where
-        ShowsPrec_0123456789876543210Sym0KindInference :: forall l arg.
+        ShowsPrec_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                 arg.
                                                           SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 l
-    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
     instance PShow Type where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     data instance Sing :: Type -> Type :: Type -> Type

--- a/tests/compile-and-dump/Singletons/T124.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T124.ghc84.template
@@ -7,15 +7,17 @@ Singletons/T124.hs:(0,0)-(0,0): Splicing declarations
     foo :: Bool -> ()
     foo True = GHC.Tuple.()
     foo False = GHC.Tuple.()
-    type FooSym1 (t :: Bool) = Foo t
+    type FooSym1 (a0123456789876543210 :: Bool) =
+        Foo a0123456789876543210
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym0KindInference) GHC.Tuple.())
-    data FooSym0 (l :: TyFun Bool ()) :: GHC.Types.Type
+    data FooSym0 :: (~>) Bool ()
       where
-        FooSym0KindInference :: forall l arg.
-                                SameKind (Apply FooSym0 arg) (FooSym1 arg) => FooSym0 l
-    type instance Apply FooSym0 l = Foo l
+        FooSym0KindInference :: forall a0123456789876543210 arg.
+                                SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
+                                FooSym0 a0123456789876543210
+    type instance Apply FooSym0 a0123456789876543210 = Foo a0123456789876543210
     type family Foo (a :: Bool) :: () where
       Foo True = Tuple0Sym0
       Foo False = Tuple0Sym0

--- a/tests/compile-and-dump/Singletons/T136.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T136.ghc84.template
@@ -33,36 +33,38 @@ Singletons/T136.hs:(0,0)-(0,0): Splicing declarations
       Succ_0123456789876543210 '[] = Apply (Apply (:@#@$) TrueSym0) '[]
       Succ_0123456789876543210 ((:) False as) = Apply (Apply (:@#@$) TrueSym0) as
       Succ_0123456789876543210 ((:) True as) = Apply (Apply (:@#@$) FalseSym0) (Apply SuccSym0 as)
-    type Succ_0123456789876543210Sym1 (t :: [Bool]) =
-        Succ_0123456789876543210 t
+    type Succ_0123456789876543210Sym1 (a0123456789876543210 :: [Bool]) =
+        Succ_0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Succ_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Succ_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Succ_0123456789876543210Sym0 (l :: TyFun [Bool] [Bool]) :: GHC.Types.Type
+    data Succ_0123456789876543210Sym0 :: (~>) [Bool] [Bool]
       where
-        Succ_0123456789876543210Sym0KindInference :: forall l arg.
+        Succ_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                            arg.
                                                      SameKind (Apply Succ_0123456789876543210Sym0 arg) (Succ_0123456789876543210Sym1 arg) =>
-                                                     Succ_0123456789876543210Sym0 l
-    type instance Apply Succ_0123456789876543210Sym0 l = Succ_0123456789876543210 l
+                                                     Succ_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Succ_0123456789876543210Sym0 a0123456789876543210 = Succ_0123456789876543210 a0123456789876543210
     type family Pred_0123456789876543210 (a :: [Bool]) :: [Bool] where
       Pred_0123456789876543210 '[] = Apply ErrorSym0 "pred 0"
       Pred_0123456789876543210 ((:) False as) = Apply (Apply (:@#@$) TrueSym0) (Apply PredSym0 as)
       Pred_0123456789876543210 ((:) True as) = Apply (Apply (:@#@$) FalseSym0) as
-    type Pred_0123456789876543210Sym1 (t :: [Bool]) =
-        Pred_0123456789876543210 t
+    type Pred_0123456789876543210Sym1 (a0123456789876543210 :: [Bool]) =
+        Pred_0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Pred_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Pred_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Pred_0123456789876543210Sym0 (l :: TyFun [Bool] [Bool]) :: GHC.Types.Type
+    data Pred_0123456789876543210Sym0 :: (~>) [Bool] [Bool]
       where
-        Pred_0123456789876543210Sym0KindInference :: forall l arg.
+        Pred_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                            arg.
                                                      SameKind (Apply Pred_0123456789876543210Sym0 arg) (Pred_0123456789876543210Sym1 arg) =>
-                                                     Pred_0123456789876543210Sym0 l
-    type instance Apply Pred_0123456789876543210Sym0 l = Pred_0123456789876543210 l
+                                                     Pred_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Pred_0123456789876543210Sym0 a0123456789876543210 = Pred_0123456789876543210 a0123456789876543210
     type family Case_0123456789876543210 i arg_0123456789876543210 t where
       Case_0123456789876543210 i arg_0123456789876543210 True = '[]
       Case_0123456789876543210 i arg_0123456789876543210 False = Apply SuccSym0 (Apply ToEnumSym0 (Apply PredSym0 i))
@@ -73,36 +75,38 @@ Singletons/T136.hs:(0,0)-(0,0): Splicing declarations
       Case_0123456789876543210 arg_0123456789876543210 i = Case_0123456789876543210 i arg_0123456789876543210 (Apply (Apply (<@#@$) i) (FromInteger 0))
     type family ToEnum_0123456789876543210 (a :: GHC.Types.Nat) :: [Bool] where
       ToEnum_0123456789876543210 arg_0123456789876543210 = Case_0123456789876543210 arg_0123456789876543210 arg_0123456789876543210
-    type ToEnum_0123456789876543210Sym1 (t :: GHC.Types.Nat) =
-        ToEnum_0123456789876543210 t
+    type ToEnum_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) =
+        ToEnum_0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ToEnum_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ToEnum_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ToEnum_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat [Bool]) :: GHC.Types.Type
+    data ToEnum_0123456789876543210Sym0 :: (~>) GHC.Types.Nat [Bool]
       where
-        ToEnum_0123456789876543210Sym0KindInference :: forall l arg.
+        ToEnum_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                              arg.
                                                        SameKind (Apply ToEnum_0123456789876543210Sym0 arg) (ToEnum_0123456789876543210Sym1 arg) =>
-                                                       ToEnum_0123456789876543210Sym0 l
-    type instance Apply ToEnum_0123456789876543210Sym0 l = ToEnum_0123456789876543210 l
+                                                       ToEnum_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply ToEnum_0123456789876543210Sym0 a0123456789876543210 = ToEnum_0123456789876543210 a0123456789876543210
     type family FromEnum_0123456789876543210 (a :: [Bool]) :: GHC.Types.Nat where
       FromEnum_0123456789876543210 '[] = FromInteger 0
       FromEnum_0123456789876543210 ((:) False as) = Apply (Apply (*@#@$) (FromInteger 2)) (Apply FromEnumSym0 as)
       FromEnum_0123456789876543210 ((:) True as) = Apply (Apply (+@#@$) (FromInteger 1)) (Apply (Apply (*@#@$) (FromInteger 2)) (Apply FromEnumSym0 as))
-    type FromEnum_0123456789876543210Sym1 (t :: [Bool]) =
-        FromEnum_0123456789876543210 t
+    type FromEnum_0123456789876543210Sym1 (a0123456789876543210 :: [Bool]) =
+        FromEnum_0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings FromEnum_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) FromEnum_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data FromEnum_0123456789876543210Sym0 (l :: TyFun [Bool] GHC.Types.Nat) :: GHC.Types.Type
+    data FromEnum_0123456789876543210Sym0 :: (~>) [Bool] GHC.Types.Nat
       where
-        FromEnum_0123456789876543210Sym0KindInference :: forall l arg.
+        FromEnum_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                arg.
                                                          SameKind (Apply FromEnum_0123456789876543210Sym0 arg) (FromEnum_0123456789876543210Sym1 arg) =>
-                                                         FromEnum_0123456789876543210Sym0 l
-    type instance Apply FromEnum_0123456789876543210Sym0 l = FromEnum_0123456789876543210 l
+                                                         FromEnum_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply FromEnum_0123456789876543210Sym0 a0123456789876543210 = FromEnum_0123456789876543210 a0123456789876543210
     instance PEnum [Bool] where
       type Succ a = Apply Succ_0123456789876543210Sym0 a
       type Pred a = Apply Pred_0123456789876543210Sym0 a

--- a/tests/compile-and-dump/Singletons/T136b.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T136b.ghc84.template
@@ -5,15 +5,18 @@ Singletons/T136b.hs:(0,0)-(0,0): Splicing declarations
   ======>
     class C a where
       meth :: a -> a
-    type MethSym1 (t :: a0123456789876543210) = Meth t
+    type MethSym1 (arg0123456789876543210 :: a0123456789876543210) =
+        Meth arg0123456789876543210
     instance SuppressUnusedWarnings MethSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MethSym0KindInference) GHC.Tuple.())
-    data MethSym0 (l :: TyFun a0123456789876543210 a0123456789876543210) :: GHC.Types.Type
+    data MethSym0 :: forall a0123456789876543210.
+                     (~>) a0123456789876543210 a0123456789876543210
       where
-        MethSym0KindInference :: forall l arg.
-                                 SameKind (Apply MethSym0 arg) (MethSym1 arg) => MethSym0 l
-    type instance Apply MethSym0 l = Meth l
+        MethSym0KindInference :: forall arg0123456789876543210 arg.
+                                 SameKind (Apply MethSym0 arg) (MethSym1 arg) =>
+                                 MethSym0 arg0123456789876543210
+    type instance Apply MethSym0 arg0123456789876543210 = Meth arg0123456789876543210
     class PC (a :: GHC.Types.Type) where
       type Meth (arg :: a) :: a
     class SC a where
@@ -29,19 +32,20 @@ Singletons/T136b.hs:(0,0)-(0,0): Splicing declarations
       meth = not
     type family Meth_0123456789876543210 (a :: Bool) :: Bool where
       Meth_0123456789876543210 a_0123456789876543210 = Apply NotSym0 a_0123456789876543210
-    type Meth_0123456789876543210Sym1 (t :: Bool) =
-        Meth_0123456789876543210 t
+    type Meth_0123456789876543210Sym1 (a0123456789876543210 :: Bool) =
+        Meth_0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Meth_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Meth_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Meth_0123456789876543210Sym0 (l :: TyFun Bool Bool) :: GHC.Types.Type
+    data Meth_0123456789876543210Sym0 :: (~>) Bool Bool
       where
-        Meth_0123456789876543210Sym0KindInference :: forall l arg.
+        Meth_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                            arg.
                                                      SameKind (Apply Meth_0123456789876543210Sym0 arg) (Meth_0123456789876543210Sym1 arg) =>
-                                                     Meth_0123456789876543210Sym0 l
-    type instance Apply Meth_0123456789876543210Sym0 l = Meth_0123456789876543210 l
+                                                     Meth_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Meth_0123456789876543210Sym0 a0123456789876543210 = Meth_0123456789876543210 a0123456789876543210
     instance PC Bool where
       type Meth a = Apply Meth_0123456789876543210Sym0 a
     instance SC Bool where

--- a/tests/compile-and-dump/Singletons/T145.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T145.ghc84.template
@@ -5,24 +5,29 @@ Singletons/T145.hs:(0,0)-(0,0): Splicing declarations
   ======>
     class Column (f :: Type -> Type) where
       col :: f a -> a -> Bool
-    type ColSym2 (t :: f0123456789876543210 a0123456789876543210) (t :: a0123456789876543210) =
-        Col t t
-    instance SuppressUnusedWarnings ColSym1 where
+    type ColSym2 (arg0123456789876543210 :: f0123456789876543210 a0123456789876543210) (arg0123456789876543210 :: a0123456789876543210) =
+        Col arg0123456789876543210 arg0123456789876543210
+    instance SuppressUnusedWarnings (ColSym1 arg0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ColSym1KindInference) GHC.Tuple.())
-    data ColSym1 (l :: f0123456789876543210 a0123456789876543210) (l :: TyFun a0123456789876543210 Bool) :: Type
+    data ColSym1 (arg0123456789876543210 :: f0123456789876543210 a0123456789876543210) :: (~>) a0123456789876543210 Bool
       where
-        ColSym1KindInference :: forall l l arg.
-                                SameKind (Apply (ColSym1 l) arg) (ColSym2 l arg) => ColSym1 l l
-    type instance Apply (ColSym1 l) l = Col l l
+        ColSym1KindInference :: forall arg0123456789876543210
+                                       arg0123456789876543210
+                                       arg.
+                                SameKind (Apply (ColSym1 arg0123456789876543210) arg) (ColSym2 arg0123456789876543210 arg) =>
+                                ColSym1 arg0123456789876543210 arg0123456789876543210
+    type instance Apply (ColSym1 arg0123456789876543210) arg0123456789876543210 = Col arg0123456789876543210 arg0123456789876543210
     instance SuppressUnusedWarnings ColSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ColSym0KindInference) GHC.Tuple.())
-    data ColSym0 (l :: TyFun (f0123456789876543210 a0123456789876543210) ((~>) a0123456789876543210 Bool)) :: Type
+    data ColSym0 :: forall a0123456789876543210 f0123456789876543210.
+                    (~>) (f0123456789876543210 a0123456789876543210) ((~>) a0123456789876543210 Bool)
       where
-        ColSym0KindInference :: forall l arg.
-                                SameKind (Apply ColSym0 arg) (ColSym1 arg) => ColSym0 l
-    type instance Apply ColSym0 l = ColSym1 l
+        ColSym0KindInference :: forall arg0123456789876543210 arg.
+                                SameKind (Apply ColSym0 arg) (ColSym1 arg) =>
+                                ColSym0 arg0123456789876543210
+    type instance Apply ColSym0 arg0123456789876543210 = ColSym1 arg0123456789876543210
     class PColumn (f :: Type -> Type) where
       type Col (arg :: f a) (arg :: a) :: Bool
     class SColumn (f :: Type -> Type) where

--- a/tests/compile-and-dump/Singletons/T159.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T159.ghc84.template
@@ -43,44 +43,53 @@ Singletons/T159.hs:0:0:: Splicing declarations
     instance SingI F where
       sing = SF
     type N1Sym0 = N1
-    type C1Sym2 (t :: T0) (t :: T1) = C1 t t
-    instance SuppressUnusedWarnings C1Sym1 where
+    type C1Sym2 (t0123456789876543210 :: T0) (t0123456789876543210 :: T1) =
+        C1 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (C1Sym1 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) C1Sym1KindInference) GHC.Tuple.())
-    data C1Sym1 (l :: T0) (l :: TyFun T1 T1) :: GHC.Types.Type
+    data C1Sym1 (t0123456789876543210 :: T0) :: (~>) T1 T1
       where
-        C1Sym1KindInference :: forall l l arg.
-                               SameKind (Apply (C1Sym1 l) arg) (C1Sym2 l arg) => C1Sym1 l l
-    type instance Apply (C1Sym1 l) l = C1 l l
+        C1Sym1KindInference :: forall t0123456789876543210
+                                      t0123456789876543210
+                                      arg.
+                               SameKind (Apply (C1Sym1 t0123456789876543210) arg) (C1Sym2 t0123456789876543210 arg) =>
+                               C1Sym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (C1Sym1 t0123456789876543210) t0123456789876543210 = C1 t0123456789876543210 t0123456789876543210
     infixr 5 `C1Sym1`
     instance SuppressUnusedWarnings C1Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) C1Sym0KindInference) GHC.Tuple.())
-    data C1Sym0 (l :: TyFun T0 ((~>) T1 T1)) :: GHC.Types.Type
+    data C1Sym0 :: (~>) T0 ((~>) T1 T1)
       where
-        C1Sym0KindInference :: forall l arg.
-                               SameKind (Apply C1Sym0 arg) (C1Sym1 arg) => C1Sym0 l
-    type instance Apply C1Sym0 l = C1Sym1 l
+        C1Sym0KindInference :: forall t0123456789876543210 arg.
+                               SameKind (Apply C1Sym0 arg) (C1Sym1 arg) =>
+                               C1Sym0 t0123456789876543210
+    type instance Apply C1Sym0 t0123456789876543210 = C1Sym1 t0123456789876543210
     infixr 5 `C1Sym0`
-    type (:&&@#@$$$) (t :: T0) (t :: T1) = (:&&) t t
-    instance SuppressUnusedWarnings (:&&@#@$$) where
+    type (:&&@#@$$$) (t0123456789876543210 :: T0) (t0123456789876543210 :: T1) =
+        (:&&) t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings ((:&&@#@$$) t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::&&@#@$$###)) GHC.Tuple.())
-    data (:&&@#@$$) (l :: T0) (l :: TyFun T1 T1) :: GHC.Types.Type
+    data (:&&@#@$$) (t0123456789876543210 :: T0) :: (~>) T1 T1
       where
-        (::&&@#@$$###) :: forall l l arg.
-                          SameKind (Apply ((:&&@#@$$) l) arg) ((:&&@#@$$$) l arg) =>
-                          (:&&@#@$$) l l
-    type instance Apply ((:&&@#@$$) l) l = (:&&) l l
+        (::&&@#@$$###) :: forall t0123456789876543210
+                                 t0123456789876543210
+                                 arg.
+                          SameKind (Apply ((:&&@#@$$) t0123456789876543210) arg) ((:&&@#@$$$) t0123456789876543210 arg) =>
+                          (:&&@#@$$) t0123456789876543210 t0123456789876543210
+    type instance Apply ((:&&@#@$$) t0123456789876543210) t0123456789876543210 = (:&&) t0123456789876543210 t0123456789876543210
     infixr 5 :&&@#@$$
     instance SuppressUnusedWarnings (:&&@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::&&@#@$###)) GHC.Tuple.())
-    data (:&&@#@$) (l :: TyFun T0 ((~>) T1 T1)) :: GHC.Types.Type
+    data :&&@#@$ :: (~>) T0 ((~>) T1 T1)
       where
-        (::&&@#@$###) :: forall l arg.
-                         SameKind (Apply (:&&@#@$) arg) ((:&&@#@$$) arg) => (:&&@#@$) l
-    type instance Apply (:&&@#@$) l = (:&&@#@$$) l
+        (::&&@#@$###) :: forall t0123456789876543210 arg.
+                         SameKind (Apply (:&&@#@$) arg) ((:&&@#@$$) arg) =>
+                         (:&&@#@$) t0123456789876543210
+    type instance Apply (:&&@#@$) t0123456789876543210 = (:&&@#@$$) t0123456789876543210
     infixr 5 :&&@#@$
     data instance Sing :: T1 -> GHC.Types.Type :: T1 -> GHC.Types.Type
       where
@@ -146,44 +155,53 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
     infixr 5 `C2`
     infixr 5 :||
     type N2Sym0 = N2
-    type C2Sym2 (t :: T0) (t :: T2) = C2 t t
-    instance SuppressUnusedWarnings C2Sym1 where
+    type C2Sym2 (t0123456789876543210 :: T0) (t0123456789876543210 :: T2) =
+        C2 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (C2Sym1 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) C2Sym1KindInference) GHC.Tuple.())
-    data C2Sym1 (l :: T0) (l :: TyFun T2 T2) :: GHC.Types.Type
+    data C2Sym1 (t0123456789876543210 :: T0) :: (~>) T2 T2
       where
-        C2Sym1KindInference :: forall l l arg.
-                               SameKind (Apply (C2Sym1 l) arg) (C2Sym2 l arg) => C2Sym1 l l
-    type instance Apply (C2Sym1 l) l = C2 l l
+        C2Sym1KindInference :: forall t0123456789876543210
+                                      t0123456789876543210
+                                      arg.
+                               SameKind (Apply (C2Sym1 t0123456789876543210) arg) (C2Sym2 t0123456789876543210 arg) =>
+                               C2Sym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (C2Sym1 t0123456789876543210) t0123456789876543210 = C2 t0123456789876543210 t0123456789876543210
     infixr 5 `C2Sym1`
     instance SuppressUnusedWarnings C2Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) C2Sym0KindInference) GHC.Tuple.())
-    data C2Sym0 (l :: TyFun T0 ((~>) T2 T2)) :: GHC.Types.Type
+    data C2Sym0 :: (~>) T0 ((~>) T2 T2)
       where
-        C2Sym0KindInference :: forall l arg.
-                               SameKind (Apply C2Sym0 arg) (C2Sym1 arg) => C2Sym0 l
-    type instance Apply C2Sym0 l = C2Sym1 l
+        C2Sym0KindInference :: forall t0123456789876543210 arg.
+                               SameKind (Apply C2Sym0 arg) (C2Sym1 arg) =>
+                               C2Sym0 t0123456789876543210
+    type instance Apply C2Sym0 t0123456789876543210 = C2Sym1 t0123456789876543210
     infixr 5 `C2Sym0`
-    type (:||@#@$$$) (t :: T0) (t :: T2) = (:||) t t
-    instance SuppressUnusedWarnings (:||@#@$$) where
+    type (:||@#@$$$) (t0123456789876543210 :: T0) (t0123456789876543210 :: T2) =
+        (:||) t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings ((:||@#@$$) t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::||@#@$$###)) GHC.Tuple.())
-    data (:||@#@$$) (l :: T0) (l :: TyFun T2 T2) :: GHC.Types.Type
+    data (:||@#@$$) (t0123456789876543210 :: T0) :: (~>) T2 T2
       where
-        (::||@#@$$###) :: forall l l arg.
-                          SameKind (Apply ((:||@#@$$) l) arg) ((:||@#@$$$) l arg) =>
-                          (:||@#@$$) l l
-    type instance Apply ((:||@#@$$) l) l = (:||) l l
+        (::||@#@$$###) :: forall t0123456789876543210
+                                 t0123456789876543210
+                                 arg.
+                          SameKind (Apply ((:||@#@$$) t0123456789876543210) arg) ((:||@#@$$$) t0123456789876543210 arg) =>
+                          (:||@#@$$) t0123456789876543210 t0123456789876543210
+    type instance Apply ((:||@#@$$) t0123456789876543210) t0123456789876543210 = (:||) t0123456789876543210 t0123456789876543210
     infixr 5 :||@#@$$
     instance SuppressUnusedWarnings (:||@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::||@#@$###)) GHC.Tuple.())
-    data (:||@#@$) (l :: TyFun T0 ((~>) T2 T2)) :: GHC.Types.Type
+    data :||@#@$ :: (~>) T0 ((~>) T2 T2)
       where
-        (::||@#@$###) :: forall l arg.
-                         SameKind (Apply (:||@#@$) arg) ((:||@#@$$) arg) => (:||@#@$) l
-    type instance Apply (:||@#@$) l = (:||@#@$$) l
+        (::||@#@$###) :: forall t0123456789876543210 arg.
+                         SameKind (Apply (:||@#@$) arg) ((:||@#@$$) arg) =>
+                         (:||@#@$) t0123456789876543210
+    type instance Apply (:||@#@$) t0123456789876543210 = (:||@#@$$) t0123456789876543210
     infixr 5 :||@#@$
     infixr 5 `SC2`
     infixr 5 :%||

--- a/tests/compile-and-dump/Singletons/T160.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T160.ghc84.template
@@ -5,35 +5,38 @@ Singletons/T160.hs:(0,0)-(0,0): Splicing declarations
   ======>
     foo :: (Num a, Eq a) => a -> a
     foo x = if (x == 0) then 1 else (typeError $ (ShowType x))
-    type Let0123456789876543210Scrutinee_0123456789876543210Sym1 t =
-        Let0123456789876543210Scrutinee_0123456789876543210 t
+    type Let0123456789876543210Scrutinee_0123456789876543210Sym1 x0123456789876543210 =
+        Let0123456789876543210Scrutinee_0123456789876543210 x0123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210Scrutinee_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Let0123456789876543210Scrutinee_0123456789876543210Sym0 x0123456789876543210
       where
-        Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference :: forall l
+        Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference :: forall x0123456789876543210
                                                                                        arg.
                                                                                 SameKind (Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 arg) (Let0123456789876543210Scrutinee_0123456789876543210Sym1 arg) =>
-                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym0 l
-    type instance Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 l = Let0123456789876543210Scrutinee_0123456789876543210 l
+                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym0 x0123456789876543210
+    type instance Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 x0123456789876543210 = Let0123456789876543210Scrutinee_0123456789876543210 x0123456789876543210
     type family Let0123456789876543210Scrutinee_0123456789876543210 x where
       Let0123456789876543210Scrutinee_0123456789876543210 x = Apply (Apply (==@#@$) x) (FromInteger 0)
     type family Case_0123456789876543210 x t where
       Case_0123456789876543210 x True = FromInteger 1
       Case_0123456789876543210 x False = Apply (Apply ($@#@$) TypeErrorSym0) (Apply ShowTypeSym0 x)
-    type FooSym1 (t :: a0123456789876543210) = Foo t
+    type FooSym1 (a0123456789876543210 :: a0123456789876543210) =
+        Foo a0123456789876543210
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym0KindInference) GHC.Tuple.())
-    data FooSym0 (l :: TyFun a0123456789876543210 a0123456789876543210) :: GHC.Types.Type
+    data FooSym0 :: forall a0123456789876543210.
+                    (~>) a0123456789876543210 a0123456789876543210
       where
-        FooSym0KindInference :: forall l arg.
-                                SameKind (Apply FooSym0 arg) (FooSym1 arg) => FooSym0 l
-    type instance Apply FooSym0 l = Foo l
+        FooSym0KindInference :: forall a0123456789876543210 arg.
+                                SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
+                                FooSym0 a0123456789876543210
+    type instance Apply FooSym0 a0123456789876543210 = Foo a0123456789876543210
     type family Foo (a :: a) :: a where
       Foo x = Case_0123456789876543210 x (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x)
     sFoo ::

--- a/tests/compile-and-dump/Singletons/T163.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T163.ghc84.template
@@ -2,24 +2,30 @@ Singletons/T163.hs:0:0:: Splicing declarations
     singletons [d| data a + b = L a | R b |]
   ======>
     data (+) a b = L a | R b
-    type LSym1 (t :: a0123456789876543210) = L t
+    type LSym1 (t0123456789876543210 :: a0123456789876543210) =
+        L t0123456789876543210
     instance SuppressUnusedWarnings LSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) LSym0KindInference) GHC.Tuple.())
-    data LSym0 (l :: TyFun a0123456789876543210 ((+) a0123456789876543210 b0123456789876543210)) :: GHC.Types.Type
+    data LSym0 :: forall a0123456789876543210 b0123456789876543210.
+                  (~>) a0123456789876543210 ((+) a0123456789876543210 b0123456789876543210)
       where
-        LSym0KindInference :: forall l arg.
-                              SameKind (Apply LSym0 arg) (LSym1 arg) => LSym0 l
-    type instance Apply LSym0 l = L l
-    type RSym1 (t :: b0123456789876543210) = R t
+        LSym0KindInference :: forall t0123456789876543210 arg.
+                              SameKind (Apply LSym0 arg) (LSym1 arg) =>
+                              LSym0 t0123456789876543210
+    type instance Apply LSym0 t0123456789876543210 = L t0123456789876543210
+    type RSym1 (t0123456789876543210 :: b0123456789876543210) =
+        R t0123456789876543210
     instance SuppressUnusedWarnings RSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) RSym0KindInference) GHC.Tuple.())
-    data RSym0 (l :: TyFun b0123456789876543210 ((+) a0123456789876543210 b0123456789876543210)) :: GHC.Types.Type
+    data RSym0 :: forall a0123456789876543210 b0123456789876543210.
+                  (~>) b0123456789876543210 ((+) a0123456789876543210 b0123456789876543210)
       where
-        RSym0KindInference :: forall l arg.
-                              SameKind (Apply RSym0 arg) (RSym1 arg) => RSym0 l
-    type instance Apply RSym0 l = R l
+        RSym0KindInference :: forall t0123456789876543210 arg.
+                              SameKind (Apply RSym0 arg) (RSym1 arg) =>
+                              RSym0 t0123456789876543210
+    type instance Apply RSym0 t0123456789876543210 = R t0123456789876543210
     data instance Sing :: (+) a b -> GHC.Types.Type :: (+) a b
                                                        -> GHC.Types.Type
       where

--- a/tests/compile-and-dump/Singletons/T166.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T166.ghc84.template
@@ -5,85 +5,100 @@ Singletons/T166.hs:(0,0)-(0,0): Splicing declarations
             foo :: a -> [Bool]
             foo x s = foosPrec 0 x s |]
   ======>
-    type FoosPrecSym3 (t :: Nat) (t :: a0123456789876543210) (t :: [Bool]) =
-        FoosPrec t t t
-    instance SuppressUnusedWarnings FoosPrecSym2 where
+    type FoosPrecSym3 (arg0123456789876543210 :: Nat) (arg0123456789876543210 :: a0123456789876543210) (arg0123456789876543210 :: [Bool]) =
+        FoosPrec arg0123456789876543210 arg0123456789876543210 arg0123456789876543210
+    instance SuppressUnusedWarnings (FoosPrecSym2 arg0123456789876543210 arg0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FoosPrecSym2KindInference) GHC.Tuple.())
-    data FoosPrecSym2 (l :: Nat) (l :: a0123456789876543210) (l :: TyFun [Bool] [Bool]) :: GHC.Types.Type
+    data FoosPrecSym2 (arg0123456789876543210 :: Nat) (arg0123456789876543210 :: a0123456789876543210) :: (~>) [Bool] [Bool]
       where
-        FoosPrecSym2KindInference :: forall l l l arg.
-                                     SameKind (Apply (FoosPrecSym2 l l) arg) (FoosPrecSym3 l l arg) =>
-                                     FoosPrecSym2 l l l
-    type instance Apply (FoosPrecSym2 l l) l = FoosPrec l l l
-    instance SuppressUnusedWarnings FoosPrecSym1 where
+        FoosPrecSym2KindInference :: forall arg0123456789876543210
+                                            arg0123456789876543210
+                                            arg0123456789876543210
+                                            arg.
+                                     SameKind (Apply (FoosPrecSym2 arg0123456789876543210 arg0123456789876543210) arg) (FoosPrecSym3 arg0123456789876543210 arg0123456789876543210 arg) =>
+                                     FoosPrecSym2 arg0123456789876543210 arg0123456789876543210 arg0123456789876543210
+    type instance Apply (FoosPrecSym2 arg0123456789876543210 arg0123456789876543210) arg0123456789876543210 = FoosPrec arg0123456789876543210 arg0123456789876543210 arg0123456789876543210
+    instance SuppressUnusedWarnings (FoosPrecSym1 arg0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FoosPrecSym1KindInference) GHC.Tuple.())
-    data FoosPrecSym1 (l :: Nat) (l :: TyFun a0123456789876543210 ((~>) [Bool] [Bool])) :: GHC.Types.Type
+    data FoosPrecSym1 (arg0123456789876543210 :: Nat) :: forall a0123456789876543210.
+                                                         (~>) a0123456789876543210 ((~>) [Bool] [Bool])
       where
-        FoosPrecSym1KindInference :: forall l l arg.
-                                     SameKind (Apply (FoosPrecSym1 l) arg) (FoosPrecSym2 l arg) =>
-                                     FoosPrecSym1 l l
-    type instance Apply (FoosPrecSym1 l) l = FoosPrecSym2 l l
+        FoosPrecSym1KindInference :: forall arg0123456789876543210
+                                            arg0123456789876543210
+                                            arg.
+                                     SameKind (Apply (FoosPrecSym1 arg0123456789876543210) arg) (FoosPrecSym2 arg0123456789876543210 arg) =>
+                                     FoosPrecSym1 arg0123456789876543210 arg0123456789876543210
+    type instance Apply (FoosPrecSym1 arg0123456789876543210) arg0123456789876543210 = FoosPrecSym2 arg0123456789876543210 arg0123456789876543210
     instance SuppressUnusedWarnings FoosPrecSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FoosPrecSym0KindInference) GHC.Tuple.())
-    data FoosPrecSym0 (l :: TyFun Nat ((~>) a0123456789876543210 ((~>) [Bool] [Bool]))) :: GHC.Types.Type
+    data FoosPrecSym0 :: forall a0123456789876543210.
+                         (~>) Nat ((~>) a0123456789876543210 ((~>) [Bool] [Bool]))
       where
-        FoosPrecSym0KindInference :: forall l arg.
+        FoosPrecSym0KindInference :: forall arg0123456789876543210 arg.
                                      SameKind (Apply FoosPrecSym0 arg) (FoosPrecSym1 arg) =>
-                                     FoosPrecSym0 l
-    type instance Apply FoosPrecSym0 l = FoosPrecSym1 l
-    type FooSym1 (t :: a0123456789876543210) = Foo t
+                                     FoosPrecSym0 arg0123456789876543210
+    type instance Apply FoosPrecSym0 arg0123456789876543210 = FoosPrecSym1 arg0123456789876543210
+    type FooSym1 (arg0123456789876543210 :: a0123456789876543210) =
+        Foo arg0123456789876543210
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym0KindInference) GHC.Tuple.())
-    data FooSym0 (l :: TyFun a0123456789876543210 [Bool]) :: GHC.Types.Type
+    data FooSym0 :: forall a0123456789876543210.
+                    (~>) a0123456789876543210 [Bool]
       where
-        FooSym0KindInference :: forall l arg.
-                                SameKind (Apply FooSym0 arg) (FooSym1 arg) => FooSym0 l
-    type instance Apply FooSym0 l = Foo l
+        FooSym0KindInference :: forall arg0123456789876543210 arg.
+                                SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
+                                FooSym0 arg0123456789876543210
+    type instance Apply FooSym0 arg0123456789876543210 = Foo arg0123456789876543210
     type family Lambda_0123456789876543210 x t where
       Lambda_0123456789876543210 x s = Apply (Apply (Apply FoosPrecSym0 (Data.Singletons.Prelude.Num.FromInteger 0)) x) s
-    type Lambda_0123456789876543210Sym2 t t =
-        Lambda_0123456789876543210 t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+    type Lambda_0123456789876543210Sym2 x0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 x0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 x0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall x0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) arg) (Lambda_0123456789876543210Sym2 x0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 x0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 x0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 x0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall x0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+                                                       Lambda_0123456789876543210Sym0 x0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 x0123456789876543210 = Lambda_0123456789876543210Sym1 x0123456789876543210
     type family Foo_0123456789876543210 (a :: a) :: [Bool] where
       Foo_0123456789876543210 x = Apply Lambda_0123456789876543210Sym0 x
-    type Foo_0123456789876543210Sym1 (t :: a0123456789876543210) =
-        Foo_0123456789876543210 t
+    type Foo_0123456789876543210Sym1 (a0123456789876543210 :: a0123456789876543210) =
+        Foo_0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Foo_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Foo_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Foo_0123456789876543210Sym0 (l :: TyFun a0123456789876543210 [Bool]) :: GHC.Types.Type
+    data Foo_0123456789876543210Sym0 :: forall a0123456789876543210.
+                                        (~>) a0123456789876543210 [Bool]
       where
-        Foo_0123456789876543210Sym0KindInference :: forall l arg.
+        Foo_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                           arg.
                                                     SameKind (Apply Foo_0123456789876543210Sym0 arg) (Foo_0123456789876543210Sym1 arg) =>
-                                                    Foo_0123456789876543210Sym0 l
-    type instance Apply Foo_0123456789876543210Sym0 l = Foo_0123456789876543210 l
+                                                    Foo_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Foo_0123456789876543210Sym0 a0123456789876543210 = Foo_0123456789876543210 a0123456789876543210
     class PFoo (a :: GHC.Types.Type) where
       type FoosPrec (arg :: Nat) (arg :: a) (arg :: [Bool]) :: [Bool]
       type Foo (arg :: a) :: [Bool]

--- a/tests/compile-and-dump/Singletons/T167.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T167.ghc84.template
@@ -8,122 +8,144 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
           instance Foo a => Foo [a] where
             foosPrec _ = fooList |]
   ======>
-    type FoosPrecSym3 (t :: Nat) (t :: a0123456789876543210) (t :: [Bool]) =
-        FoosPrec t t t
-    instance SuppressUnusedWarnings FoosPrecSym2 where
+    type FoosPrecSym3 (arg0123456789876543210 :: Nat) (arg0123456789876543210 :: a0123456789876543210) (arg0123456789876543210 :: [Bool]) =
+        FoosPrec arg0123456789876543210 arg0123456789876543210 arg0123456789876543210
+    instance SuppressUnusedWarnings (FoosPrecSym2 arg0123456789876543210 arg0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FoosPrecSym2KindInference) GHC.Tuple.())
-    data FoosPrecSym2 (l :: Nat) (l :: a0123456789876543210) (l :: TyFun [Bool] [Bool]) :: GHC.Types.Type
+    data FoosPrecSym2 (arg0123456789876543210 :: Nat) (arg0123456789876543210 :: a0123456789876543210) :: (~>) [Bool] [Bool]
       where
-        FoosPrecSym2KindInference :: forall l l l arg.
-                                     SameKind (Apply (FoosPrecSym2 l l) arg) (FoosPrecSym3 l l arg) =>
-                                     FoosPrecSym2 l l l
-    type instance Apply (FoosPrecSym2 l l) l = FoosPrec l l l
-    instance SuppressUnusedWarnings FoosPrecSym1 where
+        FoosPrecSym2KindInference :: forall arg0123456789876543210
+                                            arg0123456789876543210
+                                            arg0123456789876543210
+                                            arg.
+                                     SameKind (Apply (FoosPrecSym2 arg0123456789876543210 arg0123456789876543210) arg) (FoosPrecSym3 arg0123456789876543210 arg0123456789876543210 arg) =>
+                                     FoosPrecSym2 arg0123456789876543210 arg0123456789876543210 arg0123456789876543210
+    type instance Apply (FoosPrecSym2 arg0123456789876543210 arg0123456789876543210) arg0123456789876543210 = FoosPrec arg0123456789876543210 arg0123456789876543210 arg0123456789876543210
+    instance SuppressUnusedWarnings (FoosPrecSym1 arg0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FoosPrecSym1KindInference) GHC.Tuple.())
-    data FoosPrecSym1 (l :: Nat) (l :: TyFun a0123456789876543210 ((~>) [Bool] [Bool])) :: GHC.Types.Type
+    data FoosPrecSym1 (arg0123456789876543210 :: Nat) :: forall a0123456789876543210.
+                                                         (~>) a0123456789876543210 ((~>) [Bool] [Bool])
       where
-        FoosPrecSym1KindInference :: forall l l arg.
-                                     SameKind (Apply (FoosPrecSym1 l) arg) (FoosPrecSym2 l arg) =>
-                                     FoosPrecSym1 l l
-    type instance Apply (FoosPrecSym1 l) l = FoosPrecSym2 l l
+        FoosPrecSym1KindInference :: forall arg0123456789876543210
+                                            arg0123456789876543210
+                                            arg.
+                                     SameKind (Apply (FoosPrecSym1 arg0123456789876543210) arg) (FoosPrecSym2 arg0123456789876543210 arg) =>
+                                     FoosPrecSym1 arg0123456789876543210 arg0123456789876543210
+    type instance Apply (FoosPrecSym1 arg0123456789876543210) arg0123456789876543210 = FoosPrecSym2 arg0123456789876543210 arg0123456789876543210
     instance SuppressUnusedWarnings FoosPrecSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FoosPrecSym0KindInference) GHC.Tuple.())
-    data FoosPrecSym0 (l :: TyFun Nat ((~>) a0123456789876543210 ((~>) [Bool] [Bool]))) :: GHC.Types.Type
+    data FoosPrecSym0 :: forall a0123456789876543210.
+                         (~>) Nat ((~>) a0123456789876543210 ((~>) [Bool] [Bool]))
       where
-        FoosPrecSym0KindInference :: forall l arg.
+        FoosPrecSym0KindInference :: forall arg0123456789876543210 arg.
                                      SameKind (Apply FoosPrecSym0 arg) (FoosPrecSym1 arg) =>
-                                     FoosPrecSym0 l
-    type instance Apply FoosPrecSym0 l = FoosPrecSym1 l
-    type FooListSym2 (t :: a0123456789876543210) (t :: [Bool]) =
-        FooList t t
-    instance SuppressUnusedWarnings FooListSym1 where
+                                     FoosPrecSym0 arg0123456789876543210
+    type instance Apply FoosPrecSym0 arg0123456789876543210 = FoosPrecSym1 arg0123456789876543210
+    type FooListSym2 (arg0123456789876543210 :: a0123456789876543210) (arg0123456789876543210 :: [Bool]) =
+        FooList arg0123456789876543210 arg0123456789876543210
+    instance SuppressUnusedWarnings (FooListSym1 arg0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooListSym1KindInference) GHC.Tuple.())
-    data FooListSym1 (l :: a0123456789876543210) (l :: TyFun [Bool] [Bool]) :: GHC.Types.Type
+    data FooListSym1 (arg0123456789876543210 :: a0123456789876543210) :: (~>) [Bool] [Bool]
       where
-        FooListSym1KindInference :: forall l l arg.
-                                    SameKind (Apply (FooListSym1 l) arg) (FooListSym2 l arg) =>
-                                    FooListSym1 l l
-    type instance Apply (FooListSym1 l) l = FooList l l
+        FooListSym1KindInference :: forall arg0123456789876543210
+                                           arg0123456789876543210
+                                           arg.
+                                    SameKind (Apply (FooListSym1 arg0123456789876543210) arg) (FooListSym2 arg0123456789876543210 arg) =>
+                                    FooListSym1 arg0123456789876543210 arg0123456789876543210
+    type instance Apply (FooListSym1 arg0123456789876543210) arg0123456789876543210 = FooList arg0123456789876543210 arg0123456789876543210
     instance SuppressUnusedWarnings FooListSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooListSym0KindInference) GHC.Tuple.())
-    data FooListSym0 (l :: TyFun a0123456789876543210 ((~>) [Bool] [Bool])) :: GHC.Types.Type
+    data FooListSym0 :: forall a0123456789876543210.
+                        (~>) a0123456789876543210 ((~>) [Bool] [Bool])
       where
-        FooListSym0KindInference :: forall l arg.
+        FooListSym0KindInference :: forall arg0123456789876543210 arg.
                                     SameKind (Apply FooListSym0 arg) (FooListSym1 arg) =>
-                                    FooListSym0 l
-    type instance Apply FooListSym0 l = FooListSym1 l
+                                    FooListSym0 arg0123456789876543210
+    type instance Apply FooListSym0 arg0123456789876543210 = FooListSym1 arg0123456789876543210
     type family FooList_0123456789876543210 (a :: a) (a :: [Bool]) :: [Bool] where
       FooList_0123456789876543210 a_0123456789876543210 a_0123456789876543210 = Apply (Apply UndefinedSym0 a_0123456789876543210) a_0123456789876543210
-    type FooList_0123456789876543210Sym2 (t :: a0123456789876543210) (t :: [Bool]) =
-        FooList_0123456789876543210 t t
-    instance SuppressUnusedWarnings FooList_0123456789876543210Sym1 where
+    type FooList_0123456789876543210Sym2 (a0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: [Bool]) =
+        FooList_0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (FooList_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) FooList_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data FooList_0123456789876543210Sym1 (l :: a0123456789876543210) (l :: TyFun [Bool] [Bool]) :: GHC.Types.Type
+    data FooList_0123456789876543210Sym1 (a0123456789876543210 :: a0123456789876543210) :: (~>) [Bool] [Bool]
       where
-        FooList_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                        SameKind (Apply (FooList_0123456789876543210Sym1 l) arg) (FooList_0123456789876543210Sym2 l arg) =>
-                                                        FooList_0123456789876543210Sym1 l l
-    type instance Apply (FooList_0123456789876543210Sym1 l) l = FooList_0123456789876543210 l l
+        FooList_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                               a0123456789876543210
+                                                               arg.
+                                                        SameKind (Apply (FooList_0123456789876543210Sym1 a0123456789876543210) arg) (FooList_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                        FooList_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (FooList_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = FooList_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings FooList_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) FooList_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data FooList_0123456789876543210Sym0 (l :: TyFun a0123456789876543210 ((~>) [Bool] [Bool])) :: GHC.Types.Type
+    data FooList_0123456789876543210Sym0 :: forall a0123456789876543210.
+                                            (~>) a0123456789876543210 ((~>) [Bool] [Bool])
       where
-        FooList_0123456789876543210Sym0KindInference :: forall l arg.
+        FooList_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                               arg.
                                                         SameKind (Apply FooList_0123456789876543210Sym0 arg) (FooList_0123456789876543210Sym1 arg) =>
-                                                        FooList_0123456789876543210Sym0 l
-    type instance Apply FooList_0123456789876543210Sym0 l = FooList_0123456789876543210Sym1 l
+                                                        FooList_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply FooList_0123456789876543210Sym0 a0123456789876543210 = FooList_0123456789876543210Sym1 a0123456789876543210
     class PFoo (a :: GHC.Types.Type) where
       type FoosPrec (arg :: Nat) (arg :: a) (arg :: [Bool]) :: [Bool]
       type FooList (arg :: a) (arg :: [Bool]) :: [Bool]
       type FooList a a = Apply (Apply FooList_0123456789876543210Sym0 a) a
     type family FoosPrec_0123456789876543210 (a :: Nat) (a :: [a]) (a :: [Bool]) :: [Bool] where
       FoosPrec_0123456789876543210 _ a_0123456789876543210 a_0123456789876543210 = Apply (Apply FooListSym0 a_0123456789876543210) a_0123456789876543210
-    type FoosPrec_0123456789876543210Sym3 (t :: Nat) (t :: [a0123456789876543210]) (t :: [Bool]) =
-        FoosPrec_0123456789876543210 t t t
-    instance SuppressUnusedWarnings FoosPrec_0123456789876543210Sym2 where
+    type FoosPrec_0123456789876543210Sym3 (a0123456789876543210 :: Nat) (a0123456789876543210 :: [a0123456789876543210]) (a0123456789876543210 :: [Bool]) =
+        FoosPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (FoosPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) FoosPrec_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data FoosPrec_0123456789876543210Sym2 (l :: Nat) (l :: [a0123456789876543210]) (l :: TyFun [Bool] [Bool]) :: GHC.Types.Type
+    data FoosPrec_0123456789876543210Sym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: [a0123456789876543210]) :: (~>) [Bool] [Bool]
       where
-        FoosPrec_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                         SameKind (Apply (FoosPrec_0123456789876543210Sym2 l l) arg) (FoosPrec_0123456789876543210Sym3 l l arg) =>
-                                                         FoosPrec_0123456789876543210Sym2 l l l
-    type instance Apply (FoosPrec_0123456789876543210Sym2 l l) l = FoosPrec_0123456789876543210 l l l
-    instance SuppressUnusedWarnings FoosPrec_0123456789876543210Sym1 where
+        FoosPrec_0123456789876543210Sym2KindInference :: forall a0123456789876543210
+                                                                a0123456789876543210
+                                                                a0123456789876543210
+                                                                arg.
+                                                         SameKind (Apply (FoosPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (FoosPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
+                                                         FoosPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type instance Apply (FoosPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = FoosPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (FoosPrec_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) FoosPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data FoosPrec_0123456789876543210Sym1 (l :: Nat) (l :: TyFun [a0123456789876543210] ((~>) [Bool] [Bool])) :: GHC.Types.Type
+    data FoosPrec_0123456789876543210Sym1 (a0123456789876543210 :: Nat) :: forall a0123456789876543210.
+                                                                           (~>) [a0123456789876543210] ((~>) [Bool] [Bool])
       where
-        FoosPrec_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                         SameKind (Apply (FoosPrec_0123456789876543210Sym1 l) arg) (FoosPrec_0123456789876543210Sym2 l arg) =>
-                                                         FoosPrec_0123456789876543210Sym1 l l
-    type instance Apply (FoosPrec_0123456789876543210Sym1 l) l = FoosPrec_0123456789876543210Sym2 l l
+        FoosPrec_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                                a0123456789876543210
+                                                                arg.
+                                                         SameKind (Apply (FoosPrec_0123456789876543210Sym1 a0123456789876543210) arg) (FoosPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                         FoosPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (FoosPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = FoosPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings FoosPrec_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) FoosPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data FoosPrec_0123456789876543210Sym0 (l :: TyFun Nat ((~>) [a0123456789876543210] ((~>) [Bool] [Bool]))) :: GHC.Types.Type
+    data FoosPrec_0123456789876543210Sym0 :: forall a0123456789876543210.
+                                             (~>) Nat ((~>) [a0123456789876543210] ((~>) [Bool] [Bool]))
       where
-        FoosPrec_0123456789876543210Sym0KindInference :: forall l arg.
+        FoosPrec_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                arg.
                                                          SameKind (Apply FoosPrec_0123456789876543210Sym0 arg) (FoosPrec_0123456789876543210Sym1 arg) =>
-                                                         FoosPrec_0123456789876543210Sym0 l
-    type instance Apply FoosPrec_0123456789876543210Sym0 l = FoosPrec_0123456789876543210Sym1 l
+                                                         FoosPrec_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply FoosPrec_0123456789876543210Sym0 a0123456789876543210 = FoosPrec_0123456789876543210Sym1 a0123456789876543210
     instance PFoo [a] where
       type FoosPrec a a a = Apply (Apply (Apply FoosPrec_0123456789876543210Sym0 a) a) a
     class SFoo a where

--- a/tests/compile-and-dump/Singletons/T172.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T172.ghc84.template
@@ -3,24 +3,28 @@ Singletons/T172.hs:(0,0)-(0,0): Splicing declarations
       [d| ($>) :: Nat -> Nat -> Nat
           ($>) = (+) |]
   ======>
-    type ($>@#@$$$) (t :: Nat) (t :: Nat) = ($>) t t
-    instance SuppressUnusedWarnings ($>@#@$$) where
+    type ($>@#@$$$) (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) =
+        ($>) a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (($>@#@$$) a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:$>@#@$$###)) GHC.Tuple.())
-    data ($>@#@$$) (l :: Nat) (l :: TyFun Nat Nat) :: GHC.Types.Type
+    data ($>@#@$$) (a0123456789876543210 :: Nat) :: (~>) Nat Nat
       where
-        (:$>@#@$$###) :: forall l l arg.
-                         SameKind (Apply (($>@#@$$) l) arg) (($>@#@$$$) l arg) =>
-                         ($>@#@$$) l l
-    type instance Apply (($>@#@$$) l) l = ($>) l l
+        (:$>@#@$$###) :: forall a0123456789876543210
+                                a0123456789876543210
+                                arg.
+                         SameKind (Apply (($>@#@$$) a0123456789876543210) arg) (($>@#@$$$) a0123456789876543210 arg) =>
+                         ($>@#@$$) a0123456789876543210 a0123456789876543210
+    type instance Apply (($>@#@$$) a0123456789876543210) a0123456789876543210 = ($>) a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ($>@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:$>@#@$###)) GHC.Tuple.())
-    data ($>@#@$) (l :: TyFun Nat ((~>) Nat Nat)) :: GHC.Types.Type
+    data $>@#@$ :: (~>) Nat ((~>) Nat Nat)
       where
-        (:$>@#@$###) :: forall l arg.
-                        SameKind (Apply ($>@#@$) arg) (($>@#@$$) arg) => ($>@#@$) l
-    type instance Apply ($>@#@$) l = ($>@#@$$) l
+        (:$>@#@$###) :: forall a0123456789876543210 arg.
+                        SameKind (Apply ($>@#@$) arg) (($>@#@$$) arg) =>
+                        ($>@#@$) a0123456789876543210
+    type instance Apply ($>@#@$) a0123456789876543210 = ($>@#@$$) a0123456789876543210
     type family ($>) (a :: Nat) (a :: Nat) :: Nat where
       ($>) a_0123456789876543210 a_0123456789876543210 = Apply (Apply (+@#@$) a_0123456789876543210) a_0123456789876543210
     (%$>) ::

--- a/tests/compile-and-dump/Singletons/T176.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T176.ghc84.template
@@ -26,92 +26,113 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
       Case_0123456789876543210 x arg_0123456789876543210 _ = Baz1Sym0
     type family Lambda_0123456789876543210 x t where
       Lambda_0123456789876543210 x arg_0123456789876543210 = Case_0123456789876543210 x arg_0123456789876543210 arg_0123456789876543210
-    type Lambda_0123456789876543210Sym2 t t =
-        Lambda_0123456789876543210 t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+    type Lambda_0123456789876543210Sym2 x0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 x0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: Type
+    data Lambda_0123456789876543210Sym1 x0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall x0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) arg) (Lambda_0123456789876543210Sym2 x0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 x0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 x0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 x0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: Type
+    data Lambda_0123456789876543210Sym0 x0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall x0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
-    type Quux2Sym1 (t :: a0123456789876543210) = Quux2 t
+                                                       Lambda_0123456789876543210Sym0 x0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 x0123456789876543210 = Lambda_0123456789876543210Sym1 x0123456789876543210
+    type Quux2Sym1 (a0123456789876543210 :: a0123456789876543210) =
+        Quux2 a0123456789876543210
     instance SuppressUnusedWarnings Quux2Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Quux2Sym0KindInference) GHC.Tuple.())
-    data Quux2Sym0 (l :: TyFun a0123456789876543210 a0123456789876543210) :: Type
+    data Quux2Sym0 :: forall a0123456789876543210.
+                      (~>) a0123456789876543210 a0123456789876543210
       where
-        Quux2Sym0KindInference :: forall l arg.
-                                  SameKind (Apply Quux2Sym0 arg) (Quux2Sym1 arg) => Quux2Sym0 l
-    type instance Apply Quux2Sym0 l = Quux2 l
-    type Quux1Sym1 (t :: a0123456789876543210) = Quux1 t
+        Quux2Sym0KindInference :: forall a0123456789876543210 arg.
+                                  SameKind (Apply Quux2Sym0 arg) (Quux2Sym1 arg) =>
+                                  Quux2Sym0 a0123456789876543210
+    type instance Apply Quux2Sym0 a0123456789876543210 = Quux2 a0123456789876543210
+    type Quux1Sym1 (a0123456789876543210 :: a0123456789876543210) =
+        Quux1 a0123456789876543210
     instance SuppressUnusedWarnings Quux1Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Quux1Sym0KindInference) GHC.Tuple.())
-    data Quux1Sym0 (l :: TyFun a0123456789876543210 a0123456789876543210) :: Type
+    data Quux1Sym0 :: forall a0123456789876543210.
+                      (~>) a0123456789876543210 a0123456789876543210
       where
-        Quux1Sym0KindInference :: forall l arg.
-                                  SameKind (Apply Quux1Sym0 arg) (Quux1Sym1 arg) => Quux1Sym0 l
-    type instance Apply Quux1Sym0 l = Quux1 l
+        Quux1Sym0KindInference :: forall a0123456789876543210 arg.
+                                  SameKind (Apply Quux1Sym0 arg) (Quux1Sym1 arg) =>
+                                  Quux1Sym0 a0123456789876543210
+    type instance Apply Quux1Sym0 a0123456789876543210 = Quux1 a0123456789876543210
     type family Quux2 (a :: a) :: a where
       Quux2 x = Apply (Apply Bar2Sym0 x) Baz2Sym0
     type family Quux1 (a :: a) :: a where
       Quux1 x = Apply (Apply Bar1Sym0 x) (Apply Lambda_0123456789876543210Sym0 x)
-    type Bar1Sym2 (t :: a0123456789876543210) (t :: (~>) a0123456789876543210 b0123456789876543210) =
-        Bar1 t t
-    instance SuppressUnusedWarnings Bar1Sym1 where
+    type Bar1Sym2 (arg0123456789876543210 :: a0123456789876543210) (arg0123456789876543210 :: (~>) a0123456789876543210 b0123456789876543210) =
+        Bar1 arg0123456789876543210 arg0123456789876543210
+    instance SuppressUnusedWarnings (Bar1Sym1 arg0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Bar1Sym1KindInference) GHC.Tuple.())
-    data Bar1Sym1 (l :: a0123456789876543210) (l :: TyFun ((~>) a0123456789876543210 b0123456789876543210) b0123456789876543210) :: Type
+    data Bar1Sym1 (arg0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210.
+                                                                      (~>) ((~>) a0123456789876543210 b0123456789876543210) b0123456789876543210
       where
-        Bar1Sym1KindInference :: forall l l arg.
-                                 SameKind (Apply (Bar1Sym1 l) arg) (Bar1Sym2 l arg) => Bar1Sym1 l l
-    type instance Apply (Bar1Sym1 l) l = Bar1 l l
+        Bar1Sym1KindInference :: forall arg0123456789876543210
+                                        arg0123456789876543210
+                                        arg.
+                                 SameKind (Apply (Bar1Sym1 arg0123456789876543210) arg) (Bar1Sym2 arg0123456789876543210 arg) =>
+                                 Bar1Sym1 arg0123456789876543210 arg0123456789876543210
+    type instance Apply (Bar1Sym1 arg0123456789876543210) arg0123456789876543210 = Bar1 arg0123456789876543210 arg0123456789876543210
     instance SuppressUnusedWarnings Bar1Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Bar1Sym0KindInference) GHC.Tuple.())
-    data Bar1Sym0 (l :: TyFun a0123456789876543210 ((~>) ((~>) a0123456789876543210 b0123456789876543210) b0123456789876543210)) :: Type
+    data Bar1Sym0 :: forall a0123456789876543210 b0123456789876543210.
+                     (~>) a0123456789876543210 ((~>) ((~>) a0123456789876543210 b0123456789876543210) b0123456789876543210)
       where
-        Bar1Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Bar1Sym0 arg) (Bar1Sym1 arg) => Bar1Sym0 l
-    type instance Apply Bar1Sym0 l = Bar1Sym1 l
+        Bar1Sym0KindInference :: forall arg0123456789876543210 arg.
+                                 SameKind (Apply Bar1Sym0 arg) (Bar1Sym1 arg) =>
+                                 Bar1Sym0 arg0123456789876543210
+    type instance Apply Bar1Sym0 arg0123456789876543210 = Bar1Sym1 arg0123456789876543210
     type Baz1Sym0 = Baz1
     class PFoo1 (a :: Type) where
       type Bar1 (arg :: a) (arg :: (~>) a b) :: b
       type Baz1 :: a
-    type Bar2Sym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
-        Bar2 t t
-    instance SuppressUnusedWarnings Bar2Sym1 where
+    type Bar2Sym2 (arg0123456789876543210 :: a0123456789876543210) (arg0123456789876543210 :: b0123456789876543210) =
+        Bar2 arg0123456789876543210 arg0123456789876543210
+    instance SuppressUnusedWarnings (Bar2Sym1 arg0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Bar2Sym1KindInference) GHC.Tuple.())
-    data Bar2Sym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 b0123456789876543210) :: Type
+    data Bar2Sym1 (arg0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210.
+                                                                      (~>) b0123456789876543210 b0123456789876543210
       where
-        Bar2Sym1KindInference :: forall l l arg.
-                                 SameKind (Apply (Bar2Sym1 l) arg) (Bar2Sym2 l arg) => Bar2Sym1 l l
-    type instance Apply (Bar2Sym1 l) l = Bar2 l l
+        Bar2Sym1KindInference :: forall arg0123456789876543210
+                                        arg0123456789876543210
+                                        arg.
+                                 SameKind (Apply (Bar2Sym1 arg0123456789876543210) arg) (Bar2Sym2 arg0123456789876543210 arg) =>
+                                 Bar2Sym1 arg0123456789876543210 arg0123456789876543210
+    type instance Apply (Bar2Sym1 arg0123456789876543210) arg0123456789876543210 = Bar2 arg0123456789876543210 arg0123456789876543210
     instance SuppressUnusedWarnings Bar2Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Bar2Sym0KindInference) GHC.Tuple.())
-    data Bar2Sym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)) :: Type
+    data Bar2Sym0 :: forall a0123456789876543210 b0123456789876543210.
+                     (~>) a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)
       where
-        Bar2Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Bar2Sym0 arg) (Bar2Sym1 arg) => Bar2Sym0 l
-    type instance Apply Bar2Sym0 l = Bar2Sym1 l
+        Bar2Sym0KindInference :: forall arg0123456789876543210 arg.
+                                 SameKind (Apply Bar2Sym0 arg) (Bar2Sym1 arg) =>
+                                 Bar2Sym0 arg0123456789876543210
+    type instance Apply Bar2Sym0 arg0123456789876543210 = Bar2Sym1 arg0123456789876543210
     type Baz2Sym0 = Baz2
     class PFoo2 (a :: Type) where
       type Bar2 (arg :: a) (arg :: b) :: b

--- a/tests/compile-and-dump/Singletons/T178.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T178.ghc84.template
@@ -31,71 +31,80 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
       Compare_0123456789876543210 Opt Many = LTSym0
       Compare_0123456789876543210 Many Str = GTSym0
       Compare_0123456789876543210 Many Opt = GTSym0
-    type Compare_0123456789876543210Sym2 (t :: Occ) (t :: Occ) =
-        Compare_0123456789876543210 t t
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym1 where
+    type Compare_0123456789876543210Sym2 (a0123456789876543210 :: Occ) (a0123456789876543210 :: Occ) =
+        Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym1 (l :: Occ) (l :: TyFun Occ Ordering) :: GHC.Types.Type
+    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Occ) :: (~>) Occ Ordering
       where
-        Compare_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                        SameKind (Apply (Compare_0123456789876543210Sym1 l) arg) (Compare_0123456789876543210Sym2 l arg) =>
-                                                        Compare_0123456789876543210Sym1 l l
-    type instance Apply (Compare_0123456789876543210Sym1 l) l = Compare_0123456789876543210 l l
+        Compare_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                               a0123456789876543210
+                                                               arg.
+                                                        SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym0 (l :: TyFun Occ ((~>) Occ Ordering)) :: GHC.Types.Type
+    data Compare_0123456789876543210Sym0 :: (~>) Occ ((~>) Occ Ordering)
       where
-        Compare_0123456789876543210Sym0KindInference :: forall l arg.
+        Compare_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                               arg.
                                                         SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 l
-    type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
+                                                        Compare_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
     instance POrd Occ where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type family ShowsPrec_0123456789876543210 (a :: Nat) (a :: Occ) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 _ Str a_0123456789876543210 = Apply (Apply ShowStringSym0 "Str") a_0123456789876543210
       ShowsPrec_0123456789876543210 _ Opt a_0123456789876543210 = Apply (Apply ShowStringSym0 "Opt") a_0123456789876543210
       ShowsPrec_0123456789876543210 _ Many a_0123456789876543210 = Apply (Apply ShowStringSym0 "Many") a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym3 (t :: Nat) (t :: Occ) (t :: Symbol) =
-        ShowsPrec_0123456789876543210 t t t
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+    type ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Occ) (a0123456789876543210 :: Symbol) =
+        ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym2 (l :: Nat) (l :: Occ) (l :: TyFun Symbol Symbol) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Occ) :: (~>) Symbol Symbol
       where
-        ShowsPrec_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 l l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+        ShowsPrec_0123456789876543210Sym2KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: Nat) (l :: TyFun Occ ((~>) Symbol Symbol)) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: Nat) :: (~>) Occ ((~>) Symbol Symbol)
       where
-        ShowsPrec_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+        ShowsPrec_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun Nat ((~>) Occ ((~>) Symbol Symbol))) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) Nat ((~>) Occ ((~>) Symbol Symbol))
       where
-        ShowsPrec_0123456789876543210Sym0KindInference :: forall l arg.
+        ShowsPrec_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                 arg.
                                                           SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 l
-    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
     instance PShow Occ where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type family Equals_0123456789876543210 (a :: Occ) (b :: Occ) :: Bool where

--- a/tests/compile-and-dump/Singletons/T183.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T183.ghc84.template
@@ -57,72 +57,83 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
           g :: a -> b -> a
           g y _ = y
         in (g x) GHC.Tuple.()
-    type Let0123456789876543210GSym3 t (t :: a) (t :: b0123456789876543210) =
-        Let0123456789876543210G t t t
-    instance SuppressUnusedWarnings Let0123456789876543210GSym2 where
+    type Let0123456789876543210GSym3 x0123456789876543210 (a0123456789876543210 :: a) (a0123456789876543210 :: b0123456789876543210) =
+        Let0123456789876543210G x0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Let0123456789876543210GSym2 a0123456789876543210 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210GSym2KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210GSym2 l (l :: a) (l :: TyFun b0123456789876543210 a) :: GHC.Types.Type
+    data Let0123456789876543210GSym2 x0123456789876543210 (a0123456789876543210 :: a) :: forall b0123456789876543210.
+                                                                                         (~>) b0123456789876543210 a
       where
-        Let0123456789876543210GSym2KindInference :: forall l l l arg.
-                                                    SameKind (Apply (Let0123456789876543210GSym2 l l) arg) (Let0123456789876543210GSym3 l l arg) =>
-                                                    Let0123456789876543210GSym2 l l l
-    type instance Apply (Let0123456789876543210GSym2 l l) l = Let0123456789876543210G l l l
-    instance SuppressUnusedWarnings Let0123456789876543210GSym1 where
+        Let0123456789876543210GSym2KindInference :: forall x0123456789876543210
+                                                           a0123456789876543210
+                                                           a0123456789876543210
+                                                           arg.
+                                                    SameKind (Apply (Let0123456789876543210GSym2 x0123456789876543210 a0123456789876543210) arg) (Let0123456789876543210GSym3 x0123456789876543210 a0123456789876543210 arg) =>
+                                                    Let0123456789876543210GSym2 x0123456789876543210 a0123456789876543210 a0123456789876543210
+    type instance Apply (Let0123456789876543210GSym2 a0123456789876543210 x0123456789876543210) a0123456789876543210 = Let0123456789876543210G a0123456789876543210 x0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Let0123456789876543210GSym1 x0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210GSym1KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210GSym1 l (l :: TyFun a ((~>) b0123456789876543210 a)) :: GHC.Types.Type
+    data Let0123456789876543210GSym1 x0123456789876543210 :: forall b0123456789876543210
+                                                                    a.
+                                                             (~>) a ((~>) b0123456789876543210 a)
       where
-        Let0123456789876543210GSym1KindInference :: forall l l arg.
-                                                    SameKind (Apply (Let0123456789876543210GSym1 l) arg) (Let0123456789876543210GSym2 l arg) =>
-                                                    Let0123456789876543210GSym1 l l
-    type instance Apply (Let0123456789876543210GSym1 l) l = Let0123456789876543210GSym2 l l
+        Let0123456789876543210GSym1KindInference :: forall x0123456789876543210
+                                                           a0123456789876543210
+                                                           arg.
+                                                    SameKind (Apply (Let0123456789876543210GSym1 x0123456789876543210) arg) (Let0123456789876543210GSym2 x0123456789876543210 arg) =>
+                                                    Let0123456789876543210GSym1 x0123456789876543210 a0123456789876543210
+    type instance Apply (Let0123456789876543210GSym1 x0123456789876543210) a0123456789876543210 = Let0123456789876543210GSym2 x0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210GSym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210GSym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210GSym0 l :: GHC.Types.Type
+    data Let0123456789876543210GSym0 x0123456789876543210
       where
-        Let0123456789876543210GSym0KindInference :: forall l arg.
+        Let0123456789876543210GSym0KindInference :: forall x0123456789876543210
+                                                           arg.
                                                     SameKind (Apply Let0123456789876543210GSym0 arg) (Let0123456789876543210GSym1 arg) =>
-                                                    Let0123456789876543210GSym0 l
-    type instance Apply Let0123456789876543210GSym0 l = Let0123456789876543210GSym1 l
+                                                    Let0123456789876543210GSym0 x0123456789876543210
+    type instance Apply Let0123456789876543210GSym0 x0123456789876543210 = Let0123456789876543210GSym1 x0123456789876543210
     type family Let0123456789876543210G x (a :: a) (a :: b) :: a where
       Let0123456789876543210G x y _ = y
-    type Let0123456789876543210XSym1 t = Let0123456789876543210X t
+    type Let0123456789876543210XSym1 wild_01234567898765432100123456789876543210 =
+        Let0123456789876543210X wild_01234567898765432100123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210XSym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Let0123456789876543210XSym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210XSym0 l :: GHC.Types.Type
+    data Let0123456789876543210XSym0 wild_01234567898765432100123456789876543210
       where
-        Let0123456789876543210XSym0KindInference :: forall l arg.
+        Let0123456789876543210XSym0KindInference :: forall wild_01234567898765432100123456789876543210
+                                                           arg.
                                                     SameKind (Apply Let0123456789876543210XSym0 arg) (Let0123456789876543210XSym1 arg) =>
-                                                    Let0123456789876543210XSym0 l
-    type instance Apply Let0123456789876543210XSym0 l = Let0123456789876543210X l
+                                                    Let0123456789876543210XSym0 wild_01234567898765432100123456789876543210
+    type instance Apply Let0123456789876543210XSym0 wild_01234567898765432100123456789876543210 = Let0123456789876543210X wild_01234567898765432100123456789876543210
     type family Let0123456789876543210X wild_0123456789876543210 where
       Let0123456789876543210X wild_0123456789876543210 = (Apply JustSym0 (wild_0123456789876543210 :: a) :: Maybe a)
-    type Let0123456789876543210Scrutinee_0123456789876543210Sym1 t =
-        Let0123456789876543210Scrutinee_0123456789876543210 t
+    type Let0123456789876543210Scrutinee_0123456789876543210Sym1 x0123456789876543210 =
+        Let0123456789876543210Scrutinee_0123456789876543210 x0123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210Scrutinee_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Let0123456789876543210Scrutinee_0123456789876543210Sym0 x0123456789876543210
       where
-        Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference :: forall l
+        Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference :: forall x0123456789876543210
                                                                                        arg.
                                                                                 SameKind (Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 arg) (Let0123456789876543210Scrutinee_0123456789876543210Sym1 arg) =>
-                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym0 l
-    type instance Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 l = Let0123456789876543210Scrutinee_0123456789876543210 l
+                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym0 x0123456789876543210
+    type instance Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 x0123456789876543210 = Let0123456789876543210Scrutinee_0123456789876543210 x0123456789876543210
     type family Let0123456789876543210Scrutinee_0123456789876543210 x where
       Let0123456789876543210Scrutinee_0123456789876543210 x = (x :: Maybe a)
     type family Case_0123456789876543210 x t where
@@ -131,178 +142,214 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
       Case_0123456789876543210 arg_0123456789876543210 a_0123456789876543210 (GHC.Tuple.(,) (x :: a) (y :: b)) = Apply (Apply Tuple2Sym0 (y :: b)) (x :: a)
     type family Lambda_0123456789876543210 a_0123456789876543210 t where
       Lambda_0123456789876543210 a_0123456789876543210 arg_0123456789876543210 = Case_0123456789876543210 arg_0123456789876543210 a_0123456789876543210 arg_0123456789876543210
-    type Lambda_0123456789876543210Sym2 t t =
-        Lambda_0123456789876543210 t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+    type Lambda_0123456789876543210Sym2 a_01234567898765432100123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 a_01234567898765432100123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 a_01234567898765432100123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall a_01234567898765432100123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 a_01234567898765432100123456789876543210) arg) (Lambda_0123456789876543210Sym2 a_01234567898765432100123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 a_01234567898765432100123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 a_01234567898765432100123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 a_01234567898765432100123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 a_01234567898765432100123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall a_01234567898765432100123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
-    type Let0123456789876543210Scrutinee_0123456789876543210Sym1 t =
-        Let0123456789876543210Scrutinee_0123456789876543210 t
+                                                       Lambda_0123456789876543210Sym0 a_01234567898765432100123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 a_01234567898765432100123456789876543210 = Lambda_0123456789876543210Sym1 a_01234567898765432100123456789876543210
+    type Let0123456789876543210Scrutinee_0123456789876543210Sym1 x0123456789876543210 =
+        Let0123456789876543210Scrutinee_0123456789876543210 x0123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210Scrutinee_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Let0123456789876543210Scrutinee_0123456789876543210Sym0 x0123456789876543210
       where
-        Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference :: forall l
+        Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference :: forall x0123456789876543210
                                                                                        arg.
                                                                                 SameKind (Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 arg) (Let0123456789876543210Scrutinee_0123456789876543210Sym1 arg) =>
-                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym0 l
-    type instance Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 l = Let0123456789876543210Scrutinee_0123456789876543210 l
+                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym0 x0123456789876543210
+    type instance Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 x0123456789876543210 = Let0123456789876543210Scrutinee_0123456789876543210 x0123456789876543210
     type family Let0123456789876543210Scrutinee_0123456789876543210 x where
       Let0123456789876543210Scrutinee_0123456789876543210 x = Apply JustSym0 x
     type family Case_0123456789876543210 x t where
       Case_0123456789876543210 x (Just y :: Maybe Bool) = (y :: Bool)
-    type Foo9Sym1 (t :: a0123456789876543210) = Foo9 t
+    type Foo9Sym1 (a0123456789876543210 :: a0123456789876543210) =
+        Foo9 a0123456789876543210
     instance SuppressUnusedWarnings Foo9Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo9Sym0KindInference) GHC.Tuple.())
-    data Foo9Sym0 (l :: TyFun a0123456789876543210 a0123456789876543210) :: GHC.Types.Type
+    data Foo9Sym0 :: forall a0123456789876543210.
+                     (~>) a0123456789876543210 a0123456789876543210
       where
-        Foo9Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo9Sym0 arg) (Foo9Sym1 arg) => Foo9Sym0 l
-    type instance Apply Foo9Sym0 l = Foo9 l
-    type Foo8Sym1 (t :: Maybe a0123456789876543210) = Foo8 t
+        Foo9Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo9Sym0 arg) (Foo9Sym1 arg) =>
+                                 Foo9Sym0 a0123456789876543210
+    type instance Apply Foo9Sym0 a0123456789876543210 = Foo9 a0123456789876543210
+    type Foo8Sym1 (a0123456789876543210 :: Maybe a0123456789876543210) =
+        Foo8 a0123456789876543210
     instance SuppressUnusedWarnings Foo8Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo8Sym0KindInference) GHC.Tuple.())
-    data Foo8Sym0 (l :: TyFun (Maybe a0123456789876543210) (Maybe a0123456789876543210)) :: GHC.Types.Type
+    data Foo8Sym0 :: forall a0123456789876543210.
+                     (~>) (Maybe a0123456789876543210) (Maybe a0123456789876543210)
       where
-        Foo8Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo8Sym0 arg) (Foo8Sym1 arg) => Foo8Sym0 l
-    type instance Apply Foo8Sym0 l = Foo8 l
-    type Foo7Sym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
-        Foo7 t t
-    instance SuppressUnusedWarnings Foo7Sym1 where
+        Foo8Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo8Sym0 arg) (Foo8Sym1 arg) =>
+                                 Foo8Sym0 a0123456789876543210
+    type instance Apply Foo8Sym0 a0123456789876543210 = Foo8 a0123456789876543210
+    type Foo7Sym2 (a0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: b0123456789876543210) =
+        Foo7 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Foo7Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo7Sym1KindInference) GHC.Tuple.())
-    data Foo7Sym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 a0123456789876543210) :: GHC.Types.Type
+    data Foo7Sym1 (a0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210.
+                                                                    (~>) b0123456789876543210 a0123456789876543210
       where
-        Foo7Sym1KindInference :: forall l l arg.
-                                 SameKind (Apply (Foo7Sym1 l) arg) (Foo7Sym2 l arg) => Foo7Sym1 l l
-    type instance Apply (Foo7Sym1 l) l = Foo7 l l
+        Foo7Sym1KindInference :: forall a0123456789876543210
+                                        a0123456789876543210
+                                        arg.
+                                 SameKind (Apply (Foo7Sym1 a0123456789876543210) arg) (Foo7Sym2 a0123456789876543210 arg) =>
+                                 Foo7Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Foo7Sym1 a0123456789876543210) a0123456789876543210 = Foo7 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Foo7Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo7Sym0KindInference) GHC.Tuple.())
-    data Foo7Sym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 a0123456789876543210)) :: GHC.Types.Type
+    data Foo7Sym0 :: forall a0123456789876543210 b0123456789876543210.
+                     (~>) a0123456789876543210 ((~>) b0123456789876543210 a0123456789876543210)
       where
-        Foo7Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo7Sym0 arg) (Foo7Sym1 arg) => Foo7Sym0 l
-    type instance Apply Foo7Sym0 l = Foo7Sym1 l
-    type Foo6Sym1 (t :: Maybe (Maybe a0123456789876543210)) = Foo6 t
+        Foo7Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo7Sym0 arg) (Foo7Sym1 arg) =>
+                                 Foo7Sym0 a0123456789876543210
+    type instance Apply Foo7Sym0 a0123456789876543210 = Foo7Sym1 a0123456789876543210
+    type Foo6Sym1 (a0123456789876543210 :: Maybe (Maybe a0123456789876543210)) =
+        Foo6 a0123456789876543210
     instance SuppressUnusedWarnings Foo6Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo6Sym0KindInference) GHC.Tuple.())
-    data Foo6Sym0 (l :: TyFun (Maybe (Maybe a0123456789876543210)) (Maybe (Maybe a0123456789876543210))) :: GHC.Types.Type
+    data Foo6Sym0 :: forall a0123456789876543210.
+                     (~>) (Maybe (Maybe a0123456789876543210)) (Maybe (Maybe a0123456789876543210))
       where
-        Foo6Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo6Sym0 arg) (Foo6Sym1 arg) => Foo6Sym0 l
-    type instance Apply Foo6Sym0 l = Foo6 l
-    type Foo5Sym1 (t :: Maybe (Maybe a0123456789876543210)) = Foo5 t
+        Foo6Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo6Sym0 arg) (Foo6Sym1 arg) =>
+                                 Foo6Sym0 a0123456789876543210
+    type instance Apply Foo6Sym0 a0123456789876543210 = Foo6 a0123456789876543210
+    type Foo5Sym1 (a0123456789876543210 :: Maybe (Maybe a0123456789876543210)) =
+        Foo5 a0123456789876543210
     instance SuppressUnusedWarnings Foo5Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo5Sym0KindInference) GHC.Tuple.())
-    data Foo5Sym0 (l :: TyFun (Maybe (Maybe a0123456789876543210)) (Maybe (Maybe a0123456789876543210))) :: GHC.Types.Type
+    data Foo5Sym0 :: forall a0123456789876543210.
+                     (~>) (Maybe (Maybe a0123456789876543210)) (Maybe (Maybe a0123456789876543210))
       where
-        Foo5Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo5Sym0 arg) (Foo5Sym1 arg) => Foo5Sym0 l
-    type instance Apply Foo5Sym0 l = Foo5 l
-    type Foo4Sym1 (t :: (a0123456789876543210, b0123456789876543210)) =
-        Foo4 t
+        Foo5Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo5Sym0 arg) (Foo5Sym1 arg) =>
+                                 Foo5Sym0 a0123456789876543210
+    type instance Apply Foo5Sym0 a0123456789876543210 = Foo5 a0123456789876543210
+    type Foo4Sym1 (a0123456789876543210 :: (a0123456789876543210,
+                                            b0123456789876543210)) =
+        Foo4 a0123456789876543210
     instance SuppressUnusedWarnings Foo4Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo4Sym0KindInference) GHC.Tuple.())
-    data Foo4Sym0 (l :: TyFun (a0123456789876543210,
-                               b0123456789876543210) (b0123456789876543210,
-                                                      a0123456789876543210)) :: GHC.Types.Type
+    data Foo4Sym0 :: forall a0123456789876543210 b0123456789876543210.
+                     (~>) (a0123456789876543210,
+                           b0123456789876543210) (b0123456789876543210, a0123456789876543210)
       where
-        Foo4Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo4Sym0 arg) (Foo4Sym1 arg) => Foo4Sym0 l
-    type instance Apply Foo4Sym0 l = Foo4 l
-    type Foo3Sym1 (t :: Maybe a0123456789876543210) = Foo3 t
+        Foo4Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo4Sym0 arg) (Foo4Sym1 arg) =>
+                                 Foo4Sym0 a0123456789876543210
+    type instance Apply Foo4Sym0 a0123456789876543210 = Foo4 a0123456789876543210
+    type Foo3Sym1 (a0123456789876543210 :: Maybe a0123456789876543210) =
+        Foo3 a0123456789876543210
     instance SuppressUnusedWarnings Foo3Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo3Sym0KindInference) GHC.Tuple.())
-    data Foo3Sym0 (l :: TyFun (Maybe a0123456789876543210) a0123456789876543210) :: GHC.Types.Type
+    data Foo3Sym0 :: forall a0123456789876543210.
+                     (~>) (Maybe a0123456789876543210) a0123456789876543210
       where
-        Foo3Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) => Foo3Sym0 l
-    type instance Apply Foo3Sym0 l = Foo3 l
-    type Foo2Sym1 (t :: Maybe a0123456789876543210) = Foo2 t
+        Foo3Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
+                                 Foo3Sym0 a0123456789876543210
+    type instance Apply Foo3Sym0 a0123456789876543210 = Foo3 a0123456789876543210
+    type Foo2Sym1 (a0123456789876543210 :: Maybe a0123456789876543210) =
+        Foo2 a0123456789876543210
     instance SuppressUnusedWarnings Foo2Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo2Sym0KindInference) GHC.Tuple.())
-    data Foo2Sym0 (l :: TyFun (Maybe a0123456789876543210) a0123456789876543210) :: GHC.Types.Type
+    data Foo2Sym0 :: forall a0123456789876543210.
+                     (~>) (Maybe a0123456789876543210) a0123456789876543210
       where
-        Foo2Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) => Foo2Sym0 l
-    type instance Apply Foo2Sym0 l = Foo2 l
-    type Foo1Sym1 (t :: Maybe a0123456789876543210) = Foo1 t
+        Foo2Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) =>
+                                 Foo2Sym0 a0123456789876543210
+    type instance Apply Foo2Sym0 a0123456789876543210 = Foo2 a0123456789876543210
+    type Foo1Sym1 (a0123456789876543210 :: Maybe a0123456789876543210) =
+        Foo1 a0123456789876543210
     instance SuppressUnusedWarnings Foo1Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Foo1Sym0KindInference) GHC.Tuple.())
-    data Foo1Sym0 (l :: TyFun (Maybe a0123456789876543210) a0123456789876543210) :: GHC.Types.Type
+    data Foo1Sym0 :: forall a0123456789876543210.
+                     (~>) (Maybe a0123456789876543210) a0123456789876543210
       where
-        Foo1Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) => Foo1Sym0 l
-    type instance Apply Foo1Sym0 l = Foo1 l
-    type GSym1 t = G t
+        Foo1Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
+                                 Foo1Sym0 a0123456789876543210
+    type instance Apply Foo1Sym0 a0123456789876543210 = Foo1 a0123456789876543210
+    type GSym1 a0123456789876543210 = G a0123456789876543210
     instance SuppressUnusedWarnings GSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) GSym0KindInference) GHC.Tuple.())
-    data GSym0 l :: GHC.Types.Type
+    data GSym0 a0123456789876543210
       where
-        GSym0KindInference :: forall l arg.
-                              SameKind (Apply GSym0 arg) (GSym1 arg) => GSym0 l
-    type instance Apply GSym0 l = G l
-    type F3Sym1 t = F3 t
+        GSym0KindInference :: forall a0123456789876543210 arg.
+                              SameKind (Apply GSym0 arg) (GSym1 arg) =>
+                              GSym0 a0123456789876543210
+    type instance Apply GSym0 a0123456789876543210 = G a0123456789876543210
+    type F3Sym1 a0123456789876543210 = F3 a0123456789876543210
     instance SuppressUnusedWarnings F3Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) F3Sym0KindInference) GHC.Tuple.())
-    data F3Sym0 l :: GHC.Types.Type
+    data F3Sym0 a0123456789876543210
       where
-        F3Sym0KindInference :: forall l arg.
-                               SameKind (Apply F3Sym0 arg) (F3Sym1 arg) => F3Sym0 l
-    type instance Apply F3Sym0 l = F3 l
-    type F2Sym1 t = F2 t
+        F3Sym0KindInference :: forall a0123456789876543210 arg.
+                               SameKind (Apply F3Sym0 arg) (F3Sym1 arg) =>
+                               F3Sym0 a0123456789876543210
+    type instance Apply F3Sym0 a0123456789876543210 = F3 a0123456789876543210
+    type F2Sym1 a0123456789876543210 = F2 a0123456789876543210
     instance SuppressUnusedWarnings F2Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) F2Sym0KindInference) GHC.Tuple.())
-    data F2Sym0 l :: GHC.Types.Type
+    data F2Sym0 a0123456789876543210
       where
-        F2Sym0KindInference :: forall l arg.
-                               SameKind (Apply F2Sym0 arg) (F2Sym1 arg) => F2Sym0 l
-    type instance Apply F2Sym0 l = F2 l
-    type F1Sym1 t = F1 t
+        F2Sym0KindInference :: forall a0123456789876543210 arg.
+                               SameKind (Apply F2Sym0 arg) (F2Sym1 arg) =>
+                               F2Sym0 a0123456789876543210
+    type instance Apply F2Sym0 a0123456789876543210 = F2 a0123456789876543210
+    type F1Sym1 a0123456789876543210 = F1 a0123456789876543210
     instance SuppressUnusedWarnings F1Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) F1Sym0KindInference) GHC.Tuple.())
-    data F1Sym0 l :: GHC.Types.Type
+    data F1Sym0 a0123456789876543210
       where
-        F1Sym0KindInference :: forall l arg.
-                               SameKind (Apply F1Sym0 arg) (F1Sym1 arg) => F1Sym0 l
-    type instance Apply F1Sym0 l = F1 l
+        F1Sym0KindInference :: forall a0123456789876543210 arg.
+                               SameKind (Apply F1Sym0 arg) (F1Sym1 arg) =>
+                               F1Sym0 a0123456789876543210
+    type instance Apply F1Sym0 a0123456789876543210 = F1 a0123456789876543210
     type family Foo9 (a :: a) :: a where
       Foo9 (x :: a) = Apply (Apply (Let0123456789876543210GSym1 x) x) Tuple0Sym0
     type family Foo8 (a :: Maybe a) :: Maybe a where

--- a/tests/compile-and-dump/Singletons/T184.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T184.ghc84.template
@@ -27,383 +27,453 @@ Singletons/T184.hs:(0,0)-(0,0): Splicing declarations
     trues xs = [x | x <- xs, x]
     type family Lambda_0123456789876543210 xs t where
       Lambda_0123456789876543210 xs x = Apply (Apply (>>@#@$) (Apply GuardSym0 x)) (Apply ReturnSym0 x)
-    type Lambda_0123456789876543210Sym2 t t =
-        Lambda_0123456789876543210 t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+    type Lambda_0123456789876543210Sym2 xs0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 xs0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 xs0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 xs0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall xs0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 xs0123456789876543210) arg) (Lambda_0123456789876543210Sym2 xs0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 xs0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 xs0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 xs0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 xs0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall xs0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+                                                       Lambda_0123456789876543210Sym0 xs0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 xs0123456789876543210 = Lambda_0123456789876543210Sym1 xs0123456789876543210
     type family Lambda_0123456789876543210 xs ys x t where
       Lambda_0123456789876543210 xs ys x y = Apply ReturnSym0 (Apply (Apply Tuple2Sym0 x) y)
-    type Lambda_0123456789876543210Sym4 t t t t =
-        Lambda_0123456789876543210 t t t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym3 where
+    type Lambda_0123456789876543210Sym4 xs0123456789876543210 ys0123456789876543210 x0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 xs0123456789876543210 ys0123456789876543210 x0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym3 x0123456789876543210 ys0123456789876543210 xs0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym3KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym3 l l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym3 xs0123456789876543210 ys0123456789876543210 x0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym3KindInference :: forall l l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym3 l l l) arg) (Lambda_0123456789876543210Sym4 l l l arg) =>
-                                                       Lambda_0123456789876543210Sym3 l l l l
-    type instance Apply (Lambda_0123456789876543210Sym3 l l l) l = Lambda_0123456789876543210 l l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+        Lambda_0123456789876543210Sym3KindInference :: forall xs0123456789876543210
+                                                              ys0123456789876543210
+                                                              x0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym3 xs0123456789876543210 ys0123456789876543210 x0123456789876543210) arg) (Lambda_0123456789876543210Sym4 xs0123456789876543210 ys0123456789876543210 x0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym3 xs0123456789876543210 ys0123456789876543210 x0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym3 x0123456789876543210 ys0123456789876543210 xs0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 x0123456789876543210 ys0123456789876543210 xs0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym2 ys0123456789876543210 xs0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym2 xs0123456789876543210 ys0123456789876543210 x0123456789876543210
       where
-        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
-                                                       Lambda_0123456789876543210Sym2 l l l
-    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210Sym3 l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+        Lambda_0123456789876543210Sym2KindInference :: forall xs0123456789876543210
+                                                              ys0123456789876543210
+                                                              x0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 xs0123456789876543210 ys0123456789876543210) arg) (Lambda_0123456789876543210Sym3 xs0123456789876543210 ys0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym2 xs0123456789876543210 ys0123456789876543210 x0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym2 ys0123456789876543210 xs0123456789876543210) x0123456789876543210 = Lambda_0123456789876543210Sym3 ys0123456789876543210 xs0123456789876543210 x0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 xs0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 xs0123456789876543210 ys0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall xs0123456789876543210
+                                                              ys0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 xs0123456789876543210) arg) (Lambda_0123456789876543210Sym2 xs0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 xs0123456789876543210 ys0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 xs0123456789876543210) ys0123456789876543210 = Lambda_0123456789876543210Sym2 xs0123456789876543210 ys0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 xs0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall xs0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+                                                       Lambda_0123456789876543210Sym0 xs0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 xs0123456789876543210 = Lambda_0123456789876543210Sym1 xs0123456789876543210
     type family Lambda_0123456789876543210 xs ys t where
       Lambda_0123456789876543210 xs ys x = Apply (Apply (>>=@#@$) ys) (Apply (Apply (Apply Lambda_0123456789876543210Sym0 xs) ys) x)
-    type Lambda_0123456789876543210Sym3 t t t =
-        Lambda_0123456789876543210 t t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+    type Lambda_0123456789876543210Sym3 xs0123456789876543210 ys0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 xs0123456789876543210 ys0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym2 ys0123456789876543210 xs0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym2 xs0123456789876543210 ys0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
-                                                       Lambda_0123456789876543210Sym2 l l l
-    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+        Lambda_0123456789876543210Sym2KindInference :: forall xs0123456789876543210
+                                                              ys0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 xs0123456789876543210 ys0123456789876543210) arg) (Lambda_0123456789876543210Sym3 xs0123456789876543210 ys0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym2 xs0123456789876543210 ys0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym2 ys0123456789876543210 xs0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 ys0123456789876543210 xs0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 xs0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 xs0123456789876543210 ys0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall xs0123456789876543210
+                                                              ys0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 xs0123456789876543210) arg) (Lambda_0123456789876543210Sym2 xs0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 xs0123456789876543210 ys0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 xs0123456789876543210) ys0123456789876543210 = Lambda_0123456789876543210Sym2 xs0123456789876543210 ys0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 xs0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall xs0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+                                                       Lambda_0123456789876543210Sym0 xs0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 xs0123456789876543210 = Lambda_0123456789876543210Sym1 xs0123456789876543210
     type family Lambda_0123456789876543210 xs ys t where
       Lambda_0123456789876543210 xs ys x = Apply ReturnSym0 x
-    type Lambda_0123456789876543210Sym3 t t t =
-        Lambda_0123456789876543210 t t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+    type Lambda_0123456789876543210Sym3 xs0123456789876543210 ys0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 xs0123456789876543210 ys0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym2 ys0123456789876543210 xs0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym2 xs0123456789876543210 ys0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
-                                                       Lambda_0123456789876543210Sym2 l l l
-    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+        Lambda_0123456789876543210Sym2KindInference :: forall xs0123456789876543210
+                                                              ys0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 xs0123456789876543210 ys0123456789876543210) arg) (Lambda_0123456789876543210Sym3 xs0123456789876543210 ys0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym2 xs0123456789876543210 ys0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym2 ys0123456789876543210 xs0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 ys0123456789876543210 xs0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 xs0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 xs0123456789876543210 ys0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall xs0123456789876543210
+                                                              ys0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 xs0123456789876543210) arg) (Lambda_0123456789876543210Sym2 xs0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 xs0123456789876543210 ys0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 xs0123456789876543210) ys0123456789876543210 = Lambda_0123456789876543210Sym2 xs0123456789876543210 ys0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 xs0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall xs0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+                                                       Lambda_0123456789876543210Sym0 xs0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 xs0123456789876543210 = Lambda_0123456789876543210Sym1 xs0123456789876543210
     type family Lambda_0123456789876543210 xs ys t where
       Lambda_0123456789876543210 xs ys y = Apply ReturnSym0 y
-    type Lambda_0123456789876543210Sym3 t t t =
-        Lambda_0123456789876543210 t t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+    type Lambda_0123456789876543210Sym3 xs0123456789876543210 ys0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 xs0123456789876543210 ys0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym2 ys0123456789876543210 xs0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym2 xs0123456789876543210 ys0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
-                                                       Lambda_0123456789876543210Sym2 l l l
-    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+        Lambda_0123456789876543210Sym2KindInference :: forall xs0123456789876543210
+                                                              ys0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 xs0123456789876543210 ys0123456789876543210) arg) (Lambda_0123456789876543210Sym3 xs0123456789876543210 ys0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym2 xs0123456789876543210 ys0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym2 ys0123456789876543210 xs0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 ys0123456789876543210 xs0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 xs0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 xs0123456789876543210 ys0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall xs0123456789876543210
+                                                              ys0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 xs0123456789876543210) arg) (Lambda_0123456789876543210Sym2 xs0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 xs0123456789876543210 ys0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 xs0123456789876543210) ys0123456789876543210 = Lambda_0123456789876543210Sym2 xs0123456789876543210 ys0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 xs0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall xs0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+                                                       Lambda_0123456789876543210Sym0 xs0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 xs0123456789876543210 = Lambda_0123456789876543210Sym1 xs0123456789876543210
     type family Case_0123456789876543210 xs ys arg_0123456789876543210 t where
       Case_0123456789876543210 xs ys arg_0123456789876543210 (GHC.Tuple.(,) x y) = Apply ReturnSym0 (Apply (Apply Tuple2Sym0 x) y)
     type family Lambda_0123456789876543210 xs ys t where
       Lambda_0123456789876543210 xs ys arg_0123456789876543210 = Case_0123456789876543210 xs ys arg_0123456789876543210 arg_0123456789876543210
-    type Lambda_0123456789876543210Sym3 t t t =
-        Lambda_0123456789876543210 t t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+    type Lambda_0123456789876543210Sym3 xs0123456789876543210 ys0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 xs0123456789876543210 ys0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym2 ys0123456789876543210 xs0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym2 xs0123456789876543210 ys0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
-                                                       Lambda_0123456789876543210Sym2 l l l
-    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+        Lambda_0123456789876543210Sym2KindInference :: forall xs0123456789876543210
+                                                              ys0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 xs0123456789876543210 ys0123456789876543210) arg) (Lambda_0123456789876543210Sym3 xs0123456789876543210 ys0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym2 xs0123456789876543210 ys0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym2 ys0123456789876543210 xs0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 ys0123456789876543210 xs0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 xs0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 xs0123456789876543210 ys0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall xs0123456789876543210
+                                                              ys0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 xs0123456789876543210) arg) (Lambda_0123456789876543210Sym2 xs0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 xs0123456789876543210 ys0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 xs0123456789876543210) ys0123456789876543210 = Lambda_0123456789876543210Sym2 xs0123456789876543210 ys0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 xs0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall xs0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+                                                       Lambda_0123456789876543210Sym0 xs0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 xs0123456789876543210 = Lambda_0123456789876543210Sym1 xs0123456789876543210
     type family Lambda_0123456789876543210 ma mb a t where
       Lambda_0123456789876543210 ma mb a b = Apply (Apply (>>@#@$) (Apply GuardSym0 b)) (Apply ReturnSym0 a)
-    type Lambda_0123456789876543210Sym4 t t t t =
-        Lambda_0123456789876543210 t t t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym3 where
+    type Lambda_0123456789876543210Sym4 ma0123456789876543210 mb0123456789876543210 a0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 ma0123456789876543210 mb0123456789876543210 a0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym3 a0123456789876543210 mb0123456789876543210 ma0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym3KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym3 l l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym3 ma0123456789876543210 mb0123456789876543210 a0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym3KindInference :: forall l l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym3 l l l) arg) (Lambda_0123456789876543210Sym4 l l l arg) =>
-                                                       Lambda_0123456789876543210Sym3 l l l l
-    type instance Apply (Lambda_0123456789876543210Sym3 l l l) l = Lambda_0123456789876543210 l l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+        Lambda_0123456789876543210Sym3KindInference :: forall ma0123456789876543210
+                                                              mb0123456789876543210
+                                                              a0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym3 ma0123456789876543210 mb0123456789876543210 a0123456789876543210) arg) (Lambda_0123456789876543210Sym4 ma0123456789876543210 mb0123456789876543210 a0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym3 ma0123456789876543210 mb0123456789876543210 a0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym3 a0123456789876543210 mb0123456789876543210 ma0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 a0123456789876543210 mb0123456789876543210 ma0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym2 mb0123456789876543210 ma0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym2 ma0123456789876543210 mb0123456789876543210 a0123456789876543210
       where
-        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
-                                                       Lambda_0123456789876543210Sym2 l l l
-    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210Sym3 l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+        Lambda_0123456789876543210Sym2KindInference :: forall ma0123456789876543210
+                                                              mb0123456789876543210
+                                                              a0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 ma0123456789876543210 mb0123456789876543210) arg) (Lambda_0123456789876543210Sym3 ma0123456789876543210 mb0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym2 ma0123456789876543210 mb0123456789876543210 a0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym2 mb0123456789876543210 ma0123456789876543210) a0123456789876543210 = Lambda_0123456789876543210Sym3 mb0123456789876543210 ma0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 ma0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 ma0123456789876543210 mb0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall ma0123456789876543210
+                                                              mb0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 ma0123456789876543210) arg) (Lambda_0123456789876543210Sym2 ma0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 ma0123456789876543210 mb0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 ma0123456789876543210) mb0123456789876543210 = Lambda_0123456789876543210Sym2 ma0123456789876543210 mb0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 ma0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall ma0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+                                                       Lambda_0123456789876543210Sym0 ma0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 ma0123456789876543210 = Lambda_0123456789876543210Sym1 ma0123456789876543210
     type family Lambda_0123456789876543210 ma mb t where
       Lambda_0123456789876543210 ma mb a = Apply (Apply (>>=@#@$) mb) (Apply (Apply (Apply Lambda_0123456789876543210Sym0 ma) mb) a)
-    type Lambda_0123456789876543210Sym3 t t t =
-        Lambda_0123456789876543210 t t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+    type Lambda_0123456789876543210Sym3 ma0123456789876543210 mb0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 ma0123456789876543210 mb0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym2 mb0123456789876543210 ma0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym2 ma0123456789876543210 mb0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
-                                                       Lambda_0123456789876543210Sym2 l l l
-    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+        Lambda_0123456789876543210Sym2KindInference :: forall ma0123456789876543210
+                                                              mb0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 ma0123456789876543210 mb0123456789876543210) arg) (Lambda_0123456789876543210Sym3 ma0123456789876543210 mb0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym2 ma0123456789876543210 mb0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym2 mb0123456789876543210 ma0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 mb0123456789876543210 ma0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 ma0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 ma0123456789876543210 mb0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall ma0123456789876543210
+                                                              mb0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 ma0123456789876543210) arg) (Lambda_0123456789876543210Sym2 ma0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 ma0123456789876543210 mb0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 ma0123456789876543210) mb0123456789876543210 = Lambda_0123456789876543210Sym2 ma0123456789876543210 mb0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 ma0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall ma0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
-    type TruesSym1 (t :: [Bool]) = Trues t
+                                                       Lambda_0123456789876543210Sym0 ma0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 ma0123456789876543210 = Lambda_0123456789876543210Sym1 ma0123456789876543210
+    type TruesSym1 (a0123456789876543210 :: [Bool]) =
+        Trues a0123456789876543210
     instance SuppressUnusedWarnings TruesSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) TruesSym0KindInference) GHC.Tuple.())
-    data TruesSym0 (l :: TyFun [Bool] [Bool]) :: GHC.Types.Type
+    data TruesSym0 :: (~>) [Bool] [Bool]
       where
-        TruesSym0KindInference :: forall l arg.
-                                  SameKind (Apply TruesSym0 arg) (TruesSym1 arg) => TruesSym0 l
-    type instance Apply TruesSym0 l = Trues l
-    type CartProdSym2 (t :: [a0123456789876543210]) (t :: [b0123456789876543210]) =
-        CartProd t t
-    instance SuppressUnusedWarnings CartProdSym1 where
+        TruesSym0KindInference :: forall a0123456789876543210 arg.
+                                  SameKind (Apply TruesSym0 arg) (TruesSym1 arg) =>
+                                  TruesSym0 a0123456789876543210
+    type instance Apply TruesSym0 a0123456789876543210 = Trues a0123456789876543210
+    type CartProdSym2 (a0123456789876543210 :: [a0123456789876543210]) (a0123456789876543210 :: [b0123456789876543210]) =
+        CartProd a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (CartProdSym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) CartProdSym1KindInference) GHC.Tuple.())
-    data CartProdSym1 (l :: [a0123456789876543210]) (l :: TyFun [b0123456789876543210] [(a0123456789876543210,
-                                                                                         b0123456789876543210)]) :: GHC.Types.Type
+    data CartProdSym1 (a0123456789876543210 :: [a0123456789876543210]) :: forall b0123456789876543210.
+                                                                          (~>) [b0123456789876543210] [(a0123456789876543210,
+                                                                                                        b0123456789876543210)]
       where
-        CartProdSym1KindInference :: forall l l arg.
-                                     SameKind (Apply (CartProdSym1 l) arg) (CartProdSym2 l arg) =>
-                                     CartProdSym1 l l
-    type instance Apply (CartProdSym1 l) l = CartProd l l
+        CartProdSym1KindInference :: forall a0123456789876543210
+                                            a0123456789876543210
+                                            arg.
+                                     SameKind (Apply (CartProdSym1 a0123456789876543210) arg) (CartProdSym2 a0123456789876543210 arg) =>
+                                     CartProdSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (CartProdSym1 a0123456789876543210) a0123456789876543210 = CartProd a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings CartProdSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) CartProdSym0KindInference) GHC.Tuple.())
-    data CartProdSym0 (l :: TyFun [a0123456789876543210] ((~>) [b0123456789876543210] [(a0123456789876543210,
-                                                                                        b0123456789876543210)])) :: GHC.Types.Type
+    data CartProdSym0 :: forall a0123456789876543210
+                                b0123456789876543210.
+                         (~>) [a0123456789876543210] ((~>) [b0123456789876543210] [(a0123456789876543210,
+                                                                                    b0123456789876543210)])
       where
-        CartProdSym0KindInference :: forall l arg.
+        CartProdSym0KindInference :: forall a0123456789876543210 arg.
                                      SameKind (Apply CartProdSym0 arg) (CartProdSym1 arg) =>
-                                     CartProdSym0 l
-    type instance Apply CartProdSym0 l = CartProdSym1 l
-    type Zip'Sym2 (t :: [a0123456789876543210]) (t :: [b0123456789876543210]) =
-        Zip' t t
-    instance SuppressUnusedWarnings Zip'Sym1 where
+                                     CartProdSym0 a0123456789876543210
+    type instance Apply CartProdSym0 a0123456789876543210 = CartProdSym1 a0123456789876543210
+    type Zip'Sym2 (a0123456789876543210 :: [a0123456789876543210]) (a0123456789876543210 :: [b0123456789876543210]) =
+        Zip' a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Zip'Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Zip'Sym1KindInference) GHC.Tuple.())
-    data Zip'Sym1 (l :: [a0123456789876543210]) (l :: TyFun [b0123456789876543210] [(a0123456789876543210,
-                                                                                     b0123456789876543210)]) :: GHC.Types.Type
+    data Zip'Sym1 (a0123456789876543210 :: [a0123456789876543210]) :: forall b0123456789876543210.
+                                                                      (~>) [b0123456789876543210] [(a0123456789876543210,
+                                                                                                    b0123456789876543210)]
       where
-        Zip'Sym1KindInference :: forall l l arg.
-                                 SameKind (Apply (Zip'Sym1 l) arg) (Zip'Sym2 l arg) => Zip'Sym1 l l
-    type instance Apply (Zip'Sym1 l) l = Zip' l l
+        Zip'Sym1KindInference :: forall a0123456789876543210
+                                        a0123456789876543210
+                                        arg.
+                                 SameKind (Apply (Zip'Sym1 a0123456789876543210) arg) (Zip'Sym2 a0123456789876543210 arg) =>
+                                 Zip'Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Zip'Sym1 a0123456789876543210) a0123456789876543210 = Zip' a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Zip'Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) Zip'Sym0KindInference) GHC.Tuple.())
-    data Zip'Sym0 (l :: TyFun [a0123456789876543210] ((~>) [b0123456789876543210] [(a0123456789876543210,
-                                                                                    b0123456789876543210)])) :: GHC.Types.Type
+    data Zip'Sym0 :: forall a0123456789876543210 b0123456789876543210.
+                     (~>) [a0123456789876543210] ((~>) [b0123456789876543210] [(a0123456789876543210,
+                                                                                b0123456789876543210)])
       where
-        Zip'Sym0KindInference :: forall l arg.
-                                 SameKind (Apply Zip'Sym0 arg) (Zip'Sym1 arg) => Zip'Sym0 l
-    type instance Apply Zip'Sym0 l = Zip'Sym1 l
-    type BoogieSym2 (t :: Maybe a0123456789876543210) (t :: Maybe Bool) =
-        Boogie t t
-    instance SuppressUnusedWarnings BoogieSym1 where
+        Zip'Sym0KindInference :: forall a0123456789876543210 arg.
+                                 SameKind (Apply Zip'Sym0 arg) (Zip'Sym1 arg) =>
+                                 Zip'Sym0 a0123456789876543210
+    type instance Apply Zip'Sym0 a0123456789876543210 = Zip'Sym1 a0123456789876543210
+    type BoogieSym2 (a0123456789876543210 :: Maybe a0123456789876543210) (a0123456789876543210 :: Maybe Bool) =
+        Boogie a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (BoogieSym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BoogieSym1KindInference) GHC.Tuple.())
-    data BoogieSym1 (l :: Maybe a0123456789876543210) (l :: TyFun (Maybe Bool) (Maybe a0123456789876543210)) :: GHC.Types.Type
+    data BoogieSym1 (a0123456789876543210 :: Maybe a0123456789876543210) :: (~>) (Maybe Bool) (Maybe a0123456789876543210)
       where
-        BoogieSym1KindInference :: forall l l arg.
-                                   SameKind (Apply (BoogieSym1 l) arg) (BoogieSym2 l arg) =>
-                                   BoogieSym1 l l
-    type instance Apply (BoogieSym1 l) l = Boogie l l
+        BoogieSym1KindInference :: forall a0123456789876543210
+                                          a0123456789876543210
+                                          arg.
+                                   SameKind (Apply (BoogieSym1 a0123456789876543210) arg) (BoogieSym2 a0123456789876543210 arg) =>
+                                   BoogieSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (BoogieSym1 a0123456789876543210) a0123456789876543210 = Boogie a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings BoogieSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BoogieSym0KindInference) GHC.Tuple.())
-    data BoogieSym0 (l :: TyFun (Maybe a0123456789876543210) ((~>) (Maybe Bool) (Maybe a0123456789876543210))) :: GHC.Types.Type
+    data BoogieSym0 :: forall a0123456789876543210.
+                       (~>) (Maybe a0123456789876543210) ((~>) (Maybe Bool) (Maybe a0123456789876543210))
       where
-        BoogieSym0KindInference :: forall l arg.
-                                   SameKind (Apply BoogieSym0 arg) (BoogieSym1 arg) => BoogieSym0 l
-    type instance Apply BoogieSym0 l = BoogieSym1 l
+        BoogieSym0KindInference :: forall a0123456789876543210 arg.
+                                   SameKind (Apply BoogieSym0 arg) (BoogieSym1 arg) =>
+                                   BoogieSym0 a0123456789876543210
+    type instance Apply BoogieSym0 a0123456789876543210 = BoogieSym1 a0123456789876543210
     type family Trues (a :: [Bool]) :: [Bool] where
       Trues xs = Apply (Apply (>>=@#@$) xs) (Apply Lambda_0123456789876543210Sym0 xs)
     type family CartProd (a :: [a]) (a :: [b]) :: [(a, b)] where

--- a/tests/compile-and-dump/Singletons/T187.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T187.ghc84.template
@@ -10,30 +10,33 @@ Singletons/T187.hs:(0,0)-(0,0): Splicing declarations
     deriving instance Ord Empty
     type family Compare_0123456789876543210 (a :: Empty) (a :: Empty) :: Ordering where
       Compare_0123456789876543210 _ _ = EQSym0
-    type Compare_0123456789876543210Sym2 (t :: Empty) (t :: Empty) =
-        Compare_0123456789876543210 t t
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym1 where
+    type Compare_0123456789876543210Sym2 (a0123456789876543210 :: Empty) (a0123456789876543210 :: Empty) =
+        Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym1 (l :: Empty) (l :: TyFun Empty Ordering) :: GHC.Types.Type
+    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Empty) :: (~>) Empty Ordering
       where
-        Compare_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                        SameKind (Apply (Compare_0123456789876543210Sym1 l) arg) (Compare_0123456789876543210Sym2 l arg) =>
-                                                        Compare_0123456789876543210Sym1 l l
-    type instance Apply (Compare_0123456789876543210Sym1 l) l = Compare_0123456789876543210 l l
+        Compare_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                               a0123456789876543210
+                                                               arg.
+                                                        SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym0 (l :: TyFun Empty ((~>) Empty Ordering)) :: GHC.Types.Type
+    data Compare_0123456789876543210Sym0 :: (~>) Empty ((~>) Empty Ordering)
       where
-        Compare_0123456789876543210Sym0KindInference :: forall l arg.
+        Compare_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                               arg.
                                                         SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 l
-    type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
+                                                        Compare_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
     instance POrd Empty where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type family Equals_0123456789876543210 (a :: Empty) (b :: Empty) :: Bool where

--- a/tests/compile-and-dump/Singletons/T190.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T190.ghc84.template
@@ -10,30 +10,33 @@ Singletons/T190.hs:0:0:: Splicing declarations
     type TSym0 = T
     type family Compare_0123456789876543210 (a :: T) (a :: T) :: Ordering where
       Compare_0123456789876543210 T T = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) '[]
-    type Compare_0123456789876543210Sym2 (t :: T) (t :: T) =
-        Compare_0123456789876543210 t t
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym1 where
+    type Compare_0123456789876543210Sym2 (a0123456789876543210 :: T) (a0123456789876543210 :: T) =
+        Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym1 (l :: T) (l :: TyFun T Ordering) :: GHC.Types.Type
+    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: T) :: (~>) T Ordering
       where
-        Compare_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                        SameKind (Apply (Compare_0123456789876543210Sym1 l) arg) (Compare_0123456789876543210Sym2 l arg) =>
-                                                        Compare_0123456789876543210Sym1 l l
-    type instance Apply (Compare_0123456789876543210Sym1 l) l = Compare_0123456789876543210 l l
+        Compare_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                               a0123456789876543210
+                                                               arg.
+                                                        SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym0 (l :: TyFun T ((~>) T Ordering)) :: GHC.Types.Type
+    data Compare_0123456789876543210Sym0 :: (~>) T ((~>) T Ordering)
       where
-        Compare_0123456789876543210Sym0KindInference :: forall l arg.
+        Compare_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                               arg.
                                                         SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 l
-    type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
+                                                        Compare_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
     instance POrd T where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type family Case_0123456789876543210 n t where
@@ -41,34 +44,36 @@ Singletons/T190.hs:0:0:: Splicing declarations
       Case_0123456789876543210 n False = Apply ErrorSym0 "toEnum: bad argument"
     type family ToEnum_0123456789876543210 (a :: GHC.Types.Nat) :: T where
       ToEnum_0123456789876543210 n = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (Data.Singletons.Prelude.Num.FromInteger 0))
-    type ToEnum_0123456789876543210Sym1 (t :: GHC.Types.Nat) =
-        ToEnum_0123456789876543210 t
+    type ToEnum_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) =
+        ToEnum_0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ToEnum_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ToEnum_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ToEnum_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat T) :: GHC.Types.Type
+    data ToEnum_0123456789876543210Sym0 :: (~>) GHC.Types.Nat T
       where
-        ToEnum_0123456789876543210Sym0KindInference :: forall l arg.
+        ToEnum_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                              arg.
                                                        SameKind (Apply ToEnum_0123456789876543210Sym0 arg) (ToEnum_0123456789876543210Sym1 arg) =>
-                                                       ToEnum_0123456789876543210Sym0 l
-    type instance Apply ToEnum_0123456789876543210Sym0 l = ToEnum_0123456789876543210 l
+                                                       ToEnum_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply ToEnum_0123456789876543210Sym0 a0123456789876543210 = ToEnum_0123456789876543210 a0123456789876543210
     type family FromEnum_0123456789876543210 (a :: T) :: GHC.Types.Nat where
       FromEnum_0123456789876543210 T = Data.Singletons.Prelude.Num.FromInteger 0
-    type FromEnum_0123456789876543210Sym1 (t :: T) =
-        FromEnum_0123456789876543210 t
+    type FromEnum_0123456789876543210Sym1 (a0123456789876543210 :: T) =
+        FromEnum_0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings FromEnum_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) FromEnum_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data FromEnum_0123456789876543210Sym0 (l :: TyFun T GHC.Types.Nat) :: GHC.Types.Type
+    data FromEnum_0123456789876543210Sym0 :: (~>) T GHC.Types.Nat
       where
-        FromEnum_0123456789876543210Sym0KindInference :: forall l arg.
+        FromEnum_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                arg.
                                                          SameKind (Apply FromEnum_0123456789876543210Sym0 arg) (FromEnum_0123456789876543210Sym1 arg) =>
-                                                         FromEnum_0123456789876543210Sym0 l
-    type instance Apply FromEnum_0123456789876543210Sym0 l = FromEnum_0123456789876543210 l
+                                                         FromEnum_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply FromEnum_0123456789876543210Sym0 a0123456789876543210 = FromEnum_0123456789876543210 a0123456789876543210
     instance PEnum T where
       type ToEnum a = Apply ToEnum_0123456789876543210Sym0 a
       type FromEnum a = Apply FromEnum_0123456789876543210Sym0 a
@@ -85,41 +90,47 @@ Singletons/T190.hs:0:0:: Splicing declarations
       type MaxBound = MaxBound_0123456789876543210Sym0
     type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: T) (a :: GHC.Types.Symbol) :: GHC.Types.Symbol where
       ShowsPrec_0123456789876543210 _ T a_0123456789876543210 = Apply (Apply ShowStringSym0 "T") a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym3 (t :: GHC.Types.Nat) (t :: T) (t :: GHC.Types.Symbol) =
-        ShowsPrec_0123456789876543210 t t t
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym2 where
+    type ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: T) (a0123456789876543210 :: GHC.Types.Symbol) =
+        ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym2 (l :: GHC.Types.Nat) (l :: T) (l :: TyFun GHC.Types.Symbol GHC.Types.Symbol) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: T) :: (~>) GHC.Types.Symbol GHC.Types.Symbol
       where
-        ShowsPrec_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 l l) arg) (ShowsPrec_0123456789876543210Sym3 l l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 l l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym2 l l) l = ShowsPrec_0123456789876543210 l l l
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym1 where
+        ShowsPrec_0123456789876543210Sym2KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym1 (l :: GHC.Types.Nat) (l :: TyFun T ((~>) GHC.Types.Symbol GHC.Types.Symbol)) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: (~>) T ((~>) GHC.Types.Symbol GHC.Types.Symbol)
       where
-        ShowsPrec_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 l) arg) (ShowsPrec_0123456789876543210Sym2 l arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 l l
-    type instance Apply (ShowsPrec_0123456789876543210Sym1 l) l = ShowsPrec_0123456789876543210Sym2 l l
+        ShowsPrec_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                                 a0123456789876543210
+                                                                 arg.
+                                                          SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ShowsPrec_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data ShowsPrec_0123456789876543210Sym0 (l :: TyFun GHC.Types.Nat ((~>) T ((~>) GHC.Types.Symbol GHC.Types.Symbol))) :: GHC.Types.Type
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) T ((~>) GHC.Types.Symbol GHC.Types.Symbol))
       where
-        ShowsPrec_0123456789876543210Sym0KindInference :: forall l arg.
+        ShowsPrec_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                 arg.
                                                           SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 l
-    type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
+                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
     instance PShow T where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type family Equals_0123456789876543210 (a :: T) (b :: T) :: Bool where

--- a/tests/compile-and-dump/Singletons/T197.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T197.ghc84.template
@@ -8,25 +8,29 @@ Singletons/T197.hs:(0,0)-(0,0): Splicing declarations
     infixl 5 $$:
     ($$:) :: Bool -> Bool -> Bool
     ($$:) _ _ = False
-    type ($$:@#@$$$) (t :: Bool) (t :: Bool) = ($$:) t t
-    instance SuppressUnusedWarnings ($$:@#@$$) where
+    type ($$:@#@$$$) (a0123456789876543210 :: Bool) (a0123456789876543210 :: Bool) =
+        ($$:) a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (($$:@#@$$) a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:$$:@#@$$###)) GHC.Tuple.())
-    data ($$:@#@$$) (l :: Bool) (l :: TyFun Bool Bool) :: GHC.Types.Type
+    data ($$:@#@$$) (a0123456789876543210 :: Bool) :: (~>) Bool Bool
       where
-        (:$$:@#@$$###) :: forall l l arg.
-                          SameKind (Apply (($$:@#@$$) l) arg) (($$:@#@$$$) l arg) =>
-                          ($$:@#@$$) l l
-    type instance Apply (($$:@#@$$) l) l = ($$:) l l
+        (:$$:@#@$$###) :: forall a0123456789876543210
+                                 a0123456789876543210
+                                 arg.
+                          SameKind (Apply (($$:@#@$$) a0123456789876543210) arg) (($$:@#@$$$) a0123456789876543210 arg) =>
+                          ($$:@#@$$) a0123456789876543210 a0123456789876543210
+    type instance Apply (($$:@#@$$) a0123456789876543210) a0123456789876543210 = ($$:) a0123456789876543210 a0123456789876543210
     infixl 5 $$:@#@$$
     instance SuppressUnusedWarnings ($$:@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:$$:@#@$###)) GHC.Tuple.())
-    data ($$:@#@$) (l :: TyFun Bool ((~>) Bool Bool)) :: GHC.Types.Type
+    data $$:@#@$ :: (~>) Bool ((~>) Bool Bool)
       where
-        (:$$:@#@$###) :: forall l arg.
-                         SameKind (Apply ($$:@#@$) arg) (($$:@#@$$) arg) => ($$:@#@$) l
-    type instance Apply ($$:@#@$) l = ($$:@#@$$) l
+        (:$$:@#@$###) :: forall a0123456789876543210 arg.
+                         SameKind (Apply ($$:@#@$) arg) (($$:@#@$$) arg) =>
+                         ($$:@#@$) a0123456789876543210
+    type instance Apply ($$:@#@$) a0123456789876543210 = ($$:@#@$$) a0123456789876543210
     infixl 5 $$:@#@$
     type family ($$:) (a :: Bool) (a :: Bool) :: Bool where
       ($$:) _ _ = FalseSym0

--- a/tests/compile-and-dump/Singletons/T197b.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T197b.ghc84.template
@@ -9,45 +9,56 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
     data Pair a b = MkPair a b
     infixr 9 `Pair`
     infixr 9 `MkPair`
-    type (:*:@#@$$$) (t :: a0123456789876543210) (t :: b0123456789876543210) =
-        (:*:) t t
-    instance SuppressUnusedWarnings (:*:@#@$$) where
+    type (:*:@#@$$$) (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: b0123456789876543210) =
+        (:*:) t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings ((:*:@#@$$) t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::*:@#@$$###)) GHC.Tuple.())
-    data (:*:@#@$$) (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 ((:*:) a0123456789876543210 b0123456789876543210)) :: GHC.Types.Type
+    data (:*:@#@$$) (t0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210.
+                                                                      (~>) b0123456789876543210 ((:*:) a0123456789876543210 b0123456789876543210)
       where
-        (::*:@#@$$###) :: forall l l arg.
-                          SameKind (Apply ((:*:@#@$$) l) arg) ((:*:@#@$$$) l arg) =>
-                          (:*:@#@$$) l l
-    type instance Apply ((:*:@#@$$) l) l = (:*:) l l
+        (::*:@#@$$###) :: forall t0123456789876543210
+                                 t0123456789876543210
+                                 arg.
+                          SameKind (Apply ((:*:@#@$$) t0123456789876543210) arg) ((:*:@#@$$$) t0123456789876543210 arg) =>
+                          (:*:@#@$$) t0123456789876543210 t0123456789876543210
+    type instance Apply ((:*:@#@$$) t0123456789876543210) t0123456789876543210 = (:*:) t0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings (:*:@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::*:@#@$###)) GHC.Tuple.())
-    data (:*:@#@$) (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 ((:*:) a0123456789876543210 b0123456789876543210))) :: GHC.Types.Type
+    data :*:@#@$ :: forall a0123456789876543210 b0123456789876543210.
+                    (~>) a0123456789876543210 ((~>) b0123456789876543210 ((:*:) a0123456789876543210 b0123456789876543210))
       where
-        (::*:@#@$###) :: forall l arg.
-                         SameKind (Apply (:*:@#@$) arg) ((:*:@#@$$) arg) => (:*:@#@$) l
-    type instance Apply (:*:@#@$) l = (:*:@#@$$) l
-    type MkPairSym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
-        MkPair t t
-    instance SuppressUnusedWarnings MkPairSym1 where
+        (::*:@#@$###) :: forall t0123456789876543210 arg.
+                         SameKind (Apply (:*:@#@$) arg) ((:*:@#@$$) arg) =>
+                         (:*:@#@$) t0123456789876543210
+    type instance Apply (:*:@#@$) t0123456789876543210 = (:*:@#@$$) t0123456789876543210
+    type MkPairSym2 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: b0123456789876543210) =
+        MkPair t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (MkPairSym1 t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MkPairSym1KindInference) GHC.Tuple.())
-    data MkPairSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 (Pair a0123456789876543210 b0123456789876543210)) :: GHC.Types.Type
+    data MkPairSym1 (t0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210.
+                                                                      (~>) b0123456789876543210 (Pair a0123456789876543210 b0123456789876543210)
       where
-        MkPairSym1KindInference :: forall l l arg.
-                                   SameKind (Apply (MkPairSym1 l) arg) (MkPairSym2 l arg) =>
-                                   MkPairSym1 l l
-    type instance Apply (MkPairSym1 l) l = MkPair l l
+        MkPairSym1KindInference :: forall t0123456789876543210
+                                          t0123456789876543210
+                                          arg.
+                                   SameKind (Apply (MkPairSym1 t0123456789876543210) arg) (MkPairSym2 t0123456789876543210 arg) =>
+                                   MkPairSym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (MkPairSym1 t0123456789876543210) t0123456789876543210 = MkPair t0123456789876543210 t0123456789876543210
     infixr 9 `MkPairSym1`
     instance SuppressUnusedWarnings MkPairSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MkPairSym0KindInference) GHC.Tuple.())
-    data MkPairSym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 (Pair a0123456789876543210 b0123456789876543210))) :: GHC.Types.Type
+    data MkPairSym0 :: forall a0123456789876543210
+                              b0123456789876543210.
+                       (~>) a0123456789876543210 ((~>) b0123456789876543210 (Pair a0123456789876543210 b0123456789876543210))
       where
-        MkPairSym0KindInference :: forall l arg.
-                                   SameKind (Apply MkPairSym0 arg) (MkPairSym1 arg) => MkPairSym0 l
-    type instance Apply MkPairSym0 l = MkPairSym1 l
+        MkPairSym0KindInference :: forall t0123456789876543210 arg.
+                                   SameKind (Apply MkPairSym0 arg) (MkPairSym1 arg) =>
+                                   MkPairSym0 t0123456789876543210
+    type instance Apply MkPairSym0 t0123456789876543210 = MkPairSym1 t0123456789876543210
     infixr 9 `MkPairSym0`
     infixr 9 `SPair`
     infixr 9 `SMkPair`

--- a/tests/compile-and-dump/Singletons/T200.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T200.ghc84.template
@@ -18,91 +18,105 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
     ($$:) x y = (x :$$: y)
     (<>:) :: ErrorMessage -> ErrorMessage -> ErrorMessage
     (<>:) x y = (x :<>: y)
-    type (:$$:@#@$$$) (t :: ErrorMessage) (t :: ErrorMessage) =
-        (:$$:) t t
-    instance SuppressUnusedWarnings (:$$:@#@$$) where
+    type (:$$:@#@$$$) (t0123456789876543210 :: ErrorMessage) (t0123456789876543210 :: ErrorMessage) =
+        (:$$:) t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings ((:$$:@#@$$) t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::$$:@#@$$###)) GHC.Tuple.())
-    data (:$$:@#@$$) (l :: ErrorMessage) (l :: TyFun ErrorMessage ErrorMessage) :: GHC.Types.Type
+    data (:$$:@#@$$) (t0123456789876543210 :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage
       where
-        (::$$:@#@$$###) :: forall l l arg.
-                           SameKind (Apply ((:$$:@#@$$) l) arg) ((:$$:@#@$$$) l arg) =>
-                           (:$$:@#@$$) l l
-    type instance Apply ((:$$:@#@$$) l) l = (:$$:) l l
+        (::$$:@#@$$###) :: forall t0123456789876543210
+                                  t0123456789876543210
+                                  arg.
+                           SameKind (Apply ((:$$:@#@$$) t0123456789876543210) arg) ((:$$:@#@$$$) t0123456789876543210 arg) =>
+                           (:$$:@#@$$) t0123456789876543210 t0123456789876543210
+    type instance Apply ((:$$:@#@$$) t0123456789876543210) t0123456789876543210 = (:$$:) t0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings (:$$:@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::$$:@#@$###)) GHC.Tuple.())
-    data (:$$:@#@$) (l :: TyFun ErrorMessage ((~>) ErrorMessage ErrorMessage)) :: GHC.Types.Type
+    data :$$:@#@$ :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)
       where
-        (::$$:@#@$###) :: forall l arg.
-                          SameKind (Apply (:$$:@#@$) arg) ((:$$:@#@$$) arg) => (:$$:@#@$) l
-    type instance Apply (:$$:@#@$) l = (:$$:@#@$$) l
-    type (:<>:@#@$$$) (t :: ErrorMessage) (t :: ErrorMessage) =
-        (:<>:) t t
-    instance SuppressUnusedWarnings (:<>:@#@$$) where
+        (::$$:@#@$###) :: forall t0123456789876543210 arg.
+                          SameKind (Apply (:$$:@#@$) arg) ((:$$:@#@$$) arg) =>
+                          (:$$:@#@$) t0123456789876543210
+    type instance Apply (:$$:@#@$) t0123456789876543210 = (:$$:@#@$$) t0123456789876543210
+    type (:<>:@#@$$$) (t0123456789876543210 :: ErrorMessage) (t0123456789876543210 :: ErrorMessage) =
+        (:<>:) t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings ((:<>:@#@$$) t0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::<>:@#@$$###)) GHC.Tuple.())
-    data (:<>:@#@$$) (l :: ErrorMessage) (l :: TyFun ErrorMessage ErrorMessage) :: GHC.Types.Type
+    data (:<>:@#@$$) (t0123456789876543210 :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage
       where
-        (::<>:@#@$$###) :: forall l l arg.
-                           SameKind (Apply ((:<>:@#@$$) l) arg) ((:<>:@#@$$$) l arg) =>
-                           (:<>:@#@$$) l l
-    type instance Apply ((:<>:@#@$$) l) l = (:<>:) l l
+        (::<>:@#@$$###) :: forall t0123456789876543210
+                                  t0123456789876543210
+                                  arg.
+                           SameKind (Apply ((:<>:@#@$$) t0123456789876543210) arg) ((:<>:@#@$$$) t0123456789876543210 arg) =>
+                           (:<>:@#@$$) t0123456789876543210 t0123456789876543210
+    type instance Apply ((:<>:@#@$$) t0123456789876543210) t0123456789876543210 = (:<>:) t0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings (:<>:@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::<>:@#@$###)) GHC.Tuple.())
-    data (:<>:@#@$) (l :: TyFun ErrorMessage ((~>) ErrorMessage ErrorMessage)) :: GHC.Types.Type
+    data :<>:@#@$ :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)
       where
-        (::<>:@#@$###) :: forall l arg.
-                          SameKind (Apply (:<>:@#@$) arg) ((:<>:@#@$$) arg) => (:<>:@#@$) l
-    type instance Apply (:<>:@#@$) l = (:<>:@#@$$) l
-    type EMSym1 (t :: [Bool]) = EM t
+        (::<>:@#@$###) :: forall t0123456789876543210 arg.
+                          SameKind (Apply (:<>:@#@$) arg) ((:<>:@#@$$) arg) =>
+                          (:<>:@#@$) t0123456789876543210
+    type instance Apply (:<>:@#@$) t0123456789876543210 = (:<>:@#@$$) t0123456789876543210
+    type EMSym1 (t0123456789876543210 :: [Bool]) =
+        EM t0123456789876543210
     instance SuppressUnusedWarnings EMSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) EMSym0KindInference) GHC.Tuple.())
-    data EMSym0 (l :: TyFun [Bool] ErrorMessage) :: GHC.Types.Type
+    data EMSym0 :: (~>) [Bool] ErrorMessage
       where
-        EMSym0KindInference :: forall l arg.
-                               SameKind (Apply EMSym0 arg) (EMSym1 arg) => EMSym0 l
-    type instance Apply EMSym0 l = EM l
-    type (<>:@#@$$$) (t :: ErrorMessage) (t :: ErrorMessage) =
-        (<>:) t t
-    instance SuppressUnusedWarnings (<>:@#@$$) where
+        EMSym0KindInference :: forall t0123456789876543210 arg.
+                               SameKind (Apply EMSym0 arg) (EMSym1 arg) =>
+                               EMSym0 t0123456789876543210
+    type instance Apply EMSym0 t0123456789876543210 = EM t0123456789876543210
+    type (<>:@#@$$$) (a0123456789876543210 :: ErrorMessage) (a0123456789876543210 :: ErrorMessage) =
+        (<>:) a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings ((<>:@#@$$) a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:<>:@#@$$###)) GHC.Tuple.())
-    data (<>:@#@$$) (l :: ErrorMessage) (l :: TyFun ErrorMessage ErrorMessage) :: GHC.Types.Type
+    data (<>:@#@$$) (a0123456789876543210 :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage
       where
-        (:<>:@#@$$###) :: forall l l arg.
-                          SameKind (Apply ((<>:@#@$$) l) arg) ((<>:@#@$$$) l arg) =>
-                          (<>:@#@$$) l l
-    type instance Apply ((<>:@#@$$) l) l = (<>:) l l
+        (:<>:@#@$$###) :: forall a0123456789876543210
+                                 a0123456789876543210
+                                 arg.
+                          SameKind (Apply ((<>:@#@$$) a0123456789876543210) arg) ((<>:@#@$$$) a0123456789876543210 arg) =>
+                          (<>:@#@$$) a0123456789876543210 a0123456789876543210
+    type instance Apply ((<>:@#@$$) a0123456789876543210) a0123456789876543210 = (<>:) a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings (<>:@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:<>:@#@$###)) GHC.Tuple.())
-    data (<>:@#@$) (l :: TyFun ErrorMessage ((~>) ErrorMessage ErrorMessage)) :: GHC.Types.Type
+    data <>:@#@$ :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)
       where
-        (:<>:@#@$###) :: forall l arg.
-                         SameKind (Apply (<>:@#@$) arg) ((<>:@#@$$) arg) => (<>:@#@$) l
-    type instance Apply (<>:@#@$) l = (<>:@#@$$) l
-    type ($$:@#@$$$) (t :: ErrorMessage) (t :: ErrorMessage) =
-        ($$:) t t
-    instance SuppressUnusedWarnings ($$:@#@$$) where
+        (:<>:@#@$###) :: forall a0123456789876543210 arg.
+                         SameKind (Apply (<>:@#@$) arg) ((<>:@#@$$) arg) =>
+                         (<>:@#@$) a0123456789876543210
+    type instance Apply (<>:@#@$) a0123456789876543210 = (<>:@#@$$) a0123456789876543210
+    type ($$:@#@$$$) (a0123456789876543210 :: ErrorMessage) (a0123456789876543210 :: ErrorMessage) =
+        ($$:) a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (($$:@#@$$) a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:$$:@#@$$###)) GHC.Tuple.())
-    data ($$:@#@$$) (l :: ErrorMessage) (l :: TyFun ErrorMessage ErrorMessage) :: GHC.Types.Type
+    data ($$:@#@$$) (a0123456789876543210 :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage
       where
-        (:$$:@#@$$###) :: forall l l arg.
-                          SameKind (Apply (($$:@#@$$) l) arg) (($$:@#@$$$) l arg) =>
-                          ($$:@#@$$) l l
-    type instance Apply (($$:@#@$$) l) l = ($$:) l l
+        (:$$:@#@$$###) :: forall a0123456789876543210
+                                 a0123456789876543210
+                                 arg.
+                          SameKind (Apply (($$:@#@$$) a0123456789876543210) arg) (($$:@#@$$$) a0123456789876543210 arg) =>
+                          ($$:@#@$$) a0123456789876543210 a0123456789876543210
+    type instance Apply (($$:@#@$$) a0123456789876543210) a0123456789876543210 = ($$:) a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ($$:@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:$$:@#@$###)) GHC.Tuple.())
-    data ($$:@#@$) (l :: TyFun ErrorMessage ((~>) ErrorMessage ErrorMessage)) :: GHC.Types.Type
+    data $$:@#@$ :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)
       where
-        (:$$:@#@$###) :: forall l arg.
-                         SameKind (Apply ($$:@#@$) arg) (($$:@#@$$) arg) => ($$:@#@$) l
-    type instance Apply ($$:@#@$) l = ($$:@#@$$) l
+        (:$$:@#@$###) :: forall a0123456789876543210 arg.
+                         SameKind (Apply ($$:@#@$) arg) (($$:@#@$$) arg) =>
+                         ($$:@#@$) a0123456789876543210
+    type instance Apply ($$:@#@$) a0123456789876543210 = ($$:@#@$$) a0123456789876543210
     type family (<>:) (a :: ErrorMessage) (a :: ErrorMessage) :: ErrorMessage where
       (<>:) x y = Apply (Apply (:<>:@#@$) x) y
     type family ($$:) (a :: ErrorMessage) (a :: ErrorMessage) :: ErrorMessage where

--- a/tests/compile-and-dump/Singletons/T209.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T209.ghc84.template
@@ -18,32 +18,42 @@ Singletons/T209.hs:(0,0)-(0,0): Splicing declarations
       deriving anyclass (C Bool)
     deriving anyclass instance C a a => C a (Maybe a)
     type HmSym0 = Hm
-    type MSym3 (t :: a0123456789876543210) (t :: b0123456789876543210) (t :: Bool) =
-        M t t t
-    instance SuppressUnusedWarnings MSym2 where
+    type MSym3 (a0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: b0123456789876543210) (a0123456789876543210 :: Bool) =
+        M a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (MSym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MSym2KindInference) GHC.Tuple.())
-    data MSym2 (l :: a0123456789876543210) (l :: b0123456789876543210) (l :: TyFun Bool Bool) :: GHC.Types.Type
+    data MSym2 (a0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: b0123456789876543210) :: (~>) Bool Bool
       where
-        MSym2KindInference :: forall l l l arg.
-                              SameKind (Apply (MSym2 l l) arg) (MSym3 l l arg) => MSym2 l l l
-    type instance Apply (MSym2 l l) l = M l l l
-    instance SuppressUnusedWarnings MSym1 where
+        MSym2KindInference :: forall a0123456789876543210
+                                     a0123456789876543210
+                                     a0123456789876543210
+                                     arg.
+                              SameKind (Apply (MSym2 a0123456789876543210 a0123456789876543210) arg) (MSym3 a0123456789876543210 a0123456789876543210 arg) =>
+                              MSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type instance Apply (MSym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = M a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (MSym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MSym1KindInference) GHC.Tuple.())
-    data MSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 ((~>) Bool Bool)) :: GHC.Types.Type
+    data MSym1 (a0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210.
+                                                                 (~>) b0123456789876543210 ((~>) Bool Bool)
       where
-        MSym1KindInference :: forall l l arg.
-                              SameKind (Apply (MSym1 l) arg) (MSym2 l arg) => MSym1 l l
-    type instance Apply (MSym1 l) l = MSym2 l l
+        MSym1KindInference :: forall a0123456789876543210
+                                     a0123456789876543210
+                                     arg.
+                              SameKind (Apply (MSym1 a0123456789876543210) arg) (MSym2 a0123456789876543210 arg) =>
+                              MSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (MSym1 a0123456789876543210) a0123456789876543210 = MSym2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings MSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MSym0KindInference) GHC.Tuple.())
-    data MSym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 ((~>) Bool Bool))) :: GHC.Types.Type
+    data MSym0 :: forall a0123456789876543210 b0123456789876543210.
+                  (~>) a0123456789876543210 ((~>) b0123456789876543210 ((~>) Bool Bool))
       where
-        MSym0KindInference :: forall l arg.
-                              SameKind (Apply MSym0 arg) (MSym1 arg) => MSym0 l
-    type instance Apply MSym0 l = MSym1 l
+        MSym0KindInference :: forall a0123456789876543210 arg.
+                              SameKind (Apply MSym0 arg) (MSym1 arg) =>
+                              MSym0 a0123456789876543210
+    type instance Apply MSym0 a0123456789876543210 = MSym1 a0123456789876543210
     type family M (a :: a) (a :: b) (a :: Bool) :: Bool where
       M _ _ x = x
     class PC (a :: GHC.Types.Type) (b :: GHC.Types.Type)

--- a/tests/compile-and-dump/Singletons/T216.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T216.ghc84.template
@@ -1,0 +1,64 @@
+Singletons/T216.hs:0:0:: Splicing declarations
+    genDefunSymbols [''MyProxy, ''Symmetry]
+  ======>
+    type MyProxySym2 (k0123456789876543210 :: Type) (a0123456789876543210 :: k0123456789876543210) =
+        MyProxy k0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (MyProxySym1 k0123456789876543210) where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) MyProxySym1KindInference) GHC.Tuple.())
+    data MyProxySym1 (k0123456789876543210 :: Type) :: (~>) k0123456789876543210 Type
+      where
+        MyProxySym1KindInference :: forall k0123456789876543210
+                                           a0123456789876543210
+                                           arg.
+                                    SameKind (Apply (MyProxySym1 k0123456789876543210) arg) (MyProxySym2 k0123456789876543210 arg) =>
+                                    MyProxySym1 k0123456789876543210 a0123456789876543210
+    type instance Apply (MyProxySym1 k0123456789876543210) a0123456789876543210 = MyProxy k0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings MyProxySym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) MyProxySym0KindInference) GHC.Tuple.())
+    data MyProxySym0 :: forall (k0123456789876543210 :: Type).
+                        (~>) Type ((~>) k0123456789876543210 Type)
+      where
+        MyProxySym0KindInference :: forall k0123456789876543210 arg.
+                                    SameKind (Apply MyProxySym0 arg) (MyProxySym1 arg) =>
+                                    MyProxySym0 k0123456789876543210
+    type instance Apply MyProxySym0 k0123456789876543210 = MyProxySym1 k0123456789876543210
+    type SymmetrySym3 (a0123456789876543210 :: t0123456789876543210) (y0123456789876543210 :: t0123456789876543210) (e0123456789876543210 :: (:~:) a0123456789876543210 y0123456789876543210) =
+        Symmetry a0123456789876543210 y0123456789876543210 e0123456789876543210
+    instance SuppressUnusedWarnings (SymmetrySym2 y0123456789876543210 a0123456789876543210) where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) SymmetrySym2KindInference) GHC.Tuple.())
+    data SymmetrySym2 (a0123456789876543210 :: t0123456789876543210) (y0123456789876543210 :: t0123456789876543210) :: (~>) ((:~:) a0123456789876543210 y0123456789876543210) Type
+      where
+        SymmetrySym2KindInference :: forall a0123456789876543210
+                                            y0123456789876543210
+                                            e0123456789876543210
+                                            arg.
+                                     SameKind (Apply (SymmetrySym2 a0123456789876543210 y0123456789876543210) arg) (SymmetrySym3 a0123456789876543210 y0123456789876543210 arg) =>
+                                     SymmetrySym2 a0123456789876543210 y0123456789876543210 e0123456789876543210
+    type instance Apply (SymmetrySym2 y0123456789876543210 a0123456789876543210) e0123456789876543210 = Symmetry y0123456789876543210 a0123456789876543210 e0123456789876543210
+    instance SuppressUnusedWarnings (SymmetrySym1 a0123456789876543210) where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) SymmetrySym1KindInference) GHC.Tuple.())
+    data SymmetrySym1 (a0123456789876543210 :: t0123456789876543210) :: forall (y0123456789876543210 :: t0123456789876543210).
+                                                                        (~>) t0123456789876543210 ((~>) ((:~:) a0123456789876543210 y0123456789876543210) Type)
+      where
+        SymmetrySym1KindInference :: forall a0123456789876543210
+                                            y0123456789876543210
+                                            arg.
+                                     SameKind (Apply (SymmetrySym1 a0123456789876543210) arg) (SymmetrySym2 a0123456789876543210 arg) =>
+                                     SymmetrySym1 a0123456789876543210 y0123456789876543210
+    type instance Apply (SymmetrySym1 a0123456789876543210) y0123456789876543210 = SymmetrySym2 a0123456789876543210 y0123456789876543210
+    instance SuppressUnusedWarnings SymmetrySym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) SymmetrySym0KindInference) GHC.Tuple.())
+    data SymmetrySym0 :: forall t0123456789876543210
+                                (a0123456789876543210 :: t0123456789876543210)
+                                (y0123456789876543210 :: t0123456789876543210).
+                         (~>) t0123456789876543210 ((~>) t0123456789876543210 ((~>) ((:~:) a0123456789876543210 y0123456789876543210) Type))
+      where
+        SymmetrySym0KindInference :: forall a0123456789876543210 arg.
+                                     SameKind (Apply SymmetrySym0 arg) (SymmetrySym1 arg) =>
+                                     SymmetrySym0 a0123456789876543210
+    type instance Apply SymmetrySym0 a0123456789876543210 = SymmetrySym1 a0123456789876543210

--- a/tests/compile-and-dump/Singletons/T216.hs
+++ b/tests/compile-and-dump/Singletons/T216.hs
@@ -1,0 +1,12 @@
+module T216 where
+
+import Data.Kind
+import Data.Singletons.TH
+
+type family MyProxy k (a :: k) :: Type where
+  MyProxy _ a = Proxy a
+
+type family Symmetry (a :: t) (y :: t) (e :: a :~: y) :: Type where
+  Symmetry a y _ = y :~: a
+
+$(genDefunSymbols [''MyProxy, ''Symmetry])

--- a/tests/compile-and-dump/Singletons/T229.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T229.ghc84.template
@@ -5,16 +5,17 @@ Singletons/T229.hs:(0,0)-(0,0): Splicing declarations
   ======>
     ___foo :: Bool -> Bool
     ___foo _ = True
-    type US___fooSym1 (t :: Bool) = US___foo t
+    type US___fooSym1 (a0123456789876543210 :: Bool) =
+        US___foo a0123456789876543210
     instance SuppressUnusedWarnings US___fooSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) US___fooSym0KindInference) GHC.Tuple.())
-    data US___fooSym0 (l :: TyFun Bool Bool) :: GHC.Types.Type
+    data US___fooSym0 :: (~>) Bool Bool
       where
-        US___fooSym0KindInference :: forall l arg.
+        US___fooSym0KindInference :: forall a0123456789876543210 arg.
                                      SameKind (Apply US___fooSym0 arg) (US___fooSym1 arg) =>
-                                     US___fooSym0 l
-    type instance Apply US___fooSym0 l = US___foo l
+                                     US___fooSym0 a0123456789876543210
+    type instance Apply US___fooSym0 a0123456789876543210 = US___foo a0123456789876543210
     type family US___foo (a :: Bool) :: Bool where
       US___foo _ = TrueSym0
     ___sfoo ::

--- a/tests/compile-and-dump/Singletons/T249.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T249.ghc84.template
@@ -7,33 +7,42 @@ Singletons/T249.hs:(0,0)-(0,0): Splicing declarations
     data Foo1 a = MkFoo1 a
     data Foo2 a where MkFoo2 :: x -> Foo2 x
     data Foo3 a where MkFoo3 :: forall x. x -> Foo3 x
-    type MkFoo1Sym1 (t :: a0123456789876543210) = MkFoo1 t
+    type MkFoo1Sym1 (t0123456789876543210 :: a0123456789876543210) =
+        MkFoo1 t0123456789876543210
     instance SuppressUnusedWarnings MkFoo1Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MkFoo1Sym0KindInference) GHC.Tuple.())
-    data MkFoo1Sym0 (l :: TyFun a0123456789876543210 (Foo1 a0123456789876543210)) :: Type
+    data MkFoo1Sym0 :: forall a0123456789876543210.
+                       (~>) a0123456789876543210 (Foo1 a0123456789876543210)
       where
-        MkFoo1Sym0KindInference :: forall l arg.
-                                   SameKind (Apply MkFoo1Sym0 arg) (MkFoo1Sym1 arg) => MkFoo1Sym0 l
-    type instance Apply MkFoo1Sym0 l = MkFoo1 l
-    type MkFoo2Sym1 (t :: x0123456789876543210) = MkFoo2 t
+        MkFoo1Sym0KindInference :: forall t0123456789876543210 arg.
+                                   SameKind (Apply MkFoo1Sym0 arg) (MkFoo1Sym1 arg) =>
+                                   MkFoo1Sym0 t0123456789876543210
+    type instance Apply MkFoo1Sym0 t0123456789876543210 = MkFoo1 t0123456789876543210
+    type MkFoo2Sym1 (t0123456789876543210 :: x0123456789876543210) =
+        MkFoo2 t0123456789876543210
     instance SuppressUnusedWarnings MkFoo2Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MkFoo2Sym0KindInference) GHC.Tuple.())
-    data MkFoo2Sym0 (l :: TyFun x0123456789876543210 (Foo2 x0123456789876543210)) :: Type
+    data MkFoo2Sym0 :: forall x0123456789876543210.
+                       (~>) x0123456789876543210 (Foo2 x0123456789876543210)
       where
-        MkFoo2Sym0KindInference :: forall l arg.
-                                   SameKind (Apply MkFoo2Sym0 arg) (MkFoo2Sym1 arg) => MkFoo2Sym0 l
-    type instance Apply MkFoo2Sym0 l = MkFoo2 l
-    type MkFoo3Sym1 (t :: x0123456789876543210) = MkFoo3 t
+        MkFoo2Sym0KindInference :: forall t0123456789876543210 arg.
+                                   SameKind (Apply MkFoo2Sym0 arg) (MkFoo2Sym1 arg) =>
+                                   MkFoo2Sym0 t0123456789876543210
+    type instance Apply MkFoo2Sym0 t0123456789876543210 = MkFoo2 t0123456789876543210
+    type MkFoo3Sym1 (t0123456789876543210 :: x0123456789876543210) =
+        MkFoo3 t0123456789876543210
     instance SuppressUnusedWarnings MkFoo3Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MkFoo3Sym0KindInference) GHC.Tuple.())
-    data MkFoo3Sym0 (l :: TyFun x0123456789876543210 (Foo3 x0123456789876543210)) :: Type
+    data MkFoo3Sym0 :: forall x0123456789876543210.
+                       (~>) x0123456789876543210 (Foo3 x0123456789876543210)
       where
-        MkFoo3Sym0KindInference :: forall l arg.
-                                   SameKind (Apply MkFoo3Sym0 arg) (MkFoo3Sym1 arg) => MkFoo3Sym0 l
-    type instance Apply MkFoo3Sym0 l = MkFoo3 l
+        MkFoo3Sym0KindInference :: forall t0123456789876543210 arg.
+                                   SameKind (Apply MkFoo3Sym0 arg) (MkFoo3Sym1 arg) =>
+                                   MkFoo3Sym0 t0123456789876543210
+    type instance Apply MkFoo3Sym0 t0123456789876543210 = MkFoo3 t0123456789876543210
     data instance Sing :: Foo1 a -> Type :: Foo1 a -> Type
       where
         SMkFoo1 :: forall a (n :: a). (Sing (n :: a)) -> Sing (MkFoo1 n)

--- a/tests/compile-and-dump/Singletons/T271.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T271.ghc84.template
@@ -13,80 +13,94 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
     data Identity :: Type -> Type
       where Identity :: a -> Identity a
       deriving (Eq, Ord)
-    type ConstantSym1 (t :: a0123456789876543210) = Constant t
+    type ConstantSym1 (t0123456789876543210 :: a0123456789876543210) =
+        Constant t0123456789876543210
     instance SuppressUnusedWarnings ConstantSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) ConstantSym0KindInference) GHC.Tuple.())
-    data ConstantSym0 (l :: TyFun a0123456789876543210 (Constant (a0123456789876543210 :: Type) (b0123456789876543210 :: Type))) :: Type
+    data ConstantSym0 :: forall a0123456789876543210
+                                b0123456789876543210.
+                         (~>) a0123456789876543210 (Constant (a0123456789876543210 :: Type) (b0123456789876543210 :: Type))
       where
-        ConstantSym0KindInference :: forall l arg.
+        ConstantSym0KindInference :: forall t0123456789876543210 arg.
                                      SameKind (Apply ConstantSym0 arg) (ConstantSym1 arg) =>
-                                     ConstantSym0 l
-    type instance Apply ConstantSym0 l = Constant l
-    type IdentitySym1 (t :: a0123456789876543210) = Identity t
+                                     ConstantSym0 t0123456789876543210
+    type instance Apply ConstantSym0 t0123456789876543210 = Constant t0123456789876543210
+    type IdentitySym1 (t0123456789876543210 :: a0123456789876543210) =
+        Identity t0123456789876543210
     instance SuppressUnusedWarnings IdentitySym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) IdentitySym0KindInference) GHC.Tuple.())
-    data IdentitySym0 (l :: TyFun a0123456789876543210 (Identity a0123456789876543210)) :: Type
+    data IdentitySym0 :: forall a0123456789876543210.
+                         (~>) a0123456789876543210 (Identity a0123456789876543210)
       where
-        IdentitySym0KindInference :: forall l arg.
+        IdentitySym0KindInference :: forall t0123456789876543210 arg.
                                      SameKind (Apply IdentitySym0 arg) (IdentitySym1 arg) =>
-                                     IdentitySym0 l
-    type instance Apply IdentitySym0 l = Identity l
+                                     IdentitySym0 t0123456789876543210
+    type instance Apply IdentitySym0 t0123456789876543210 = Identity t0123456789876543210
     type family Compare_0123456789876543210 (a :: Constant a b) (a :: Constant a b) :: Ordering where
       Compare_0123456789876543210 (Constant a_0123456789876543210) (Constant b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) '[])
-    type Compare_0123456789876543210Sym2 (t :: Constant a0123456789876543210 b0123456789876543210) (t :: Constant a0123456789876543210 b0123456789876543210) =
-        Compare_0123456789876543210 t t
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym1 where
+    type Compare_0123456789876543210Sym2 (a0123456789876543210 :: Constant a0123456789876543210 b0123456789876543210) (a0123456789876543210 :: Constant a0123456789876543210 b0123456789876543210) =
+        Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym1 (l :: Constant a0123456789876543210 b0123456789876543210) (l :: TyFun (Constant a0123456789876543210 b0123456789876543210) Ordering) :: Type
+    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Constant a0123456789876543210 b0123456789876543210) :: (~>) (Constant a0123456789876543210 b0123456789876543210) Ordering
       where
-        Compare_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                        SameKind (Apply (Compare_0123456789876543210Sym1 l) arg) (Compare_0123456789876543210Sym2 l arg) =>
-                                                        Compare_0123456789876543210Sym1 l l
-    type instance Apply (Compare_0123456789876543210Sym1 l) l = Compare_0123456789876543210 l l
+        Compare_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                               a0123456789876543210
+                                                               arg.
+                                                        SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym0 (l :: TyFun (Constant a0123456789876543210 b0123456789876543210) ((~>) (Constant a0123456789876543210 b0123456789876543210) Ordering)) :: Type
+    data Compare_0123456789876543210Sym0 :: forall a0123456789876543210
+                                                   b0123456789876543210.
+                                            (~>) (Constant a0123456789876543210 b0123456789876543210) ((~>) (Constant a0123456789876543210 b0123456789876543210) Ordering)
       where
-        Compare_0123456789876543210Sym0KindInference :: forall l arg.
+        Compare_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                               arg.
                                                         SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 l
-    type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
+                                                        Compare_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
     instance POrd (Constant a b) where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type family Compare_0123456789876543210 (a :: Identity a) (a :: Identity a) :: Ordering where
       Compare_0123456789876543210 (Identity a_0123456789876543210) (Identity b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) '[])
-    type Compare_0123456789876543210Sym2 (t :: Identity a0123456789876543210) (t :: Identity a0123456789876543210) =
-        Compare_0123456789876543210 t t
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym1 where
+    type Compare_0123456789876543210Sym2 (a0123456789876543210 :: Identity a0123456789876543210) (a0123456789876543210 :: Identity a0123456789876543210) =
+        Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym1 (l :: Identity a0123456789876543210) (l :: TyFun (Identity a0123456789876543210) Ordering) :: Type
+    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Identity a0123456789876543210) :: (~>) (Identity a0123456789876543210) Ordering
       where
-        Compare_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                        SameKind (Apply (Compare_0123456789876543210Sym1 l) arg) (Compare_0123456789876543210Sym2 l arg) =>
-                                                        Compare_0123456789876543210Sym1 l l
-    type instance Apply (Compare_0123456789876543210Sym1 l) l = Compare_0123456789876543210 l l
+        Compare_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                               a0123456789876543210
+                                                               arg.
+                                                        SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Compare_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Compare_0123456789876543210Sym0 (l :: TyFun (Identity a0123456789876543210) ((~>) (Identity a0123456789876543210) Ordering)) :: Type
+    data Compare_0123456789876543210Sym0 :: forall a0123456789876543210.
+                                            (~>) (Identity a0123456789876543210) ((~>) (Identity a0123456789876543210) Ordering)
       where
-        Compare_0123456789876543210Sym0KindInference :: forall l arg.
+        Compare_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                               arg.
                                                         SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 l
-    type instance Apply Compare_0123456789876543210Sym0 l = Compare_0123456789876543210Sym1 l
+                                                        Compare_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
     instance POrd (Identity a) where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type family Equals_0123456789876543210 (a :: Constant a b) (b :: Constant a b) :: Bool where

--- a/tests/compile-and-dump/Singletons/T287.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T287.ghc84.template
@@ -10,90 +10,105 @@ Singletons/T287.hs:(0,0)-(0,0): Splicing declarations
       (<<>>) :: a -> a -> a
     instance S b => S (a -> b) where
       (<<>>) f g = \ x -> ((f x) <<>> (g x))
-    type (<<>>@#@$$$) (t :: a0123456789876543210) (t :: a0123456789876543210) =
-        (<<>>) t t
-    instance SuppressUnusedWarnings (<<>>@#@$$) where
+    type (<<>>@#@$$$) (arg0123456789876543210 :: a0123456789876543210) (arg0123456789876543210 :: a0123456789876543210) =
+        (<<>>) arg0123456789876543210 arg0123456789876543210
+    instance SuppressUnusedWarnings ((<<>>@#@$$) arg0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:<<>>@#@$$###)) GHC.Tuple.())
-    data (<<>>@#@$$) (l :: a0123456789876543210) (l :: TyFun a0123456789876543210 a0123456789876543210) :: GHC.Types.Type
+    data (<<>>@#@$$) (arg0123456789876543210 :: a0123456789876543210) :: (~>) a0123456789876543210 a0123456789876543210
       where
-        (:<<>>@#@$$###) :: forall l l arg.
-                           SameKind (Apply ((<<>>@#@$$) l) arg) ((<<>>@#@$$$) l arg) =>
-                           (<<>>@#@$$) l l
-    type instance Apply ((<<>>@#@$$) l) l = (<<>>) l l
+        (:<<>>@#@$$###) :: forall arg0123456789876543210
+                                  arg0123456789876543210
+                                  arg.
+                           SameKind (Apply ((<<>>@#@$$) arg0123456789876543210) arg) ((<<>>@#@$$$) arg0123456789876543210 arg) =>
+                           (<<>>@#@$$) arg0123456789876543210 arg0123456789876543210
+    type instance Apply ((<<>>@#@$$) arg0123456789876543210) arg0123456789876543210 = (<<>>) arg0123456789876543210 arg0123456789876543210
     instance SuppressUnusedWarnings (<<>>@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:<<>>@#@$###)) GHC.Tuple.())
-    data (<<>>@#@$) (l :: TyFun a0123456789876543210 ((~>) a0123456789876543210 a0123456789876543210)) :: GHC.Types.Type
+    data <<>>@#@$ :: forall a0123456789876543210.
+                     (~>) a0123456789876543210 ((~>) a0123456789876543210 a0123456789876543210)
       where
-        (:<<>>@#@$###) :: forall l arg.
-                          SameKind (Apply (<<>>@#@$) arg) ((<<>>@#@$$) arg) => (<<>>@#@$) l
-    type instance Apply (<<>>@#@$) l = (<<>>@#@$$) l
+        (:<<>>@#@$###) :: forall arg0123456789876543210 arg.
+                          SameKind (Apply (<<>>@#@$) arg) ((<<>>@#@$$) arg) =>
+                          (<<>>@#@$) arg0123456789876543210
+    type instance Apply (<<>>@#@$) arg0123456789876543210 = (<<>>@#@$$) arg0123456789876543210
     class PS (a :: GHC.Types.Type) where
       type (<<>>) (arg :: a) (arg :: a) :: a
     type family Lambda_0123456789876543210 f g t where
       Lambda_0123456789876543210 f g x = Apply (Apply (<<>>@#@$) (Apply f x)) (Apply g x)
-    type Lambda_0123456789876543210Sym3 t t t =
-        Lambda_0123456789876543210 t t t
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym2 where
+    type Lambda_0123456789876543210Sym3 f0123456789876543210 g0123456789876543210 t0123456789876543210 =
+        Lambda_0123456789876543210 f0123456789876543210 g0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym2 g0123456789876543210 f0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym2KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym2 l l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym2 f0123456789876543210 g0123456789876543210 t0123456789876543210
       where
-        Lambda_0123456789876543210Sym2KindInference :: forall l l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 l l) arg) (Lambda_0123456789876543210Sym3 l l arg) =>
-                                                       Lambda_0123456789876543210Sym2 l l l
-    type instance Apply (Lambda_0123456789876543210Sym2 l l) l = Lambda_0123456789876543210 l l l
-    instance SuppressUnusedWarnings Lambda_0123456789876543210Sym1 where
+        Lambda_0123456789876543210Sym2KindInference :: forall f0123456789876543210
+                                                              g0123456789876543210
+                                                              t0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym2 f0123456789876543210 g0123456789876543210) arg) (Lambda_0123456789876543210Sym3 f0123456789876543210 g0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym2 f0123456789876543210 g0123456789876543210 t0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym2 g0123456789876543210 f0123456789876543210) t0123456789876543210 = Lambda_0123456789876543210 g0123456789876543210 f0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (Lambda_0123456789876543210Sym1 f0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym1 l l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym1 f0123456789876543210 g0123456789876543210
       where
-        Lambda_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 l) arg) (Lambda_0123456789876543210Sym2 l arg) =>
-                                                       Lambda_0123456789876543210Sym1 l l
-    type instance Apply (Lambda_0123456789876543210Sym1 l) l = Lambda_0123456789876543210Sym2 l l
+        Lambda_0123456789876543210Sym1KindInference :: forall f0123456789876543210
+                                                              g0123456789876543210
+                                                              arg.
+                                                       SameKind (Apply (Lambda_0123456789876543210Sym1 f0123456789876543210) arg) (Lambda_0123456789876543210Sym2 f0123456789876543210 arg) =>
+                                                       Lambda_0123456789876543210Sym1 f0123456789876543210 g0123456789876543210
+    type instance Apply (Lambda_0123456789876543210Sym1 f0123456789876543210) g0123456789876543210 = Lambda_0123456789876543210Sym2 f0123456789876543210 g0123456789876543210
     instance SuppressUnusedWarnings Lambda_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Lambda_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Lambda_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Lambda_0123456789876543210Sym0 f0123456789876543210
       where
-        Lambda_0123456789876543210Sym0KindInference :: forall l arg.
+        Lambda_0123456789876543210Sym0KindInference :: forall f0123456789876543210
+                                                              arg.
                                                        SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
-                                                       Lambda_0123456789876543210Sym0 l
-    type instance Apply Lambda_0123456789876543210Sym0 l = Lambda_0123456789876543210Sym1 l
+                                                       Lambda_0123456789876543210Sym0 f0123456789876543210
+    type instance Apply Lambda_0123456789876543210Sym0 f0123456789876543210 = Lambda_0123456789876543210Sym1 f0123456789876543210
     type family TFHelper_0123456789876543210 (a :: (~>) a b) (a :: (~>) a b) :: (~>) a b where
       TFHelper_0123456789876543210 f g = Apply (Apply Lambda_0123456789876543210Sym0 f) g
-    type TFHelper_0123456789876543210Sym2 (t :: (~>) a0123456789876543210 b0123456789876543210) (t :: (~>) a0123456789876543210 b0123456789876543210) =
-        TFHelper_0123456789876543210 t t
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym1 where
+    type TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: (~>) a0123456789876543210 b0123456789876543210) (a0123456789876543210 :: (~>) a0123456789876543210 b0123456789876543210) =
+        TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) TFHelper_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data TFHelper_0123456789876543210Sym1 (l :: (~>) a0123456789876543210 b0123456789876543210) (l :: TyFun ((~>) a0123456789876543210 b0123456789876543210) ((~>) a0123456789876543210 b0123456789876543210)) :: GHC.Types.Type
+    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: (~>) a0123456789876543210 b0123456789876543210) :: (~>) ((~>) a0123456789876543210 b0123456789876543210) ((~>) a0123456789876543210 b0123456789876543210)
       where
-        TFHelper_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                         SameKind (Apply (TFHelper_0123456789876543210Sym1 l) arg) (TFHelper_0123456789876543210Sym2 l arg) =>
-                                                         TFHelper_0123456789876543210Sym1 l l
-    type instance Apply (TFHelper_0123456789876543210Sym1 l) l = TFHelper_0123456789876543210 l l
+        TFHelper_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                                a0123456789876543210
+                                                                arg.
+                                                         SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) TFHelper_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data TFHelper_0123456789876543210Sym0 (l :: TyFun ((~>) a0123456789876543210 b0123456789876543210) ((~>) ((~>) a0123456789876543210 b0123456789876543210) ((~>) a0123456789876543210 b0123456789876543210))) :: GHC.Types.Type
+    data TFHelper_0123456789876543210Sym0 :: forall a0123456789876543210
+                                                    b0123456789876543210.
+                                             (~>) ((~>) a0123456789876543210 b0123456789876543210) ((~>) ((~>) a0123456789876543210 b0123456789876543210) ((~>) a0123456789876543210 b0123456789876543210))
       where
-        TFHelper_0123456789876543210Sym0KindInference :: forall l arg.
+        TFHelper_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                arg.
                                                          SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 l
-    type instance Apply TFHelper_0123456789876543210Sym0 l = TFHelper_0123456789876543210Sym1 l
+                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
     instance PS ((~>) a b) where
       type (<<>>) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
     class SS a where

--- a/tests/compile-and-dump/Singletons/T29.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T29.ghc84.template
@@ -17,42 +17,50 @@ Singletons/T29.hs:(0,0)-(0,0): Splicing declarations
     baz x = (not $! x)
     ban :: Bool -> Bool
     ban x = ((not . (not . not)) $! x)
-    type BanSym1 (t :: Bool) = Ban t
+    type BanSym1 (a0123456789876543210 :: Bool) =
+        Ban a0123456789876543210
     instance SuppressUnusedWarnings BanSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BanSym0KindInference) GHC.Tuple.())
-    data BanSym0 (l :: TyFun Bool Bool) :: GHC.Types.Type
+    data BanSym0 :: (~>) Bool Bool
       where
-        BanSym0KindInference :: forall l arg.
-                                SameKind (Apply BanSym0 arg) (BanSym1 arg) => BanSym0 l
-    type instance Apply BanSym0 l = Ban l
-    type BazSym1 (t :: Bool) = Baz t
+        BanSym0KindInference :: forall a0123456789876543210 arg.
+                                SameKind (Apply BanSym0 arg) (BanSym1 arg) =>
+                                BanSym0 a0123456789876543210
+    type instance Apply BanSym0 a0123456789876543210 = Ban a0123456789876543210
+    type BazSym1 (a0123456789876543210 :: Bool) =
+        Baz a0123456789876543210
     instance SuppressUnusedWarnings BazSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BazSym0KindInference) GHC.Tuple.())
-    data BazSym0 (l :: TyFun Bool Bool) :: GHC.Types.Type
+    data BazSym0 :: (~>) Bool Bool
       where
-        BazSym0KindInference :: forall l arg.
-                                SameKind (Apply BazSym0 arg) (BazSym1 arg) => BazSym0 l
-    type instance Apply BazSym0 l = Baz l
-    type BarSym1 (t :: Bool) = Bar t
+        BazSym0KindInference :: forall a0123456789876543210 arg.
+                                SameKind (Apply BazSym0 arg) (BazSym1 arg) =>
+                                BazSym0 a0123456789876543210
+    type instance Apply BazSym0 a0123456789876543210 = Baz a0123456789876543210
+    type BarSym1 (a0123456789876543210 :: Bool) =
+        Bar a0123456789876543210
     instance SuppressUnusedWarnings BarSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BarSym0KindInference) GHC.Tuple.())
-    data BarSym0 (l :: TyFun Bool Bool) :: GHC.Types.Type
+    data BarSym0 :: (~>) Bool Bool
       where
-        BarSym0KindInference :: forall l arg.
-                                SameKind (Apply BarSym0 arg) (BarSym1 arg) => BarSym0 l
-    type instance Apply BarSym0 l = Bar l
-    type FooSym1 (t :: Bool) = Foo t
+        BarSym0KindInference :: forall a0123456789876543210 arg.
+                                SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
+                                BarSym0 a0123456789876543210
+    type instance Apply BarSym0 a0123456789876543210 = Bar a0123456789876543210
+    type FooSym1 (a0123456789876543210 :: Bool) =
+        Foo a0123456789876543210
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym0KindInference) GHC.Tuple.())
-    data FooSym0 (l :: TyFun Bool Bool) :: GHC.Types.Type
+    data FooSym0 :: (~>) Bool Bool
       where
-        FooSym0KindInference :: forall l arg.
-                                SameKind (Apply FooSym0 arg) (FooSym1 arg) => FooSym0 l
-    type instance Apply FooSym0 l = Foo l
+        FooSym0KindInference :: forall a0123456789876543210 arg.
+                                SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
+                                FooSym0 a0123456789876543210
+    type instance Apply FooSym0 a0123456789876543210 = Foo a0123456789876543210
     type family Ban (a :: Bool) :: Bool where
       Ban x = Apply (Apply ($!@#@$) (Apply (Apply (.@#@$) NotSym0) (Apply (Apply (.@#@$) NotSym0) NotSym0))) x
     type family Baz (a :: Bool) :: Bool where

--- a/tests/compile-and-dump/Singletons/T297.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T297.ghc84.template
@@ -25,15 +25,16 @@ Singletons/T297.hs:(0,0)-(0,0): Splicing declarations
     type Let0123456789876543210XSym0 = Let0123456789876543210X
     type family Let0123456789876543210X where
       Let0123456789876543210X = Let0123456789876543210ZSym0
-    type FSym1 t = F t
+    type FSym1 a0123456789876543210 = F a0123456789876543210
     instance SuppressUnusedWarnings FSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FSym0KindInference) GHC.Tuple.())
-    data FSym0 l :: Type
+    data FSym0 a0123456789876543210
       where
-        FSym0KindInference :: forall l arg.
-                              SameKind (Apply FSym0 arg) (FSym1 arg) => FSym0 l
-    type instance Apply FSym0 l = F l
+        FSym0KindInference :: forall a0123456789876543210 arg.
+                              SameKind (Apply FSym0 arg) (FSym1 arg) =>
+                              FSym0 a0123456789876543210
+    type instance Apply FSym0 a0123456789876543210 = F a0123456789876543210
     type family F a where
       F MyProxy = Let0123456789876543210XSym0
     sF :: forall arg. Sing arg -> Sing (Apply FSym0 arg)

--- a/tests/compile-and-dump/Singletons/T312.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T312.ghc84.template
@@ -7,50 +7,62 @@ Singletons/T312.hs:(0,0)-(0,0): Splicing declarations
     class Foo a where
       bar :: a -> b -> b
       bar _ x = x
-    type BarSym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
-        Bar t t
-    instance SuppressUnusedWarnings BarSym1 where
+    type BarSym2 (arg0123456789876543210 :: a0123456789876543210) (arg0123456789876543210 :: b0123456789876543210) =
+        Bar arg0123456789876543210 arg0123456789876543210
+    instance SuppressUnusedWarnings (BarSym1 arg0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BarSym1KindInference) GHC.Tuple.())
-    data BarSym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 b0123456789876543210) :: GHC.Types.Type
+    data BarSym1 (arg0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210.
+                                                                     (~>) b0123456789876543210 b0123456789876543210
       where
-        BarSym1KindInference :: forall l l arg.
-                                SameKind (Apply (BarSym1 l) arg) (BarSym2 l arg) => BarSym1 l l
-    type instance Apply (BarSym1 l) l = Bar l l
+        BarSym1KindInference :: forall arg0123456789876543210
+                                       arg0123456789876543210
+                                       arg.
+                                SameKind (Apply (BarSym1 arg0123456789876543210) arg) (BarSym2 arg0123456789876543210 arg) =>
+                                BarSym1 arg0123456789876543210 arg0123456789876543210
+    type instance Apply (BarSym1 arg0123456789876543210) arg0123456789876543210 = Bar arg0123456789876543210 arg0123456789876543210
     instance SuppressUnusedWarnings BarSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BarSym0KindInference) GHC.Tuple.())
-    data BarSym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)) :: GHC.Types.Type
+    data BarSym0 :: forall a0123456789876543210 b0123456789876543210.
+                    (~>) a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)
       where
-        BarSym0KindInference :: forall l arg.
-                                SameKind (Apply BarSym0 arg) (BarSym1 arg) => BarSym0 l
-    type instance Apply BarSym0 l = BarSym1 l
+        BarSym0KindInference :: forall arg0123456789876543210 arg.
+                                SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
+                                BarSym0 arg0123456789876543210
+    type instance Apply BarSym0 arg0123456789876543210 = BarSym1 arg0123456789876543210
     type family Bar_0123456789876543210 (a :: a) (a :: b) :: b where
       Bar_0123456789876543210 _ x = x
-    type Bar_0123456789876543210Sym2 (t :: a0123456789876543210) (t :: b0123456789876543210) =
-        Bar_0123456789876543210 t t
-    instance SuppressUnusedWarnings Bar_0123456789876543210Sym1 where
+    type Bar_0123456789876543210Sym2 (a0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: b0123456789876543210) =
+        Bar_0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (Bar_0123456789876543210Sym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Bar_0123456789876543210Sym1KindInference)
                GHC.Tuple.())
-    data Bar_0123456789876543210Sym1 (l :: a0123456789876543210) (l :: TyFun b0123456789876543210 b0123456789876543210) :: GHC.Types.Type
+    data Bar_0123456789876543210Sym1 (a0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210.
+                                                                                       (~>) b0123456789876543210 b0123456789876543210
       where
-        Bar_0123456789876543210Sym1KindInference :: forall l l arg.
-                                                    SameKind (Apply (Bar_0123456789876543210Sym1 l) arg) (Bar_0123456789876543210Sym2 l arg) =>
-                                                    Bar_0123456789876543210Sym1 l l
-    type instance Apply (Bar_0123456789876543210Sym1 l) l = Bar_0123456789876543210 l l
+        Bar_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                           a0123456789876543210
+                                                           arg.
+                                                    SameKind (Apply (Bar_0123456789876543210Sym1 a0123456789876543210) arg) (Bar_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                    Bar_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Bar_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Bar_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings Bar_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) Bar_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Bar_0123456789876543210Sym0 (l :: TyFun a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)) :: GHC.Types.Type
+    data Bar_0123456789876543210Sym0 :: forall a0123456789876543210
+                                               b0123456789876543210.
+                                        (~>) a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)
       where
-        Bar_0123456789876543210Sym0KindInference :: forall l arg.
+        Bar_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                           arg.
                                                     SameKind (Apply Bar_0123456789876543210Sym0 arg) (Bar_0123456789876543210Sym1 arg) =>
-                                                    Bar_0123456789876543210Sym0 l
-    type instance Apply Bar_0123456789876543210Sym0 l = Bar_0123456789876543210Sym1 l
+                                                    Bar_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Bar_0123456789876543210Sym0 a0123456789876543210 = Bar_0123456789876543210Sym1 a0123456789876543210
     class PFoo (a :: GHC.Types.Type) where
       type Bar (arg :: a) (arg :: b) :: b
       type Bar a a = Apply (Apply Bar_0123456789876543210Sym0 a) a

--- a/tests/compile-and-dump/Singletons/T313.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T313.ghc84.template
@@ -22,42 +22,48 @@ Singletons/T313.hs:(0,0)-(0,0): Splicing declarations
       type PFoo4 a = Maybe a
     instance PC a where
       type PFoo4 a = Maybe a
-    type PFoo1Sym1 t = PFoo1 t
+    type PFoo1Sym1 a0123456789876543210 = PFoo1 a0123456789876543210
     instance SuppressUnusedWarnings PFoo1Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) PFoo1Sym0KindInference) GHC.Tuple.())
-    data PFoo1Sym0 l :: Type
+    data PFoo1Sym0 a0123456789876543210
       where
-        PFoo1Sym0KindInference :: forall l arg.
-                                  SameKind (Apply PFoo1Sym0 arg) (PFoo1Sym1 arg) => PFoo1Sym0 l
-    type instance Apply PFoo1Sym0 l = PFoo1 l
-    type PFoo3Sym1 t = PFoo3 t
+        PFoo1Sym0KindInference :: forall a0123456789876543210 arg.
+                                  SameKind (Apply PFoo1Sym0 arg) (PFoo1Sym1 arg) =>
+                                  PFoo1Sym0 a0123456789876543210
+    type instance Apply PFoo1Sym0 a0123456789876543210 = PFoo1 a0123456789876543210
+    type PFoo3Sym1 a0123456789876543210 = PFoo3 a0123456789876543210
     instance SuppressUnusedWarnings PFoo3Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) PFoo3Sym0KindInference) GHC.Tuple.())
-    data PFoo3Sym0 l :: Type
+    data PFoo3Sym0 a0123456789876543210
       where
-        PFoo3Sym0KindInference :: forall l arg.
-                                  SameKind (Apply PFoo3Sym0 arg) (PFoo3Sym1 arg) => PFoo3Sym0 l
-    type instance Apply PFoo3Sym0 l = PFoo3 l
-    type PFoo2Sym1 (t :: Type) = PFoo2 t
+        PFoo3Sym0KindInference :: forall a0123456789876543210 arg.
+                                  SameKind (Apply PFoo3Sym0 arg) (PFoo3Sym1 arg) =>
+                                  PFoo3Sym0 a0123456789876543210
+    type instance Apply PFoo3Sym0 a0123456789876543210 = PFoo3 a0123456789876543210
+    type PFoo2Sym1 (a0123456789876543210 :: Type) =
+        PFoo2 a0123456789876543210
     instance SuppressUnusedWarnings PFoo2Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) PFoo2Sym0KindInference) GHC.Tuple.())
-    data PFoo2Sym0 (l :: TyFun Type Type) :: Type
+    data PFoo2Sym0 :: (~>) Type Type
       where
-        PFoo2Sym0KindInference :: forall l arg.
-                                  SameKind (Apply PFoo2Sym0 arg) (PFoo2Sym1 arg) => PFoo2Sym0 l
-    type instance Apply PFoo2Sym0 l = PFoo2 l
-    type PFoo4Sym1 (t :: Type) = PFoo4 t
+        PFoo2Sym0KindInference :: forall a0123456789876543210 arg.
+                                  SameKind (Apply PFoo2Sym0 arg) (PFoo2Sym1 arg) =>
+                                  PFoo2Sym0 a0123456789876543210
+    type instance Apply PFoo2Sym0 a0123456789876543210 = PFoo2 a0123456789876543210
+    type PFoo4Sym1 (a0123456789876543210 :: Type) =
+        PFoo4 a0123456789876543210
     instance SuppressUnusedWarnings PFoo4Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) PFoo4Sym0KindInference) GHC.Tuple.())
-    data PFoo4Sym0 (l :: TyFun Type Type) :: Type
+    data PFoo4Sym0 :: (~>) Type Type
       where
-        PFoo4Sym0KindInference :: forall l arg.
-                                  SameKind (Apply PFoo4Sym0 arg) (PFoo4Sym1 arg) => PFoo4Sym0 l
-    type instance Apply PFoo4Sym0 l = PFoo4 l
+        PFoo4Sym0KindInference :: forall a0123456789876543210 arg.
+                                  SameKind (Apply PFoo4Sym0 arg) (PFoo4Sym1 arg) =>
+                                  PFoo4Sym0 a0123456789876543210
+    type instance Apply PFoo4Sym0 a0123456789876543210 = PFoo4 a0123456789876543210
     class PPC (a :: Type)
     instance PPC a
 Singletons/T313.hs:(0,0)-(0,0): Splicing declarations
@@ -84,42 +90,48 @@ Singletons/T313.hs:(0,0)-(0,0): Splicing declarations
       type SFoo4 a = Maybe a
     instance SC a where
       type SFoo4 a = Maybe a
-    type SFoo1Sym1 t = SFoo1 t
+    type SFoo1Sym1 a0123456789876543210 = SFoo1 a0123456789876543210
     instance SuppressUnusedWarnings SFoo1Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SFoo1Sym0KindInference) GHC.Tuple.())
-    data SFoo1Sym0 l :: Type
+    data SFoo1Sym0 a0123456789876543210
       where
-        SFoo1Sym0KindInference :: forall l arg.
-                                  SameKind (Apply SFoo1Sym0 arg) (SFoo1Sym1 arg) => SFoo1Sym0 l
-    type instance Apply SFoo1Sym0 l = SFoo1 l
-    type SFoo3Sym1 t = SFoo3 t
+        SFoo1Sym0KindInference :: forall a0123456789876543210 arg.
+                                  SameKind (Apply SFoo1Sym0 arg) (SFoo1Sym1 arg) =>
+                                  SFoo1Sym0 a0123456789876543210
+    type instance Apply SFoo1Sym0 a0123456789876543210 = SFoo1 a0123456789876543210
+    type SFoo3Sym1 a0123456789876543210 = SFoo3 a0123456789876543210
     instance SuppressUnusedWarnings SFoo3Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SFoo3Sym0KindInference) GHC.Tuple.())
-    data SFoo3Sym0 l :: Type
+    data SFoo3Sym0 a0123456789876543210
       where
-        SFoo3Sym0KindInference :: forall l arg.
-                                  SameKind (Apply SFoo3Sym0 arg) (SFoo3Sym1 arg) => SFoo3Sym0 l
-    type instance Apply SFoo3Sym0 l = SFoo3 l
-    type SFoo2Sym1 (t :: Type) = SFoo2 t
+        SFoo3Sym0KindInference :: forall a0123456789876543210 arg.
+                                  SameKind (Apply SFoo3Sym0 arg) (SFoo3Sym1 arg) =>
+                                  SFoo3Sym0 a0123456789876543210
+    type instance Apply SFoo3Sym0 a0123456789876543210 = SFoo3 a0123456789876543210
+    type SFoo2Sym1 (a0123456789876543210 :: Type) =
+        SFoo2 a0123456789876543210
     instance SuppressUnusedWarnings SFoo2Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SFoo2Sym0KindInference) GHC.Tuple.())
-    data SFoo2Sym0 (l :: TyFun Type Type) :: Type
+    data SFoo2Sym0 :: (~>) Type Type
       where
-        SFoo2Sym0KindInference :: forall l arg.
-                                  SameKind (Apply SFoo2Sym0 arg) (SFoo2Sym1 arg) => SFoo2Sym0 l
-    type instance Apply SFoo2Sym0 l = SFoo2 l
-    type SFoo4Sym1 (t :: Type) = SFoo4 t
+        SFoo2Sym0KindInference :: forall a0123456789876543210 arg.
+                                  SameKind (Apply SFoo2Sym0 arg) (SFoo2Sym1 arg) =>
+                                  SFoo2Sym0 a0123456789876543210
+    type instance Apply SFoo2Sym0 a0123456789876543210 = SFoo2 a0123456789876543210
+    type SFoo4Sym1 (a0123456789876543210 :: Type) =
+        SFoo4 a0123456789876543210
     instance SuppressUnusedWarnings SFoo4Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) SFoo4Sym0KindInference) GHC.Tuple.())
-    data SFoo4Sym0 (l :: TyFun Type Type) :: Type
+    data SFoo4Sym0 :: (~>) Type Type
       where
-        SFoo4Sym0KindInference :: forall l arg.
-                                  SameKind (Apply SFoo4Sym0 arg) (SFoo4Sym1 arg) => SFoo4Sym0 l
-    type instance Apply SFoo4Sym0 l = SFoo4 l
+        SFoo4Sym0KindInference :: forall a0123456789876543210 arg.
+                                  SameKind (Apply SFoo4Sym0 arg) (SFoo4Sym1 arg) =>
+                                  SFoo4Sym0 a0123456789876543210
+    type instance Apply SFoo4Sym0 a0123456789876543210 = SFoo4 a0123456789876543210
     class PSC (a :: Type)
     instance PSC a
     class SSC (a :: Type)

--- a/tests/compile-and-dump/Singletons/T316.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T316.ghc84.template
@@ -3,37 +3,44 @@ Singletons/T316.hs:(0,0)-(0,0): Splicing declarations
       [d| replaceAllGTypes :: (a -> Type -> a) -> [Type] -> [a] -> [a]
           replaceAllGTypes f types as = zipWith f as types |]
   ======>
-    type ReplaceAllGTypesSym3 (t :: (Data.Singletons.Internal.~>) a0123456789876543210 ((Data.Singletons.Internal.~>) Type a0123456789876543210)) (t :: [Type]) (t :: [a0123456789876543210]) =
-        ReplaceAllGTypes t t t
-    instance SuppressUnusedWarnings ReplaceAllGTypesSym2 where
+    type ReplaceAllGTypesSym3 (a0123456789876543210 :: (Data.Singletons.Internal.~>) a0123456789876543210 ((Data.Singletons.Internal.~>) Type a0123456789876543210)) (a0123456789876543210 :: [Type]) (a0123456789876543210 :: [a0123456789876543210]) =
+        ReplaceAllGTypes a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ReplaceAllGTypesSym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ReplaceAllGTypesSym2KindInference) GHC.Tuple.())
-    data ReplaceAllGTypesSym2 (l :: (Data.Singletons.Internal.~>) a0123456789876543210 ((Data.Singletons.Internal.~>) Type a0123456789876543210)) (l :: [Type]) (l :: TyFun [a0123456789876543210] [a0123456789876543210]) :: Type
+    data ReplaceAllGTypesSym2 (a0123456789876543210 :: (Data.Singletons.Internal.~>) a0123456789876543210 ((Data.Singletons.Internal.~>) Type a0123456789876543210)) (a0123456789876543210 :: [Type]) :: (Data.Singletons.Internal.~>) [a0123456789876543210] [a0123456789876543210]
       where
-        ReplaceAllGTypesSym2KindInference :: forall l l l arg.
-                                             Data.Singletons.Internal.SameKind (Apply (ReplaceAllGTypesSym2 l l) arg) (ReplaceAllGTypesSym3 l l arg) =>
-                                             ReplaceAllGTypesSym2 l l l
-    type instance Apply (ReplaceAllGTypesSym2 l l) l = ReplaceAllGTypes l l l
-    instance SuppressUnusedWarnings ReplaceAllGTypesSym1 where
+        ReplaceAllGTypesSym2KindInference :: forall a0123456789876543210
+                                                    a0123456789876543210
+                                                    a0123456789876543210
+                                                    arg.
+                                             Data.Singletons.Internal.SameKind (Apply (ReplaceAllGTypesSym2 a0123456789876543210 a0123456789876543210) arg) (ReplaceAllGTypesSym3 a0123456789876543210 a0123456789876543210 arg) =>
+                                             ReplaceAllGTypesSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type instance Apply (ReplaceAllGTypesSym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ReplaceAllGTypes a0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (ReplaceAllGTypesSym1 a0123456789876543210) where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ReplaceAllGTypesSym1KindInference) GHC.Tuple.())
-    data ReplaceAllGTypesSym1 (l :: (Data.Singletons.Internal.~>) a0123456789876543210 ((Data.Singletons.Internal.~>) Type a0123456789876543210)) (l :: TyFun [Type] ((Data.Singletons.Internal.~>) [a0123456789876543210] [a0123456789876543210])) :: Type
+    data ReplaceAllGTypesSym1 (a0123456789876543210 :: (Data.Singletons.Internal.~>) a0123456789876543210 ((Data.Singletons.Internal.~>) Type a0123456789876543210)) :: (Data.Singletons.Internal.~>) [Type] ((Data.Singletons.Internal.~>) [a0123456789876543210] [a0123456789876543210])
       where
-        ReplaceAllGTypesSym1KindInference :: forall l l arg.
-                                             Data.Singletons.Internal.SameKind (Apply (ReplaceAllGTypesSym1 l) arg) (ReplaceAllGTypesSym2 l arg) =>
-                                             ReplaceAllGTypesSym1 l l
-    type instance Apply (ReplaceAllGTypesSym1 l) l = ReplaceAllGTypesSym2 l l
+        ReplaceAllGTypesSym1KindInference :: forall a0123456789876543210
+                                                    a0123456789876543210
+                                                    arg.
+                                             Data.Singletons.Internal.SameKind (Apply (ReplaceAllGTypesSym1 a0123456789876543210) arg) (ReplaceAllGTypesSym2 a0123456789876543210 arg) =>
+                                             ReplaceAllGTypesSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (ReplaceAllGTypesSym1 a0123456789876543210) a0123456789876543210 = ReplaceAllGTypesSym2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ReplaceAllGTypesSym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,) ReplaceAllGTypesSym0KindInference) GHC.Tuple.())
-    data ReplaceAllGTypesSym0 (l :: TyFun ((Data.Singletons.Internal.~>) a0123456789876543210 ((Data.Singletons.Internal.~>) Type a0123456789876543210)) ((Data.Singletons.Internal.~>) [Type] ((Data.Singletons.Internal.~>) [a0123456789876543210] [a0123456789876543210]))) :: Type
+    data ReplaceAllGTypesSym0 :: forall a0123456789876543210.
+                                 (Data.Singletons.Internal.~>) ((Data.Singletons.Internal.~>) a0123456789876543210 ((Data.Singletons.Internal.~>) Type a0123456789876543210)) ((Data.Singletons.Internal.~>) [Type] ((Data.Singletons.Internal.~>) [a0123456789876543210] [a0123456789876543210]))
       where
-        ReplaceAllGTypesSym0KindInference :: forall l arg.
+        ReplaceAllGTypesSym0KindInference :: forall a0123456789876543210
+                                                    arg.
                                              Data.Singletons.Internal.SameKind (Apply ReplaceAllGTypesSym0 arg) (ReplaceAllGTypesSym1 arg) =>
-                                             ReplaceAllGTypesSym0 l
-    type instance Apply ReplaceAllGTypesSym0 l = ReplaceAllGTypesSym1 l
+                                             ReplaceAllGTypesSym0 a0123456789876543210
+    type instance Apply ReplaceAllGTypesSym0 a0123456789876543210 = ReplaceAllGTypesSym1 a0123456789876543210
     type family ReplaceAllGTypes (a :: (Data.Singletons.Internal.~>) a ((Data.Singletons.Internal.~>) Type a)) (a :: [Type]) (a :: [a]) :: [a] where
       ReplaceAllGTypes f types as = Apply (Apply (Apply ZipWithSym0 f) as) types

--- a/tests/compile-and-dump/Singletons/T322.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T322.ghc84.template
@@ -8,24 +8,29 @@ Singletons/T322.hs:(0,0)-(0,0): Splicing declarations
     (!) :: Bool -> Bool -> Bool
     (!) = (||)
     infixr 2 !
-    type (!@#@$$$) (t :: Bool) (t :: Bool) = (:!) t t
-    instance SuppressUnusedWarnings (!@#@$$) where
+    type (!@#@$$$) (a0123456789876543210 :: Bool) (a0123456789876543210 :: Bool) =
+        (:!) a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings ((!@#@$$) a0123456789876543210) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:!@#@$$###)) GHC.Tuple.())
-    data (!@#@$$) (l :: Bool) (l :: TyFun Bool Bool) :: GHC.Types.Type
+    data (!@#@$$) (a0123456789876543210 :: Bool) :: (~>) Bool Bool
       where
-        (:!@#@$$###) :: forall l l arg.
-                        SameKind (Apply ((!@#@$$) l) arg) ((!@#@$$$) l arg) => (!@#@$$) l l
-    type instance Apply ((!@#@$$) l) l = (:!) l l
+        (:!@#@$$###) :: forall a0123456789876543210
+                               a0123456789876543210
+                               arg.
+                        SameKind (Apply ((!@#@$$) a0123456789876543210) arg) ((!@#@$$$) a0123456789876543210 arg) =>
+                        (!@#@$$) a0123456789876543210 a0123456789876543210
+    type instance Apply ((!@#@$$) a0123456789876543210) a0123456789876543210 = (:!) a0123456789876543210 a0123456789876543210
     infixr 2 !@#@$$
     instance SuppressUnusedWarnings (!@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:!@#@$###)) GHC.Tuple.())
-    data (!@#@$) (l :: TyFun Bool ((~>) Bool Bool)) :: GHC.Types.Type
+    data !@#@$ :: (~>) Bool ((~>) Bool Bool)
       where
-        (:!@#@$###) :: forall l arg.
-                       SameKind (Apply (!@#@$) arg) ((!@#@$$) arg) => (!@#@$) l
-    type instance Apply (!@#@$) l = (!@#@$$) l
+        (:!@#@$###) :: forall a0123456789876543210 arg.
+                       SameKind (Apply (!@#@$) arg) ((!@#@$$) arg) =>
+                       (!@#@$) a0123456789876543210
+    type instance Apply (!@#@$) a0123456789876543210 = (!@#@$$) a0123456789876543210
     infixr 2 !@#@$
     type family (:!) (a :: Bool) (a :: Bool) :: Bool where
       (:!) a_0123456789876543210 a_0123456789876543210 = Apply (Apply (||@#@$) a_0123456789876543210) a_0123456789876543210

--- a/tests/compile-and-dump/Singletons/T33.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T33.ghc84.template
@@ -5,15 +5,17 @@ Singletons/T33.hs:(0,0)-(0,0): Splicing declarations
   ======>
     foo :: (Bool, Bool) -> ()
     foo ~(_, _) = GHC.Tuple.()
-    type FooSym1 (t :: (Bool, Bool)) = Foo t
+    type FooSym1 (a0123456789876543210 :: (Bool, Bool)) =
+        Foo a0123456789876543210
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym0KindInference) GHC.Tuple.())
-    data FooSym0 (l :: TyFun (Bool, Bool) ()) :: GHC.Types.Type
+    data FooSym0 :: (~>) (Bool, Bool) ()
       where
-        FooSym0KindInference :: forall l arg.
-                                SameKind (Apply FooSym0 arg) (FooSym1 arg) => FooSym0 l
-    type instance Apply FooSym0 l = Foo l
+        FooSym0KindInference :: forall a0123456789876543210 arg.
+                                SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
+                                FooSym0 a0123456789876543210
+    type instance Apply FooSym0 a0123456789876543210 = Foo a0123456789876543210
     type family Foo (a :: (Bool, Bool)) :: () where
       Foo (GHC.Tuple.(,) _ _) = Tuple0Sym0
     sFoo ::

--- a/tests/compile-and-dump/Singletons/T54.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T54.ghc84.template
@@ -5,34 +5,35 @@ Singletons/T54.hs:(0,0)-(0,0): Splicing declarations
   ======>
     g :: Bool -> Bool
     g e = (case [not] of { [_] -> not }) e
-    type Let0123456789876543210Scrutinee_0123456789876543210Sym1 t =
-        Let0123456789876543210Scrutinee_0123456789876543210 t
+    type Let0123456789876543210Scrutinee_0123456789876543210Sym1 e0123456789876543210 =
+        Let0123456789876543210Scrutinee_0123456789876543210 e0123456789876543210
     instance SuppressUnusedWarnings Let0123456789876543210Scrutinee_0123456789876543210Sym0 where
       suppressUnusedWarnings
         = snd
             ((GHC.Tuple.(,)
                 Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference)
                GHC.Tuple.())
-    data Let0123456789876543210Scrutinee_0123456789876543210Sym0 l :: GHC.Types.Type
+    data Let0123456789876543210Scrutinee_0123456789876543210Sym0 e0123456789876543210
       where
-        Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference :: forall l
+        Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference :: forall e0123456789876543210
                                                                                        arg.
                                                                                 SameKind (Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 arg) (Let0123456789876543210Scrutinee_0123456789876543210Sym1 arg) =>
-                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym0 l
-    type instance Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 l = Let0123456789876543210Scrutinee_0123456789876543210 l
+                                                                                Let0123456789876543210Scrutinee_0123456789876543210Sym0 e0123456789876543210
+    type instance Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 e0123456789876543210 = Let0123456789876543210Scrutinee_0123456789876543210 e0123456789876543210
     type family Let0123456789876543210Scrutinee_0123456789876543210 e where
       Let0123456789876543210Scrutinee_0123456789876543210 e = Apply (Apply (:@#@$) NotSym0) '[]
     type family Case_0123456789876543210 e t where
       Case_0123456789876543210 e '[_] = NotSym0
-    type GSym1 (t :: Bool) = G t
+    type GSym1 (a0123456789876543210 :: Bool) = G a0123456789876543210
     instance SuppressUnusedWarnings GSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) GSym0KindInference) GHC.Tuple.())
-    data GSym0 (l :: TyFun Bool Bool) :: GHC.Types.Type
+    data GSym0 :: (~>) Bool Bool
       where
-        GSym0KindInference :: forall l arg.
-                              SameKind (Apply GSym0 arg) (GSym1 arg) => GSym0 l
-    type instance Apply GSym0 l = G l
+        GSym0KindInference :: forall a0123456789876543210 arg.
+                              SameKind (Apply GSym0 arg) (GSym1 arg) =>
+                              GSym0 a0123456789876543210
+    type instance Apply GSym0 a0123456789876543210 = G a0123456789876543210
     type family G (a :: Bool) :: Bool where
       G e = Apply (Case_0123456789876543210 e (Let0123456789876543210Scrutinee_0123456789876543210Sym1 e)) e
     sG :: forall (t :: Bool). Sing t -> Sing (Apply GSym0 t :: Bool)

--- a/tests/compile-and-dump/Singletons/T78.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T78.ghc84.template
@@ -9,15 +9,17 @@ Singletons/T78.hs:(0,0)-(0,0): Splicing declarations
     foo (Just False) = False
     foo (Just True) = True
     foo Nothing = False
-    type FooSym1 (t :: Maybe Bool) = Foo t
+    type FooSym1 (a0123456789876543210 :: Maybe Bool) =
+        Foo a0123456789876543210
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym0KindInference) GHC.Tuple.())
-    data FooSym0 (l :: TyFun (Maybe Bool) Bool) :: GHC.Types.Type
+    data FooSym0 :: (~>) (Maybe Bool) Bool
       where
-        FooSym0KindInference :: forall l arg.
-                                SameKind (Apply FooSym0 arg) (FooSym1 arg) => FooSym0 l
-    type instance Apply FooSym0 l = Foo l
+        FooSym0KindInference :: forall a0123456789876543210 arg.
+                                SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
+                                FooSym0 a0123456789876543210
+    type instance Apply FooSym0 a0123456789876543210 = Foo a0123456789876543210
     type family Foo (a :: Maybe Bool) :: Bool where
       Foo (Just False) = FalseSym0
       Foo (Just True) = TrueSym0

--- a/tests/compile-and-dump/Singletons/TopLevelPatterns.ghc84.template
+++ b/tests/compile-and-dump/Singletons/TopLevelPatterns.ghc84.template
@@ -7,25 +7,30 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
     data Foo = Bar Bool Bool
     type FalseSym0 = False
     type TrueSym0 = True
-    type BarSym2 (t :: Bool) (t :: Bool) = Bar t t
-    instance SuppressUnusedWarnings BarSym1 where
+    type BarSym2 (t0123456789876543210 :: Bool) (t0123456789876543210 :: Bool) =
+        Bar t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (BarSym1 t0123456789876543210) where
       suppressUnusedWarnings
         = Data.Tuple.snd
             ((GHC.Tuple.(,) BarSym1KindInference) GHC.Tuple.())
-    data BarSym1 (l :: Bool) (l :: TyFun Bool Foo) :: GHC.Types.Type
+    data BarSym1 (t0123456789876543210 :: Bool) :: (~>) Bool Foo
       where
-        BarSym1KindInference :: forall l l arg.
-                                SameKind (Apply (BarSym1 l) arg) (BarSym2 l arg) => BarSym1 l l
-    type instance Apply (BarSym1 l) l = Bar l l
+        BarSym1KindInference :: forall t0123456789876543210
+                                       t0123456789876543210
+                                       arg.
+                                SameKind (Apply (BarSym1 t0123456789876543210) arg) (BarSym2 t0123456789876543210 arg) =>
+                                BarSym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (BarSym1 t0123456789876543210) t0123456789876543210 = Bar t0123456789876543210 t0123456789876543210
     instance SuppressUnusedWarnings BarSym0 where
       suppressUnusedWarnings
         = Data.Tuple.snd
             ((GHC.Tuple.(,) BarSym0KindInference) GHC.Tuple.())
-    data BarSym0 (l :: TyFun Bool ((~>) Bool Foo)) :: GHC.Types.Type
+    data BarSym0 :: (~>) Bool ((~>) Bool Foo)
       where
-        BarSym0KindInference :: forall l arg.
-                                SameKind (Apply BarSym0 arg) (BarSym1 arg) => BarSym0 l
-    type instance Apply BarSym0 l = BarSym1 l
+        BarSym0KindInference :: forall t0123456789876543210 arg.
+                                SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
+                                BarSym0 t0123456789876543210
+    type instance Apply BarSym0 t0123456789876543210 = BarSym1 t0123456789876543210
     data instance Sing :: Bool -> GHC.Types.Type :: Bool
                                                     -> GHC.Types.Type
       where
@@ -130,61 +135,70 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
       Case_0123456789876543210 '[_,
                                  y_0123456789876543210] = y_0123456789876543210
     type False_Sym0 = False_
-    type NotSym1 (t :: Bool) = Not t
+    type NotSym1 (a0123456789876543210 :: Bool) =
+        Not a0123456789876543210
     instance SuppressUnusedWarnings NotSym0 where
       suppressUnusedWarnings
         = Data.Tuple.snd
             ((GHC.Tuple.(,) NotSym0KindInference) GHC.Tuple.())
-    data NotSym0 (l :: TyFun Bool Bool) :: GHC.Types.Type
+    data NotSym0 :: (~>) Bool Bool
       where
-        NotSym0KindInference :: forall l arg.
-                                SameKind (Apply NotSym0 arg) (NotSym1 arg) => NotSym0 l
-    type instance Apply NotSym0 l = Not l
-    type IdSym1 (t :: a0123456789876543210) = Id t
+        NotSym0KindInference :: forall a0123456789876543210 arg.
+                                SameKind (Apply NotSym0 arg) (NotSym1 arg) =>
+                                NotSym0 a0123456789876543210
+    type instance Apply NotSym0 a0123456789876543210 = Not a0123456789876543210
+    type IdSym1 (a0123456789876543210 :: a0123456789876543210) =
+        Id a0123456789876543210
     instance SuppressUnusedWarnings IdSym0 where
       suppressUnusedWarnings
         = Data.Tuple.snd ((GHC.Tuple.(,) IdSym0KindInference) GHC.Tuple.())
-    data IdSym0 (l :: TyFun a0123456789876543210 a0123456789876543210) :: GHC.Types.Type
+    data IdSym0 :: forall a0123456789876543210.
+                   (~>) a0123456789876543210 a0123456789876543210
       where
-        IdSym0KindInference :: forall l arg.
-                               SameKind (Apply IdSym0 arg) (IdSym1 arg) => IdSym0 l
-    type instance Apply IdSym0 l = Id l
-    type FSym1 (t :: Bool) = F t
+        IdSym0KindInference :: forall a0123456789876543210 arg.
+                               SameKind (Apply IdSym0 arg) (IdSym1 arg) =>
+                               IdSym0 a0123456789876543210
+    type instance Apply IdSym0 a0123456789876543210 = Id a0123456789876543210
+    type FSym1 (a0123456789876543210 :: Bool) = F a0123456789876543210
     instance SuppressUnusedWarnings FSym0 where
       suppressUnusedWarnings
         = Data.Tuple.snd ((GHC.Tuple.(,) FSym0KindInference) GHC.Tuple.())
-    data FSym0 (l :: TyFun Bool Bool) :: GHC.Types.Type
+    data FSym0 :: (~>) Bool Bool
       where
-        FSym0KindInference :: forall l arg.
-                              SameKind (Apply FSym0 arg) (FSym1 arg) => FSym0 l
-    type instance Apply FSym0 l = F l
-    type GSym1 (t :: Bool) = G t
+        FSym0KindInference :: forall a0123456789876543210 arg.
+                              SameKind (Apply FSym0 arg) (FSym1 arg) =>
+                              FSym0 a0123456789876543210
+    type instance Apply FSym0 a0123456789876543210 = F a0123456789876543210
+    type GSym1 (a0123456789876543210 :: Bool) = G a0123456789876543210
     instance SuppressUnusedWarnings GSym0 where
       suppressUnusedWarnings
         = Data.Tuple.snd ((GHC.Tuple.(,) GSym0KindInference) GHC.Tuple.())
-    data GSym0 (l :: TyFun Bool Bool) :: GHC.Types.Type
+    data GSym0 :: (~>) Bool Bool
       where
-        GSym0KindInference :: forall l arg.
-                              SameKind (Apply GSym0 arg) (GSym1 arg) => GSym0 l
-    type instance Apply GSym0 l = G l
-    type HSym1 (t :: Bool) = H t
+        GSym0KindInference :: forall a0123456789876543210 arg.
+                              SameKind (Apply GSym0 arg) (GSym1 arg) =>
+                              GSym0 a0123456789876543210
+    type instance Apply GSym0 a0123456789876543210 = G a0123456789876543210
+    type HSym1 (a0123456789876543210 :: Bool) = H a0123456789876543210
     instance SuppressUnusedWarnings HSym0 where
       suppressUnusedWarnings
         = Data.Tuple.snd ((GHC.Tuple.(,) HSym0KindInference) GHC.Tuple.())
-    data HSym0 (l :: TyFun Bool Bool) :: GHC.Types.Type
+    data HSym0 :: (~>) Bool Bool
       where
-        HSym0KindInference :: forall l arg.
-                              SameKind (Apply HSym0 arg) (HSym1 arg) => HSym0 l
-    type instance Apply HSym0 l = H l
-    type ISym1 (t :: Bool) = I t
+        HSym0KindInference :: forall a0123456789876543210 arg.
+                              SameKind (Apply HSym0 arg) (HSym1 arg) =>
+                              HSym0 a0123456789876543210
+    type instance Apply HSym0 a0123456789876543210 = H a0123456789876543210
+    type ISym1 (a0123456789876543210 :: Bool) = I a0123456789876543210
     instance SuppressUnusedWarnings ISym0 where
       suppressUnusedWarnings
         = Data.Tuple.snd ((GHC.Tuple.(,) ISym0KindInference) GHC.Tuple.())
-    data ISym0 (l :: TyFun Bool Bool) :: GHC.Types.Type
+    data ISym0 :: (~>) Bool Bool
       where
-        ISym0KindInference :: forall l arg.
-                              SameKind (Apply ISym0 arg) (ISym1 arg) => ISym0 l
-    type instance Apply ISym0 l = I l
+        ISym0KindInference :: forall a0123456789876543210 arg.
+                              SameKind (Apply ISym0 arg) (ISym1 arg) =>
+                              ISym0 a0123456789876543210
+    type instance Apply ISym0 a0123456789876543210 = I a0123456789876543210
     type JSym0 = J
     type KSym0 = K
     type LSym0 = L

--- a/tests/compile-and-dump/Singletons/Undef.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Undef.ghc84.template
@@ -9,24 +9,28 @@ Singletons/Undef.hs:(0,0)-(0,0): Splicing declarations
     foo = undefined
     bar :: Bool -> Bool
     bar = error "urk"
-    type BarSym1 (t :: Bool) = Bar t
+    type BarSym1 (a0123456789876543210 :: Bool) =
+        Bar a0123456789876543210
     instance SuppressUnusedWarnings BarSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) BarSym0KindInference) GHC.Tuple.())
-    data BarSym0 (l :: TyFun Bool Bool) :: GHC.Types.Type
+    data BarSym0 :: (~>) Bool Bool
       where
-        BarSym0KindInference :: forall l arg.
-                                SameKind (Apply BarSym0 arg) (BarSym1 arg) => BarSym0 l
-    type instance Apply BarSym0 l = Bar l
-    type FooSym1 (t :: Bool) = Foo t
+        BarSym0KindInference :: forall a0123456789876543210 arg.
+                                SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
+                                BarSym0 a0123456789876543210
+    type instance Apply BarSym0 a0123456789876543210 = Bar a0123456789876543210
+    type FooSym1 (a0123456789876543210 :: Bool) =
+        Foo a0123456789876543210
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) FooSym0KindInference) GHC.Tuple.())
-    data FooSym0 (l :: TyFun Bool Bool) :: GHC.Types.Type
+    data FooSym0 :: (~>) Bool Bool
       where
-        FooSym0KindInference :: forall l arg.
-                                SameKind (Apply FooSym0 arg) (FooSym1 arg) => FooSym0 l
-    type instance Apply FooSym0 l = Foo l
+        FooSym0KindInference :: forall a0123456789876543210 arg.
+                                SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
+                                FooSym0 a0123456789876543210
+    type instance Apply FooSym0 a0123456789876543210 = Foo a0123456789876543210
     type family Bar (a :: Bool) :: Bool where
       Bar a_0123456789876543210 = Apply (Apply ErrorSym0 "urk") a_0123456789876543210
     type family Foo (a :: Bool) :: Bool where


### PR DESCRIPTION
This patch augments `genDefunSymbols` with the power to defunctionalize types that make use of dependent quantification _à la_ `TypeInType`, such as:

```haskell
type family MyProxy k (a :: k) :: Type where
   MyProxy k (a :: k) = Proxy a
```

The process by which this happens is explained in a very beefy `Note [Defunctionalization and TypeInType]`.

Fixes #216.