### PR TITLE
Use QuantifiedConstraints to make ShowSing less ad hoc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,22 @@ Changelog for singletons project
   Haskell-generated code may require `GADTs` in situations that didn't require
   it before.
 
+* Overhaul the way derived `Show` instances for singleton types works. Before,
+  there was an awkward `ShowSing` class (which was essentially a cargo-culted
+  version of `Show` specialized for `Sing`) that one had to create instances
+  for separately. Now that GHC has `QuantifiedConstraints`, we can scrap this
+  whole class and turn `ShowSing` into a simple type synonym:
+
+  ```haskell
+  type ShowSing k = forall z. Show (Sing (z :: k))
+  ```
+
+  Now, instead of generating a hand-written `ShowSing` and `Show` instance for
+  each singleton type, we only generate a single (derived!) `Show` instance.
+  As a result of this change, you will likely need to enable
+  `QuantifiedConstraints` and `StandaloneDeriving` if you single any derived
+  `Show` instances in your code.
+
 * The kind of the type parameter to `SingI` is no longer specified. This only
   affects you if you were using the `sing` method with `TypeApplications`. For
   instance, if you were using `sing @Bool @True` before, then you will now need

--- a/README.md
+++ b/README.md
@@ -50,8 +50,10 @@ following:
 * `InstanceSigs`
 * `KindSignatures`
 * `NoStarIsType`
+* `QuantifiedConstraints`
 * `RankNTypes`
 * `ScopedTypeVariables`
+* `StandaloneDeriving`
 * `TemplateHaskell`
 * `TypeFamilies`
 * `TypeInType`

--- a/src/Data/Singletons.hs
+++ b/src/Data/Singletons.hs
@@ -3,10 +3,13 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeInType #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -----------------------------------------------------------------------------
@@ -127,9 +130,7 @@ instance SNum k => Num (SomeSing k) where
   signum (SomeSing a) = SomeSing (sSignum a)
   fromInteger n = withSomeSing (fromIntegral n) (SomeSing . sFromInteger)
 
-instance ShowSing k => Show (SomeSing k) where
-  showsPrec p (SomeSing s) =
-    showParen (p > 10) $ showString "SomeSing " . showsSingPrec 11 s
+deriving instance ShowSing k => Show (SomeSing k)
 
 instance SSemigroup k => Semigroup (SomeSing k) where
   SomeSing a <> SomeSing b = SomeSing (a %<> b)

--- a/src/Data/Singletons/CustomStar.hs
+++ b/src/Data/Singletons/CustomStar.hs
@@ -89,7 +89,7 @@ singletonStar names = do
     dataDeclEqCxt <- inferConstraints (DConPr ''Eq) (DConT repName) fakeCtors
     let dataDeclEqInst = DerivedDecl (Just dataDeclEqCxt) (DConT repName) dataDecl
     ordInst  <- mkOrdInstance Nothing (DConT repName) dataDecl
-    showInst <- mkShowInstance ForPromotion Nothing (DConT repName) dataDecl
+    showInst <- mkShowInstance Nothing (DConT repName) dataDecl
     (pInsts, promDecls) <- promoteM [] $ do promoteDataDec dataDecl
                                             promoteDerivedEqDec dataDeclEqInst
                                             traverse (promoteInstanceDec mempty)

--- a/src/Data/Singletons/Names.hs
+++ b/src/Data/Singletons/Names.hs
@@ -41,7 +41,7 @@ boolName, andName, tyEqName, compareName, minBoundName,
   singletonsToEnumName, singletonsFromEnumName, enumName, singletonsEnumName,
   equalsName, constraintName,
   showName, showCharName, showCommaSpaceName, showParenName, showsPrecName,
-  showSpaceName, showStringName, showSingName, showsSingPrecName,
+  showSpaceName, showStringName, showSingName,
   composeName, gtName, tyFromStringName, sFromStringName,
   foldableName, foldMapName, memptyName, mappendName, foldrName,
   functorName, fmapName, replaceName,
@@ -115,7 +115,6 @@ showSpaceName = 'showSpace
 showsPrecName = 'showsPrec
 showStringName = 'showString
 showSingName = mk_name_tc "Data.Singletons.ShowSing" "ShowSing"
-showsSingPrecName = mk_name_v "Data.Singletons.ShowSing" "showsSingPrec"
 composeName = '(.)
 gtName = '(>)
 showCommaSpaceName = 'showCommaSpace

--- a/src/Data/Singletons/Partition.hs
+++ b/src/Data/Singletons/Partition.hs
@@ -265,12 +265,12 @@ partitionDeriving mb_strat deriv_pred mb_ctxt ty data_decl =
           -- See Note [DerivedDecl] in Data.Singletons.Syntax
         , ( eqName, return $ mk_derived_eq_inst derived_decl )
           -- See Note [DerivedDecl] in Data.Singletons.Syntax
-        , ( showName, do -- This will become PShow/SShow instances...
-                         inst_for_promotion <- mk_instance (mkShowInstance ForPromotion)
-                         -- ...and this will become ShowSing/Show instances.
-                         let inst_for_ShowSing = derived_decl
+        , ( showName, do -- These will become PShow/SShow instances...
+                         inst_for_promotion <- mk_instance mkShowInstance
+                         -- ...and this will become a Show instance.
+                         let inst_for_show = derived_decl
                          pure $ mempty { pd_instance_decs     = [inst_for_promotion]
-                                       , pd_derived_show_decs = [inst_for_ShowSing] } )
+                                       , pd_derived_show_decs = [inst_for_show] } )
         ]
 
 -- Is this being used with an explicit stock strategy, or no strategy at all?

--- a/src/Data/Singletons/Prelude/Monoid.hs
+++ b/src/Data/Singletons/Prelude/Monoid.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}

--- a/src/Data/Singletons/Prelude/Semigroup.hs
+++ b/src/Data/Singletons/Prelude/Semigroup.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}

--- a/src/Data/Singletons/Promote.hs
+++ b/src/Data/Singletons/Promote.hs
@@ -141,7 +141,7 @@ promoteShowInstances = concatMapM promoteShowInstance
 
 -- | Produce an instance for 'PShow' from the given type
 promoteShowInstance :: DsMonad q => Name -> q [Dec]
-promoteShowInstance = promoteInstance (mkShowInstance ForPromotion) "Show"
+promoteShowInstance = promoteInstance mkShowInstance "Show"
 
 -- | Produce an instance for @(==)@ (type-level equality) from the given type
 promoteEqInstance :: DsMonad q => Name -> q [Dec]

--- a/src/Data/Singletons/Syntax.hs
+++ b/src/Data/Singletons/Syntax.hs
@@ -228,9 +228,9 @@ Why are these instances handled outside of partitionDecs?
   in Data.Singletons.Promote and Data.Singletons.Single (depending on the task
   at hand).
 * Deriving Show in singletons not only derives PShow/SShow instances, but it
-  also derives ShowSing/Sing instances for singletons types. To make this work,
+  also derives Show instances for singletons types. To make this work,
   we let partitionDecs handle the PShow/SShow instances, but we also stick the
   relevant info into a DerivedDecl value for later use in
-  Data.Singletons.Single, where we additionally generate ShowSing/Show
+  Data.Singletons.Single, where we additionally generate Show
   instances.
 -}

--- a/src/Data/Singletons/TypeLits.hs
+++ b/src/Data/Singletons/TypeLits.hs
@@ -53,7 +53,7 @@ module Data.Singletons.TypeLits (
 import Data.Singletons.Internal
 import Data.Singletons.Prelude.Tuple
 import Data.Singletons.Promote
-import Data.Singletons.ShowSing ()      -- for ShowSing/Show instances
+import Data.Singletons.ShowSing ()      -- for Show instances
 import Data.Singletons.TypeLits.Internal
 
 import Data.String (IsString(..))

--- a/src/Data/Singletons/TypeRepTYPE.hs
+++ b/src/Data/Singletons/TypeRepTYPE.hs
@@ -26,7 +26,7 @@ module Data.Singletons.TypeRepTYPE (
   -- > newtype instance Sing :: forall (rep :: RuntimeRep). TYPE rep -> Type where
   -- >   STypeRep :: forall (rep :: RuntimeRep) (a :: TYPE rep). TypeRep a -> Sing a
   --
-  -- Instances for 'SingI', 'SingKind', 'SEq', 'SDecide', 'ShowSing', and
+  -- Instances for 'SingI', 'SingKind', 'SEq', 'SDecide', and
   -- 'TestCoercion' are also supplied.
 
   SomeTypeRepTYPE(..)
@@ -37,7 +37,6 @@ import Data.Singletons.Prelude.Instances
 import Data.Singletons.Internal
 import Data.Singletons.Prelude.Eq
 import Data.Singletons.Decide
-import Data.Singletons.ShowSing
 import Data.Type.Equality ((:~:)(..))
 import GHC.Exts (RuntimeRep, TYPE)
 import Type.Reflection
@@ -99,6 +98,3 @@ instance SDecide (TYPE rep) where
     case eqTypeRep tra trb of
       Just HRefl -> Proved Refl
       Nothing    -> Disproved (\Refl -> error "Type.Reflection.eqTypeRep failed")
-
-instance ShowSing (TYPE rep) where
-  showsSingPrec = showsPrec

--- a/tests/SingletonsTestSuiteUtils.hs
+++ b/tests/SingletonsTestSuiteUtils.hs
@@ -70,6 +70,7 @@ ghcOpts = ghcFlags ++ [
   , "-XTypeApplications"
   , "-XEmptyCase"
   , "-XNoStarIsType"
+  , "-XQuantifiedConstraints"
   ]
 
 -- Compile a test using specified GHC options. Save output to file, filter with

--- a/tests/compile-and-dump/GradingClient/Database.ghc86.template
+++ b/tests/compile-and-dump/GradingClient/Database.ghc86.template
@@ -2507,57 +2507,10 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       (%~) SCZ SCX = Disproved (\ x -> case x of)
       (%~) SCZ SCY = Disproved (\ x -> case x of)
       (%~) SCZ SCZ = Proved Refl
-    instance (Data.Singletons.ShowSing.ShowSing U,
-              Data.Singletons.ShowSing.ShowSing Nat) =>
-             Data.Singletons.ShowSing.ShowSing U where
-      Data.Singletons.ShowSing.showsSingPrec _ SBOOL = showString "SBOOL"
-      Data.Singletons.ShowSing.showsSingPrec _ SSTRING
-        = showString "SSTRING"
-      Data.Singletons.ShowSing.showsSingPrec _ SNAT = showString "SNAT"
-      Data.Singletons.ShowSing.showsSingPrec
-        p_0123456789876543210
-        (SVEC arg_0123456789876543210 arg_0123456789876543210)
-        = (showParen (((>) p_0123456789876543210) 10))
-            (((.) (showString "SVEC "))
-               (((.)
-                   ((Data.Singletons.ShowSing.showsSingPrec 11)
-                      arg_0123456789876543210))
-                  (((.) GHC.Show.showSpace)
-                     ((Data.Singletons.ShowSing.showsSingPrec 11)
-                        arg_0123456789876543210))))
-    instance (Data.Singletons.ShowSing.ShowSing U,
-              Data.Singletons.ShowSing.ShowSing Nat) =>
-             Show (Sing (z :: U)) where
-      showsPrec = Data.Singletons.ShowSing.showsSingPrec
-    instance Data.Singletons.ShowSing.ShowSing AChar where
-      Data.Singletons.ShowSing.showsSingPrec _ SCA = showString "SCA"
-      Data.Singletons.ShowSing.showsSingPrec _ SCB = showString "SCB"
-      Data.Singletons.ShowSing.showsSingPrec _ SCC = showString "SCC"
-      Data.Singletons.ShowSing.showsSingPrec _ SCD = showString "SCD"
-      Data.Singletons.ShowSing.showsSingPrec _ SCE = showString "SCE"
-      Data.Singletons.ShowSing.showsSingPrec _ SCF = showString "SCF"
-      Data.Singletons.ShowSing.showsSingPrec _ SCG = showString "SCG"
-      Data.Singletons.ShowSing.showsSingPrec _ SCH = showString "SCH"
-      Data.Singletons.ShowSing.showsSingPrec _ SCI = showString "SCI"
-      Data.Singletons.ShowSing.showsSingPrec _ SCJ = showString "SCJ"
-      Data.Singletons.ShowSing.showsSingPrec _ SCK = showString "SCK"
-      Data.Singletons.ShowSing.showsSingPrec _ SCL = showString "SCL"
-      Data.Singletons.ShowSing.showsSingPrec _ SCM = showString "SCM"
-      Data.Singletons.ShowSing.showsSingPrec _ SCN = showString "SCN"
-      Data.Singletons.ShowSing.showsSingPrec _ SCO = showString "SCO"
-      Data.Singletons.ShowSing.showsSingPrec _ SCP = showString "SCP"
-      Data.Singletons.ShowSing.showsSingPrec _ SCQ = showString "SCQ"
-      Data.Singletons.ShowSing.showsSingPrec _ SCR = showString "SCR"
-      Data.Singletons.ShowSing.showsSingPrec _ SCS = showString "SCS"
-      Data.Singletons.ShowSing.showsSingPrec _ SCT = showString "SCT"
-      Data.Singletons.ShowSing.showsSingPrec _ SCU = showString "SCU"
-      Data.Singletons.ShowSing.showsSingPrec _ SCV = showString "SCV"
-      Data.Singletons.ShowSing.showsSingPrec _ SCW = showString "SCW"
-      Data.Singletons.ShowSing.showsSingPrec _ SCX = showString "SCX"
-      Data.Singletons.ShowSing.showsSingPrec _ SCY = showString "SCY"
-      Data.Singletons.ShowSing.showsSingPrec _ SCZ = showString "SCZ"
-    instance Show (Sing (z :: AChar)) where
-      showsPrec = Data.Singletons.ShowSing.showsSingPrec
+    deriving instance (Data.Singletons.ShowSing.ShowSing U,
+                       Data.Singletons.ShowSing.ShowSing Nat) =>
+                      Show (Sing (z :: U))
+    deriving instance Show (Sing (z :: AChar))
     instance SingI BOOL where
       sing = SBOOL
     instance SingI STRING where

--- a/tests/compile-and-dump/Singletons/DataValues.ghc86.template
+++ b/tests/compile-and-dump/Singletons/DataValues.ghc86.template
@@ -169,24 +169,9 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
                                 (sFromInteger (sing :: Sing 11))))
                             sArg_0123456789876543210))))))
             sA_0123456789876543210
-    instance (Data.Singletons.ShowSing.ShowSing a,
-              Data.Singletons.ShowSing.ShowSing b) =>
-             Data.Singletons.ShowSing.ShowSing (Pair a b) where
-      Data.Singletons.ShowSing.showsSingPrec
-        p_0123456789876543210
-        (SPair arg_0123456789876543210 arg_0123456789876543210)
-        = (showParen (((>) p_0123456789876543210) 10))
-            (((.) (showString "SPair "))
-               (((.)
-                   ((Data.Singletons.ShowSing.showsSingPrec 11)
-                      arg_0123456789876543210))
-                  (((.) GHC.Show.showSpace)
-                     ((Data.Singletons.ShowSing.showsSingPrec 11)
-                        arg_0123456789876543210))))
-    instance (Data.Singletons.ShowSing.ShowSing a,
-              Data.Singletons.ShowSing.ShowSing b) =>
-             Show (Sing (z :: Pair a b)) where
-      showsPrec = Data.Singletons.ShowSing.showsSingPrec
+    deriving instance (Data.Singletons.ShowSing.ShowSing a,
+                       Data.Singletons.ShowSing.ShowSing b) =>
+                      Show (Sing (z :: Pair a b))
     instance (SingI n, SingI n) => SingI (Pair (n :: a) (n :: b)) where
       sing = (SPair sing) sing
     instance SingI (PairSym0 :: (~>) a ((~>) b (Pair a b))) where

--- a/tests/compile-and-dump/Singletons/EmptyShowDeriving.ghc86.template
+++ b/tests/compile-and-dump/Singletons/EmptyShowDeriving.ghc86.template
@@ -65,8 +65,4 @@ Singletons/EmptyShowDeriving.hs:(0,0)-(0,0): Splicing declarations
              ((case sV_0123456789876543210 of) ::
                 Sing (Case_0123456789876543210 v_0123456789876543210 a_0123456789876543210 v_0123456789876543210)))
             sA_0123456789876543210
-    instance Data.Singletons.ShowSing.ShowSing Foo where
-      Data.Singletons.ShowSing.showsSingPrec _ v_0123456789876543210
-        = case v_0123456789876543210 of
-    instance Show (Sing (z :: Foo)) where
-      showsPrec = Data.Singletons.ShowSing.showsSingPrec
+    deriving instance Show (Sing (z :: Foo))

--- a/tests/compile-and-dump/Singletons/Maybe.ghc86.template
+++ b/tests/compile-and-dump/Singletons/Maybe.ghc86.template
@@ -128,20 +128,8 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
             Proved Refl -> Proved Refl
             Disproved contra
               -> Disproved (\ refl -> case refl of { Refl -> contra Refl })
-    instance Data.Singletons.ShowSing.ShowSing a =>
-             Data.Singletons.ShowSing.ShowSing (Maybe a) where
-      Data.Singletons.ShowSing.showsSingPrec _ SNothing
-        = showString "SNothing"
-      Data.Singletons.ShowSing.showsSingPrec
-        p_0123456789876543210
-        (SJust arg_0123456789876543210)
-        = (showParen (((>) p_0123456789876543210) 10))
-            (((.) (showString "SJust "))
-               ((Data.Singletons.ShowSing.showsSingPrec 11)
-                  arg_0123456789876543210))
-    instance Data.Singletons.ShowSing.ShowSing a =>
-             Show (Sing (z :: Maybe a)) where
-      showsPrec = Data.Singletons.ShowSing.showsSingPrec
+    deriving instance Data.Singletons.ShowSing.ShowSing a =>
+                      Show (Sing (z :: Maybe a))
     instance SingI Nothing where
       sing = SNothing
     instance SingI n => SingI (Just (n :: a)) where

--- a/tests/compile-and-dump/Singletons/Nat.ghc86.template
+++ b/tests/compile-and-dump/Singletons/Nat.ghc86.template
@@ -254,19 +254,8 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
             Proved Refl -> Proved Refl
             Disproved contra
               -> Disproved (\ refl -> case refl of { Refl -> contra Refl })
-    instance Data.Singletons.ShowSing.ShowSing Nat =>
-             Data.Singletons.ShowSing.ShowSing Nat where
-      Data.Singletons.ShowSing.showsSingPrec _ SZero = showString "SZero"
-      Data.Singletons.ShowSing.showsSingPrec
-        p_0123456789876543210
-        (SSucc arg_0123456789876543210)
-        = (showParen (((>) p_0123456789876543210) 10))
-            (((.) (showString "SSucc "))
-               ((Data.Singletons.ShowSing.showsSingPrec 11)
-                  arg_0123456789876543210))
-    instance Data.Singletons.ShowSing.ShowSing Nat =>
-             Show (Sing (z :: Nat)) where
-      showsPrec = Data.Singletons.ShowSing.showsSingPrec
+    deriving instance Data.Singletons.ShowSing.ShowSing Nat =>
+                      Show (Sing (z :: Nat))
     instance SingI Zero where
       sing = SZero
     instance SingI n => SingI (Succ (n :: Nat)) where

--- a/tests/compile-and-dump/Singletons/PatternMatching.ghc86.template
+++ b/tests/compile-and-dump/Singletons/PatternMatching.ghc86.template
@@ -169,24 +169,9 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
                                 (sFromInteger (sing :: Sing 11))))
                             sArg_0123456789876543210))))))
             sA_0123456789876543210
-    instance (Data.Singletons.ShowSing.ShowSing a,
-              Data.Singletons.ShowSing.ShowSing b) =>
-             Data.Singletons.ShowSing.ShowSing (Pair a b) where
-      Data.Singletons.ShowSing.showsSingPrec
-        p_0123456789876543210
-        (SPair arg_0123456789876543210 arg_0123456789876543210)
-        = (showParen (((>) p_0123456789876543210) 10))
-            (((.) (showString "SPair "))
-               (((.)
-                   ((Data.Singletons.ShowSing.showsSingPrec 11)
-                      arg_0123456789876543210))
-                  (((.) GHC.Show.showSpace)
-                     ((Data.Singletons.ShowSing.showsSingPrec 11)
-                        arg_0123456789876543210))))
-    instance (Data.Singletons.ShowSing.ShowSing a,
-              Data.Singletons.ShowSing.ShowSing b) =>
-             Show (Sing (z :: Pair a b)) where
-      showsPrec = Data.Singletons.ShowSing.showsSingPrec
+    deriving instance (Data.Singletons.ShowSing.ShowSing a,
+                       Data.Singletons.ShowSing.ShowSing b) =>
+                      Show (Sing (z :: Pair a b))
     instance (SingI n, SingI n) => SingI (Pair (n :: a) (n :: b)) where
       sing = (SPair sing) sing
     instance SingI (PairSym0 :: (~>) a ((~>) b (Pair a b))) where

--- a/tests/compile-and-dump/Singletons/ShowDeriving.ghc86.template
+++ b/tests/compile-and-dump/Singletons/ShowDeriving.ghc86.template
@@ -507,79 +507,11 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                                      ((applySing ((singFun2 @ShowCharSym0) sShowChar))
                                         (sing :: Sing "}")))))))))))
             sA_0123456789876543210
-    instance Data.Singletons.ShowSing.ShowSing Foo1 where
-      Data.Singletons.ShowSing.showsSingPrec _ SMkFoo1
-        = showString "SMkFoo1"
-    instance Show (Sing (z :: Foo1)) where
-      showsPrec = Data.Singletons.ShowSing.showsSingPrec
-    instance Data.Singletons.ShowSing.ShowSing a =>
-             Data.Singletons.ShowSing.ShowSing (Foo2 a) where
-      Data.Singletons.ShowSing.showsSingPrec
-        p_0123456789876543210
-        (SMkFoo2a arg_0123456789876543210 arg_0123456789876543210)
-        = (showParen (((>) p_0123456789876543210) 10))
-            (((.) (showString "SMkFoo2a "))
-               (((.)
-                   ((Data.Singletons.ShowSing.showsSingPrec 11)
-                      arg_0123456789876543210))
-                  (((.) GHC.Show.showSpace)
-                     ((Data.Singletons.ShowSing.showsSingPrec 11)
-                        arg_0123456789876543210))))
-      Data.Singletons.ShowSing.showsSingPrec
-        p_0123456789876543210
-        (SMkFoo2b argL_0123456789876543210 argR_0123456789876543210)
-        = (showParen (((>) p_0123456789876543210) 9))
-            (((.)
-                ((Data.Singletons.ShowSing.showsSingPrec 10)
-                   argL_0123456789876543210))
-               (((.) (showString " `SMkFoo2b` "))
-                  ((Data.Singletons.ShowSing.showsSingPrec 10)
-                     argR_0123456789876543210)))
-      Data.Singletons.ShowSing.showsSingPrec
-        p_0123456789876543210
-        ((:%*:) arg_0123456789876543210 arg_0123456789876543210)
-        = (showParen (((>) p_0123456789876543210) 10))
-            (((.) (showString "(:%*:) "))
-               (((.)
-                   ((Data.Singletons.ShowSing.showsSingPrec 11)
-                      arg_0123456789876543210))
-                  (((.) GHC.Show.showSpace)
-                     ((Data.Singletons.ShowSing.showsSingPrec 11)
-                        arg_0123456789876543210))))
-      Data.Singletons.ShowSing.showsSingPrec
-        p_0123456789876543210
-        ((:%&:) argL_0123456789876543210 argR_0123456789876543210)
-        = (showParen (((>) p_0123456789876543210) 9))
-            (((.)
-                ((Data.Singletons.ShowSing.showsSingPrec 10)
-                   argL_0123456789876543210))
-               (((.) (showString " :%&: "))
-                  ((Data.Singletons.ShowSing.showsSingPrec 10)
-                     argR_0123456789876543210)))
-    instance Data.Singletons.ShowSing.ShowSing a =>
-             Show (Sing (z :: Foo2 a)) where
-      showsPrec = Data.Singletons.ShowSing.showsSingPrec
-    instance Data.Singletons.ShowSing.ShowSing Bool =>
-             Data.Singletons.ShowSing.ShowSing Foo3 where
-      Data.Singletons.ShowSing.showsSingPrec
-        p_0123456789876543210
-        (SMkFoo3 arg_0123456789876543210 arg_0123456789876543210)
-        = (showParen (((>) p_0123456789876543210) 10))
-            (((.) (showString "SMkFoo3 "))
-               (((.) (showChar '{'))
-                  (((.) (showString "sGetFoo3a = "))
-                     (((.)
-                         ((Data.Singletons.ShowSing.showsSingPrec 0)
-                            arg_0123456789876543210))
-                        (((.) GHC.Show.showCommaSpace)
-                           (((.) (showString "(%***) = "))
-                              (((.)
-                                  ((Data.Singletons.ShowSing.showsSingPrec 0)
-                                     arg_0123456789876543210))
-                                 (showChar '}'))))))))
-    instance Data.Singletons.ShowSing.ShowSing Bool =>
-             Show (Sing (z :: Foo3)) where
-      showsPrec = Data.Singletons.ShowSing.showsSingPrec
+    deriving instance Show (Sing (z :: Foo1))
+    deriving instance Data.Singletons.ShowSing.ShowSing a =>
+                      Show (Sing (z :: Foo2 a))
+    deriving instance Data.Singletons.ShowSing.ShowSing Bool =>
+                      Show (Sing (z :: Foo3))
     instance SingI MkFoo1 where
       sing = SMkFoo1
     instance (SingI n, SingI n) =>

--- a/tests/compile-and-dump/Singletons/StandaloneDeriving.ghc86.template
+++ b/tests/compile-and-dump/Singletons/StandaloneDeriving.ghc86.template
@@ -425,26 +425,9 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
       (%~) SS1 SS2 = Disproved (\ x -> case x of)
       (%~) SS2 SS1 = Disproved (\ x -> case x of)
       (%~) SS2 SS2 = Proved Refl
-    instance Data.Singletons.ShowSing.ShowSing a =>
-             Data.Singletons.ShowSing.ShowSing (T a ()) where
-      Data.Singletons.ShowSing.showsSingPrec
-        p_0123456789876543210
-        ((:%*:) argL_0123456789876543210 argR_0123456789876543210)
-        = (showParen (((>) p_0123456789876543210) 9))
-            (((.)
-                ((Data.Singletons.ShowSing.showsSingPrec 10)
-                   argL_0123456789876543210))
-               (((.) (showString " :%*: "))
-                  ((Data.Singletons.ShowSing.showsSingPrec 10)
-                     argR_0123456789876543210)))
-    instance Data.Singletons.ShowSing.ShowSing a =>
-             Show (Sing (z :: T a ())) where
-      showsPrec = Data.Singletons.ShowSing.showsSingPrec
-    instance Data.Singletons.ShowSing.ShowSing S where
-      Data.Singletons.ShowSing.showsSingPrec _ SS1 = showString "SS1"
-      Data.Singletons.ShowSing.showsSingPrec _ SS2 = showString "SS2"
-    instance Show (Sing (z :: S)) where
-      showsPrec = Data.Singletons.ShowSing.showsSingPrec
+    deriving instance Data.Singletons.ShowSing.ShowSing a =>
+                      Show (Sing (z :: T a ()))
+    deriving instance Show (Sing (z :: S))
     instance (SingI n, SingI n) =>
              SingI ((:*:) (n :: a) (n :: b)) where
       sing = ((:%*:) sing) sing

--- a/tests/compile-and-dump/Singletons/T178.ghc86.template
+++ b/tests/compile-and-dump/Singletons/T178.ghc86.template
@@ -201,12 +201,7 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
       (%~) SMany SStr = Disproved (\ x -> case x of)
       (%~) SMany SOpt = Disproved (\ x -> case x of)
       (%~) SMany SMany = Proved Refl
-    instance Data.Singletons.ShowSing.ShowSing Occ where
-      Data.Singletons.ShowSing.showsSingPrec _ SStr = showString "SStr"
-      Data.Singletons.ShowSing.showsSingPrec _ SOpt = showString "SOpt"
-      Data.Singletons.ShowSing.showsSingPrec _ SMany = showString "SMany"
-    instance Show (Sing (z :: Occ)) where
-      showsPrec = Data.Singletons.ShowSing.showsSingPrec
+    deriving instance Show (Sing (z :: Occ))
     instance SingI Str where
       sing = SStr
     instance SingI Opt where

--- a/tests/compile-and-dump/Singletons/T190.ghc86.template
+++ b/tests/compile-and-dump/Singletons/T190.ghc86.template
@@ -183,9 +183,6 @@ Singletons/T190.hs:0:0:: Splicing declarations
       (%==) ST ST = STrue
     instance SDecide T where
       (%~) ST ST = Proved Refl
-    instance Data.Singletons.ShowSing.ShowSing T where
-      Data.Singletons.ShowSing.showsSingPrec _ ST = showString "ST"
-    instance Show (Sing (z :: T)) where
-      showsPrec = Data.Singletons.ShowSing.showsSingPrec
+    deriving instance Show (Sing (z :: T))
     instance SingI T where
       sing = ST


### PR DESCRIPTION
This implements a nice simplification permitted by the existence of `QuantifiedConstraints`. We can take the `ShowSing` class, which is wildly ad hoc, and convert it into a much more svelte quantified constraint synonym. In particular, we can take code like this:

```haskell
instance (ShowSing a, ShowSing b) => ShowSing (Either a b) where showsSingPrec = ...
instance (ShowSing a, ShowSing b) => Show (Sing (e :: Either a b)) where showsPrec = showsSingPrec
```

And replace it with a much more concise equivalent:

```haskell
type ShowSing k = (forall (z :: k). Show (Sing z) :: Constraint)
deriving instance (ShowSing a, ShowSing b) => Show (Sing (e :: Either a b))
```

This means that anyone who singles derived `Show` instances will now need to enable `QuantifiedConstraints` and `StandaloneDeriving`, but this shouldn't be too burdensome.