### PR TITLE
Fix #353

### DIFF
--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -100,6 +100,7 @@ tests =
     , compileAndDumpStdTest "T332"
     , compileAndDumpStdTest "T342"
     , compileAndDumpStdTest "FunctorLikeDeriving"
+    , compileAndDumpStdTest "T353"
     ],
     testCompileAndDumpGroup "Promote"
     [ compileAndDumpStdTest "Constructors"

--- a/tests/compile-and-dump/Singletons/T353.ghc86.template
+++ b/tests/compile-and-dump/Singletons/T353.ghc86.template
@@ -1,0 +1,104 @@
+Singletons/T353.hs:(0,0)-(0,0): Splicing declarations
+    singletons
+      [d| type family Symmetry (a :: Proxy t) (y :: Proxy t) (e :: (a :: Proxy (t :: k))
+                                                                   :~:
+                                                                   (y :: Proxy (t :: k))) :: Type where
+            Symmetry a y _ = y :~: a |]
+  ======>
+    type family Symmetry (a :: Proxy t) (y :: Proxy t) (e :: (:~:) (a :: Proxy (t :: k)) (y :: Proxy (t :: k))) :: Type where
+      Symmetry a y _ = (:~:) y a
+    type SymmetrySym3 (a0123456789876543210 :: Proxy t0123456789876543210) (y0123456789876543210 :: Proxy t0123456789876543210) (e0123456789876543210 :: (:~:) (a0123456789876543210 :: Proxy (t0123456789876543210 :: k0123456789876543210)) (y0123456789876543210 :: Proxy (t0123456789876543210 :: k0123456789876543210))) =
+        Symmetry a0123456789876543210 y0123456789876543210 e0123456789876543210
+    instance SuppressUnusedWarnings (SymmetrySym2 y0123456789876543210 a0123456789876543210) where
+      suppressUnusedWarnings = snd (((,) SymmetrySym2KindInference) ())
+    data SymmetrySym2 (a0123456789876543210 :: Proxy (t0123456789876543210 :: k0123456789876543210)) (y0123456789876543210 :: Proxy (t0123456789876543210 :: k0123456789876543210)) :: (~>) ((:~:) (a0123456789876543210 :: Proxy (t0123456789876543210 :: k0123456789876543210)) (y0123456789876543210 :: Proxy (t0123456789876543210 :: k0123456789876543210))) Type
+      where
+        SymmetrySym2KindInference :: forall a0123456789876543210
+                                            y0123456789876543210
+                                            e0123456789876543210
+                                            arg. SameKind (Apply (SymmetrySym2 a0123456789876543210 y0123456789876543210) arg) (SymmetrySym3 a0123456789876543210 y0123456789876543210 arg) =>
+                                     SymmetrySym2 a0123456789876543210 y0123456789876543210 e0123456789876543210
+    type instance Apply (SymmetrySym2 y0123456789876543210 a0123456789876543210) e0123456789876543210 = Symmetry y0123456789876543210 a0123456789876543210 e0123456789876543210
+    instance SuppressUnusedWarnings (SymmetrySym1 a0123456789876543210) where
+      suppressUnusedWarnings = snd (((,) SymmetrySym1KindInference) ())
+    data SymmetrySym1 (a0123456789876543210 :: Proxy (t0123456789876543210 :: k0123456789876543210)) :: forall (y0123456789876543210 :: Proxy t0123456789876543210).
+                                                                                                        (~>) (Proxy t0123456789876543210) ((~>) ((:~:) (a0123456789876543210 :: Proxy (t0123456789876543210 :: k0123456789876543210)) (y0123456789876543210 :: Proxy (t0123456789876543210 :: k0123456789876543210))) Type)
+      where
+        SymmetrySym1KindInference :: forall a0123456789876543210
+                                            y0123456789876543210
+                                            arg. SameKind (Apply (SymmetrySym1 a0123456789876543210) arg) (SymmetrySym2 a0123456789876543210 arg) =>
+                                     SymmetrySym1 a0123456789876543210 y0123456789876543210
+    type instance Apply (SymmetrySym1 a0123456789876543210) y0123456789876543210 = SymmetrySym2 a0123456789876543210 y0123456789876543210
+    instance SuppressUnusedWarnings SymmetrySym0 where
+      suppressUnusedWarnings = snd (((,) SymmetrySym0KindInference) ())
+    data SymmetrySym0 :: forall k0123456789876543210
+                                (t0123456789876543210 :: k0123456789876543210)
+                                (a0123456789876543210 :: Proxy t0123456789876543210)
+                                (y0123456789876543210 :: Proxy t0123456789876543210).
+                         (~>) (Proxy t0123456789876543210) ((~>) (Proxy t0123456789876543210) ((~>) ((:~:) (a0123456789876543210 :: Proxy (t0123456789876543210 :: k0123456789876543210)) (y0123456789876543210 :: Proxy (t0123456789876543210 :: k0123456789876543210))) Type))
+      where
+        SymmetrySym0KindInference :: forall a0123456789876543210
+                                            arg. SameKind (Apply SymmetrySym0 arg) (SymmetrySym1 arg) =>
+                                     SymmetrySym0 a0123456789876543210
+    type instance Apply SymmetrySym0 a0123456789876543210 = SymmetrySym1 a0123456789876543210
+Singletons/T353.hs:0:0:: Splicing declarations
+    genDefunSymbols [''Prod]
+  ======>
+    type MkProdSym2 (t0123456789876543210 :: f0123456789876543210 p0123456789876543210) (t0123456789876543210 :: g0123456789876543210 p0123456789876543210) =
+        MkProd t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (MkProdSym1 t0123456789876543210) where
+      suppressUnusedWarnings = snd (((,) MkProdSym1KindInference) ())
+    data MkProdSym1 (t0123456789876543210 :: (f0123456789876543210 :: k0123456789876543210
+                                                                      -> Type) (p0123456789876543210 :: k0123456789876543210)) :: forall (g0123456789876543210 :: k0123456789876543210
+                                                                                                                                                                  -> Type).
+                                                                                                                                  (~>) (g0123456789876543210 p0123456789876543210) (Prod (f0123456789876543210 :: k0123456789876543210
+                                                                                                                                                                                                                  -> Type) (g0123456789876543210 :: k0123456789876543210
+                                                                                                                                                                                                                                                    -> Type) (p0123456789876543210 :: k0123456789876543210))
+      where
+        MkProdSym1KindInference :: forall t0123456789876543210
+                                          t0123456789876543210
+                                          arg. SameKind (Apply (MkProdSym1 t0123456789876543210) arg) (MkProdSym2 t0123456789876543210 arg) =>
+                                   MkProdSym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (MkProdSym1 t0123456789876543210) t0123456789876543210 = MkProd t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings MkProdSym0 where
+      suppressUnusedWarnings = snd (((,) MkProdSym0KindInference) ())
+    data MkProdSym0 :: forall k0123456789876543210
+                              (f0123456789876543210 :: k0123456789876543210 -> Type)
+                              (g0123456789876543210 :: k0123456789876543210 -> Type)
+                              (p0123456789876543210 :: k0123456789876543210).
+                       (~>) (f0123456789876543210 p0123456789876543210) ((~>) (g0123456789876543210 p0123456789876543210) (Prod (f0123456789876543210 :: k0123456789876543210
+                                                                                                                                                         -> Type) (g0123456789876543210 :: k0123456789876543210
+                                                                                                                                                                                           -> Type) (p0123456789876543210 :: k0123456789876543210)))
+      where
+        MkProdSym0KindInference :: forall t0123456789876543210
+                                          arg. SameKind (Apply MkProdSym0 arg) (MkProdSym1 arg) =>
+                                   MkProdSym0 t0123456789876543210
+    type instance Apply MkProdSym0 t0123456789876543210 = MkProdSym1 t0123456789876543210
+Singletons/T353.hs:0:0:: Splicing declarations
+    genDefunSymbols [''Foo]
+  ======>
+    type MkFooSym2 (t0123456789876543210 :: Proxy a0123456789876543210) (t0123456789876543210 :: Proxy b0123456789876543210) =
+        MkFoo t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (MkFooSym1 t0123456789876543210) where
+      suppressUnusedWarnings = snd (((,) MkFooSym1KindInference) ())
+    data MkFooSym1 (t0123456789876543210 :: Proxy (a0123456789876543210 :: k0123456789876543210)) :: forall k0123456789876543210
+                                                                                                            (b0123456789876543210 :: k0123456789876543210).
+                                                                                                     (~>) (Proxy b0123456789876543210) (Foo (a0123456789876543210 :: k0123456789876543210) (b0123456789876543210 :: k0123456789876543210))
+      where
+        MkFooSym1KindInference :: forall t0123456789876543210
+                                         t0123456789876543210
+                                         arg. SameKind (Apply (MkFooSym1 t0123456789876543210) arg) (MkFooSym2 t0123456789876543210 arg) =>
+                                  MkFooSym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (MkFooSym1 t0123456789876543210) t0123456789876543210 = MkFoo t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings MkFooSym0 where
+      suppressUnusedWarnings = snd (((,) MkFooSym0KindInference) ())
+    data MkFooSym0 :: forall k0123456789876543210
+                             (a0123456789876543210 :: k0123456789876543210)
+                             k0123456789876543210
+                             (b0123456789876543210 :: k0123456789876543210).
+                      (~>) (Proxy a0123456789876543210) ((~>) (Proxy b0123456789876543210) (Foo (a0123456789876543210 :: k0123456789876543210) (b0123456789876543210 :: k0123456789876543210)))
+      where
+        MkFooSym0KindInference :: forall t0123456789876543210
+                                         arg. SameKind (Apply MkFooSym0 arg) (MkFooSym1 arg) =>
+                                  MkFooSym0 t0123456789876543210
+    type instance Apply MkFooSym0 t0123456789876543210 = MkFooSym1 t0123456789876543210

--- a/tests/compile-and-dump/Singletons/T353.hs
+++ b/tests/compile-and-dump/Singletons/T353.hs
@@ -1,0 +1,17 @@
+module T353 where
+
+import Data.Kind
+import Data.Proxy
+import Data.Singletons.TH
+
+$(singletons [d|
+  type family Symmetry (a :: Proxy t) (y :: Proxy t)
+                       (e :: (a :: Proxy (t :: k)) :~: (y :: Proxy (t :: k))) :: Type where
+    Symmetry a y _ = y :~: a
+  |])
+
+data Prod f g p = MkProd (f p) (g p)
+$(genDefunSymbols [''Prod])
+
+data Foo a b = MkFoo (Proxy a) (Proxy b)
+$(genDefunSymbols [''Foo])


### PR DESCRIPTION
Essentially, this fixes a problem by using more explicit kind signatures. I've augmented `Note [Defunctionalization and dependent quantification]` with a slightly more complicated example which tickles the bug in #353, and explain what extra steps we must do to avoid the bug in step (2)(ii).