### PR TITLE
Fix #332 by using local declarations when desugaring in `singletons`

### DIFF
--- a/src/Data/Singletons/Single.hs
+++ b/src/Data/Singletons/Single.hs
@@ -96,8 +96,9 @@ genSingletons names = do
 singletons :: DsMonad q => q [Dec] -> q [Dec]
 singletons qdecs = do
   decs <- qdecs
-  singDecs <- wrapDesugar singTopLevelDecs decs
-  return (decs ++ singDecs)
+  ddecs <- withLocalDeclarations decs $ dsDecs decs
+  singDecs <- singTopLevelDecs decs ddecs
+  return (decs ++ decsToTH singDecs)
 
 -- | Make promoted and singleton versions of all declarations given, discarding
 -- the original declarations. Note that a singleton based on a datatype needs

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -97,6 +97,7 @@ tests =
     , compileAndDumpStdTest "T322"
     , compileAndDumpStdTest "NatSymbolReflexive"
     , compileAndDumpStdTest "T323"
+    , compileAndDumpStdTest "T332"
     ],
     testCompileAndDumpGroup "Promote"
     [ compileAndDumpStdTest "Constructors"

--- a/tests/compile-and-dump/Singletons/T332.ghc84.template
+++ b/tests/compile-and-dump/Singletons/T332.ghc84.template
@@ -1,0 +1,60 @@
+Singletons/T332.hs:(0,0)-(0,0): Splicing declarations
+    promote
+      [d| f :: Foo -> ()
+          f MkFoo {} = ()
+          
+          data Foo = MkFoo |]
+  ======>
+    data Foo = MkFoo
+    f :: Foo -> ()
+    f MkFoo {} = GHC.Tuple.()
+    type FSym1 (a0123456789876543210 :: Foo) = F a0123456789876543210
+    instance SuppressUnusedWarnings FSym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) FSym0KindInference) GHC.Tuple.())
+    data FSym0 :: (~>) Foo ()
+      where
+        FSym0KindInference :: forall a0123456789876543210 arg.
+                              SameKind (Apply FSym0 arg) (FSym1 arg) =>
+                              FSym0 a0123456789876543210
+    type instance Apply FSym0 a0123456789876543210 = F a0123456789876543210
+    type family F (a :: Foo) :: () where
+      F MkFoo = Tuple0Sym0
+    type MkFooSym0 = MkFoo
+Singletons/T332.hs:(0,0)-(0,0): Splicing declarations
+    singletons
+      [d| b :: Bar -> ()
+          b MkBar {} = ()
+          
+          data Bar = MkBar |]
+  ======>
+    data Bar = MkBar
+    b :: Bar -> ()
+    b MkBar {} = GHC.Tuple.()
+    type MkBarSym0 = MkBar
+    type BSym1 (a0123456789876543210 :: Bar) = B a0123456789876543210
+    instance SuppressUnusedWarnings BSym0 where
+      suppressUnusedWarnings
+        = snd ((GHC.Tuple.(,) BSym0KindInference) GHC.Tuple.())
+    data BSym0 :: (~>) Bar ()
+      where
+        BSym0KindInference :: forall a0123456789876543210 arg.
+                              SameKind (Apply BSym0 arg) (BSym1 arg) =>
+                              BSym0 a0123456789876543210
+    type instance Apply BSym0 a0123456789876543210 = B a0123456789876543210
+    type family B (a :: Bar) :: () where
+      B MkBar = Tuple0Sym0
+    sB :: forall (t :: Bar). Sing t -> Sing (Apply BSym0 t :: ())
+    sB SMkBar = STuple0
+    instance SingI (BSym0 :: (~>) Bar ()) where
+      sing = (singFun1 @BSym0) sB
+    data instance Sing :: Bar -> GHC.Types.Type :: Bar
+                                                   -> GHC.Types.Type
+      where SMkBar :: Sing MkBar
+    type SBar = (Sing :: Bar -> GHC.Types.Type)
+    instance SingKind Bar where
+      type Demote Bar = Bar
+      fromSing SMkBar = MkBar
+      toSing MkBar = SomeSing SMkBar
+    instance SingI MkBar where
+      sing = SMkBar

--- a/tests/compile-and-dump/Singletons/T332.hs
+++ b/tests/compile-and-dump/Singletons/T332.hs
@@ -1,0 +1,17 @@
+module T332 where
+
+import Data.Singletons.TH
+
+$(promote [d|
+  data Foo = MkFoo
+
+  f :: Foo -> ()
+  f MkFoo{} = ()
+  |])
+
+$(singletons [d|
+  data Bar = MkBar
+
+  b :: Bar -> ()
+  b MkBar{} = ()
+  |])


### PR DESCRIPTION
Note that `singTopLevelDecs` itself also invokes `withLocalDeclarations`, so to avoid grabbing the same set of local declarations twice in `singletons`, I split up a call to `wrapDesugar` to invoke `withLocalDeclarations` only over the scope of `dsDecs`.