### PR TITLE
Fix #323 by generating fixity declarations for defunctionalization symbols

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,9 @@ Changelog for singletons project
   synonym did nothing whatsoever, and promoting or singling a type family
   produced an error.)
 
+* `singletons` now produces fixity declarations for defunctionalization
+  symbols when appropriate.
+
 * Add `(%<=?)`, a singled version of `(<=?)` from `GHC.TypeNats`, as well as
   defunctionalization symbols for `(<=?)`, to `Data.Singletons.TypeLits`.
 

--- a/src/Data/Singletons/Single.hs
+++ b/src/Data/Singletons/Single.hs
@@ -324,7 +324,7 @@ singClassD (ClassDecl { cd_cxt  = cls_cxt
   sing_meths <- mapM (uncurry (singLetDecRHS (Map.fromList tyvar_names)
                                              res_ki_map))
                      (Map.toList default_defns)
-  fixities' <- traverse (uncurry singInfixDecl) fixities
+  fixities' <- traverse (uncurry singInfixDecl) $ Map.toList fixities
   cls_cxt' <- mapM singPred cls_cxt
   return $ DClassD cls_cxt'
                    (singClassName cls_name)
@@ -430,7 +430,7 @@ singLetDecEnv (LetDecEnv { lde_defns     = defns
   let prom_list = Map.toList proms
   (typeSigs, letBinds, tyvarNames, res_kis)
     <- unzip4 <$> mapM (uncurry (singTySig defns types bound_kvs)) prom_list
-  infix_decls' <- traverse (uncurry singInfixDecl) infix_decls
+  infix_decls' <- traverse (uncurry singInfixDecl) $ Map.toList infix_decls
   let res_ki_map = Map.fromList [ (name, res_ki) | ((name, _), Just res_ki)
                                                      <- zip prom_list res_kis ]
   bindLets letBinds $ do

--- a/src/Data/Singletons/Single/Fixity.hs
+++ b/src/Data/Singletons/Single/Fixity.hs
@@ -7,8 +7,8 @@ import Data.Singletons.Util
 import Data.Singletons.Names
 import Language.Haskell.TH.Desugar
 
-singInfixDecl :: DsMonad q => Fixity -> Name -> q DLetDec
-singInfixDecl fixity name = do
+singInfixDecl :: DsMonad q => Name -> Fixity -> q DLetDec
+singInfixDecl name fixity = do
   mb_ns <- reifyNameSpace name
   pure $ DInfixD fixity
        $ case mb_ns of
@@ -24,7 +24,7 @@ singFixityDeclaration name = do
   mFixity <- qReifyFixity name
   case mFixity of
     Nothing     -> pure []
-    Just fixity -> sequenceA [DLetDec <$> singInfixDecl fixity name]
+    Just fixity -> sequenceA [DLetDec <$> singInfixDecl name fixity]
 
 singFixityDeclarations :: DsMonad q => [Name] -> q [DDec]
 singFixityDeclarations = concatMapM trySingFixityDeclaration

--- a/src/Data/Singletons/Syntax.hs
+++ b/src/Data/Singletons/Syntax.hs
@@ -146,7 +146,7 @@ type ULetDecRHS = LetDecRHS Unannotated
 data LetDecEnv ann = LetDecEnv
                    { lde_defns :: Map Name (LetDecRHS ann)
                    , lde_types :: Map Name DType   -- type signatures
-                   , lde_infix :: [(Fixity, Name)] -- infix declarations
+                   , lde_infix :: Map Name Fixity  -- infix declarations
                    , lde_proms :: IfAnn ann (Map Name DType) () -- possibly, promotions
                    , lde_bound_kvs :: IfAnn ann (Map Name (Set Name)) ()
                      -- The set of bound variables in scope.
@@ -161,7 +161,7 @@ instance Semigroup ULetDecEnv where
     LetDecEnv (defns1 <> defns2) (types1 <> types2) (infx1 <> infx2) () ()
 
 instance Monoid ULetDecEnv where
-  mempty = LetDecEnv Map.empty Map.empty [] () ()
+  mempty = LetDecEnv Map.empty Map.empty Map.empty () ()
 
 valueBinding :: Name -> ULetDecRHS -> ULetDecEnv
 valueBinding n v = emptyLetDecEnv { lde_defns = Map.singleton n v }
@@ -170,7 +170,7 @@ typeBinding :: Name -> DType -> ULetDecEnv
 typeBinding n t = emptyLetDecEnv { lde_types = Map.singleton n t }
 
 infixDecl :: Fixity -> Name -> ULetDecEnv
-infixDecl f n = emptyLetDecEnv { lde_infix = [(f,n)] }
+infixDecl f n = emptyLetDecEnv { lde_infix = Map.singleton n f }
 
 emptyLetDecEnv :: ULetDecEnv
 emptyLetDecEnv = mempty

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -94,6 +94,7 @@ tests =
     , compileAndDumpStdTest "T316"
     , compileAndDumpStdTest "T322"
     , compileAndDumpStdTest "NatSymbolReflexive"
+    , compileAndDumpStdTest "T323"
     ],
     testCompileAndDumpGroup "Promote"
     [ compileAndDumpStdTest "Constructors"

--- a/tests/compile-and-dump/Singletons/Classes.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Classes.ghc84.template
@@ -141,6 +141,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
                           SameKind (Apply ((<=>@#@$$) l) arg) ((<=>@#@$$$) l arg) =>
                           (<=>@#@$$) l l
     type instance Apply ((<=>@#@$$) l) l = (<=>) l l
+    infix 4 <=>@#@$$
     instance SuppressUnusedWarnings (<=>@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:<=>@#@$###)) GHC.Tuple.())
@@ -149,6 +150,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         (:<=>@#@$###) :: forall l arg.
                          SameKind (Apply (<=>@#@$) arg) ((<=>@#@$$) arg) => (<=>@#@$) l
     type instance Apply (<=>@#@$) l = (<=>@#@$$) l
+    infix 4 <=>@#@$
     type family TFHelper_0123456789876543210 (a :: a) (a :: a) :: Ordering where
       TFHelper_0123456789876543210 a_0123456789876543210 a_0123456789876543210 = Apply (Apply MycompareSym0 a_0123456789876543210) a_0123456789876543210
     type TFHelper_0123456789876543210Sym2 (t :: a0123456789876543210) (t :: a0123456789876543210) =

--- a/tests/compile-and-dump/Singletons/Fixity.ghc84.template
+++ b/tests/compile-and-dump/Singletons/Fixity.ghc84.template
@@ -27,6 +27,7 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
                            SameKind (Apply ((====@#@$$) l) arg) ((====@#@$$$) l arg) =>
                            (====@#@$$) l l
     type instance Apply ((====@#@$$) l) l = (====) l l
+    infix 4 ====@#@$$
     instance SuppressUnusedWarnings (====@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:====@#@$###)) GHC.Tuple.())
@@ -35,6 +36,7 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
         (:====@#@$###) :: forall l arg.
                           SameKind (Apply (====@#@$) arg) ((====@#@$$) arg) => (====@#@$) l
     type instance Apply (====@#@$) l = (====@#@$$) l
+    infix 4 ====@#@$
     type family (====) (a :: a) (a :: a) :: a where
       (====) a _ = a
     type (<=>@#@$$$) (t :: a0123456789876543210) (t :: a0123456789876543210) =
@@ -48,6 +50,7 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
                           SameKind (Apply ((<=>@#@$$) l) arg) ((<=>@#@$$$) l arg) =>
                           (<=>@#@$$) l l
     type instance Apply ((<=>@#@$$) l) l = (<=>) l l
+    infix 4 <=>@#@$$
     instance SuppressUnusedWarnings (<=>@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:<=>@#@$###)) GHC.Tuple.())
@@ -56,6 +59,7 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
         (:<=>@#@$###) :: forall l arg.
                          SameKind (Apply (<=>@#@$) arg) ((<=>@#@$$) arg) => (<=>@#@$) l
     type instance Apply (<=>@#@$) l = (<=>@#@$$) l
+    infix 4 <=>@#@$
     class PMyOrd (a :: GHC.Types.Type) where
       type (<=>) (arg :: a) (arg :: a) :: Ordering
     infix 4 %====

--- a/tests/compile-and-dump/Singletons/ShowDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/ShowDeriving.ghc84.template
@@ -79,6 +79,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                                     SameKind (Apply (MkFoo2bSym1 l) arg) (MkFoo2bSym2 l arg) =>
                                     MkFoo2bSym1 l l
     type instance Apply (MkFoo2bSym1 l) l = MkFoo2b l l
+    infixl 5 `MkFoo2bSym1`
     instance SuppressUnusedWarnings MkFoo2bSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MkFoo2bSym0KindInference) GHC.Tuple.())
@@ -88,6 +89,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                                     SameKind (Apply MkFoo2bSym0 arg) (MkFoo2bSym1 arg) =>
                                     MkFoo2bSym0 l
     type instance Apply MkFoo2bSym0 l = MkFoo2bSym1 l
+    infixl 5 `MkFoo2bSym0`
     type (:*:@#@$$$) (t :: a0123456789876543210) (t :: a0123456789876543210) =
         (:*:) t t
     instance SuppressUnusedWarnings (:*:@#@$$) where
@@ -99,6 +101,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                           SameKind (Apply ((:*:@#@$$) l) arg) ((:*:@#@$$$) l arg) =>
                           (:*:@#@$$) l l
     type instance Apply ((:*:@#@$$) l) l = (:*:) l l
+    infixl 5 :*:@#@$$
     instance SuppressUnusedWarnings (:*:@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::*:@#@$###)) GHC.Tuple.())
@@ -107,6 +110,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         (::*:@#@$###) :: forall l arg.
                          SameKind (Apply (:*:@#@$) arg) ((:*:@#@$$) arg) => (:*:@#@$) l
     type instance Apply (:*:@#@$) l = (:*:@#@$$) l
+    infixl 5 :*:@#@$
     type (:&:@#@$$$) (t :: a0123456789876543210) (t :: a0123456789876543210) =
         (:&:) t t
     instance SuppressUnusedWarnings (:&:@#@$$) where
@@ -118,6 +122,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                           SameKind (Apply ((:&:@#@$$) l) arg) ((:&:@#@$$$) l arg) =>
                           (:&:@#@$$) l l
     type instance Apply ((:&:@#@$$) l) l = (:&:) l l
+    infixl 5 :&:@#@$$
     instance SuppressUnusedWarnings (:&:@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::&:@#@$###)) GHC.Tuple.())
@@ -126,6 +131,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         (::&:@#@$###) :: forall l arg.
                          SameKind (Apply (:&:@#@$) arg) ((:&:@#@$$) arg) => (:&:@#@$) l
     type instance Apply (:&:@#@$) l = (:&:@#@$$) l
+    infixl 5 :&:@#@$
     type MkFoo3Sym2 (t :: Bool) (t :: Bool) = MkFoo3 t t
     instance SuppressUnusedWarnings MkFoo3Sym1 where
       suppressUnusedWarnings
@@ -264,9 +270,9 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply ShowsPrec_0123456789876543210Sym0 l = ShowsPrec_0123456789876543210Sym1 l
     instance PShow Foo3 where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
-    infixl 5 :%&:
-    infixl 5 :%*:
     infixl 5 `SMkFoo2b`
+    infixl 5 :%*:
+    infixl 5 :%&:
     data instance Sing :: Foo1 -> GHC.Types.Type :: Foo1
                                                     -> GHC.Types.Type
       where SMkFoo1 :: Sing MkFoo1

--- a/tests/compile-and-dump/Singletons/StandaloneDeriving.ghc84.template
+++ b/tests/compile-and-dump/Singletons/StandaloneDeriving.ghc84.template
@@ -36,6 +36,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
                           SameKind (Apply ((:*:@#@$$) l) arg) ((:*:@#@$$$) l arg) =>
                           (:*:@#@$$) l l
     type instance Apply ((:*:@#@$$) l) l = (:*:) l l
+    infixl 6 :*:@#@$$
     instance SuppressUnusedWarnings (:*:@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::*:@#@$###)) GHC.Tuple.())
@@ -44,6 +45,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
         (::*:@#@$###) :: forall l arg.
                          SameKind (Apply (:*:@#@$) arg) ((:*:@#@$$) arg) => (:*:@#@$) l
     type instance Apply (:*:@#@$) l = (:*:@#@$$) l
+    infixl 6 :*:@#@$
     type S1Sym0 = S1
     type S2Sym0 = S2
     type family Compare_0123456789876543210 (a :: T a ()) (a :: T a ()) :: Ordering where

--- a/tests/compile-and-dump/Singletons/T159.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T159.ghc84.template
@@ -52,6 +52,7 @@ Singletons/T159.hs:0:0:: Splicing declarations
         C1Sym1KindInference :: forall l l arg.
                                SameKind (Apply (C1Sym1 l) arg) (C1Sym2 l arg) => C1Sym1 l l
     type instance Apply (C1Sym1 l) l = C1 l l
+    infixr 5 `C1Sym1`
     instance SuppressUnusedWarnings C1Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) C1Sym0KindInference) GHC.Tuple.())
@@ -60,6 +61,7 @@ Singletons/T159.hs:0:0:: Splicing declarations
         C1Sym0KindInference :: forall l arg.
                                SameKind (Apply C1Sym0 arg) (C1Sym1 arg) => C1Sym0 l
     type instance Apply C1Sym0 l = C1Sym1 l
+    infixr 5 `C1Sym0`
     type (:&&@#@$$$) (t :: T0) (t :: T1) = (:&&) t t
     instance SuppressUnusedWarnings (:&&@#@$$) where
       suppressUnusedWarnings
@@ -70,6 +72,7 @@ Singletons/T159.hs:0:0:: Splicing declarations
                           SameKind (Apply ((:&&@#@$$) l) arg) ((:&&@#@$$$) l arg) =>
                           (:&&@#@$$) l l
     type instance Apply ((:&&@#@$$) l) l = (:&&) l l
+    infixr 5 :&&@#@$$
     instance SuppressUnusedWarnings (:&&@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::&&@#@$###)) GHC.Tuple.())
@@ -78,6 +81,7 @@ Singletons/T159.hs:0:0:: Splicing declarations
         (::&&@#@$###) :: forall l arg.
                          SameKind (Apply (:&&@#@$) arg) ((:&&@#@$$) arg) => (:&&@#@$) l
     type instance Apply (:&&@#@$) l = (:&&@#@$$) l
+    infixr 5 :&&@#@$
     data instance Sing :: T1 -> GHC.Types.Type :: T1 -> GHC.Types.Type
       where
         SN1 :: Sing N1
@@ -132,6 +136,7 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
         C2Sym1KindInference :: forall l l arg.
                                SameKind (Apply (C2Sym1 l) arg) (C2Sym2 l arg) => C2Sym1 l l
     type instance Apply (C2Sym1 l) l = C2 l l
+    infixr 5 `C2Sym1`
     instance SuppressUnusedWarnings C2Sym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) C2Sym0KindInference) GHC.Tuple.())
@@ -140,6 +145,7 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
         C2Sym0KindInference :: forall l arg.
                                SameKind (Apply C2Sym0 arg) (C2Sym1 arg) => C2Sym0 l
     type instance Apply C2Sym0 l = C2Sym1 l
+    infixr 5 `C2Sym0`
     type (:||@#@$$$) (t :: T0) (t :: T2) = (:||) t t
     instance SuppressUnusedWarnings (:||@#@$$) where
       suppressUnusedWarnings
@@ -150,6 +156,7 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
                           SameKind (Apply ((:||@#@$$) l) arg) ((:||@#@$$$) l arg) =>
                           (:||@#@$$) l l
     type instance Apply ((:||@#@$$) l) l = (:||) l l
+    infixr 5 :||@#@$$
     instance SuppressUnusedWarnings (:||@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (::||@#@$###)) GHC.Tuple.())
@@ -158,8 +165,9 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
         (::||@#@$###) :: forall l arg.
                          SameKind (Apply (:||@#@$) arg) ((:||@#@$$) arg) => (:||@#@$) l
     type instance Apply (:||@#@$) l = (:||@#@$$) l
-    infixr 5 :%||
+    infixr 5 :||@#@$
     infixr 5 `SC2`
+    infixr 5 :%||
     data instance Sing :: T2 -> GHC.Types.Type :: T2 -> GHC.Types.Type
       where
         SN2 :: Sing N2

--- a/tests/compile-and-dump/Singletons/T197.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T197.ghc84.template
@@ -18,6 +18,7 @@ Singletons/T197.hs:(0,0)-(0,0): Splicing declarations
                           SameKind (Apply (($$:@#@$$) l) arg) (($$:@#@$$$) l arg) =>
                           ($$:@#@$$) l l
     type instance Apply (($$:@#@$$) l) l = ($$:) l l
+    infixl 5 $$:@#@$$
     instance SuppressUnusedWarnings ($$:@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:$$:@#@$###)) GHC.Tuple.())
@@ -26,6 +27,7 @@ Singletons/T197.hs:(0,0)-(0,0): Splicing declarations
         (:$$:@#@$###) :: forall l arg.
                          SameKind (Apply ($$:@#@$) arg) (($$:@#@$$) arg) => ($$:@#@$) l
     type instance Apply ($$:@#@$) l = ($$:@#@$$) l
+    infixl 5 $$:@#@$
     type family ($$:) (a :: Bool) (a :: Bool) :: Bool where
       ($$:) _ _ = FalseSym0
     infixl 5 %$$:

--- a/tests/compile-and-dump/Singletons/T197b.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T197b.ghc84.template
@@ -39,6 +39,7 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
                                    SameKind (Apply (MkPairSym1 l) arg) (MkPairSym2 l arg) =>
                                    MkPairSym1 l l
     type instance Apply (MkPairSym1 l) l = MkPair l l
+    infixr 9 `MkPairSym1`
     instance SuppressUnusedWarnings MkPairSym0 where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) MkPairSym0KindInference) GHC.Tuple.())
@@ -47,8 +48,9 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
         MkPairSym0KindInference :: forall l arg.
                                    SameKind (Apply MkPairSym0 arg) (MkPairSym1 arg) => MkPairSym0 l
     type instance Apply MkPairSym0 l = MkPairSym1 l
-    infixr 9 `SMkPair`
+    infixr 9 `MkPairSym0`
     infixr 9 `SPair`
+    infixr 9 `SMkPair`
     data instance Sing :: (:*:) a b -> GHC.Types.Type :: (:*:) a b
                                                          -> GHC.Types.Type
       where

--- a/tests/compile-and-dump/Singletons/T322.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T322.ghc84.template
@@ -17,6 +17,7 @@ Singletons/T322.hs:(0,0)-(0,0): Splicing declarations
         (:!@#@$$###) :: forall l l arg.
                         SameKind (Apply ((!@#@$$) l) arg) ((!@#@$$$) l arg) => (!@#@$$) l l
     type instance Apply ((!@#@$$) l) l = (:!) l l
+    infixr 2 !@#@$$
     instance SuppressUnusedWarnings (!@#@$) where
       suppressUnusedWarnings
         = snd ((GHC.Tuple.(,) (:!@#@$###)) GHC.Tuple.())
@@ -25,6 +26,7 @@ Singletons/T322.hs:(0,0)-(0,0): Splicing declarations
         (:!@#@$###) :: forall l arg.
                        SameKind (Apply (!@#@$) arg) ((!@#@$$) arg) => (!@#@$) l
     type instance Apply (!@#@$) l = (!@#@$$) l
+    infixr 2 !@#@$
     type family (:!) (a :: Bool) (a :: Bool) :: Bool where
       (:!) a_0123456789876543210 a_0123456789876543210 = Apply (Apply (||@#@$) a_0123456789876543210) a_0123456789876543210
     infixr 2 :!

--- a/tests/compile-and-dump/Singletons/T323.hs
+++ b/tests/compile-and-dump/Singletons/T323.hs
@@ -1,0 +1,7 @@
+module T323 where
+
+import Data.Singletons.Prelude
+import Data.Type.Equality
+
+test :: f .@#@$$$ (g .@#@$$$ h) :~: f .@#@$$$ g .@#@$$$ h
+test = Refl


### PR DESCRIPTION
This mostly involves some minor plumbing to `defunctionalize` and its call sites. Along the way, I did a little refactoring of `lde_infix`, converting it from an association list to a proper `Map` to facilitate faster lookups (since we now need to do so before calling `defunctionalize`, which takes a `Fixity` argument, in certain spots).