### PR TITLE
Parallelize the test suite (for real this time)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,7 @@ install:
   - "echo '  type: git' >> cabal.project"
   - "echo '  location: https://github.com/goldfirere/th-desugar' >> cabal.project"
   - "echo '  tag: 567145eddeb5f6692a75e74d4a2dc575b1ad6f29' >> cabal.project"
+  - "printf 'write-ghc-environment-files: always' >> cabal.project"
   - touch cabal.project.local
   - "if ! $NOINSTALLEDCONSTRAINTS; then for pkg in $($HCPKG list --simple-output); do echo $pkg  | grep -vw -- singletons | grep -vw -- accept-all | sed 's/^/constraints: /' | sed 's/-[^-]*$/ installed/' >> cabal.project.local; done; fi"
   - cat cabal.project || true
@@ -112,6 +113,7 @@ script:
   - "echo '  type: git' >> cabal.project"
   - "echo '  location: https://github.com/goldfirere/th-desugar' >> cabal.project"
   - "echo '  tag: 567145eddeb5f6692a75e74d4a2dc575b1ad6f29' >> cabal.project"
+  - "printf 'write-ghc-environment-files: always' >> cabal.project"
   - touch cabal.project.local
   - "if ! $NOINSTALLEDCONSTRAINTS; then for pkg in $($HCPKG list --simple-output); do echo $pkg  | grep -vw -- singletons | grep -vw -- accept-all | sed 's/^/constraints: /' | sed 's/-[^-]*$/ installed/' >> cabal.project.local; done; fi"
   - cat cabal.project || true

--- a/singletons.cabal
+++ b/singletons.cabal
@@ -144,7 +144,7 @@ library
 test-suite singletons-test-suite
   type:               exitcode-stdio-1.0
   hs-source-dirs:     tests
-  ghc-options:        -Wall
+  ghc-options:        -Wall -threaded -with-rtsopts=-maxN16
   default-language:   Haskell2010
   main-is:            SingletonsTestSuite.hs
   other-modules:      ByHand
@@ -155,5 +155,5 @@ test-suite singletons-test-suite
                       filepath >= 1.3,
                       process >= 1.1,
                       singletons,
-                      tasty >= 0.6,
+                      tasty >= 1.2,
                       tasty-golden >= 2.2


### PR DESCRIPTION
This is a better attempt to fix #123 in which I use `tasty-1.2`'s new API for expressing test dependencies. (I previously attempted to parallelize the test suite in commit 7962d08821e8d5b82b5d754488ee3a41cca4b10d, but that ended disastrously. See https://github.com/goldfirere/singletons/issues/123#issuecomment-363908783 for more details.)

I also use `-maxN16` this time instead of `-N`. It's unclear how well this scales, so I decided to be cautious at cap it off at 16. Testing this locally on my machine, using `-maxN16` reduces the build time from about 90 to 15 seconds, which is pretty nice in its own right. (If more adventurous users want to attempt using more threads, they can always override this themselves.)