### PR TITLE
Support promoting and singling InstanceSigs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -111,6 +111,8 @@ Changelog for singletons project
 
 * Permit singling of expression and pattern signatures.
 
+* Permit promotion and singling of `InstanceSigs`.
+
 * `sError` and `sUndefined` now have `HasCallStack` constraints, like their
   counterparts `error` and `undefined`. The promoted and singled counterparts
   to `errorWithoutStackTrace` have also been added in case you do not want

--- a/README.md
+++ b/README.md
@@ -592,6 +592,7 @@ The following constructs are fully supported:
 * class and instance declarations
 * scoped type variables
 * signatures (e.g., `(x :: Maybe a)`) in expressions and patterns
+* `InstanceSigs`
 * higher-kinded type variables (see below)
 * finite arithmetic sequences (see below)
 * functional dependencies (with limitations -- see below)
@@ -740,3 +741,24 @@ Known bugs
 * Singled code that contains uses type families is likely to fail due to GHC
   Trac #12564. Note that singling type family declarations themselves is fine
   (and often desired, since that produces defunctionalization symbols for them).
+* Singling instances of poly-kinded type classes is likely to fail due to
+  [#358](https://github.com/goldfirere/singletons/issues/358).
+  However, one can often work around the issue by using `InstanceSigs`. For
+  instance, the following code will not single:
+
+  ```haskell
+  class C (f :: k -> Type) where
+    method :: f a
+
+  instance C [] where
+    method = []
+  ```
+
+  Adding a type signature for `method` in the `C []` is sufficient
+  to work around the issue, though:
+
+  ```haskell
+  instance C [] where
+    method :: [a]
+    method = []
+  ```

--- a/src/Data/Singletons/Deriving/Bounded.hs
+++ b/src/Data/Singletons/Deriving/Bounded.hs
@@ -54,5 +54,6 @@ mkBoundedInstance mb_ctxt ty (DataDecl _ _ cons) = do
   return $ InstDecl { id_cxt = constraints
                     , id_name = boundedName
                     , id_arg_tys = [ty]
+                    , id_sigs  = mempty
                     , id_meths = [ (minBoundName, mk_rhs minRHS)
                                  , (maxBoundName, mk_rhs maxRHS) ] }

--- a/src/Data/Singletons/Deriving/Enum.hs
+++ b/src/Data/Singletons/Deriving/Enum.hs
@@ -50,5 +50,6 @@ mkEnumInstance mb_ctxt ty (DataDecl data_name tvbs cons) = do
                       -- to use Nat instead of Int
 
                    , id_arg_tys = [ty]
+                   , id_sigs    = mempty
                    , id_meths   = [ (singletonsToEnumName, to_enum)
                                   , (singletonsFromEnumName, from_enum) ] })

--- a/src/Data/Singletons/Deriving/Foldable.hs
+++ b/src/Data/Singletons/Deriving/Foldable.hs
@@ -95,4 +95,5 @@ mkFoldableInstance mb_ctxt ty dd@(DataDecl _ _ cons) = do
   return $ InstDecl { id_cxt = constraints
                     , id_name = foldableName
                     , id_arg_tys = [ty]
+                    , id_sigs  = mempty
                     , id_meths = meths }

--- a/src/Data/Singletons/Deriving/Functor.hs
+++ b/src/Data/Singletons/Deriving/Functor.hs
@@ -86,6 +86,7 @@ mkFunctorInstance mb_ctxt ty dd@(DataDecl _ _ cons) = do
   return $ InstDecl { id_cxt = constraints
                     , id_name = functorName
                     , id_arg_tys = [ty]
+                    , id_sigs  = mempty
                     , id_meths = [ (fmapName,    UFunction fmap_clauses)
                                  , (replaceName, UFunction replace_clauses)
                                  ] }

--- a/src/Data/Singletons/Deriving/Ord.hs
+++ b/src/Data/Singletons/Deriving/Ord.hs
@@ -37,6 +37,7 @@ mkOrdInstance mb_ctxt ty (DataDecl _ _ cons) = do
   return (InstDecl { id_cxt = constraints
                    , id_name = ordName
                    , id_arg_tys = [ty]
+                   , id_sigs  = mempty
                    , id_meths = [(compareName, UFunction clauses)] })
 
 mk_equal_clause :: Quasi q => DCon -> q DClause

--- a/src/Data/Singletons/Deriving/Show.hs
+++ b/src/Data/Singletons/Deriving/Show.hs
@@ -34,6 +34,7 @@ mkShowInstance mb_ctxt ty (DataDecl _ _ cons) = do
   return $ InstDecl { id_cxt = constraints
                     , id_name = showName
                     , id_arg_tys = [ty]
+                    , id_sigs  = mempty
                     , id_meths = [ (showsPrecName, UFunction clauses) ] }
 
 mk_showsPrec :: DsMonad q => [DCon] -> q [DClause]

--- a/src/Data/Singletons/Deriving/Traversable.hs
+++ b/src/Data/Singletons/Deriving/Traversable.hs
@@ -65,4 +65,5 @@ mkTraversableInstance mb_ctxt ty dd@(DataDecl _ _ cons) = do
   return $ InstDecl { id_cxt = constraints
                     , id_name = traversableName
                     , id_arg_tys = [ty]
+                    , id_sigs  = mempty
                     , id_meths = [ (traverseName, UFunction trav_clauses) ] }

--- a/src/Data/Singletons/Syntax.hs
+++ b/src/Data/Singletons/Syntax.hs
@@ -73,6 +73,7 @@ data ClassDecl ann = ClassDecl { cd_cxt  :: DCxt
 data InstDecl  ann = InstDecl { id_cxt     :: DCxt
                               , id_name    :: Name
                               , id_arg_tys :: [DType]
+                              , id_sigs    :: Map Name DType
                               , id_meths   :: [(Name, LetDecRHS ann)] }
 
 type UClassDecl = ClassDecl Unannotated

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -101,6 +101,7 @@ tests =
     , compileAndDumpStdTest "T342"
     , compileAndDumpStdTest "FunctorLikeDeriving"
     , compileAndDumpStdTest "T353"
+    , compileAndDumpStdTest "T358"
     ],
     testCompileAndDumpGroup "Promote"
     [ compileAndDumpStdTest "Constructors"

--- a/tests/compile-and-dump/Singletons/T358.ghc86.template
+++ b/tests/compile-and-dump/Singletons/T358.ghc86.template
@@ -1,0 +1,116 @@
+Singletons/T358.hs:(0,0)-(0,0): Splicing declarations
+    singletons
+      [d| class C1 (f :: k -> Type) where
+            method1 :: f a
+          class C2 a where
+            method2a, method2b :: forall b. b -> a
+          
+          instance C1 [] where
+            method1 :: [a]
+            method1 = []
+          instance C2 [a] where
+            method2a _ = []
+            method2b :: forall b. b -> [a]
+            method2b _ = [] |]
+  ======>
+    class C1 (f :: k -> Type) where
+      method1 :: f a
+    instance C1 [] where
+      method1 :: [a]
+      method1 = []
+    class C2 a where
+      method2a :: forall b. b -> a
+      method2b :: forall b. b -> a
+    instance C2 [a] where
+      method2b :: forall b. b -> [a]
+      method2a _ = []
+      method2b _ = []
+    type Method1Sym0 = Method1
+    class PC1 (f :: k -> Type) where
+      type Method1 :: f a
+    type Method2aSym1 (arg0123456789876543210 :: b0123456789876543210) =
+        Method2a arg0123456789876543210
+    instance SuppressUnusedWarnings Method2aSym0 where
+      suppressUnusedWarnings = snd (((,) Method2aSym0KindInference) ())
+    data Method2aSym0 :: forall a0123456789876543210
+                                b0123456789876543210.
+                         (~>) b0123456789876543210 a0123456789876543210
+      where
+        Method2aSym0KindInference :: forall arg0123456789876543210
+                                            arg. SameKind (Apply Method2aSym0 arg) (Method2aSym1 arg) =>
+                                     Method2aSym0 arg0123456789876543210
+    type instance Apply Method2aSym0 arg0123456789876543210 = Method2a arg0123456789876543210
+    type Method2bSym1 (arg0123456789876543210 :: b0123456789876543210) =
+        Method2b arg0123456789876543210
+    instance SuppressUnusedWarnings Method2bSym0 where
+      suppressUnusedWarnings = snd (((,) Method2bSym0KindInference) ())
+    data Method2bSym0 :: forall a0123456789876543210
+                                b0123456789876543210.
+                         (~>) b0123456789876543210 a0123456789876543210
+      where
+        Method2bSym0KindInference :: forall arg0123456789876543210
+                                            arg. SameKind (Apply Method2bSym0 arg) (Method2bSym1 arg) =>
+                                     Method2bSym0 arg0123456789876543210
+    type instance Apply Method2bSym0 arg0123456789876543210 = Method2b arg0123456789876543210
+    class PC2 (a :: Type) where
+      type Method2a (arg :: b) :: a
+      type Method2b (arg :: b) :: a
+    type family Method1_0123456789876543210 :: [a] where
+      Method1_0123456789876543210 = '[]
+    type Method1_0123456789876543210Sym0 = Method1_0123456789876543210
+    instance PC1 [] where
+      type Method1 = Method1_0123456789876543210Sym0
+    type family Method2a_0123456789876543210 (a :: b) :: [a] where
+      Method2a_0123456789876543210 _ = '[]
+    type Method2a_0123456789876543210Sym1 (a0123456789876543210 :: b0123456789876543210) =
+        Method2a_0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings Method2a_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd (((,) Method2a_0123456789876543210Sym0KindInference) ())
+    data Method2a_0123456789876543210Sym0 :: forall a0123456789876543210
+                                                    b0123456789876543210.
+                                             (~>) b0123456789876543210 [a0123456789876543210]
+      where
+        Method2a_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                arg. SameKind (Apply Method2a_0123456789876543210Sym0 arg) (Method2a_0123456789876543210Sym1 arg) =>
+                                                         Method2a_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Method2a_0123456789876543210Sym0 a0123456789876543210 = Method2a_0123456789876543210 a0123456789876543210
+    type family Method2b_0123456789876543210 (a :: b) :: [a] where
+      Method2b_0123456789876543210 _ = '[]
+    type Method2b_0123456789876543210Sym1 (a0123456789876543210 :: b0123456789876543210) =
+        Method2b_0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings Method2b_0123456789876543210Sym0 where
+      suppressUnusedWarnings
+        = snd (((,) Method2b_0123456789876543210Sym0KindInference) ())
+    data Method2b_0123456789876543210Sym0 :: forall a0123456789876543210
+                                                    b0123456789876543210.
+                                             (~>) b0123456789876543210 [a0123456789876543210]
+      where
+        Method2b_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                                arg. SameKind (Apply Method2b_0123456789876543210Sym0 arg) (Method2b_0123456789876543210Sym1 arg) =>
+                                                         Method2b_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Method2b_0123456789876543210Sym0 a0123456789876543210 = Method2b_0123456789876543210 a0123456789876543210
+    instance PC2 [a] where
+      type Method2a a = Apply Method2a_0123456789876543210Sym0 a
+      type Method2b a = Apply Method2b_0123456789876543210Sym0 a
+    class SC1 (f :: k -> Type) where
+      sMethod1 :: forall a. Sing (Method1Sym0 :: f a)
+    class SC2 a where
+      sMethod2a ::
+        forall b (t :: b). Sing t -> Sing (Apply Method2aSym0 t :: a)
+      sMethod2b ::
+        forall b (t :: b). Sing t -> Sing (Apply Method2bSym0 t :: a)
+    instance SC1 [] where
+      sMethod1 :: forall a. Sing (Method1Sym0 :: [a])
+      sMethod1 = Data.Singletons.Prelude.Instances.SNil
+    instance SC2 [a] where
+      sMethod2a ::
+        forall b (t :: b). Sing t -> Sing (Apply Method2aSym0 t :: [a])
+      sMethod2b ::
+        forall b (t :: b). Sing t -> Sing (Apply Method2bSym0 t :: [a])
+      sMethod2a _ = Data.Singletons.Prelude.Instances.SNil
+      sMethod2b _ = Data.Singletons.Prelude.Instances.SNil
+    instance SC2 a => SingI (Method2aSym0 :: (~>) b a) where
+      sing = (singFun1 @Method2aSym0) sMethod2a
+    instance SC2 a => SingI (Method2bSym0 :: (~>) b a) where
+      sing = (singFun1 @Method2bSym0) sMethod2b

--- a/tests/compile-and-dump/Singletons/T358.hs
+++ b/tests/compile-and-dump/Singletons/T358.hs
@@ -1,0 +1,24 @@
+module T358 where
+
+import Data.Kind
+import Data.Singletons.TH
+
+$(singletons [d|
+  class C1 (f :: k -> Type) where
+    method1 :: f a
+
+  instance C1 [] where
+    method1 :: [a]
+    method1 = []
+
+  class C2 a where
+    method2a, method2b :: forall b. b -> a
+
+  -- Test that variables bound by instance head aren't quantified by the
+  -- generated InstanceSigs
+  instance C2 [a] where
+    method2a _ = []
+
+    method2b :: forall b. b -> [a]
+    method2b _ = []
+  |])


### PR DESCRIPTION
This turns out to be not so bad implementation-wise. The key step is stashing an extra `Map Name DType` in each `InstDecl` to store each instance signature, and consulting that when trying to determine what a instance method's type should be (before all the other tricks we currently pull).

Fixes #358 (at least, to the extent that is currently possible with today's GHC).