### PR TITLE
Replace the default implementation of PEq((==)) with a custom type family

### DIFF
--- a/src/Data/Singletons/Prelude/Eq.hs
+++ b/src/Data/Singletons/Prelude/Eq.hs
@@ -18,8 +18,12 @@
 
 module Data.Singletons.Prelude.Eq (
   PEq(..), SEq(..),
+  DefaultEq,
+
+  -- * Defunctionalization symbols
   type (==@#@$), type (==@#@$$), type (==@#@$$$),
-  type (/=@#@$), type (/=@#@$$), type (/=@#@$$$)
+  type (/=@#@$), type (/=@#@$$), type (/=@#@$$$),
+  DefaultEqSym0, DefaultEqSym1, DefaultEqSym2
   ) where
 
 import Data.Singletons.Internal
@@ -28,24 +32,35 @@ import Data.Singletons.Single
 import Data.Singletons.Prelude.Instances
 import Data.Singletons.Util
 import Data.Singletons.Promote
-import qualified Data.Type.Equality as DTE
+import qualified Data.Type.Equality as DTE ()
 
 -- NB: These must be defined by hand because of the custom handling of the
--- default for (==) to use Data.Type.Equality.==
+-- default for (==) to use DefaultEq
 
 -- | The promoted analogue of 'Eq'. If you supply no definition for '(==)',
--- then it defaults to a use of '(DTE.==)', from "Data.Type.Equality".
+-- then it defaults to a use of 'DefaultEq'.
 class PEq a where
   type (==) (x :: a) (y :: a) :: Bool
   type (/=) (x :: a) (y :: a) :: Bool
 
-  type (x :: a) == (y :: a) = x DTE.== y
+  type (x :: a) == (y :: a) = x `DefaultEq` y
   type (x :: a) /= (y :: a) = Not (x == y)
 
   infix 4 ==
   infix 4 /=
 
-$(genDefunSymbols [''(==), ''(/=)])
+-- | A sensible way to compute Boolean equality for types of any kind. Note
+-- that this definition is slightly different from the '(DTE.==)' type family
+-- from "Data.Type.Equality" in @base@, as '(DTE.==)' attempts to distinguish
+-- applications of type constructors from other types. As a result,
+-- @a == a@ does not reduce to 'True' for every @a@, but @'DefaultEq' a a@
+-- /does/ reduce to 'True' for every @a@. The latter behavior is more desirable
+-- for @singletons@' purposes, so we use it instead of '(DTE.==)'.
+type family DefaultEq (a :: k) (b :: k) :: Bool where
+  DefaultEq a a = 'True
+  DefaultEq a b = 'False
+
+$(genDefunSymbols [''(==), ''(/=), ''DefaultEq])
 
 -- | The singleton analogue of 'Eq'. Unlike the definition for 'Eq', it is required
 -- that instances define a body for '(%==)'. You may also supply a body for '(%/=)'.

--- a/src/Data/Singletons/TypeLits/Internal.hs
+++ b/src/Data/Singletons/TypeLits/Internal.hs
@@ -100,10 +100,8 @@ instance SDecide Symbol where
     where errStr = "Broken Symbol singletons"
 
 -- PEq instances
-instance PEq Nat where
-  type (a :: Nat) == (b :: Nat) = TL.CmpNat a b == 'EQ
-instance PEq Symbol where
-  type (a :: Symbol) == (b :: Symbol) = TL.CmpSymbol a b == 'EQ
+instance PEq Nat
+instance PEq Symbol
 
 -- need SEq instances for TypeLits kinds
 instance SEq Nat where

--- a/src/Data/Singletons/TypeRepTYPE.hs
+++ b/src/Data/Singletons/TypeRepTYPE.hs
@@ -85,13 +85,7 @@ instance SingKind (TYPE rep) where
   fromSing (STypeRep tr) = SomeTypeRepTYPE tr
   toSing (SomeTypeRepTYPE tr) = SomeSing $ STypeRep tr
 
-instance PEq (TYPE rep) where
-  type a == b = EqTYPE a b
-
-type family EqTYPE (a :: TYPE rep) (b :: TYPE rep) where
-  EqTYPE (a :: TYPE rep) (a :: TYPE rep) = 'True
-  EqTYPE a               b               = 'False
-
+instance PEq (TYPE rep)
 instance SEq (TYPE rep) where
   STypeRep tra %== STypeRep trb =
     case eqTypeRep tra trb of


### PR DESCRIPTION
Fixes #333.