### PR TITLE
Define `source-repository head` stanza

### DIFF
--- a/singletons.cabal
+++ b/singletons.cabal
@@ -40,6 +40,11 @@ source-repository this
   location: https://github.com/goldfirere/singletons.git
   tag:      v2.5
 
+source-repository head
+  type:     git
+  location: https://github.com/goldfirere/singletons.git
+  branch:   master
+
 custom-setup
   setup-depends:
     base      >= 4.11 && < 4.12,


### PR DESCRIPTION
I'm not sure if this was left out on purpose, but defining it means that `cabal get -s singletons` will pick up that one by default, rather than error out.

if in fact this was left out deliberately, please ignore the PR

/cc @RyanGlScott 