### PR TITLE
Produce defunctionalization symbols for type synonym/family declarations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,11 @@ Changelog for singletons project
   allowing it to work over more open kinds. Also rename `SomeTypeRepStar` to
   `SomeTypeRepTYPE`, and change its definition accordingly.
 
+* Promoting or singling a type synonym or type family declaration now produces
+  defunctionalization symbols for it. (Previously, promoting or singling a type
+  synonym did nothing whatsoever, and promoting or singling a type family
+  produced an error.)
+
 * Add `(%<=?)`, a singled version of `(<=?)` from `GHC.TypeNats`, as well as
   defunctionalization symbols for `(<=?)`, to `Data.Singletons.TypeLits`.
 

--- a/README.md
+++ b/README.md
@@ -689,3 +689,6 @@ Known bugs
   problem is that a use of an associated type family tied to a class with
   fundeps doesn't provoke the fundep to kick in. This is GHC's problem, in
   the end.
+* Singled code that contains uses type families is likely to fail due to GHC
+  Trac #12564. Note that singling type family declarations themselves is fine
+  (and often desired, since that produces defunctionalization symbols for them).

--- a/src/Data/Singletons/Promote.hs
+++ b/src/Data/Singletons/Promote.hs
@@ -188,12 +188,16 @@ promoteDecs :: [DDec] -> PrM ()
 promoteDecs raw_decls = do
   decls <- expand raw_decls     -- expand type synonyms
   checkForRepInDecls decls
-  PDecs { pd_let_decs          = let_decs
-        , pd_class_decs        = classes
-        , pd_instance_decs     = insts
-        , pd_data_decs         = datas
-        , pd_derived_eq_decs   = derived_eq_decs } <- partitionDecs decls
+  PDecs { pd_let_decs                = let_decs
+        , pd_class_decs              = classes
+        , pd_instance_decs           = insts
+        , pd_data_decs               = datas
+        , pd_ty_syn_decs             = ty_syns
+        , pd_open_type_family_decs   = o_tyfams
+        , pd_closed_type_family_decs = c_tyfams
+        , pd_derived_eq_decs         = derived_eq_decs } <- partitionDecs decls
 
+  defunTypeDecls ty_syns c_tyfams o_tyfams
     -- promoteLetDecs returns LetBinds, which we don't need at top level
   _ <- promoteLetDecs noPrefix let_decs
   mapM_ promoteClassDec classes

--- a/src/Data/Singletons/Single.hs
+++ b/src/Data/Singletons/Single.hs
@@ -20,6 +20,7 @@ import Data.Singletons.Deriving.Enum
 import Data.Singletons.Deriving.Show
 import Data.Singletons.Util
 import Data.Singletons.Promote
+import Data.Singletons.Promote.Defun
 import Data.Singletons.Promote.Monad ( promoteM )
 import Data.Singletons.Promote.Type
 import Data.Singletons.Names
@@ -239,14 +240,18 @@ singInfo (DPatSynI {}) =
 singTopLevelDecs :: DsMonad q => [Dec] -> [DDec] -> q [DDec]
 singTopLevelDecs locals raw_decls = withLocalDeclarations locals $ do
   decls <- expand raw_decls     -- expand type synonyms
-  PDecs { pd_let_decs          = letDecls
-        , pd_class_decs        = classes
-        , pd_instance_decs     = insts
-        , pd_data_decs         = datas
-        , pd_derived_eq_decs   = derivedEqDecs
-        , pd_derived_show_decs = derivedShowDecs } <- partitionDecs decls
+  PDecs { pd_let_decs                = letDecls
+        , pd_class_decs              = classes
+        , pd_instance_decs           = insts
+        , pd_data_decs               = datas
+        , pd_ty_syn_decs             = ty_syns
+        , pd_open_type_family_decs   = o_tyfams
+        , pd_closed_type_family_decs = c_tyfams
+        , pd_derived_eq_decs         = derivedEqDecs
+        , pd_derived_show_decs       = derivedShowDecs } <- partitionDecs decls
 
   ((letDecEnv, classes', insts'), promDecls) <- promoteM locals $ do
+    defunTypeDecls ty_syns c_tyfams o_tyfams
     promoteDataDecs datas
     (_, letDecEnv) <- promoteLetDecs noPrefix letDecls
     classes' <- mapM promoteClassDec classes

--- a/src/Data/Singletons/Syntax.hs
+++ b/src/Data/Singletons/Syntax.hs
@@ -45,8 +45,23 @@ instance Monoid PromDPatInfos where
 -- See @Note [Singling pattern signatures]@.
 type SingDSigPaInfos = [(DExp, DType)]
 
-  -- the relevant part of declarations
-data DataDecl      = DataDecl NewOrData Name [DTyVarBndr] [DCon] [DPred]
+-- The parts of data declarations that are relevant to singletons.
+data DataDecl = DataDecl NewOrData Name [DTyVarBndr] [DCon] [DPred]
+
+-- The parts of type synonyms that are relevant to singletons.
+data TySynDecl = TySynDecl Name [DTyVarBndr]
+
+-- The parts of open type families that are relevant to singletons.
+type OpenTypeFamilyDecl = TypeFamilyDecl 'Open
+
+-- The parts of closed type families that are relevant to singletons.
+type ClosedTypeFamilyDecl = TypeFamilyDecl 'Closed
+
+-- The parts of type families that are relevant to singletons.
+newtype TypeFamilyDecl (info :: FamilyInfo)
+  = TypeFamilyDecl { getTypeFamilyDecl :: DTypeFamilyHead }
+-- Whether a type family is open or closed.
+data FamilyInfo = Open | Closed
 
 data ClassDecl ann = ClassDecl { cd_cxt  :: DCxt
                                , cd_name :: Name

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -90,6 +90,7 @@ tests =
     , compileAndDumpStdTest "TypeRepTYPE"
     , compileAndDumpStdTest "T297"
     , compileAndDumpStdTest "T312"
+    , compileAndDumpStdTest "T313"
     , compileAndDumpStdTest "T316"
     ],
     testCompileAndDumpGroup "Promote"

--- a/tests/compile-and-dump/Singletons/T178.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T178.ghc84.template
@@ -14,6 +14,7 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
     type U = [(Symbol, Occ)]
     empty :: U
     empty = []
+    type USym0 = U
     type StrSym0 = Str
     type OptSym0 = Opt
     type ManySym0 = Many

--- a/tests/compile-and-dump/Singletons/T313.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T313.ghc84.template
@@ -1,0 +1,126 @@
+Singletons/T313.hs:(0,0)-(0,0): Splicing declarations
+    promote
+      [d| type PFoo1 a = Maybe a
+          type family PFoo2 a
+          type family PFoo3 a where
+            PFoo3 a = Maybe a
+          class PC (a :: Type) where
+            type PFoo4 a
+            type PFoo4 a = Maybe a
+          
+          type instance PFoo2 a = Maybe a
+          instance PC a where
+            type PFoo4 a = Maybe a |]
+  ======>
+    type PFoo1 a = Maybe a
+    type family PFoo2 a
+    type instance PFoo2 a = Maybe a
+    type family PFoo3 a where
+      PFoo3 a = Maybe a
+    class PC (a :: Type) where
+      type PFoo4 a
+      type PFoo4 a = Maybe a
+    instance PC a where
+      type PFoo4 a = Maybe a
+    type PFoo1Sym1 t = PFoo1 t
+    instance SuppressUnusedWarnings PFoo1Sym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) PFoo1Sym0KindInference) GHC.Tuple.())
+    data PFoo1Sym0 l :: Type
+      where
+        PFoo1Sym0KindInference :: forall l arg.
+                                  SameKind (Apply PFoo1Sym0 arg) (PFoo1Sym1 arg) => PFoo1Sym0 l
+    type instance Apply PFoo1Sym0 l = PFoo1 l
+    type PFoo3Sym1 t = PFoo3 t
+    instance SuppressUnusedWarnings PFoo3Sym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) PFoo3Sym0KindInference) GHC.Tuple.())
+    data PFoo3Sym0 l :: Type
+      where
+        PFoo3Sym0KindInference :: forall l arg.
+                                  SameKind (Apply PFoo3Sym0 arg) (PFoo3Sym1 arg) => PFoo3Sym0 l
+    type instance Apply PFoo3Sym0 l = PFoo3 l
+    type PFoo2Sym1 (t :: Type) = PFoo2 t
+    instance SuppressUnusedWarnings PFoo2Sym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) PFoo2Sym0KindInference) GHC.Tuple.())
+    data PFoo2Sym0 (l :: TyFun Type Type) :: Type
+      where
+        PFoo2Sym0KindInference :: forall l arg.
+                                  SameKind (Apply PFoo2Sym0 arg) (PFoo2Sym1 arg) => PFoo2Sym0 l
+    type instance Apply PFoo2Sym0 l = PFoo2 l
+    type PFoo4Sym1 (t :: Type) = PFoo4 t
+    instance SuppressUnusedWarnings PFoo4Sym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) PFoo4Sym0KindInference) GHC.Tuple.())
+    data PFoo4Sym0 (l :: TyFun Type Type) :: Type
+      where
+        PFoo4Sym0KindInference :: forall l arg.
+                                  SameKind (Apply PFoo4Sym0 arg) (PFoo4Sym1 arg) => PFoo4Sym0 l
+    type instance Apply PFoo4Sym0 l = PFoo4 l
+    class PPC (a :: Type)
+    instance PPC a
+Singletons/T313.hs:(0,0)-(0,0): Splicing declarations
+    singletons
+      [d| type SFoo1 a = Maybe a
+          type family SFoo2 a
+          type family SFoo3 a where
+            SFoo3 a = Maybe a
+          class SC (a :: Type) where
+            type SFoo4 a
+            type SFoo4 a = Maybe a
+          
+          type instance SFoo2 a = Maybe a
+          instance SC a where
+            type SFoo4 a = Maybe a |]
+  ======>
+    type SFoo1 a = Maybe a
+    type family SFoo2 a
+    type instance SFoo2 a = Maybe a
+    type family SFoo3 a where
+      SFoo3 a = Maybe a
+    class SC (a :: Type) where
+      type SFoo4 a
+      type SFoo4 a = Maybe a
+    instance SC a where
+      type SFoo4 a = Maybe a
+    type SFoo1Sym1 t = SFoo1 t
+    instance SuppressUnusedWarnings SFoo1Sym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) SFoo1Sym0KindInference) GHC.Tuple.())
+    data SFoo1Sym0 l :: Type
+      where
+        SFoo1Sym0KindInference :: forall l arg.
+                                  SameKind (Apply SFoo1Sym0 arg) (SFoo1Sym1 arg) => SFoo1Sym0 l
+    type instance Apply SFoo1Sym0 l = SFoo1 l
+    type SFoo3Sym1 t = SFoo3 t
+    instance SuppressUnusedWarnings SFoo3Sym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) SFoo3Sym0KindInference) GHC.Tuple.())
+    data SFoo3Sym0 l :: Type
+      where
+        SFoo3Sym0KindInference :: forall l arg.
+                                  SameKind (Apply SFoo3Sym0 arg) (SFoo3Sym1 arg) => SFoo3Sym0 l
+    type instance Apply SFoo3Sym0 l = SFoo3 l
+    type SFoo2Sym1 (t :: Type) = SFoo2 t
+    instance SuppressUnusedWarnings SFoo2Sym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) SFoo2Sym0KindInference) GHC.Tuple.())
+    data SFoo2Sym0 (l :: TyFun Type Type) :: Type
+      where
+        SFoo2Sym0KindInference :: forall l arg.
+                                  SameKind (Apply SFoo2Sym0 arg) (SFoo2Sym1 arg) => SFoo2Sym0 l
+    type instance Apply SFoo2Sym0 l = SFoo2 l
+    type SFoo4Sym1 (t :: Type) = SFoo4 t
+    instance SuppressUnusedWarnings SFoo4Sym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) SFoo4Sym0KindInference) GHC.Tuple.())
+    data SFoo4Sym0 (l :: TyFun Type Type) :: Type
+      where
+        SFoo4Sym0KindInference :: forall l arg.
+                                  SameKind (Apply SFoo4Sym0 arg) (SFoo4Sym1 arg) => SFoo4Sym0 l
+    type instance Apply SFoo4Sym0 l = SFoo4 l
+    class PSC (a :: Type)
+    instance PSC a
+    class SSC (a :: Type)
+    instance SSC a

--- a/tests/compile-and-dump/Singletons/T313.hs
+++ b/tests/compile-and-dump/Singletons/T313.hs
@@ -1,0 +1,38 @@
+module T313 where
+
+import Data.Kind
+import Data.Singletons.TH
+
+$(promote [d|
+  type PFoo1 a = Maybe a
+
+  type family   PFoo2 a
+  type instance PFoo2 a = Maybe a
+
+  type family PFoo3 a where
+    PFoo3 a = Maybe a
+
+  class PC (a :: Type) where
+    type PFoo4 a
+    type PFoo4 a = Maybe a
+
+  instance PC a where
+    type PFoo4 a = Maybe a
+  |])
+
+$(singletons [d|
+  type SFoo1 a = Maybe a
+
+  type family   SFoo2 a
+  type instance SFoo2 a = Maybe a
+
+  type family SFoo3 a where
+    SFoo3 a = Maybe a
+
+  class SC (a :: Type) where
+    type SFoo4 a
+    type SFoo4 a = Maybe a
+
+  instance SC a where
+    type SFoo4 a = Maybe a
+  |])


### PR DESCRIPTION
This patch is really quite simple in the end—it just augments `PartitionedDecs` with extra fields for type synonym and family declarations, and plumbs them through to `defunctionalize`.

Fixes #313, and fixes #198 (insofar as it does all that singletons can, short of fixing #12564 itself).