### PR TITLE
Fix #361 by removing ad hockery from promoteType

### DIFF
--- a/src/Data/Singletons/Promote/Type.hs
+++ b/src/Data/Singletons/Promote/Type.hs
@@ -42,7 +42,6 @@ promoteType = go []
     go args     (DVarT name) = return $ foldType (DVarT name) args
     go []       (DConT name)
       | name == typeRepName               = return $ DConT typeKindName
-      | name == stringName                = return $ DConT symbolName
       | nameBase name == nameBase repName = return $ DConT typeKindName
     go args     (DConT name)
       | Just n <- unboxedTupleNameDegree_maybe name
@@ -50,7 +49,7 @@ promoteType = go []
       | otherwise
       = return $ foldType (DConT name) args
     go [k1, k2] DArrowT = return $ DConT tyFunArrowName `DAppT` k1 `DAppT` k2
-    go _ (DLitT _) = fail "Cannot promote a type-level literal"
+    go _        ty@DLitT{} = pure ty
 
     go args     hd = fail $ "Illegal Haskell construct encountered:\n" ++
                             "headed by: " ++ show hd ++ "\n" ++

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -109,6 +109,7 @@ tests =
     , compileAndDumpStdTest "Pragmas"
     , compileAndDumpStdTest "Prelude"
     , compileAndDumpStdTest "T180"
+    , compileAndDumpStdTest "T361"
     ],
     testGroup "Database client"
     [ compileAndDumpTest "GradingClient/Database" ghcOpts

--- a/tests/compile-and-dump/Promote/T361.ghc86.template
+++ b/tests/compile-and-dump/Promote/T361.ghc86.template
@@ -1,0 +1,21 @@
+Promote/T361.hs:0:0:: Splicing declarations
+    genDefunSymbols [''Proxy] ======> type ProxySym0 = Proxy
+Promote/T361.hs:(0,0)-(0,0): Splicing declarations
+    promote
+      [d| f :: Proxy 1 -> Proxy 2
+          f Proxy = Proxy |]
+  ======>
+    f :: Proxy 1 -> Proxy 2
+    f Proxy = Proxy
+    type FSym1 (a0123456789876543210 :: Proxy 1) =
+        F a0123456789876543210
+    instance SuppressUnusedWarnings FSym0 where
+      suppressUnusedWarnings = snd (((,) FSym0KindInference) ())
+    data FSym0 :: (~>) (Proxy 1) (Proxy 2)
+      where
+        FSym0KindInference :: forall a0123456789876543210
+                                     arg. SameKind (Apply FSym0 arg) (FSym1 arg) =>
+                              FSym0 a0123456789876543210
+    type instance Apply FSym0 a0123456789876543210 = F a0123456789876543210
+    type family F (a :: Proxy 1) :: Proxy 2 where
+      F Proxy = ProxySym0

--- a/tests/compile-and-dump/Promote/T361.hs
+++ b/tests/compile-and-dump/Promote/T361.hs
@@ -1,0 +1,11 @@
+module T361 where
+
+import Data.Proxy
+import Data.Singletons.TH
+
+$(genDefunSymbols [''Proxy])
+
+$(promote [d|
+  f :: Proxy 1 -> Proxy 2
+  f Proxy = Proxy
+  |])

--- a/tests/compile-and-dump/Singletons/LambdaCase.ghc86.template
+++ b/tests/compile-and-dump/Singletons/LambdaCase.ghc86.template
@@ -18,17 +18,17 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
     foo1 :: a -> Maybe a -> a
     foo1 d x
       = (\case
-           \ (Just y) -> y
-           \ Nothing -> d)
+           Just y -> y
+           Nothing -> d)
           x
     foo2 :: a -> Maybe a -> a
     foo2 d _
       = (\case
-           \ (Just y) -> y
-           \ Nothing -> d)
+           Just y -> y
+           Nothing -> d)
           (Just d)
     foo3 :: a -> b -> a
-    foo3 a b = (\case \ (p, _) -> p) (a, b)
+    foo3 a b = (\case (p, _) -> p) (a, b)
     type family Case_0123456789876543210 a b x_0123456789876543210 t where
       Case_0123456789876543210 a b x_0123456789876543210 '(p, _) = p
     type family Lambda_0123456789876543210 a b t where


### PR DESCRIPTION
This removes a vesitigal special case for promoting `String`s, as well as an unnecessary restriction on promoting type literals, from `promoteType`.