### PR TITLE
Use fromIntegral to avoid GHCJS conflict

### DIFF
--- a/src/Data/Singletons/Util.hs
+++ b/src/Data/Singletons/Util.hs
@@ -96,7 +96,7 @@ qNewUnique :: DsMonad q => q Int
 qNewUnique = do
   Name _ flav <- qNewName "x"
   case flav of
-    NameU n -> return n
+    NameU n -> return $ fromIntegral n
     _       -> error "Internal error: `qNewName` didn't return a NameU"
 
 checkForRep :: Quasi q => [Name] -> q ()


### PR DESCRIPTION
This fixes an issue I am getting on GHCJS:

```

src/Data/Singletons/Util.hs:69:16: error:
    • Couldn't match type ‘Integer’ with ‘Int’
      Expected type: q Int
        Actual type: q Uniq
    • In the expression: return n
      In a case alternative: NameU n -> return n
      In a stmt of a 'do' block:
        case flav of
          NameU n -> return n
          _ -> error "Internal error: `qNewName` didn't return a NameU"
   |
69 |     NameU n -> return n
   |                ^^^^^^^^
```