### PR TITLE
Refactor deriving-related code

### DIFF
--- a/singletons.cabal
+++ b/singletons.cabal
@@ -122,6 +122,7 @@ library
                       Data.Singletons.Deriving.Enum
                       Data.Singletons.Deriving.Ord
                       Data.Singletons.Deriving.Show
+                      Data.Singletons.Deriving.Util
                       Data.Singletons.Internal
                       Data.Singletons.Prelude.List.NonEmpty.Internal
                       Data.Singletons.Prelude.Semigroup.Internal

--- a/src/Data/Singletons/Deriving/Bounded.hs
+++ b/src/Data/Singletons/Deriving/Bounded.hs
@@ -3,7 +3,7 @@
 -- Module      :  Data.Singletons.Deriving.Bounded
 -- Copyright   :  (C) 2015 Richard Eisenberg
 -- License     :  BSD-style (see LICENSE)
--- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
 -- Stability   :  experimental
 -- Portability :  non-portable
 --
@@ -19,12 +19,13 @@ import Data.Singletons.Names
 import Data.Singletons.Util
 import Data.Singletons.Syntax
 import Data.Singletons.Deriving.Infer
+import Data.Singletons.Deriving.Util
 import Control.Monad
 
 -- monadic only for failure and parallelism with other functions
 -- that make instances
-mkBoundedInstance :: DsMonad q => Maybe DCxt -> DType -> [DCon] -> q UInstDecl
-mkBoundedInstance mb_ctxt ty cons = do
+mkBoundedInstance :: DsMonad q => DerivDesc q
+mkBoundedInstance mb_ctxt ty (DataDecl _ _ cons) = do
   -- We can derive instance of Bounded if datatype is an enumeration (all
   -- constructors must be nullary) or has only one constructor. See Section 11
   -- of Haskell 2010 Language Report.

--- a/src/Data/Singletons/Deriving/Enum.hs
+++ b/src/Data/Singletons/Deriving/Enum.hs
@@ -16,6 +16,7 @@ module Data.Singletons.Deriving.Enum ( mkEnumInstance ) where
 import Language.Haskell.TH.Syntax
 import Language.Haskell.TH.Ppr
 import Language.Haskell.TH.Desugar
+import Data.Singletons.Deriving.Util
 import Data.Singletons.Syntax
 import Data.Singletons.Util
 import Data.Singletons.Names
@@ -23,8 +24,10 @@ import Control.Monad
 import Data.Maybe
 
 -- monadic for failure only
-mkEnumInstance :: Quasi q => Bool -> Maybe DCxt -> DType -> [DCon] -> q UInstDecl
-mkEnumInstance non_vanilla mb_ctxt ty cons = do
+mkEnumInstance :: DsMonad q => DerivDesc q
+mkEnumInstance mb_ctxt ty (DataDecl data_name tvbs cons) = do
+  let data_ty = foldTypeTvbs (DConT data_name) tvbs
+  non_vanilla <- isNonVanillaDataType data_ty cons
   when (null cons ||
         any (\(DCon _ _ _ f _) ->
               non_vanilla || not (null $ tysOfConFields f)) cons) $

--- a/src/Data/Singletons/Deriving/Infer.hs
+++ b/src/Data/Singletons/Deriving/Infer.hs
@@ -5,7 +5,7 @@
 -- Module      :  Data.Singletons.Deriving.Infer
 -- Copyright   :  (C) 2015 Richard Eisenberg
 -- License     :  BSD-style (see LICENSE)
--- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
 -- Stability   :  experimental
 -- Portability :  non-portable
 --

--- a/src/Data/Singletons/Deriving/Ord.hs
+++ b/src/Data/Singletons/Deriving/Ord.hs
@@ -3,7 +3,7 @@
 -- Module      :  Data.Singletons.Deriving.Ord
 -- Copyright   :  (C) 2015 Richard Eisenberg
 -- License     :  BSD-style (see LICENSE)
--- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
 -- Stability   :  experimental
 -- Portability :  non-portable
 --
@@ -18,11 +18,12 @@ import Data.Singletons.Names
 import Data.Singletons.Util
 import Language.Haskell.TH.Syntax
 import Data.Singletons.Deriving.Infer
+import Data.Singletons.Deriving.Util
 import Data.Singletons.Syntax
 
 -- | Make a *non-singleton* Ord instance
-mkOrdInstance :: DsMonad q => Maybe DCxt -> DType -> [DCon] -> q UInstDecl
-mkOrdInstance mb_ctxt ty cons = do
+mkOrdInstance :: DsMonad q => DerivDesc q
+mkOrdInstance mb_ctxt ty (DataDecl _ _ cons) = do
   constraints <- inferConstraintsDef mb_ctxt (DConPr ordName) ty cons
   compare_eq_clauses <- mapM mk_equal_clause cons
   let compare_noneq_clauses = map (uncurry mk_nonequal_clause)

--- a/src/Data/Singletons/Deriving/Show.hs
+++ b/src/Data/Singletons/Deriving/Show.hs
@@ -23,14 +23,13 @@ import Data.Singletons.Names
 import Data.Singletons.Util
 import Data.Singletons.Syntax
 import Data.Singletons.Deriving.Infer
+import Data.Singletons.Deriving.Util
 import Data.Maybe (fromMaybe)
 import GHC.Lexeme (startsConSym, startsVarSym)
 import GHC.Show (appPrec, appPrec1)
 
-mkShowInstance :: DsMonad q
-               => ShowMode -> Maybe DCxt -> DType -> [DCon]
-               -> q UInstDecl
-mkShowInstance mode mb_ctxt ty cons = do
+mkShowInstance :: DsMonad q => ShowMode -> DerivDesc q
+mkShowInstance mode mb_ctxt ty (DataDecl _ _ cons) = do
   clauses <- mk_showsPrec mode cons
   constraints <- inferConstraintsDef (fmap (mkShowContext mode) mb_ctxt)
                                      (DConPr (mk_Show_name mode))

--- a/src/Data/Singletons/Deriving/Util.hs
+++ b/src/Data/Singletons/Deriving/Util.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Singletons.Deriving.Util
+-- Copyright   :  (C) 2018 Ryan Scott
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Utilities used by the `deriving` machinery in singletons.
+--
+----------------------------------------------------------------------------
+module Data.Singletons.Deriving.Util where
+
+import Data.Singletons.Syntax
+import Language.Haskell.TH.Desugar
+
+-- A generic type signature for describing how to produce a derived instance.
+type DerivDesc q
+   = Maybe DCxt  -- (Just ctx) if ctx was provided via StandaloneDeriving.
+                 -- Nothing if using a deriving clause.
+  -> DType       -- The data type argument to the class.
+  -> DataDecl    -- The original data type information.
+  -> q UInstDecl -- The derived instance.
+
+-- | Is this data type a non-vanilla data type? Here, \"non-vanilla\" refers to
+-- any data type that cannot be expressed using Haskell98 syntax. For instance,
+-- this GADT:
+--
+-- @
+-- data Foo :: Type -> Type where
+--   MkFoo :: forall a. a -> Foo a
+-- @
+--
+-- Is equivalent to this Haskell98 data type:
+--
+-- @
+-- data Foo a = MkFoo a
+-- @
+--
+-- However, the following GADT is non-vanilla:
+--
+-- @
+-- data Bar :: Type -> Type where
+--   MkBar :: Int -> Bar Int
+-- @
+--
+-- Since there is no equivalent Haskell98 data type. The closest you could get
+-- is this:
+--
+-- @
+-- data Bar a = (a ~ Int) => MkBar Int
+-- @
+--
+-- Which requires language extensions to write.
+--
+-- A data type is a non-vanilla if one of the following conditions are met:
+--
+-- 1. A constructor has any existentially quantified type variables.
+--
+-- 2. A constructor has a context.
+--
+-- We care about this because some derivable stock classes, such as 'Enum',
+-- forbid derived instances for non-vanilla data types.
+isNonVanillaDataType :: forall q. DsMonad q => DType -> [DCon] -> q Bool
+isNonVanillaDataType data_ty = anyM $ \con@(DCon _ ctxt _ _ _) -> do
+    ex_tvbs <- conExistentialTvbs data_ty con
+    return $ not $ null ex_tvbs && null ctxt
+  where
+    anyM :: (a -> q Bool) -> [a] -> q Bool
+    anyM _ [] = return False
+    anyM p (x:xs) = do
+      b <- p x
+      if b then return True else anyM p xs

--- a/src/Data/Singletons/Single/Data.hs
+++ b/src/Data/Singletons/Single/Data.hs
@@ -26,7 +26,7 @@ import Data.Set (Set)
 -- We wish to consider the promotion of "Rep" to be *
 -- not a promoted data constructor.
 singDataD :: DataDecl -> SgM [DDec]
-singDataD (DataDecl _nd name tvbs ctors _derivings) = do
+singDataD (DataDecl name tvbs ctors) = do
   let tvbNames = map extractTvbName tvbs
   k <- promoteType (foldType (DConT name) (map DVarT tvbNames))
   ctors' <- mapM singCtor ctors

--- a/src/Data/Singletons/Syntax.hs
+++ b/src/Data/Singletons/Syntax.hs
@@ -46,7 +46,7 @@ instance Monoid PromDPatInfos where
 type SingDSigPaInfos = [(DExp, DType)]
 
 -- The parts of data declarations that are relevant to singletons.
-data DataDecl = DataDecl NewOrData Name [DTyVarBndr] [DCon] [DPred]
+data DataDecl = DataDecl Name [DTyVarBndr] [DCon]
 
 -- The parts of type synonyms that are relevant to singletons.
 data TySynDecl = TySynDecl Name [DTyVarBndr]
@@ -196,7 +196,7 @@ buildLetDecEnv = go emptyLetDecEnv
 data DerivedDecl (cls :: Type -> Constraint) = DerivedDecl
   { ded_mb_cxt :: Maybe DCxt
   , ded_type   :: DType
-  , ded_cons   :: [DCon]
+  , ded_decl   :: DataDecl
   }
 
 type DerivedEqDecl   = DerivedDecl Eq
@@ -218,7 +218,7 @@ information to recreate the derived instance:
    a deriving clause (ded_mb_cxt)
 2. The datatype, applied to some number of type arguments, as in the
    instance declaration (ded_type)
-3. The datatype's constructors (ded_cons)
+3. The datatype's original information, as provided through DataDecl (ded_decl)
 
 Why are these instances handled outside of partitionDecs?
 

--- a/src/Data/Singletons/Util.hs
+++ b/src/Data/Singletons/Util.hs
@@ -30,6 +30,7 @@ import Data.Semigroup as Semigroup
 import Data.Foldable
 import Data.Traversable
 import Data.Generics
+import Data.Maybe
 import Data.Void
 import Control.Monad.Fail ( MonadFail )
 
@@ -361,6 +362,13 @@ unfoldType = go []
     go acc (DSigT t _)      = go acc t
     go acc (DForallT _ _ t) = go acc t
     go acc t                = t :| acc
+
+-- Construct a data type's variable binders, possibly using fresh variables
+-- from the data type's kind signature.
+buildDataDTvbs :: DsMonad q => [DTyVarBndr] -> Maybe DKind -> q [DTyVarBndr]
+buildDataDTvbs tvbs mk = do
+  extra_tvbs <- mkExtraDKindBinders $ fromMaybe (DConT typeKindName) mk
+  pure $ tvbs ++ extra_tvbs
 
 -- apply an expression to a list of expressions
 foldExp :: DExp -> [DExp] -> DExp


### PR DESCRIPTION
While working on https://github.com/goldfirere/singletons/issues/184 (in particular, while trying to add the ability to derive `Functor`, `Foldable`, and `Traversable`), I discovered that the code around `Data.Singletons.Deriving.*` is a bit icky. This PR is an attempt to clean it up a little in preparation for https://github.com/goldfirere/singletons/issues/184. In particular:

* I introduce a new internal module, `Data.Singletons.Deriving.Util`, which for now only contains two things. (I'll need to add more things later.)
* Within `Data.Singletons.Deriving.Util`, I introduce a `DerivDesc` type synonym, which gives a generic type signature for deriving an instance. It turns out that this type was used in several places across `singletons`, so I found it convenient to have a common name for it.

  I also changed the last argument of `DerivDesc` from `[DCon]` to `DataDecl`, since (1) deriving `Functor` _et al._ needs other information from `DataDecl`, and (2) this lets us clean up a gross hack in which `Enum` needs to know whether the data type is vanilla or not. Instead of computing this vanilla-ness for every derived instance (and then discarding it unless we're deriving `Enum`), we can simply defer the vanilla-ness check to deriving `Enum` only, and having a `DataDecl` gives us all the information we need to compute the vanilla-ness.
* Speaking of which, `DataDecl` had `NewOrData` and `[DPred]` fields that were never used. I deleted them as part of a general cleanup.

The net result is that the code is slightly less _ad hoc_ and more extensible to changes in the future. No change in behavior.