### PR TITLE
export Endo newtype wrapper

### DIFF
--- a/src/Data/Singletons/Prelude/Foldable.hs
+++ b/src/Data/Singletons/Prelude/Foldable.hs
@@ -101,7 +101,6 @@ import Data.Kind
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Monoid hiding (All(..), Any(..), Endo(..), Product(..), Sum(..))
 import qualified Data.Monoid as Monoid (All(..), Any(..), Product(..), Sum(..))
-import Data.Singletons.Internal
 import Data.Singletons.Prelude.Base
   hiding (Foldr, FoldrSym0, FoldrSym1, FoldrSym2, FoldrSym3, sFoldr)
 import Data.Singletons.Prelude.Bool
@@ -130,20 +129,6 @@ import Data.Singletons.Prelude.Semigroup.Internal
 import Data.Singletons.Promote
 import Data.Singletons.Single
 import Data.Singletons.TypeLits.Internal
-
-newtype Endo a = Endo (a ~> a)
-data instance Sing :: forall a. Endo a -> Type where
-  SEndo :: Sing x -> Sing ('Endo x)
-data EndoSym0 :: forall a. (a ~> a) ~> Endo a
-type instance Apply EndoSym0 x = 'Endo x
-
-$(singletonsOnly [d|
-  instance Semigroup (Endo a) where
-          Endo x <> Endo y = Endo (x . y)
-
-  instance Monoid (Endo a) where
-          mempty = Endo id
-  |])
 
 newtype MaxInternal a = MaxInternal (Maybe a)
 data instance Sing :: forall a. MaxInternal a -> Type where

--- a/src/Data/Singletons/Prelude/Monoid.hs
+++ b/src/Data/Singletons/Prelude/Monoid.hs
@@ -31,7 +31,7 @@ module Data.Singletons.Prelude.Monoid (
   PMonoid(..), SMonoid(..),
 
   Sing(SDual, sGetDual, SAll, sGetAll, SAny, sGetAny, SSum, sGetSum,
-       SProduct, sGetProduct, SFirst, sGetFirst, SLast, sGetLast),
+       SProduct, sGetProduct, SFirst, sGetFirst, SLast, sGetLast, SEndo),
   GetDual, GetAll, GetAny, GetSum, GetProduct, GetFirst, GetLast,
 
   SDual, SAll, SAny, SSum, SProduct, SFirst, SLast,
@@ -51,7 +51,7 @@ module Data.Singletons.Prelude.Monoid (
 
 import Data.Monoid (First(..), Last(..))
 import Data.Ord (Down(..))
-import Data.Semigroup hiding (First(..), Last(..))
+import Data.Semigroup hiding (First(..), Last(..), Endo(..))
 import Data.Singletons.Prelude.Base
 import Data.Singletons.Prelude.Eq
 import Data.Singletons.Prelude.Instances
@@ -210,4 +210,9 @@ $(singletonsOnly [d|
 
   instance Monoid (Last a) where
           mempty = Last Nothing
+
+  instance Monoid (Endo a) where
+          mempty = Endo id
   |])
+
+

--- a/src/Data/Singletons/Prelude/Semigroup.hs
+++ b/src/Data/Singletons/Prelude/Semigroup.hs
@@ -35,7 +35,7 @@ module Data.Singletons.Prelude.Semigroup (
        SWrapMonoid, sUnwrapMonoid, SDual, sGetDual,
        SAll, sGetAll, SAny, sGetAny,
        SSum, sGetSum, SProduct, sGetProduct,
-       SOption, sGetOption, SArg),
+       SOption, sGetOption, SArg, SEndo),
   GetMin, GetMax, GetFirst, GetLast, GetDual,
   GetAll, GetAny, GetSum, GetProduct, GetOption,
 

--- a/src/Data/Singletons/Prelude/Semigroup/Internal.hs
+++ b/src/Data/Singletons/Prelude/Semigroup/Internal.hs
@@ -35,6 +35,7 @@ module Data.Singletons.Prelude.Semigroup.Internal where
 
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Ord (Down(..))
+import Data.Kind
 import Data.Proxy
 import Data.Semigroup (Dual(..), All(..), Any(..), Sum(..), Product(..), Option(..))
 import Data.Singletons.Internal
@@ -278,3 +279,15 @@ sSum_ = SSum
 
 sProduct_ :: forall a (x :: a). Sing x -> Sing (Product_ x)
 sProduct_ = SProduct
+
+newtype Endo a = Endo (a ~> a)
+data instance Sing :: forall a. Endo a -> Type where
+  SEndo :: Sing x -> Sing ('Endo x)
+data EndoSym0 :: forall a. (a ~> a) ~> Endo a
+type instance Apply EndoSym0 x = 'Endo x
+
+
+$(singletonsOnly [d|
+  instance Semigroup (Endo a) where
+          Endo x <> Endo y = Endo (x . y)
+  |])


### PR DESCRIPTION
Not sure if this is a desirable thing, but just a PR exporting the internal `Endo` wrapper.  I was using one myself for some of my own code and thought it might be useful to not duplicate code, but I do understand that the `Endo` wraper does break some of the consistency in the singletons API, so it would also make sense to hide it as an internal tool only.