### PR TITLE
Fix the remainder of #356

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Changelog for singletons project
 
 2.6
 ---
+* Require GHC 8.8.
 * GHC's behavior surrounding kind inference for local definitions has changed
   in 8.8, and certain code that `singletons` generates for local definitions
   may no longer typecheck as a result. While we have taken measures to mitigate

--- a/src/Data/Singletons/Internal.hs
+++ b/src/Data/Singletons/Internal.hs
@@ -202,8 +202,8 @@ data family TyCon :: (k1 -> k2) -> unmatchable_fun
 -- I (Richard) wasn't sure what concrete value the ticket would
 -- have, given that we don't know how to begin fixing it.
 type family ApplyTyCon :: (k1 -> k2) -> (k1 ~> unmatchable_fun) where
-  ApplyTyCon = (ApplyTyConAux2 :: (k1 -> k2 -> k3) -> (k1 ~> unmatchable_fun))
-  ApplyTyCon = (ApplyTyConAux1 :: (k1 -> k2)       -> (k1 ~> k2))
+  ApplyTyCon @k1 @(k2 -> k3) @unmatchable_fun = ApplyTyConAux2
+  ApplyTyCon @k1 @k2         @k2              = ApplyTyConAux1
 -- Upon first glance, the definition of ApplyTyCon (as well as the
 -- corresponding Apply instance for TyCon) seems a little indirect. One might
 -- wonder why these aren't defined like so:

--- a/src/Data/Singletons/Partition.hs
+++ b/src/Data/Singletons/Partition.hs
@@ -35,7 +35,6 @@ import Language.Haskell.TH.Desugar.OMap.Strict (OMap)
 import Data.Singletons.Util
 
 import Control.Monad
-import qualified Control.Monad.Fail as Fail
 import Data.Bifunctor (bimap)
 import qualified Data.Map as Map
 import Data.Map (Map)
@@ -154,7 +153,7 @@ partitionDec (DStandaloneDerivD mb_strat ctxt ty) =
 partitionDec dec =
   fail $ "Declaration cannot be promoted: " ++ pprint (decToTH dec)
 
-partitionClassDec :: Fail.MonadFail m => DDec -> m (ULetDecEnv, [OpenTypeFamilyDecl])
+partitionClassDec :: MonadFail m => DDec -> m (ULetDecEnv, [OpenTypeFamilyDecl])
 partitionClassDec (DLetDec (DSigD name ty)) =
   pure (typeBinding name ty, mempty)
 partitionClassDec (DLetDec (DValD (DVarP name) exp)) =
@@ -173,9 +172,9 @@ partitionClassDec (DTySynInstD {}) =
   -- we already record the type family itself separately.
   pure (mempty, mempty)
 partitionClassDec _ =
-  Fail.fail "Only method declarations can be promoted within a class."
+  fail "Only method declarations can be promoted within a class."
 
-partitionInstanceDec :: Fail.MonadFail m => DDec
+partitionInstanceDec :: MonadFail m => DDec
                      -> m ( Maybe (Name, ULetDecRHS) -- right-hand sides of methods
                           , OMap Name DType          -- method type signatures
                           )
@@ -192,7 +191,7 @@ partitionInstanceDec (DTySynInstD {}) =
   -- There's no need to track associated type family instances, since
   -- we already record the type family itself separately.
 partitionInstanceDec _ =
-  Fail.fail "Only method bodies can be promoted within an instance."
+  fail "Only method bodies can be promoted within an instance."
 
 partitionDeriving
   :: forall m. DsMonad m

--- a/src/Data/Singletons/Promote.hs
+++ b/src/Data/Singletons/Promote.hs
@@ -35,7 +35,6 @@ import Prelude hiding (exp)
 import Control.Applicative (Alternative(..))
 import Control.Arrow (second)
 import Control.Monad
-import qualified Control.Monad.Fail as Fail
 import Control.Monad.Trans.Maybe
 import Control.Monad.Writer
 import qualified Data.Map.Strict as Map
@@ -827,12 +826,12 @@ promoteLitExp (StringL str) = do
 promoteLitExp lit =
   fail ("Only string and natural number literals can be promoted: " ++ show lit)
 
-promoteLitPat :: Fail.MonadFail m => Lit -> m DType
+promoteLitPat :: MonadFail m => Lit -> m DType
 promoteLitPat (IntegerL n)
   | n >= 0    = return $ (DLitT (NumTyLit n))
   | otherwise =
-    Fail.fail $ "Negative literal patterns are not allowed,\n" ++
-                "because literal patterns are promoted to natural numbers."
+    fail $ "Negative literal patterns are not allowed,\n" ++
+           "because literal patterns are promoted to natural numbers."
 promoteLitPat (StringL str) = return $ DLitT (StrTyLit str)
 promoteLitPat lit =
   fail ("Only string and natural number literals can be promoted: " ++ show lit)

--- a/src/Data/Singletons/Promote/Monad.hs
+++ b/src/Data/Singletons/Promote/Monad.hs
@@ -28,7 +28,6 @@ import qualified Language.Haskell.TH.Desugar.OSet as OSet
 import Language.Haskell.TH.Desugar.OSet (OSet)
 import Data.Singletons.Names
 import Data.Singletons.Syntax
-import qualified Control.Monad.Fail as Fail
 
 type LetExpansions = OMap Name DType  -- from **term-level** name
 
@@ -50,7 +49,7 @@ emptyPrEnv = PrEnv { pr_lambda_bound = OMap.empty
 newtype PrM a = PrM (ReaderT PrEnv (WriterT [DDec] Q) a)
   deriving ( Functor, Applicative, Monad, Quasi
            , MonadReader PrEnv, MonadWriter [DDec]
-           , Fail.MonadFail, MonadIO )
+           , MonadFail, MonadIO )
 
 instance DsMonad PrM where
   localDeclarations = asks pr_local_decls

--- a/src/Data/Singletons/Single/Monad.hs
+++ b/src/Data/Singletons/Single/Monad.hs
@@ -29,7 +29,6 @@ import Language.Haskell.TH.Desugar
 import Control.Monad.Reader
 import Control.Monad.Writer
 import Control.Applicative
-import qualified Control.Monad.Fail as Fail
 
 -- environment during singling
 data SgEnv =
@@ -48,7 +47,7 @@ emptySgEnv = SgEnv { sg_let_binds   = Map.empty
 newtype SgM a = SgM (ReaderT SgEnv (WriterT [DDec] Q) a)
   deriving ( Functor, Applicative, Monad
            , MonadReader SgEnv, MonadWriter [DDec]
-           , Fail.MonadFail, MonadIO )
+           , MonadFail, MonadIO )
 
 liftSgM :: Q a -> SgM a
 liftSgM = SgM . lift . lift

--- a/src/Data/Singletons/Util.hs
+++ b/src/Data/Singletons/Util.hs
@@ -33,7 +33,6 @@ import Data.Traversable
 import Data.Generics
 import Data.Maybe
 import Data.Void
-import qualified Control.Monad.Fail as Fail
 
 -- The list of types that singletons processes by default
 basicTypes :: [Name]
@@ -357,7 +356,7 @@ wrapDesugar f th = do
 newtype QWithAux m q a = QWA { runQWA :: WriterT m q a }
   deriving ( Functor, Applicative, Monad, MonadTrans
            , MonadWriter m, MonadReader r
-           , Fail.MonadFail, MonadIO )
+           , MonadFail, MonadIO )
 
 -- make a Quasi instance for easy lifting
 instance (Quasi q, Monoid m) => Quasi (QWithAux m q) where


### PR DESCRIPTION
This fixes #356 for good by checking off the last two tasks in its description:

* Now that `MonadFail` is exported by the `Prelude`, we no longer need to import `Control.Monad.Fail`.
* We can use visible kind applications to simplify the presentation of `ApplyTyCon` to make it obvious how the two equations differ.