### PR TITLE
Make Sing a type family

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,14 +40,21 @@ Changelog for singletons project
     This is unlikely to affect you unless you define 'Show' instances for
     singleton types by hand. For more information, refer to the Haddocks for
     `ShowSing'` in `Data.Singletons.ShowSing`.
-  * It is no longer possible to define a single `TestEquality` and
-    `TestCoercion` instance that covers all `Sing`s, as one cannot put type
-    families inside of instance heads. Instead, `singletons` now generates a
-    separate `TestEquality`/`TestCoercion` instance for every data type that
-    singletons a derived `Eq` instance. In addition, the
-    `Data.Singletons.Decide` module now provides top-level
-    `decideEquality`/`decideCoercion` functions which provide the behavior
-    of `testEquality`/`testCoercion`, but monomorphized to `Sing`.
+  * GHC does not permit type class instances to mention type families, which
+    means that it is no longer possible to define instances that mention the
+    `Sing` type constructor. For this reason, a `WrappedSing` data type (which
+    is a newtype around `Sing`) was introduced so that one can hang instances
+    off of it.
+
+    This had one noticeable effect in `singletons`
+    itself: there are no longer `TestEquality Sing` or `TestCoercion Sing`
+    instances. Instead, `singletons` now generates a separate
+    `TestEquality`/`TestCoercion` instance for every data type that singles a
+    derived `Eq` instance. In addition, the `Data.Singletons.Decide` module
+    now provides top-level `decideEquality`/`decideCoercion` functions which
+    provide the behavior of `testEquality`/`testCoercion`, but monomorphized
+    to `Sing`. Finally, `TestEquality`/`TestCoercion` instances are provided
+    for `WrappedSing`.
 * GHC's behavior surrounding kind inference for local definitions has changed
   in 8.8, and certain code that `singletons` generates for local definitions
   may no longer typecheck as a result. While we have taken measures to mitigate

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ following:
 * `PolyKinds`
 * `RankNTypes`
 * `ScopedTypeVariables`
-* `StandaloneDeriving`
 * `TemplateHaskell`
 * `TypeApplications`
 * `TypeFamilies`
@@ -152,10 +151,10 @@ Please refer to the singletons paper for a more in-depth explanation of these
 definitions. Many of the definitions were developed in tandem with Iavor Diatchki.
 
 ```haskell
-data family Sing (a :: k)
+type family Sing :: k -> Type
 ```
 
-The data family of singleton types. A new instance of this data family is
+The type family of singleton types. A new instance of this type family is
 generated for every new singleton type.
 
 ```haskell
@@ -222,9 +221,10 @@ the advantage that your program can take action when two types do _not_ equal,
 while propositional equality has the advantage that GHC can use the equality
 of types during type inference.
 
-Instances of both `SEq` and `SDecide` are generated when `singletons` is called
-on a datatype that has `deriving Eq`. You can also generate these instances
-directly through functions exported from `Data.Singletons.TH`.
+Instances of `SEq`, `SDecide`, `TestEquality`, and `TestCoercion` are generated
+when `singletons` is called on a datatype that has `deriving Eq`. You can also
+generate these instances directly through functions exported from
+`Data.Singletons.TH`.
 
 
 `Show` classes
@@ -692,8 +692,8 @@ Support for `*`
 
 The built-in Haskell promotion mechanism does not yet have a full story around
 the kind `*` (the kind of types that have values). Ideally, promoting some form
-of `TypeRep` would yield `*`, but the implementation of TypeRep would have to be
-updated for this to really work out. In the meantime, users who wish to
+of `TypeRep` would yield `*`, but the implementation of `TypeRep` would have to
+be updated for this to really work out. In the meantime, users who wish to
 experiment with this feature have two options:
 
 1) The module `Data.Singletons.TypeRepTYPE` has all the definitions possible for
@@ -701,14 +701,12 @@ making `*` the promoted version of `TypeRep`, as `TypeRep` is currently implemen
 The singleton associated with `TypeRep` has one constructor:
 
     ```haskell
-    newtype instance Sing :: forall (rep :: RuntimeRep). TYPE rep -> Type where
-      STypeRep :: forall (rep :: RuntimeRep) (a :: TYPE rep). TypeRep a -> Sing a
+    type instance Sing @(TYPE rep) = TypeRep
     ```
 
-   (Recall that `type * = TYPE LiftedRep`.) Thus, a `TypeRep` is stored in the
-singleton constructor. However, any datatypes that store `TypeRep`s will not
-generally work as expected; the built-in promotion mechanism will not promote
-`TypeRep` to `*`.
+    (Recall that `type * = TYPE LiftedRep`.) Note that any datatypes that store
+`TypeRep`s will not generally work as expected; the built-in promotion
+mechanism will not promote `TypeRep` to `*`.
 
 2) The module `Data.Singletons.CustomStar` allows the programmer to define a subset
 of types with which to work. See the Haddock documentation for the function

--- a/src/Data/Singletons.hs
+++ b/src/Data/Singletons.hs
@@ -78,7 +78,6 @@ module Data.Singletons (
   Proxy(..),
 
   -- * Defunctionalization symbols
-  SingSym0, SingSym1,
   DemoteSym0, DemoteSym1,
   SameKindSym0, SameKindSym1, SameKindSym2,
   KindOfSym0, KindOfSym1,
@@ -177,7 +176,7 @@ instance SIsString k => IsString (SomeSing k) where
 ---- Defunctionalization symbols -------------------------------------
 ----------------------------------------------------------------------
 
-$(genDefunSymbols [''Sing, ''Demote, ''SameKind, ''KindOf, ''(~>), ''Apply, ''(@@)])
+$(genDefunSymbols [''Demote, ''SameKind, ''KindOf, ''(~>), ''Apply, ''(@@)])
 -- SingFunction1 et al. are not defunctionalizable at the moment due to Trac #9269
 
 {- $SLambdaPatternSynonyms

--- a/src/Data/Singletons.hs
+++ b/src/Data/Singletons.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
@@ -38,7 +39,7 @@
 module Data.Singletons (
   -- * Main singleton definitions
 
-  Sing(SLambda, applySing), (@@),
+  Sing, SLambda(..), (@@),
 
   SingI(..), SingKind(..),
 
@@ -77,6 +78,7 @@ module Data.Singletons (
   Proxy(..),
 
   -- * Defunctionalization symbols
+  SingSym0, SingSym1,
   DemoteSym0, DemoteSym1,
   SameKindSym0, SameKindSym1, SameKindSym2,
   KindOfSym0, KindOfSym1,
@@ -157,7 +159,10 @@ instance SNum k => Num (SomeSing k) where
   signum (SomeSing a) = SomeSing (sSignum a)
   fromInteger n = withSomeSing (fromIntegral n) (SomeSing . sFromInteger)
 
-deriving instance ShowSing k => Show (SomeSing k)
+instance ShowSing k => Show (SomeSing k) where
+  showsPrec p (SomeSing (s :: Sing a)) =
+    showParen (p > 10) $ showString "SomeSing " . showsPrec 11 s
+      :: ShowSing' a => ShowS
 
 instance SSemigroup k => Semigroup (SomeSing k) where
   SomeSing a <> SomeSing b = SomeSing (a %<> b)
@@ -172,8 +177,8 @@ instance SIsString k => IsString (SomeSing k) where
 ---- Defunctionalization symbols -------------------------------------
 ----------------------------------------------------------------------
 
-$(genDefunSymbols [''Demote, ''SameKind, ''KindOf, ''(~>), ''Apply, ''(@@)])
--- SingFunction1 et al. are not defunctionalizable at the moment due to #198
+$(genDefunSymbols [''Sing, ''Demote, ''SameKind, ''KindOf, ''(~>), ''Apply, ''(@@)])
+-- SingFunction1 et al. are not defunctionalizable at the moment due to Trac #9269
 
 {- $SLambdaPatternSynonyms
 

--- a/src/Data/Singletons/CustomStar.hs
+++ b/src/Data/Singletons/CustomStar.hs
@@ -60,10 +60,11 @@ import Data.Singletons.Prelude.Bool
 -- and its singleton. However, because @Rep@ is promoted to @*@, the singleton
 -- is perhaps slightly unexpected:
 --
--- > data instance Sing (a :: *) where
+-- > data SRep (a :: *) where
 -- >   SNat :: Sing Nat
 -- >   SBool :: Sing Bool
 -- >   SMaybe :: Sing a -> Sing (Maybe a)
+-- > type instance Sing = SRep
 --
 -- The unexpected part is that @Nat@, @Bool@, and @Maybe@ above are the real @Nat@,
 -- @Bool@, and @Maybe@, not just promoted data constructors.
@@ -87,9 +88,9 @@ singletonStar names = do
     -- We opt to infer the constraints for the Eq instance here so that when it's
     -- promoted, Rep will be promoted to Type.
     dataDeclEqCxt <- inferConstraints (DConT ''Eq) (DConT repName) fakeCtors
-    let dataDeclEqInst = DerivedDecl (Just dataDeclEqCxt) (DConT repName) dataDecl
+    let dataDeclEqInst = DerivedDecl (Just dataDeclEqCxt) (DConT repName) repName dataDecl
     ordInst  <- mkOrdInstance Nothing (DConT repName) dataDecl
-    showInst <- mkShowInstance Nothing (DConT repName) dataDecl
+    showInst <- mkShowInstance ForPromotion Nothing (DConT repName) dataDecl
     (pInsts, promDecls) <- promoteM [] $ do promoteDataDec dataDecl
                                             promoteDerivedEqDec dataDeclEqInst
                                             traverse (promoteInstanceDec mempty)

--- a/src/Data/Singletons/Decide.hs
+++ b/src/Data/Singletons/Decide.hs
@@ -20,10 +20,10 @@ module Data.Singletons.Decide (
   SDecide(..),
 
   -- * Supporting definitions
-  (:~:)(..), Void, Refuted, Decision(..)
+  (:~:)(..), Void, Refuted, Decision(..),
+  decideEquality, decideCoercion
   ) where
 
-import Data.Kind (Type)
 import Data.Singletons.Internal
 import Data.Type.Coercion
 import Data.Type.Equality
@@ -51,14 +51,20 @@ class SDecide k where
   (%~) :: forall (a :: k) (b :: k). Sing a -> Sing b -> Decision (a :~: b)
   infix 4 %~
 
-instance SDecide k => TestEquality (Sing :: k -> Type) where
-  testEquality a b =
-    case a %~ b of
-      Proved Refl -> Just Refl
-      Disproved _ -> Nothing
+-- | A suitable default implementation for 'testEquality' that leverages
+-- 'SDecide'.
+decideEquality :: forall k (a :: k) (b :: k). SDecide k
+               => Sing a -> Sing b -> Maybe (a :~: b)
+decideEquality a b =
+  case a %~ b of
+    Proved Refl -> Just Refl
+    Disproved _ -> Nothing
 
-instance SDecide k => TestCoercion (Sing :: k -> Type) where
-  testCoercion a b =
-    case a %~ b of
-      Proved Refl -> Just Coercion
-      Disproved _ -> Nothing
+-- | A suitable default implementation for 'testCoercion' that leverages
+-- 'SDecide'.
+decideCoercion :: forall k (a :: k) (b :: k). SDecide k
+               => Sing a -> Sing b -> Maybe (Coercion a b)
+decideCoercion a b =
+  case a %~ b of
+    Proved Refl -> Just Coercion
+    Disproved _ -> Nothing

--- a/src/Data/Singletons/Decide.hs
+++ b/src/Data/Singletons/Decide.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE RankNTypes, PolyKinds, DataKinds, TypeOperators,
-             TypeFamilies, FlexibleContexts, UndecidableInstances, GADTs #-}
+             TypeFamilies, FlexibleContexts, UndecidableInstances,
+             GADTs, TypeApplications #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -----------------------------------------------------------------------------
@@ -60,6 +61,9 @@ decideEquality a b =
     Proved Refl -> Just Refl
     Disproved _ -> Nothing
 
+instance SDecide k => TestEquality (WrappedSing @k) where
+  testEquality (WrapSing s1) (WrapSing s2) = decideEquality s1 s2
+
 -- | A suitable default implementation for 'testCoercion' that leverages
 -- 'SDecide'.
 decideCoercion :: forall k (a :: k) (b :: k). SDecide k
@@ -68,3 +72,6 @@ decideCoercion a b =
   case a %~ b of
     Proved Refl -> Just Coercion
     Disproved _ -> Nothing
+
+instance SDecide k => TestCoercion (WrappedSing @k) where
+  testCoercion (WrapSing s1) (WrapSing s2) = decideCoercion s1 s2

--- a/src/Data/Singletons/Deriving/Show.hs
+++ b/src/Data/Singletons/Deriving/Show.hs
@@ -13,6 +13,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module Data.Singletons.Deriving.Show (
     mkShowInstance
+  , ShowMode(..)
   , mkShowSingContext
   ) where
 
@@ -27,60 +28,84 @@ import Data.Maybe (fromMaybe)
 import GHC.Lexeme (startsConSym, startsVarSym)
 import GHC.Show (appPrec, appPrec1)
 
-mkShowInstance :: DsMonad q => DerivDesc q
-mkShowInstance mb_ctxt ty (DataDecl _ _ cons) = do
-  clauses <- mk_showsPrec cons
-  constraints <- inferConstraintsDef mb_ctxt (DConT showName) ty cons
+mkShowInstance :: DsMonad q => ShowMode -> DerivDesc q
+mkShowInstance mode mb_ctxt ty (DataDecl _ _ cons) = do
+  clauses <- mk_showsPrec mode cons
+  constraints <- inferConstraintsDef (fmap (mkShowSingContext mode) mb_ctxt)
+                                     (DConT (mk_Show_name mode))
+                                     ty cons
+  ty' <- mk_Show_inst_ty mode ty
   return $ InstDecl { id_cxt = constraints
                     , id_name = showName
-                    , id_arg_tys = [ty]
+                    , id_arg_tys = [ty']
                     , id_sigs  = mempty
                     , id_meths = [ (showsPrecName, UFunction clauses) ] }
 
-mk_showsPrec :: DsMonad q => [DCon] -> q [DClause]
-mk_showsPrec cons = do
+mk_showsPrec :: DsMonad q => ShowMode -> [DCon] -> q [DClause]
+mk_showsPrec mode cons = do
     p <- newUniqueName "p" -- The precedence argument (not always used)
     if null cons
        then do v <- newUniqueName "v"
                pure [DClause [DWildP, DVarP v] (DCaseE (DVarE v) [])]
-       else mapM (mk_showsPrec_clause p) cons
+       else mapM (mk_showsPrec_clause mode p) cons
 
 mk_showsPrec_clause :: forall q. DsMonad q
-                    => Name -> DCon
+                    => ShowMode -> Name -> DCon
                     -> q DClause
-mk_showsPrec_clause p (DCon _ _ con_name con_fields _) = go con_fields
+mk_showsPrec_clause mode p (DCon _ _ con_name con_fields _) = go con_fields
   where
+    con_name' :: Name
+    con_name' = case mode of
+                  ForPromotion  -> con_name
+                  ForShowSing{} -> singDataConName con_name
+
     go :: DConFields -> q DClause
 
     -- No fields: print just the constructor name, with no parentheses
     go (DNormalC _ []) = return $
-      DClause [DWildP, DConP con_name []] $
-        DVarE showStringName `DAppE` dStringE (parenInfixConName con_name "")
+      DClause [DWildP, DConP con_name' []] $
+        DVarE showStringName `DAppE` dStringE (parenInfixConName con_name' "")
 
     -- Infix constructors have special Show treatment.
-    go (DNormalC True [_, _]) = do
-      argL <- newUniqueName "argL"
-      argR <- newUniqueName "argR"
-      fi <- fromMaybe defaultFixity <$> reifyFixityWithLocals con_name
-      let con_prec = case fi of Fixity prec _ -> prec
-          op_name  = nameBase con_name
-          infixOpE = DAppE (DVarE showStringName) . dStringE $
-                       if isInfixDataCon op_name
-                          then " "  ++ op_name ++ " "
-                          -- Make sure to handle infix data constructors
-                          -- like (Int `Foo` Int)
-                          else " `" ++ op_name ++ "` "
-      return $ DClause [DVarP p, DConP con_name [DVarP argL, DVarP argR]] $
-        (DVarE showParenName `DAppE` (DVarE gtName `DAppE` DVarE p
-                                                   `DAppE` dIntegerE con_prec))
-          `DAppE` (DVarE composeName
-                     `DAppE` showsPrecE (con_prec + 1) argL
-                     `DAppE` (DVarE composeName
-                                `DAppE` infixOpE
-                                `DAppE` showsPrecE (con_prec + 1) argR))
+    go (DNormalC True tys@[_, _])
+        -- Although the (:) constructor is infix, its singled counterpart SCons
+        -- is not, which matters if we're deriving a ShowSing instance.
+        -- Unless we remove this special case (see #234), we will simply
+        -- shunt it along as if we were dealing with a prefix constructor.
+      | ForShowSing{} <- mode
+      , con_name == consName
+      = go (DNormalC False tys)
+
+      | otherwise
+      = do argL   <- newUniqueName "argL"
+           argR   <- newUniqueName "argR"
+           argTyL <- newUniqueName "argTyL"
+           argTyR <- newUniqueName "argTyR"
+           fi <- fromMaybe defaultFixity <$> reifyFixityWithLocals con_name'
+           let con_prec = case fi of Fixity prec _ -> prec
+               op_name  = nameBase con_name'
+               infixOpE = DAppE (DVarE showStringName) . dStringE $
+                            if isInfixDataCon op_name
+                               then " "  ++ op_name ++ " "
+                               -- Make sure to handle infix data constructors
+                               -- like (Int `Foo` Int)
+                               else " `" ++ op_name ++ "` "
+           return $ DClause [ DVarP p
+                            , DConP con_name' $
+                              zipWith (mk_Show_arg_pat mode) [argL, argR] [argTyL, argTyR]
+                            ] $
+             mk_Show_rhs_sig mode [argTyL, argTyR] $
+             (DVarE showParenName `DAppE` (DVarE gtName `DAppE` DVarE p
+                                                        `DAppE` dIntegerE con_prec))
+               `DAppE` (DVarE composeName
+                          `DAppE` showsPrecE (con_prec + 1) argL
+                          `DAppE` (DVarE composeName
+                                     `DAppE` infixOpE
+                                     `DAppE` showsPrecE (con_prec + 1) argR))
 
     go (DNormalC _ tys) = do
-      args <- mapM (const $ newUniqueName "arg") tys
+      args   <- mapM (const $ newUniqueName "arg")   tys
+      argTys <- mapM (const $ newUniqueName "argTy") tys
       let show_args     = map (showsPrecE appPrec1) args
           composed_args = foldr1 (\v q -> DVarE composeName
                                            `DAppE` v
@@ -89,9 +114,13 @@ mk_showsPrec_clause p (DCon _ _ con_name con_fields _) = go con_fields
                                                      `DAppE` q)) show_args
           named_args = DVarE composeName
                          `DAppE` (DVarE showStringName
-                                   `DAppE` dStringE (parenInfixConName con_name " "))
+                                   `DAppE` dStringE (parenInfixConName con_name' " "))
                          `DAppE` composed_args
-      return $ DClause [DVarP p, DConP con_name $ map DVarP args] $
+      return $ DClause [ DVarP p
+                       , DConP con_name' $
+                         zipWith (mk_Show_arg_pat mode) args argTys
+                       ] $
+        mk_Show_rhs_sig mode argTys $
         DVarE showParenName
           `DAppE` (DVarE gtName `DAppE` DVarE p `DAppE` dIntegerE appPrec)
           `DAppE` named_args
@@ -101,10 +130,14 @@ mk_showsPrec_clause p (DCon _ _ con_name con_fields _) = go con_fields
     go (DRecC []) = go (DNormalC False [])
 
     go (DRecC tys) = do
-      args <- mapM (const $ newUniqueName "arg") tys
+      args   <- mapM (const $ newUniqueName "arg")   tys
+      argTys <- mapM (const $ newUniqueName "argTy") tys
       let show_args =
             concatMap (\((arg_name, _, _), arg) ->
-                        let arg_nameBase = nameBase arg_name
+                        let arg_name'    = case mode of
+                                             ForPromotion  -> arg_name
+                                             ForShowSing{} -> singValName arg_name
+                            arg_nameBase = nameBase arg_name'
                             infix_rec    = showParen (isSym arg_nameBase)
                                                      (showString arg_nameBase) ""
                         in [ DVarE showStringName `DAppE` dStringE (infix_rec ++ " = ")
@@ -112,16 +145,20 @@ mk_showsPrec_clause p (DCon _ _ con_name con_fields _) = go con_fields
                            , DVarE showCommaSpaceName
                            ])
                       (zip tys args)
-          brace_comma_args =   (DVarE showCharName `DAppE` dCharE '{')
+          brace_comma_args =   (DVarE showCharName `DAppE` dCharE mode '{')
                              : take (length show_args - 1) show_args
           composed_args = foldr (\x y -> DVarE composeName `DAppE` x `DAppE` y)
-                                (DVarE showCharName `DAppE` dCharE '}')
+                                (DVarE showCharName `DAppE` dCharE mode '}')
                                 brace_comma_args
           named_args = DVarE composeName
                          `DAppE` (DVarE showStringName
-                                   `DAppE` dStringE (parenInfixConName con_name " "))
+                                   `DAppE` dStringE (parenInfixConName con_name' " "))
                          `DAppE` composed_args
-      return $ DClause [DVarP p, DConP con_name $ map DVarP args] $
+      return $ DClause [ DVarP p
+                       , DConP con_name' $
+                         zipWith (mk_Show_arg_pat mode) args argTys
+                       ] $
+        mk_Show_rhs_sig mode argTys $
         DVarE showParenName
           `DAppE` (DVarE gtName `DAppE` DVarE p `DAppE` dIntegerE appPrec)
           `DAppE` named_args
@@ -136,9 +173,14 @@ parenInfixConName conName =
 showsPrecE :: Int -> Name -> DExp
 showsPrecE prec n = DVarE showsPrecName `DAppE` dIntegerE prec `DAppE` DVarE n
 
-dCharE :: Char -> DExp
-dCharE c = DLitE $ StringL [c] -- There aren't type-level characters yet,
-                               -- so fake it with a string
+dCharE :: ShowMode -> Char -> DExp
+dCharE mode = DLitE . to_lit
+  where
+    to_lit :: Char -> Lit
+    to_lit c = case mode of
+                 ForPromotion  -> StringL [c] -- There aren't type-level characters yet,
+                                              -- so fake it with a string
+                 ForShowSing{} -> CharL c
 
 dStringE :: String -> DExp
 dStringE = DLitE . StringL
@@ -150,13 +192,54 @@ isSym :: String -> Bool
 isSym ""      = False
 isSym (c : _) = startsVarSym c || startsConSym c
 
+-----
+-- ShowMode
+-----
+
+-- | Is a 'Show' instance being generated to be promoted/singled, or is it
+-- being generated to create a 'Show' instance for a singleton type?
+data ShowMode = ForPromotion      -- ^ For promotion/singling
+              | ForShowSing Name  -- ^ For a 'Show' instance.
+                                  --   Bundles the 'Name' of the data type.
+
 -- | Turn a context like @('Show' a, 'Show' b)@ into @('ShowSing' a, 'ShowSing' b)@.
--- This is necessary for standalone-derived 'Show' instances for singleton types.
-mkShowSingContext :: DCxt -> DCxt
-mkShowSingContext = map show_to_SingShow
+-- This is necessary for 'Show' instances for singleton types.
+mkShowSingContext :: ShowMode -> DCxt -> DCxt
+mkShowSingContext ForPromotion  = id
+mkShowSingContext ForShowSing{} = map show_to_SingShow
   where
     show_to_SingShow :: DPred -> DPred
     show_to_SingShow = modifyConNameDType $ \n ->
                          if n == showName
                             then showSingName
                             else n
+
+mk_Show_name :: ShowMode -> Name
+mk_Show_name ForPromotion  = showName
+mk_Show_name ForShowSing{} = showSingName
+
+-- If we're creating a 'Show' instance for a singleon type, decorate the type
+-- appropriately (e.g., turn @Maybe a@ into @SMaybe (z :: Maybe a)@).
+-- Otherwise, return the type (@Maybe a@) unchanged.
+mk_Show_inst_ty :: Quasi q => ShowMode -> DType -> q DType
+mk_Show_inst_ty ForPromotion           ty = pure ty
+mk_Show_inst_ty (ForShowSing ty_tycon) ty = do
+  z <- qNewName "z"
+  pure $ DConT (singTyConName ty_tycon) `DAppT` (DVarT z `DSigT` ty)
+
+-- If we're creating a 'Show' instance for a singleton type, create a pattern
+-- of the form @(sx :: Sing x)@. Otherwise, simply return the pattern @sx@.
+mk_Show_arg_pat :: ShowMode -> Name -> Name -> DPat
+mk_Show_arg_pat ForPromotion  arg _      = DVarP arg
+mk_Show_arg_pat ForShowSing{} arg arg_ty =
+  DSigP (DVarP arg) (DConT singFamilyName `DAppT` DVarT arg_ty)
+
+-- If we're creating a 'Show' instance for a singleton type, decorate the
+-- expression with an explicit signature of the form
+-- @e :: (ShowSing' a_1, ..., ShowSing' a_n) => ShowS@. Otherwise, return
+-- the expression (@e@) unchanged.
+mk_Show_rhs_sig :: ShowMode -> [Name] -> DExp -> DExp
+mk_Show_rhs_sig ForPromotion  _            e = e
+mk_Show_rhs_sig ForShowSing{} arg_ty_names e =
+  e `DSigE` DForallT [] (map (DAppT (DConT showSing'Name) . DVarT) arg_ty_names)
+                        (DConT showSName)

--- a/src/Data/Singletons/Names.hs
+++ b/src/Data/Singletons/Names.hs
@@ -18,6 +18,8 @@ import Language.Haskell.TH.Desugar
 import GHC.TypeLits ( Nat, Symbol )
 import GHC.Exts ( Constraint )
 import GHC.Show ( showCommaSpace, showSpace )
+import Data.Type.Equality ( TestEquality(..) )
+import Data.Type.Coercion ( TestCoercion(..) )
 import Data.Typeable ( TypeRep )
 import Data.Singletons.Util
 import Control.Applicative
@@ -34,6 +36,8 @@ boolName, andName, tyEqName, compareName, minBoundName,
   sIfName,
   someSingTypeName, someSingDataName,
   sListName, sDecideClassName, sDecideMethName,
+  testEqualityClassName, testEqualityMethName, decideEqualityName,
+  testCoercionClassName, testCoercionMethName, decideCoercionName,
   provedName, disprovedName, reflName, toSingName, fromSingName,
   equalityName, applySingName, suppressClassName, suppressMethodName,
   thenCmpName,
@@ -41,8 +45,8 @@ boolName, andName, tyEqName, compareName, minBoundName,
   sNegateName, errorName, foldlName, cmpEQName, cmpLTName, cmpGTName,
   singletonsToEnumName, singletonsFromEnumName, enumName, singletonsEnumName,
   equalsName, constraintName,
-  showName, showCharName, showCommaSpaceName, showParenName, showsPrecName,
-  showSpaceName, showStringName, showSingName,
+  showName, showSName, showCharName, showCommaSpaceName, showParenName, showsPrecName,
+  showSpaceName, showStringName, showSingName, showSing'Name,
   composeName, gtName, tyFromStringName, sFromStringName,
   foldableName, foldMapName, memptyName, mappendName, foldrName,
   functorName, fmapName, replaceName,
@@ -88,6 +92,12 @@ someSingDataName = 'SomeSing
 sListName = mk_name_tc "Data.Singletons.Prelude.Instances" "SList"
 sDecideClassName = ''SDecide
 sDecideMethName = '(%~)
+testEqualityClassName = ''TestEquality
+testEqualityMethName = 'testEquality
+decideEqualityName = 'decideEquality
+testCoercionClassName = ''TestCoercion
+testCoercionMethName = 'testCoercion
+decideCoercionName = 'decideCoercion
 provedName = 'Proved
 disprovedName = 'Disproved
 reflName = 'Refl
@@ -113,12 +123,14 @@ singletonsEnumName = mk_name_tc "Data.Singletons.Prelude.Enum" "Enum"
 equalsName = '(==)
 constraintName = ''Constraint
 showName = ''Show
+showSName = ''ShowS
 showCharName = 'showChar
 showParenName = 'showParen
 showSpaceName = 'showSpace
 showsPrecName = 'showsPrec
 showStringName = 'showString
 showSingName = mk_name_tc "Data.Singletons.ShowSing" "ShowSing"
+showSing'Name = mk_name_tc "Data.Singletons.ShowSing" "ShowSing'"
 composeName = '(.)
 gtName = '(>)
 showCommaSpaceName = 'showCommaSpace

--- a/src/Data/Singletons/Prelude.hs
+++ b/src/Data/Singletons/Prelude.hs
@@ -22,15 +22,11 @@ module Data.Singletons.Prelude (
   -- * Basic singleton definitions
   module Data.Singletons,
 
-  Sing(SFalse, STrue, SNil, SCons, SJust, SNothing, SLeft, SRight, SLT, SEQ, SGT,
-       STuple0, STuple2, STuple3, STuple4, STuple5, STuple6, STuple7),
+  -- * Singleton types
 
-  -- * Singleton type synonyms
-
-  -- | These synonyms are all kind-restricted synonyms of 'Sing'.
-  -- For example 'SBool' requires an argument of kind 'Bool'.
-  SBool, SList, SMaybe, SEither, SOrdering,
-  STuple0, STuple2, STuple3, STuple4, STuple5, STuple6, STuple7,
+  SBool(..), SList(..), SMaybe(..), SEither(..), SOrdering(..),
+  STuple0(..), STuple2(..), STuple3(..), STuple4(..),
+  STuple5(..), STuple6(..), STuple7(..),
 
   -- * Functions working with 'Bool'
   If, sIf, Not, sNot, type (&&), type (||), (%&&), (%||), Otherwise, sOtherwise,

--- a/src/Data/Singletons/Prelude/Applicative.hs
+++ b/src/Data/Singletons/Prelude/Applicative.hs
@@ -28,7 +28,7 @@
 module Data.Singletons.Prelude.Applicative (
   PApplicative(..), SApplicative(..),
   PAlternative(..), SAlternative(..),
-  Sing (SConst, sGetConst), SConst, Const, GetConst,
+  Sing, SConst(..), Const, GetConst,
   type (<$>), (%<$>), type (<$), (%<$), type (<**>), (%<**>),
   LiftA, sLiftA, LiftA3, sLiftA3, Optional, sOptional,
 

--- a/src/Data/Singletons/Prelude/Bool.hs
+++ b/src/Data/Singletons/Prelude/Bool.hs
@@ -24,16 +24,7 @@
 
 module Data.Singletons.Prelude.Bool (
   -- * The 'Bool' singleton
-
-  Sing(SFalse, STrue),
-  -- | Though Haddock doesn't show it, the 'Sing' instance above declares
-  -- constructors
-  --
-  -- > SFalse :: Sing False
-  -- > STrue  :: Sing True
-
-  SBool,
-  -- | 'SBool' is a kind-restricted synonym for 'Sing': @type SBool (a :: Bool) = Sing a@
+  Sing, SBool(..),
 
   -- * Conditionals
   If, sIf,

--- a/src/Data/Singletons/Prelude/Const.hs
+++ b/src/Data/Singletons/Prelude/Const.hs
@@ -26,8 +26,7 @@
 
 module Data.Singletons.Prelude.Const (
   -- * The 'Const' singleton
-  Sing(SConst, sGetConst),
-  SConst, GetConst,
+  Sing, SConst(..), GetConst,
 
   -- * Defunctionalization symbols
   ConstSym0, ConstSym1,
@@ -71,9 +70,9 @@ Assumes that `b` is of kind Type. Until we get a more reliable story for
 poly-kinded Sing instances (see #150), we simply write the Sing instance by
 hand.
 -}
-data instance Sing :: forall (k :: Type) (a :: Type) (b :: k). Const a b -> Type where
-  SConst :: { sGetConst :: Sing a } -> Sing ('Const a)
-type SConst = (Sing :: Const a b -> Type)
+data SConst :: forall (k :: Type) (a :: Type) (b :: k). Const a b -> Type where
+  SConst :: { sGetConst :: Sing a } -> SConst ('Const a)
+type instance Sing = SConst
 instance SingKind a => SingKind (Const a b) where
   type Demote (Const a b) = Const (Demote a) b
   fromSing (SConst sa) = Const (fromSing sa)

--- a/src/Data/Singletons/Prelude/Either.hs
+++ b/src/Data/Singletons/Prelude/Either.hs
@@ -24,16 +24,7 @@
 
 module Data.Singletons.Prelude.Either (
   -- * The 'Either' singleton
-  Sing(SLeft, SRight),
-  -- | Though Haddock doesn't show it, the 'Sing' instance above declares
-  -- constructors
-  --
-  -- > SLeft  :: Sing a -> Sing (Left a)
-  -- > SRight :: Sing b -> Sing (Right b)
-
-  SEither,
-  -- | 'SEither' is a kind-restricted synonym for 'Sing':
-  -- @type SEither (a :: Either x y) = Sing a@
+  Sing, SEither(..),
 
   -- * Singletons from @Data.Either@
   either_, Either_, sEither_,

--- a/src/Data/Singletons/Prelude/Foldable.hs
+++ b/src/Data/Singletons/Prelude/Foldable.hs
@@ -108,7 +108,8 @@ import Data.Singletons.Prelude.Base
 import Data.Singletons.Prelude.Bool
 import Data.Singletons.Prelude.Either
 import Data.Singletons.Prelude.Eq
-import Data.Singletons.Prelude.Instances (Sing(..), type (:@#@$))
+import Data.Singletons.Prelude.Instances
+  hiding (Foldl, FoldlSym0(..), FoldlSym1(..), FoldlSym2(..), FoldlSym3, sFoldl)
 import Data.Singletons.Prelude.List.Internal.Disambiguation
 import Data.Singletons.Prelude.Maybe
 import Data.Singletons.Prelude.Monad.Internal
@@ -133,8 +134,9 @@ import Data.Singletons.Single
 import Data.Singletons.TypeLits.Internal
 
 newtype Endo a = Endo (a ~> a)
-data instance Sing :: forall a. Endo a -> Type where
-  SEndo :: Sing x -> Sing ('Endo x)
+data SEndo :: forall a. Endo a -> Type where
+  SEndo :: Sing x -> SEndo ('Endo x)
+type instance Sing = SEndo
 data EndoSym0 :: forall a. (a ~> a) ~> Endo a
 type instance Apply EndoSym0 x = 'Endo x
 
@@ -147,13 +149,15 @@ $(singletonsOnly [d|
   |])
 
 newtype MaxInternal a = MaxInternal (Maybe a)
-data instance Sing :: forall a. MaxInternal a -> Type where
-  SMaxInternal :: Sing x -> Sing ('MaxInternal x)
+data SMaxInternal :: forall a. MaxInternal a -> Type where
+  SMaxInternal :: Sing x -> SMaxInternal ('MaxInternal x)
+type instance Sing = SMaxInternal
 $(genDefunSymbols [''MaxInternal])
 
 newtype MinInternal a = MinInternal (Maybe a)
-data instance Sing :: forall a. MinInternal a -> Type where
-  SMinInternal :: Sing x -> Sing ('MinInternal x)
+data SMinInternal :: forall a. MinInternal a -> Type where
+  SMinInternal :: Sing x -> SMinInternal ('MinInternal x)
+type instance Sing = SMinInternal
 $(genDefunSymbols [''MinInternal])
 
 $(singletonsOnly [d|

--- a/src/Data/Singletons/Prelude/Identity.hs
+++ b/src/Data/Singletons/Prelude/Identity.hs
@@ -26,8 +26,7 @@
 
 module Data.Singletons.Prelude.Identity (
   -- * The 'Identity' singleton
-  Sing(SIdentity, sRunIdentity),
-  SIdentity, RunIdentity,
+  Sing, SIdentity(..), RunIdentity,
 
   -- * Defunctionalization symbols
   IdentitySym0, IdentitySym1,

--- a/src/Data/Singletons/Prelude/Instances.hs
+++ b/src/Data/Singletons/Prelude/Instances.hs
@@ -14,8 +14,12 @@ re-exported from various places.
              TypeApplications #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Data.Singletons.Prelude.Instances where
+module Data.Singletons.Prelude.Instances (
+    module Data.Singletons.Prelude.Instances
+  , Sing
+  ) where
 
+import Data.Singletons.Internal
 import Data.Singletons.Single
 import Data.Singletons.Util
 

--- a/src/Data/Singletons/Prelude/List.hs
+++ b/src/Data/Singletons/Prelude/List.hs
@@ -22,15 +22,7 @@
 
 module Data.Singletons.Prelude.List (
   -- * The singleton for lists
-  Sing(SNil, SCons),
-  -- | Though Haddock doesn't show it, the 'Sing' instance above declares
-  -- constructors
-  --
-  -- > SNil  :: Sing '[]
-  -- > SCons :: Sing (h :: k) -> Sing (t :: [k]) -> Sing (h ': t)
-
-  SList,
-  -- | 'SList' is a kind-restricted synonym for 'Sing': @type SList (a :: [k]) = Sing a@
+  Sing, SList(..),
 
   -- * Basic functions
   type (++), (%++), Head, sHead, Last, sLast, Tail, sTail, Init, sInit,
@@ -267,7 +259,7 @@ import Data.Singletons.Prelude.Base
        )
 import Data.Singletons.Prelude.Foldable
 import Data.Singletons.Prelude.Instances
-       (Sing(..), SList, NilSym0, type (:@#@$), type (:@#@$$), type (:@#@$$$))
+       (Sing, SList(..), NilSym0, type (:@#@$), type (:@#@$$), type (:@#@$$$))
 import Data.Singletons.Prelude.Traversable
 
 import Data.Singletons.Prelude.List.Internal

--- a/src/Data/Singletons/Prelude/List/NonEmpty.hs
+++ b/src/Data/Singletons/Prelude/List/NonEmpty.hs
@@ -25,17 +25,7 @@
 
 module Data.Singletons.Prelude.List.NonEmpty (
   -- * The 'NonEmpty' singleton
-
-  Sing((:%|)),
-
-  -- | Though Haddock doesn't show it, the 'Sing' instance above declares
-  -- constructor
-  --
-  -- > (:%|) :: Sing h -> Sing t -> Sing (h :| t)
-
-  SNonEmpty,
-  -- | 'SNonEmpty' is a kind-restricted synonym for 'Sing':
-  -- @type SNonEmpty (a :: NonEmpty) = Sing a@
+  Sing, SNonEmpty(..),
 
   -- * Non-empty stream transformations
   Map, sMap,

--- a/src/Data/Singletons/Prelude/Maybe.hs
+++ b/src/Data/Singletons/Prelude/Maybe.hs
@@ -25,16 +25,7 @@
 
 module Data.Singletons.Prelude.Maybe (
   -- The 'Maybe' singleton
-
-  Sing(SNothing, SJust),
-  -- | Though Haddock doesn't show it, the 'Sing' instance above declares
-  -- constructors
-  --
-  -- > SNothing :: Sing Nothing
-  -- > SJust    :: Sing a -> Sing (Just a)
-
-  SMaybe,
-  -- | 'SBool' is a kind-restricted synonym for 'Sing': @type SMaybe (a :: Maybe k) = Sing a@
+  Sing, SMaybe(..),
 
   -- * Singletons from @Data.Maybe@
   maybe_, Maybe_, sMaybe_,

--- a/src/Data/Singletons/Prelude/Monoid.hs
+++ b/src/Data/Singletons/Prelude/Monoid.hs
@@ -30,11 +30,9 @@
 module Data.Singletons.Prelude.Monoid (
   PMonoid(..), SMonoid(..),
 
-  Sing(SDual, sGetDual, SAll, sGetAll, SAny, sGetAny, SSum, sGetSum,
-       SProduct, sGetProduct, SFirst, sGetFirst, SLast, sGetLast),
+  Sing, SDual(..), SAll(..), SAny(..),
+  SSum(..), SProduct(..), SFirst(..), SLast(..),
   GetDual, GetAll, GetAny, GetSum, GetProduct, GetFirst, GetLast,
-
-  SDual, SAll, SAny, SSum, SProduct, SFirst, SLast,
 
   -- ** Defunctionalization symbols
   MemptySym0,
@@ -59,7 +57,7 @@ import Data.Singletons.Prelude.Monad.Internal
 import Data.Singletons.Prelude.Num
 import Data.Singletons.Prelude.Ord
 import Data.Singletons.Prelude.Semigroup.Internal hiding
-       (Sing(SFirst, SLast), SFirst, SLast,
+       (SFirst, SLast,
         FirstSym0, FirstSym1, FirstSym0KindInference,
         LastSym0,  LastSym1,  LastSym0KindInference,
         GetFirst,  GetFirstSym0, GetFirstSym1, GetFirstSym0KindInference,

--- a/src/Data/Singletons/Prelude/Ord.hs
+++ b/src/Data/Singletons/Prelude/Ord.hs
@@ -27,9 +27,7 @@ module Data.Singletons.Prelude.Ord (
   -- it returns its first argument.
   thenCmp, ThenCmp, sThenCmp,
 
-  Sing(SLT, SEQ, SGT, SDown),
-
-  SOrdering, SDown,
+  Sing, SOrdering(..), SDown(..),
 
   -- ** Defunctionalization symbols
   ThenCmpSym0, ThenCmpSym1, ThenCmpSym2,

--- a/src/Data/Singletons/Prelude/Semigroup.hs
+++ b/src/Data/Singletons/Prelude/Semigroup.hs
@@ -30,17 +30,11 @@
 module Data.Singletons.Prelude.Semigroup (
   PSemigroup(..), SSemigroup(..),
 
-  Sing(SMin, sGetMin, SMax, sGetMax,
-       SFirst, sGetFirst, SLast, sGetLast,
-       SWrapMonoid, sUnwrapMonoid, SDual, sGetDual,
-       SAll, sGetAll, SAny, sGetAny,
-       SSum, sGetSum, SProduct, sGetProduct,
-       SOption, sGetOption, SArg),
-  GetMin, GetMax, GetFirst, GetLast, GetDual,
+  Sing, SMin(..), SMax(..), SFirst(..), SLast(..),
+  SWrappedMonoid(..), SDual(..), SAll(..), SAny(..),
+  SSum(..), SProduct(..), SOption(..), SArg(..),
+  GetMin, GetMax, GetFirst, GetLast, UnwrapMonoid, GetDual,
   GetAll, GetAny, GetSum, GetProduct, GetOption,
-
-  SMin, SMax, SFirst, SLast, SWrappedMonoid, SDual,
-  SAll, SAny, SSum, SProduct, SOption, SArg,
 
   option_, sOption_, Option_,
 
@@ -79,7 +73,7 @@ import Data.Singletons.Prelude.Instances
 import Data.Singletons.Prelude.Maybe
 import Data.Singletons.Prelude.Monad.Internal
 import Data.Singletons.Prelude.Monoid hiding
-       (Sing(SFirst, SLast), SFirst, sGetFirst, SLast, sGetLast,
+       (SFirst(..), SLast(..),
         FirstSym0, FirstSym1, LastSym0, LastSym1,
         GetFirst,  GetFirstSym0, GetFirstSym1,
         GetLast,   GetLastSym0,  GetLastSym1)

--- a/src/Data/Singletons/Prelude/Traversable.hs
+++ b/src/Data/Singletons/Prelude/Traversable.hs
@@ -64,14 +64,16 @@ import Data.Singletons.Prelude.Monoid
 import Data.Singletons.Single
 
 newtype StateL s a = StateL (s ~> (s, a))
-data instance Sing :: forall s a. StateL s a -> Type where
-  SStateL :: Sing x -> Sing ('StateL x)
+data SStateL :: forall s a. StateL s a -> Type where
+  SStateL :: Sing x -> SStateL ('StateL x)
+type instance Sing = SStateL
 data StateLSym0 :: forall s a. (s ~> (s, a)) ~> StateL s a
 type instance Apply StateLSym0 x = 'StateL x
 
 newtype StateR s a = StateR (s ~> (s, a))
-data instance Sing :: forall s a. StateR s a -> Type where
-  SStateR :: Sing x -> Sing ('StateR x)
+data SStateR :: forall s a. StateR s a -> Type where
+  SStateR :: Sing x -> SStateR ('StateR x)
+type instance Sing = SStateR
 data StateRSym0 :: forall s a. (s ~> (s, a)) ~> StateR s a
 type instance Apply StateRSym0 x = 'StateR x
 

--- a/src/Data/Singletons/Prelude/Tuple.hs
+++ b/src/Data/Singletons/Prelude/Tuple.hs
@@ -26,8 +26,8 @@ module Data.Singletons.Prelude.Tuple (
   -- * Singleton definitions
   -- | See 'Data.Singletons.Prelude.Sing' for more info.
 
-  Sing(STuple0, STuple2, STuple3, STuple4, STuple5, STuple6, STuple7),
-  STuple0, STuple2, STuple3, STuple4, STuple5, STuple6, STuple7,
+  Sing, STuple0(..), STuple2(..), STuple3(..),
+  STuple4(..), STuple5(..), STuple6(..), STuple7(..),
 
   -- * Singletons from @Data.Tuple@
   Fst, sFst, Snd, sSnd, Curry, sCurry, Uncurry, sUncurry, Swap, sSwap,

--- a/src/Data/Singletons/Promote.hs
+++ b/src/Data/Singletons/Promote.hs
@@ -142,7 +142,7 @@ promoteShowInstances = concatMapM promoteShowInstance
 
 -- | Produce an instance for 'PShow' from the given type
 promoteShowInstance :: DsMonad q => Name -> q [Dec]
-promoteShowInstance = promoteInstance mkShowInstance "Show"
+promoteShowInstance = promoteInstance (mkShowInstance ForPromotion) "Show"
 
 -- | Produce an instance for @(==)@ (type-level equality) from the given type
 promoteEqInstance :: DsMonad q => Name -> q [Dec]

--- a/src/Data/Singletons/Promote/Monad.hs
+++ b/src/Data/Singletons/Promote/Monad.hs
@@ -9,8 +9,8 @@ The PrM monad allows reading from a PrEnv environment and writing to a list
 of DDec, and is wrapped around a Q.
 -}
 
-{-# LANGUAGE GeneralizedNewtypeDeriving, StandaloneDeriving,
-             FlexibleContexts, TypeFamilies, KindSignatures #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving, FlexibleContexts,
+             TypeFamilies, KindSignatures #-}
 
 module Data.Singletons.Promote.Monad (
   PrM, promoteM, promoteM_, promoteMDecs, VarPromotions,

--- a/src/Data/Singletons/ShowSing.hs
+++ b/src/Data/Singletons/ShowSing.hs
@@ -268,6 +268,15 @@ ultimately went with.
 -}
 
 ------------------------------------------------------------
+-- WrappedSing instance
+------------------------------------------------------------
+
+instance ShowSing k => Show (WrappedSing (a :: k)) where
+  showsPrec p (WrapSing s) =
+    showParen (p > 10) $ showString "WrapSing " . showsPrec 11 s
+      :: ShowSing' a => ShowS
+
+------------------------------------------------------------
 -- TypeLits instances
 ------------------------------------------------------------
 

--- a/src/Data/Singletons/Single/Data.hs
+++ b/src/Data/Singletons/Single/Data.hs
@@ -66,7 +66,8 @@ singDataD (DataDecl name tvbs ctors) = do
         DTySynInstD $ DTySynEqn Nothing
                                 (DConT singFamilyName `DAppKindT` k)
                                 (DConT singDataName)
-      kindedSingTy = DArrowT `DAppT` k `DAppT` DConT typeKindName
+      kindedSingTy = DForallT (map DPlainTV tvbNames) [] $
+                     DArrowT `DAppT` k `DAppT` DConT typeKindName
 
   return $ (DDataD Data [] singDataName [] (Just kindedSingTy) ctors' []) :
            singSynInst :

--- a/src/Data/Singletons/Syntax.hs
+++ b/src/Data/Singletons/Syntax.hs
@@ -8,7 +8,7 @@ and contains various other AST definitions.
 -}
 
 {-# LANGUAGE DataKinds, TypeFamilies, PolyKinds, DeriveDataTypeable,
-             StandaloneDeriving, FlexibleInstances, ConstraintKinds #-}
+             FlexibleInstances, ConstraintKinds #-}
 
 module Data.Singletons.Syntax where
 
@@ -194,9 +194,10 @@ buildLetDecEnv = go emptyLetDecEnv
 
 -- See Note [DerivedDecl]
 data DerivedDecl (cls :: Type -> Constraint) = DerivedDecl
-  { ded_mb_cxt :: Maybe DCxt
-  , ded_type   :: DType
-  , ded_decl   :: DataDecl
+  { ded_mb_cxt     :: Maybe DCxt
+  , ded_type       :: DType
+  , ded_type_tycon :: Name
+  , ded_decl       :: DataDecl
   }
 
 type DerivedEqDecl   = DerivedDecl Eq
@@ -218,15 +219,16 @@ information to recreate the derived instance:
    a deriving clause (ded_mb_cxt)
 2. The datatype, applied to some number of type arguments, as in the
    instance declaration (ded_type)
-3. The datatype's original information, as provided through DataDecl (ded_decl)
+3. The datatype name (ded_type_tycon), cached for convenience
+4. The datatype's constructors (ded_cons)
 
 Why are these instances handled outside of partitionDecs?
 
 * Deriving Eq in singletons not only derives PEq/SEq instances, but it also
-  derives SDecide instances. This additional complication makes Eq difficult
-  to integrate with the other deriving machinery, so we handle it specially
-  in Data.Singletons.Promote and Data.Singletons.Single (depending on the task
-  at hand).
+  derives SDecide, TestEquality, and TestCoercion instances. This additional
+  complication makes Eq difficult to integrate with the other deriving
+  machinery, so we handle it specially in Data.Singletons.Promote and
+  Data.Singletons.Single (depending on the task at hand).
 * Deriving Show in singletons not only derives PShow/SShow instances, but it
   also derives Show instances for singletons types. To make this work,
   we let partitionDecs handle the PShow/SShow instances, but we also stick the

--- a/src/Data/Singletons/TH.hs
+++ b/src/Data/Singletons/TH.hs
@@ -42,14 +42,15 @@ module Data.Singletons.TH (
   -- ** Functions to generate 'Show' instances
   promoteShowInstances, promoteShowInstance,
   singShowInstances, singShowInstance,
+  showSingInstances, showSingInstance,
 
   -- ** Utility functions
   singITyConInstances, singITyConInstance,
   cases, sCases,
 
   -- * Basic singleton definitions
-  Sing(SFalse, STrue, STuple0, STuple2, STuple3, STuple4, STuple5, STuple6, STuple7,
-       SLT, SEQ, SGT),
+  SBool(..), STuple0(..), STuple2(..), STuple3(..), STuple4(..),
+  STuple5(..), STuple6(..), STuple7(..), SOrdering(..),
   module Data.Singletons,
 
   -- * Auxiliary definitions

--- a/src/Data/Singletons/TypeError.hs
+++ b/src/Data/Singletons/TypeError.hs
@@ -28,7 +28,7 @@
 module Data.Singletons.TypeError (
   TypeError, sTypeError, typeError,
   ErrorMessage'(..), ErrorMessage, PErrorMessage,
-  Sing(SText, SShowType, (:%<>:), (:%$$:)), SErrorMessage,
+  Sing, SErrorMessage(..),
   ConvertPErrorMessage, showErrorMessage,
 
   -- * Defunctionalization symbols
@@ -75,18 +75,15 @@ type ErrorMessage  = ErrorMessage' Text.Text
 -- | A type-level `ErrorMessage'` which uses 'Symbol' as its text kind.
 type PErrorMessage = ErrorMessage' Symbol
 
-data instance Sing :: PErrorMessage -> Type where
-  -- It would be lovely to not have to write those (:: PErrorMessage) kind
-  -- ascriptions in the return types of each constructor.
-  -- See Trac #14111.
-  SText     :: Sing t             -> Sing ('Text t      :: PErrorMessage)
-  SShowType :: Sing ty            -> Sing ('ShowType ty :: PErrorMessage)
-  (:%<>:)   :: Sing e1 -> Sing e2 -> Sing (e1 ':<>: e2  :: PErrorMessage)
-  (:%$$:)   :: Sing e1 -> Sing e2 -> Sing (e1 ':$$: e2  :: PErrorMessage)
+data SErrorMessage :: PErrorMessage -> Type where
+  SText     :: Sing t             -> SErrorMessage ('Text t)
+  SShowType :: Sing ty            -> SErrorMessage ('ShowType ty)
+  (:%<>:)   :: Sing e1 -> Sing e2 -> SErrorMessage (e1 ':<>: e2)
+  (:%$$:)   :: Sing e1 -> Sing e2 -> SErrorMessage (e1 ':$$: e2)
 infixl 6 :%<>:
 infixl 5 :%$$:
 
-type SErrorMessage = (Sing :: PErrorMessage -> Type)
+type instance Sing = SErrorMessage
 
 instance SingKind PErrorMessage where
   type Demote PErrorMessage = ErrorMessage

--- a/src/Data/Singletons/TypeLits.hs
+++ b/src/Data/Singletons/TypeLits.hs
@@ -19,8 +19,7 @@
 
 module Data.Singletons.TypeLits (
   Nat, Symbol,
-  Sing(SNat, SSym),
-  SNat, SSymbol, withKnownNat, withKnownSymbol,
+  Sing, SNat(..), SSymbol(..), withKnownNat, withKnownSymbol,
   Error, sError,
   ErrorWithoutStackTrace, sErrorWithoutStackTrace,
   Undefined, sUndefined,

--- a/src/Data/Singletons/TypeLits/Internal.hs
+++ b/src/Data/Singletons/TypeLits/Internal.hs
@@ -16,15 +16,14 @@
 {-# LANGUAGE PolyKinds, DataKinds, TypeFamilies, FlexibleInstances,
              UndecidableInstances, ScopedTypeVariables, RankNTypes,
              GADTs, FlexibleContexts, TypeOperators, ConstraintKinds,
-             TemplateHaskell, StandaloneDeriving,
-             TypeApplications #-}
+             TemplateHaskell, TypeApplications #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Data.Singletons.TypeLits.Internal (
-  Sing(..),
+  Sing,
 
   Nat, Symbol,
-  SNat, SSymbol, withKnownNat, withKnownSymbol,
+  SNat(..), SSymbol(..), withKnownNat, withKnownSymbol,
   Error, sError,
   ErrorWithoutStackTrace, sErrorWithoutStackTrace,
   Undefined, sUndefined,
@@ -59,7 +58,8 @@ import Data.Text ( Text )
 ---- TypeLits singletons ---------------------------------------------
 ----------------------------------------------------------------------
 
-data instance Sing (n :: Nat) = KnownNat n => SNat
+data SNat (n :: Nat) = KnownNat n => SNat
+type instance Sing = SNat
 
 instance KnownNat n => SingI n where
   sing = SNat
@@ -70,7 +70,8 @@ instance SingKind Nat where
   toSing n = case TN.someNatVal n of
                SomeNat (_ :: Proxy n) -> SomeSing (SNat :: Sing n)
 
-data instance Sing (n :: Symbol) = KnownSymbol n => SSym
+data SSymbol (n :: Symbol) = KnownSymbol n => SSym
+type instance Sing = SSymbol
 
 instance KnownSymbol n => SingI n where
   sing = SSym
@@ -121,12 +122,6 @@ instance POrd Nat where
 
 instance POrd Symbol where
   type (a :: Symbol) `Compare` (b :: Symbol) = a `TL.CmpSymbol` b
-
--- | Kind-restricted synonym for 'Sing' for @Nat@s
-type SNat (x :: Nat) = Sing x
-
--- | Kind-restricted synonym for 'Sing' for @Symbol@s
-type SSymbol (x :: Symbol) = Sing x
 
 -- SOrd instances
 instance SOrd Nat where

--- a/src/Data/Singletons/Util.hs
+++ b/src/Data/Singletons/Util.hs
@@ -9,9 +9,8 @@ Users of the package should not need to consult this file.
 
 {-# LANGUAGE TypeSynonymInstances, FlexibleInstances, RankNTypes,
              TemplateHaskell, GeneralizedNewtypeDeriving,
-             MultiParamTypeClasses, StandaloneDeriving,
-             UndecidableInstances, MagicHash, UnboxedTuples,
-             LambdaCase, NoMonomorphismRestriction #-}
+             MultiParamTypeClasses, UndecidableInstances, MagicHash,
+             UnboxedTuples, LambdaCase, NoMonomorphismRestriction #-}
 
 module Data.Singletons.Util where
 

--- a/tests/ByHand.hs
+++ b/tests/ByHand.hs
@@ -163,7 +163,7 @@ instance SingKind Bool where
 
 -- Maybe
 
-data SMaybe :: Maybe k -> Type where
+data SMaybe :: forall k. Maybe k -> Type where
   SNothing :: SMaybe Nothing
   SJust :: forall k (a :: k). Sing a -> SMaybe (Just a)
 type instance Sing = SMaybe
@@ -205,7 +205,7 @@ instance SingKind k => SingKind (Maybe k) where
 
 -- List
 
-data SList :: List k -> Type where
+data SList :: forall k. List k -> Type where
   SNil :: SList Nil
   SCons :: forall k (h :: k) (t :: List k). Sing h -> SList t -> SList (Cons h t)
 type instance Sing = SList
@@ -260,7 +260,7 @@ instance SingKind k => SingKind (List k) where
 
 -- Either
 
-data SEither :: Either k1 k2 -> Type where
+data SEither :: forall k1 k2. Either k1 k2 -> Type where
   SLeft :: forall k1 (a :: k1). Sing a -> SEither (Left a)
   SRight :: forall k2 (b :: k2). Sing b -> SEither (Right b)
 type instance Sing = SEither
@@ -297,7 +297,7 @@ instance (SDecide k1, SDecide k2) => SDecide (Either k1 k2) where
 data Composite :: Type -> Type -> Type where
   MkComp :: Either (Maybe a) b -> Composite a b
 
-data SComposite :: Composite k1 k2 -> Type where
+data SComposite :: forall k1 k2. Composite k1 k2 -> Type where
   SMkComp :: forall k1 k2 (a :: Either (Maybe k1) k2). SEither a -> SComposite (MkComp a)
 type instance Sing = SComposite
 

--- a/tests/ByHand.hs
+++ b/tests/ByHand.hs
@@ -88,9 +88,10 @@ sIf SFalse _ c = c
 
 -- Nat
 
-data instance Sing :: Nat -> Type where
-  SZero :: Sing Zero
-  SSucc :: Sing n -> Sing (Succ n)
+data SNat :: Nat -> Type where
+  SZero :: SNat Zero
+  SSucc :: SNat n -> SNat (Succ n)
+type instance Sing = SNat
 
 data SuccSym0 :: Nat ~> Nat
 type instance Apply SuccSym0 x = Succ x
@@ -130,9 +131,10 @@ instance SingKind Nat where
 
 -- Bool
 
-data instance Sing :: Bool -> Type where
-  SFalse :: Sing False
-  STrue :: Sing True
+data SBool :: Bool -> Type where
+  SFalse :: SBool False
+  STrue :: SBool True
+type instance Sing = SBool
 
 (&&) :: Bool -> Bool -> Bool
 False && _ = False
@@ -161,9 +163,10 @@ instance SingKind Bool where
 
 -- Maybe
 
-data instance Sing :: Maybe k -> Type where
-  SNothing :: Sing Nothing
-  SJust :: forall k (a :: k). Sing a -> Sing (Just a)
+data SMaybe :: Maybe k -> Type where
+  SNothing :: SMaybe Nothing
+  SJust :: forall k (a :: k). Sing a -> SMaybe (Just a)
+type instance Sing = SMaybe
 
 type family EqualsMaybe (a :: Maybe k) (b :: Maybe k) where
   EqualsMaybe Nothing Nothing = True
@@ -202,9 +205,10 @@ instance SingKind k => SingKind (Maybe k) where
 
 -- List
 
-data instance Sing :: List k -> Type where
-  SNil :: Sing Nil
-  SCons :: forall k (h :: k) (t :: List k). Sing h -> Sing t -> Sing (Cons h t)
+data SList :: List k -> Type where
+  SNil :: SList Nil
+  SCons :: forall k (h :: k) (t :: List k). Sing h -> SList t -> SList (Cons h t)
+type instance Sing = SList
 
 type NilSym0 = Nil
 
@@ -256,9 +260,10 @@ instance SingKind k => SingKind (List k) where
 
 -- Either
 
-data instance Sing :: Either k1 k2 -> Type where
-  SLeft :: forall k1 (a :: k1). Sing a -> Sing (Left a)
-  SRight :: forall k2 (b :: k2). Sing b -> Sing (Right b)
+data SEither :: Either k1 k2 -> Type where
+  SLeft :: forall k1 (a :: k1). Sing a -> SEither (Left a)
+  SRight :: forall k2 (b :: k2). Sing b -> SEither (Right b)
+type instance Sing = SEither
 
 instance (SingI a) => SingI (Left (a :: k)) where
   sing = SLeft sing
@@ -292,8 +297,9 @@ instance (SDecide k1, SDecide k2) => SDecide (Either k1 k2) where
 data Composite :: Type -> Type -> Type where
   MkComp :: Either (Maybe a) b -> Composite a b
 
-data instance Sing :: Composite k1 k2 -> Type where
-  SMkComp :: forall k1 k2 (a :: Either (Maybe k1) k2). Sing a -> Sing (MkComp a)
+data SComposite :: Composite k1 k2 -> Type where
+  SMkComp :: forall k1 k2 (a :: Either (Maybe k1) k2). SEither a -> SComposite (MkComp a)
+type instance Sing = SComposite
 
 instance SingI a => SingI (MkComp (a :: Either (Maybe k1) k2)) where
   sing = SMkComp sing
@@ -314,7 +320,8 @@ instance (SDecide k1, SDecide k2) => SDecide (Composite k1 k2) where
 -- Empty
 
 data Empty
-data instance Sing :: Empty -> Type
+data SEmpty :: Empty -> Type
+type instance Sing = SEmpty
 instance SingKind Empty where
   type Demote Empty = Empty
   fromSing = \case
@@ -328,10 +335,11 @@ data Vec :: Type -> Nat -> Type where
 
 data Rep = Nat | Maybe Rep | Vec Rep Nat
 
-data instance Sing :: Type -> Type where
-  SNat :: Sing Nat
-  SMaybe :: Sing a -> Sing (Maybe a)
-  SVec :: Sing a -> Sing n -> Sing (Vec a n)
+data SRep :: Type -> Type where
+  SNat :: SRep Nat
+  SMaybe :: SRep a -> SRep (Maybe a)
+  SVec :: SRep a -> SNat n -> SRep (Vec a n)
+type instance Sing = SRep
 
 instance SingI Nat where
   sing = SNat
@@ -723,7 +731,7 @@ impNat _ sm = (sing :: Sing n) %+ sm
 callImpNat :: forall n m. Sing n -> Sing m -> Sing (n + m)
 callImpNat sn sm = withSingI sn (impNat (Proxy :: Proxy n) sm)
 
-instance Show (Sing (n :: Nat)) where
+instance Show (SNat n) where
   show SZero = "SZero"
   show (SSucc n) = "SSucc (" ++ (show n) ++ ")"
 
@@ -857,8 +865,9 @@ sFI = unSingFun2 (singFun2 @FI (\p ls ->
 
 ------------------------------------------------------------
 
-data G a where
+data G :: Type -> Type where
   MkG :: G Bool
 
-data instance Sing :: G a -> Type where
-  SMkG :: Sing MkG
+data SG :: forall a. G a -> Type where
+  SMkG :: SG MkG
+type instance Sing = SG

--- a/tests/ByHand2.hs
+++ b/tests/ByHand2.hs
@@ -31,13 +31,15 @@ instance Eq Nat where
   Succ _ == Zero = False
   Succ x == Succ y = x == y
 
-data instance Sing :: Bool -> Type where
-  SFalse :: Sing 'False
-  STrue  :: Sing 'True
+data SBool :: Bool -> Type where
+  SFalse :: SBool 'False
+  STrue  :: SBool 'True
+type instance Sing = SBool
 
-data instance Sing :: Nat -> Type where
-  SZero :: Sing 'Zero
-  SSucc :: Sing n -> Sing ('Succ n)
+data SNat :: Nat -> Type where
+  SZero :: SNat 'Zero
+  SSucc :: SNat n -> SNat ('Succ n)
+type instance Sing = SNat
 
 type family Not (x :: Bool) :: Bool where
   Not 'True = 'False
@@ -112,10 +114,11 @@ instance POrd Nat where
   type Compare ('Succ x) 'Zero     = 'GT
   type Compare ('Succ x) ('Succ y) = Compare x y
 
-data instance Sing :: Ordering -> Type where
-  SLT :: Sing 'LT
-  SEQ :: Sing 'EQ
-  SGT :: Sing 'GT
+data SOrdering :: Ordering -> Type where
+  SLT :: SOrdering 'LT
+  SEQ :: SOrdering 'EQ
+  SGT :: SOrdering 'GT
+type instance Sing = SOrdering
 
 instance PEq Ordering where
   type 'LT == 'LT = 'True

--- a/tests/compile-and-dump/GradingClient/Database.ghc88.template
+++ b/tests/compile-and-dump/GradingClient/Database.ghc88.template
@@ -52,11 +52,11 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       Equals_0123456789876543210 (_ :: Nat) (_ :: Nat) = FalseSym0
     instance PEq Nat where
       type (==) a b = Equals_0123456789876543210 a b
-    data instance Sing :: Nat -> Type
+    data SNat :: Nat -> Type
       where
-        SZero :: Sing Zero
-        SSucc :: forall (n :: Nat). (Sing (n :: Nat)) -> Sing (Succ n)
-    type SNat = Sing :: Nat -> Type
+        SZero :: SNat Zero
+        SSucc :: forall (n :: Nat). (Sing (n :: Nat)) -> SNat (Succ n)
+    type instance Sing @Nat = SNat
     instance SingKind Nat where
       type Demote Nat = Nat
       fromSing SZero = Zero
@@ -110,6 +110,14 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
             Proved Refl -> Proved Refl
             Disproved contra
               -> Disproved (\ refl -> case refl of { Refl -> contra Refl })
+    instance SDecide Nat =>
+             Data.Type.Equality.TestEquality (SNat :: Nat -> Type) where
+      Data.Type.Equality.testEquality
+        = Data.Singletons.Decide.decideEquality
+    instance SDecide Nat =>
+             Data.Type.Coercion.TestCoercion (SNat :: Nat -> Type) where
+      Data.Type.Coercion.testCoercion
+        = Data.Singletons.Decide.decideCoercion
     instance SingI Zero where
       sing = SZero
     instance SingI n => SingI (Succ (n :: Nat)) where
@@ -707,14 +715,14 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SingI d =>
              SingI (AppendSym1 (d :: Schema) :: (~>) Schema Schema) where
       sing = (singFun1 @(AppendSym1 (d :: Schema))) (sAppend (sing @d))
-    data instance Sing :: U -> Type
+    data SU :: U -> Type
       where
-        SBOOL :: Sing BOOL
-        SSTRING :: Sing STRING
-        SNAT :: Sing NAT
+        SBOOL :: SU BOOL
+        SSTRING :: SU STRING
+        SNAT :: SU NAT
         SVEC :: forall (n :: U) (n :: Nat).
-                (Sing (n :: U)) -> (Sing (n :: Nat)) -> Sing (VEC n n)
-    type SU = Sing :: U -> Type
+                (Sing (n :: U)) -> (Sing (n :: Nat)) -> SU (VEC n n)
+    type instance Sing @U = SU
     instance SingKind U where
       type Demote U = U
       fromSing SBOOL = BOOL
@@ -729,35 +737,35 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
               ((,) (toSing b :: SomeSing U)) (toSing b :: SomeSing Nat)
           of {
             (,) (SomeSing c) (SomeSing c) -> SomeSing ((SVEC c) c) }
-    data instance Sing :: AChar -> Type
+    data SAChar :: AChar -> Type
       where
-        SCA :: Sing CA
-        SCB :: Sing CB
-        SCC :: Sing CC
-        SCD :: Sing CD
-        SCE :: Sing CE
-        SCF :: Sing CF
-        SCG :: Sing CG
-        SCH :: Sing CH
-        SCI :: Sing CI
-        SCJ :: Sing CJ
-        SCK :: Sing CK
-        SCL :: Sing CL
-        SCM :: Sing CM
-        SCN :: Sing CN
-        SCO :: Sing CO
-        SCP :: Sing CP
-        SCQ :: Sing CQ
-        SCR :: Sing CR
-        SCS :: Sing CS
-        SCT :: Sing CT
-        SCU :: Sing CU
-        SCV :: Sing CV
-        SCW :: Sing CW
-        SCX :: Sing CX
-        SCY :: Sing CY
-        SCZ :: Sing CZ
-    type SAChar = Sing :: AChar -> Type
+        SCA :: SAChar CA
+        SCB :: SAChar CB
+        SCC :: SAChar CC
+        SCD :: SAChar CD
+        SCE :: SAChar CE
+        SCF :: SAChar CF
+        SCG :: SAChar CG
+        SCH :: SAChar CH
+        SCI :: SAChar CI
+        SCJ :: SAChar CJ
+        SCK :: SAChar CK
+        SCL :: SAChar CL
+        SCM :: SAChar CM
+        SCN :: SAChar CN
+        SCO :: SAChar CO
+        SCP :: SAChar CP
+        SCQ :: SAChar CQ
+        SCR :: SAChar CR
+        SCS :: SAChar CS
+        SCT :: SAChar CT
+        SCU :: SAChar CU
+        SCV :: SAChar CV
+        SCW :: SAChar CW
+        SCX :: SAChar CX
+        SCY :: SAChar CY
+        SCZ :: SAChar CZ
+    type instance Sing @AChar = SAChar
     instance SingKind AChar where
       type Demote AChar = AChar
       fromSing SCA = CA
@@ -812,11 +820,11 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       toSing CX = SomeSing SCX
       toSing CY = SomeSing SCY
       toSing CZ = SomeSing SCZ
-    data instance Sing :: Attribute -> Type
+    data SAttribute :: Attribute -> Type
       where
         SAttr :: forall (n :: [AChar]) (n :: U).
-                 (Sing (n :: [AChar])) -> (Sing (n :: U)) -> Sing (Attr n n)
-    type SAttribute = Sing :: Attribute -> Type
+                 (Sing (n :: [AChar])) -> (Sing (n :: U)) -> SAttribute (Attr n n)
+    type instance Sing @Attribute = SAttribute
     instance SingKind Attribute where
       type Demote Attribute = Attribute
       fromSing (SAttr b b) = (Attr (fromSing b)) (fromSing b)
@@ -825,11 +833,11 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
               ((,) (toSing b :: SomeSing [AChar])) (toSing b :: SomeSing U)
           of {
             (,) (SomeSing c) (SomeSing c) -> SomeSing ((SAttr c) c) }
-    data instance Sing :: Schema -> Type
+    data SSchema :: Schema -> Type
       where
         SSch :: forall (n :: [Attribute]).
-                (Sing (n :: [Attribute])) -> Sing (Sch n)
-    type SSchema = Sing :: Schema -> Type
+                (Sing (n :: [Attribute])) -> SSchema (Sch n)
+    type instance Sing @Schema = SSchema
     instance SingKind Schema where
       type Demote Schema = Schema
       fromSing (SSch b) = Sch (fromSing b)
@@ -1153,6 +1161,14 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
               -> Disproved (\ refl -> case refl of { Refl -> contra Refl })
             (,) _ (Disproved contra)
               -> Disproved (\ refl -> case refl of { Refl -> contra Refl })
+    instance (SDecide U, SDecide Nat) =>
+             Data.Type.Equality.TestEquality (SU :: U -> Type) where
+      Data.Type.Equality.testEquality
+        = Data.Singletons.Decide.decideEquality
+    instance (SDecide U, SDecide Nat) =>
+             Data.Type.Coercion.TestCoercion (SU :: U -> Type) where
+      Data.Type.Coercion.testCoercion
+        = Data.Singletons.Decide.decideCoercion
     instance SEq AChar where
       (%==) SCA SCA = STrue
       (%==) SCA SCB = SFalse
@@ -2507,10 +2523,59 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       (%~) SCZ SCX = Disproved (\ x -> case x of)
       (%~) SCZ SCY = Disproved (\ x -> case x of)
       (%~) SCZ SCZ = Proved Refl
-    deriving instance (Data.Singletons.ShowSing.ShowSing U,
-                       Data.Singletons.ShowSing.ShowSing Nat) =>
-                      Show (Sing (z :: U))
-    deriving instance Show (Sing (z :: AChar))
+    instance Data.Type.Equality.TestEquality (SAChar :: AChar
+                                                        -> Type) where
+      Data.Type.Equality.testEquality
+        = Data.Singletons.Decide.decideEquality
+    instance Data.Type.Coercion.TestCoercion (SAChar :: AChar
+                                                        -> Type) where
+      Data.Type.Coercion.testCoercion
+        = Data.Singletons.Decide.decideCoercion
+    instance (Data.Singletons.ShowSing.ShowSing U,
+              Data.Singletons.ShowSing.ShowSing Nat) =>
+             Show (SU (z :: U)) where
+      showsPrec _ SBOOL = showString "SBOOL"
+      showsPrec _ SSTRING = showString "SSTRING"
+      showsPrec _ SNAT = showString "SNAT"
+      showsPrec
+        p_0123456789876543210
+        (SVEC (arg_0123456789876543210 :: Sing argTy_0123456789876543210)
+              (arg_0123456789876543210 :: Sing argTy_0123456789876543210))
+        = (showParen (((>) p_0123456789876543210) 10))
+            (((.) (showString "SVEC "))
+               (((.) ((showsPrec 11) arg_0123456789876543210))
+                  (((.) GHC.Show.showSpace)
+                     ((showsPrec 11) arg_0123456789876543210)))) ::
+            (Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210,
+             Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210) =>
+            ShowS
+    instance Show (SAChar (z :: AChar)) where
+      showsPrec _ SCA = showString "SCA"
+      showsPrec _ SCB = showString "SCB"
+      showsPrec _ SCC = showString "SCC"
+      showsPrec _ SCD = showString "SCD"
+      showsPrec _ SCE = showString "SCE"
+      showsPrec _ SCF = showString "SCF"
+      showsPrec _ SCG = showString "SCG"
+      showsPrec _ SCH = showString "SCH"
+      showsPrec _ SCI = showString "SCI"
+      showsPrec _ SCJ = showString "SCJ"
+      showsPrec _ SCK = showString "SCK"
+      showsPrec _ SCL = showString "SCL"
+      showsPrec _ SCM = showString "SCM"
+      showsPrec _ SCN = showString "SCN"
+      showsPrec _ SCO = showString "SCO"
+      showsPrec _ SCP = showString "SCP"
+      showsPrec _ SCQ = showString "SCQ"
+      showsPrec _ SCR = showString "SCR"
+      showsPrec _ SCS = showString "SCS"
+      showsPrec _ SCT = showString "SCT"
+      showsPrec _ SCU = showString "SCU"
+      showsPrec _ SCV = showString "SCV"
+      showsPrec _ SCW = showString "SCW"
+      showsPrec _ SCX = showString "SCX"
+      showsPrec _ SCY = showString "SCY"
+      showsPrec _ SCZ = showString "SCZ"
     instance SingI BOOL where
       sing = SBOOL
     instance SingI STRING where

--- a/tests/compile-and-dump/InsertionSort/InsertionSortImp.ghc88.template
+++ b/tests/compile-and-dump/InsertionSort/InsertionSortImp.ghc88.template
@@ -13,11 +13,11 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
                                         arg. SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
                                  SuccSym0 t0123456789876543210
     type instance Apply SuccSym0 t0123456789876543210 = Succ t0123456789876543210
-    data instance Sing :: Nat -> Type
+    data SNat :: Nat -> Type
       where
-        SZero :: Sing Zero
-        SSucc :: forall (n :: Nat). (Sing (n :: Nat)) -> Sing (Succ n)
-    type SNat = Sing :: Nat -> Type
+        SZero :: SNat Zero
+        SSucc :: forall (n :: Nat). (Sing (n :: Nat)) -> SNat (Succ n)
+    type instance Sing @Nat = SNat
     instance SingKind Nat where
       type Demote Nat = Nat
       fromSing SZero = Zero

--- a/tests/compile-and-dump/Singletons/AsPattern.ghc88.template
+++ b/tests/compile-and-dump/Singletons/AsPattern.ghc88.template
@@ -363,12 +363,12 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun1 @BarSym0) sBar
     instance SingI (MaybePlusSym0 :: (~>) (Maybe Nat) (Maybe Nat)) where
       sing = (singFun1 @MaybePlusSym0) sMaybePlus
-    data instance Sing :: Baz -> GHC.Types.Type
+    data SBaz :: Baz -> GHC.Types.Type
       where
         SBaz :: forall (n :: Nat) (n :: Nat) (n :: Nat).
                 (Sing (n :: Nat))
-                -> (Sing (n :: Nat)) -> (Sing (n :: Nat)) -> Sing (Baz n n n)
-    type SBaz = Sing :: Baz -> GHC.Types.Type
+                -> (Sing (n :: Nat)) -> (Sing (n :: Nat)) -> SBaz (Baz n n n)
+    type instance Sing @Baz = SBaz
     instance SingKind Baz where
       type Demote Baz = Baz
       fromSing (SBaz b b b)

--- a/tests/compile-and-dump/Singletons/BoundedDeriving.ghc88.template
+++ b/tests/compile-and-dump/Singletons/BoundedDeriving.ghc88.template
@@ -124,20 +124,20 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance PBounded Pair where
       type MinBound = MinBound_0123456789876543210Sym0
       type MaxBound = MaxBound_0123456789876543210Sym0
-    data instance Sing :: Foo1 -> Type where SFoo1 :: Sing Foo1
-    type SFoo1 = Sing :: Foo1 -> Type
+    data SFoo1 :: Foo1 -> Type where SFoo1 :: SFoo1 Foo1
+    type instance Sing @Foo1 = SFoo1
     instance SingKind Foo1 where
       type Demote Foo1 = Foo1
       fromSing SFoo1 = Foo1
       toSing Foo1 = SomeSing SFoo1
-    data instance Sing :: Foo2 -> Type
+    data SFoo2 :: Foo2 -> Type
       where
-        SA :: Sing A
-        SB :: Sing B
-        SC :: Sing C
-        SD :: Sing D
-        SE :: Sing E
-    type SFoo2 = Sing :: Foo2 -> Type
+        SA :: SFoo2 A
+        SB :: SFoo2 B
+        SC :: SFoo2 C
+        SD :: SFoo2 D
+        SE :: SFoo2 E
+    type instance Sing @Foo2 = SFoo2
     instance SingKind Foo2 where
       type Demote Foo2 = Foo2
       fromSing SA = A
@@ -150,31 +150,31 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
       toSing C = SomeSing SC
       toSing D = SomeSing SD
       toSing E = SomeSing SE
-    data instance Sing :: Foo3 a -> Type
-      where SFoo3 :: forall a (n :: a). (Sing (n :: a)) -> Sing (Foo3 n)
-    type SFoo3 = Sing :: Foo3 a -> Type
+    data SFoo3 :: Foo3 a -> Type
+      where SFoo3 :: forall a (n :: a). (Sing (n :: a)) -> SFoo3 (Foo3 n)
+    type instance Sing @(Foo3 a) = SFoo3
     instance SingKind a => SingKind (Foo3 a) where
       type Demote (Foo3 a) = Foo3 (Demote a)
       fromSing (SFoo3 b) = Foo3 (fromSing b)
       toSing (Foo3 (b :: Demote a))
         = case toSing b :: SomeSing a of {
             SomeSing c -> SomeSing (SFoo3 c) }
-    data instance Sing :: Foo4 a b -> Type
+    data SFoo4 :: Foo4 a b -> Type
       where
-        SFoo41 :: Sing Foo41
-        SFoo42 :: Sing Foo42
-    type SFoo4 = Sing :: Foo4 a b -> Type
+        SFoo41 :: SFoo4 Foo41
+        SFoo42 :: SFoo4 Foo42
+    type instance Sing @(Foo4 a b) = SFoo4
     instance (SingKind a, SingKind b) => SingKind (Foo4 a b) where
       type Demote (Foo4 a b) = Foo4 (Demote a) (Demote b)
       fromSing SFoo41 = Foo41
       fromSing SFoo42 = Foo42
       toSing Foo41 = SomeSing SFoo41
       toSing Foo42 = SomeSing SFoo42
-    data instance Sing :: Pair -> Type
+    data SPair :: Pair -> Type
       where
         SPair :: forall (n :: Bool) (n :: Bool).
-                 (Sing (n :: Bool)) -> (Sing (n :: Bool)) -> Sing (Pair n n)
-    type SPair = Sing :: Pair -> Type
+                 (Sing (n :: Bool)) -> (Sing (n :: Bool)) -> SPair (Pair n n)
+    type instance Sing @Pair = SPair
     instance SingKind Pair where
       type Demote Pair = Pair
       fromSing (SPair b b) = (Pair (fromSing b)) (fromSing b)

--- a/tests/compile-and-dump/Singletons/BoundedDeriving.ghc88.template
+++ b/tests/compile-and-dump/Singletons/BoundedDeriving.ghc88.template
@@ -150,7 +150,7 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
       toSing C = SomeSing SC
       toSing D = SomeSing SD
       toSing E = SomeSing SE
-    data SFoo3 :: Foo3 a -> Type
+    data SFoo3 :: forall a. Foo3 a -> Type
       where SFoo3 :: forall a (n :: a). (Sing (n :: a)) -> SFoo3 (Foo3 n)
     type instance Sing @(Foo3 a) = SFoo3
     instance SingKind a => SingKind (Foo3 a) where
@@ -159,7 +159,7 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
       toSing (Foo3 (b :: Demote a))
         = case toSing b :: SomeSing a of {
             SomeSing c -> SomeSing (SFoo3 c) }
-    data SFoo4 :: Foo4 a b -> Type
+    data SFoo4 :: forall a b. Foo4 a b -> Type
       where
         SFoo41 :: SFoo4 Foo41
         SFoo42 :: SFoo4 Foo42

--- a/tests/compile-and-dump/Singletons/BoxUnBox.ghc88.template
+++ b/tests/compile-and-dump/Singletons/BoxUnBox.ghc88.template
@@ -37,7 +37,7 @@ Singletons/BoxUnBox.hs:(0,0)-(0,0): Splicing declarations
     sUnBox (SFBox (sA :: Sing a)) = sA
     instance SingI (UnBoxSym0 :: (~>) (Box a) a) where
       sing = (singFun1 @UnBoxSym0) sUnBox
-    data SBox :: Box a -> GHC.Types.Type
+    data SBox :: forall a. Box a -> GHC.Types.Type
       where SFBox :: forall a (n :: a). (Sing (n :: a)) -> SBox (FBox n)
     type instance Sing @(Box a) = SBox
     instance SingKind a => SingKind (Box a) where

--- a/tests/compile-and-dump/Singletons/BoxUnBox.ghc88.template
+++ b/tests/compile-and-dump/Singletons/BoxUnBox.ghc88.template
@@ -37,9 +37,9 @@ Singletons/BoxUnBox.hs:(0,0)-(0,0): Splicing declarations
     sUnBox (SFBox (sA :: Sing a)) = sA
     instance SingI (UnBoxSym0 :: (~>) (Box a) a) where
       sing = (singFun1 @UnBoxSym0) sUnBox
-    data instance Sing :: Box a -> GHC.Types.Type
-      where SFBox :: forall a (n :: a). (Sing (n :: a)) -> Sing (FBox n)
-    type SBox = Sing :: Box a -> GHC.Types.Type
+    data SBox :: Box a -> GHC.Types.Type
+      where SFBox :: forall a (n :: a). (Sing (n :: a)) -> SBox (FBox n)
+    type instance Sing @(Box a) = SBox
     instance SingKind a => SingKind (Box a) where
       type Demote (Box a) = Box (Demote a)
       fromSing (SFBox b) = FBox (fromSing b)

--- a/tests/compile-and-dump/Singletons/Classes.ghc88.template
+++ b/tests/compile-and-dump/Singletons/Classes.ghc88.template
@@ -311,22 +311,22 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @ConstSym0) sConst
     instance SingI d => SingI (ConstSym1 (d :: a) :: (~>) b a) where
       sing = (singFun1 @(ConstSym1 (d :: a))) (sConst (sing @d))
-    data instance Sing :: Foo -> GHC.Types.Type
+    data SFoo :: Foo -> GHC.Types.Type
       where
-        SA :: Sing A
-        SB :: Sing B
-    type SFoo = Sing :: Foo -> GHC.Types.Type
+        SA :: SFoo A
+        SB :: SFoo B
+    type instance Sing @Foo = SFoo
     instance SingKind Foo where
       type Demote Foo = Foo
       fromSing SA = A
       fromSing SB = B
       toSing A = SomeSing SA
       toSing B = SomeSing SB
-    data instance Sing :: Foo2 -> GHC.Types.Type
+    data SFoo2 :: Foo2 -> GHC.Types.Type
       where
-        SF :: Sing F
-        SG :: Sing G
-    type SFoo2 = Sing :: Foo2 -> GHC.Types.Type
+        SF :: SFoo2 F
+        SG :: SFoo2 G
+    type instance Sing @Foo2 = SFoo2
     instance SingKind Foo2 where
       type Demote Foo2 = Foo2
       fromSing SF = F
@@ -540,11 +540,11 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply Mycompare_0123456789876543210Sym0 a0123456789876543210 = Mycompare_0123456789876543210Sym1 a0123456789876543210
     instance PMyOrd Nat' where
       type Mycompare a a = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
-    data instance Sing :: Nat' -> GHC.Types.Type
+    data SNat' :: Nat' -> GHC.Types.Type
       where
-        SZero' :: Sing Zero'
-        SSucc' :: forall (n :: Nat'). (Sing (n :: Nat')) -> Sing (Succ' n)
-    type SNat' = Sing :: Nat' -> GHC.Types.Type
+        SZero' :: SNat' Zero'
+        SSucc' :: forall (n :: Nat'). (Sing (n :: Nat')) -> SNat' (Succ' n)
+    type instance Sing @Nat' = SNat'
     instance SingKind Nat' where
       type Demote Nat' = Nat'
       fromSing SZero' = Zero'

--- a/tests/compile-and-dump/Singletons/Classes2.ghc88.template
+++ b/tests/compile-and-dump/Singletons/Classes2.ghc88.template
@@ -53,12 +53,12 @@ Singletons/Classes2.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply Mycompare_0123456789876543210Sym0 a0123456789876543210 = Mycompare_0123456789876543210Sym1 a0123456789876543210
     instance PMyOrd NatFoo where
       type Mycompare a a = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
-    data instance Sing :: NatFoo -> GHC.Types.Type
+    data SNatFoo :: NatFoo -> GHC.Types.Type
       where
-        SZeroFoo :: Sing ZeroFoo
+        SZeroFoo :: SNatFoo ZeroFoo
         SSuccFoo :: forall (n :: NatFoo).
-                    (Sing (n :: NatFoo)) -> Sing (SuccFoo n)
-    type SNatFoo = Sing :: NatFoo -> GHC.Types.Type
+                    (Sing (n :: NatFoo)) -> SNatFoo (SuccFoo n)
+    type instance Sing @NatFoo = SNatFoo
     instance SingKind NatFoo where
       type Demote NatFoo = NatFoo
       fromSing SZeroFoo = ZeroFoo

--- a/tests/compile-and-dump/Singletons/DataValues.ghc88.template
+++ b/tests/compile-and-dump/Singletons/DataValues.ghc88.template
@@ -121,11 +121,11 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
            ((applySing ((singFun2 @PairSym0) SPair))
               ((applySing ((singFun1 @SuccSym0) SSucc)) SZero)))
           ((applySing ((applySing ((singFun2 @(:@#@$)) SCons)) SZero)) SNil)
-    data instance Sing :: Pair a b -> GHC.Types.Type
+    data SPair :: Pair a b -> GHC.Types.Type
       where
         SPair :: forall a b (n :: a) (n :: b).
-                 (Sing (n :: a)) -> (Sing (n :: b)) -> Sing (Pair n n)
-    type SPair = Sing :: Pair a b -> GHC.Types.Type
+                 (Sing (n :: a)) -> (Sing (n :: b)) -> SPair (Pair n n)
+    type instance Sing @(Pair a b) = SPair
     instance (SingKind a, SingKind b) => SingKind (Pair a b) where
       type Demote (Pair a b) = Pair (Demote a) (Demote b)
       fromSing (SPair b b) = (Pair (fromSing b)) (fromSing b)
@@ -169,9 +169,21 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
                                 (sFromInteger (sing :: Sing 11))))
                             sArg_0123456789876543210))))))
             sA_0123456789876543210
-    deriving instance (Data.Singletons.ShowSing.ShowSing a,
-                       Data.Singletons.ShowSing.ShowSing b) =>
-                      Show (Sing (z :: Pair a b))
+    instance (Data.Singletons.ShowSing.ShowSing a,
+              Data.Singletons.ShowSing.ShowSing b) =>
+             Show (SPair (z :: Pair a b)) where
+      showsPrec
+        p_0123456789876543210
+        (SPair (arg_0123456789876543210 :: Sing argTy_0123456789876543210)
+               (arg_0123456789876543210 :: Sing argTy_0123456789876543210))
+        = (showParen (((>) p_0123456789876543210) 10))
+            (((.) (showString "SPair "))
+               (((.) ((showsPrec 11) arg_0123456789876543210))
+                  (((.) GHC.Show.showSpace)
+                     ((showsPrec 11) arg_0123456789876543210)))) ::
+            (Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210,
+             Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210) =>
+            ShowS
     instance (SingI n, SingI n) => SingI (Pair (n :: a) (n :: b)) where
       sing = (SPair sing) sing
     instance SingI (PairSym0 :: (~>) a ((~>) b (Pair a b))) where

--- a/tests/compile-and-dump/Singletons/DataValues.ghc88.template
+++ b/tests/compile-and-dump/Singletons/DataValues.ghc88.template
@@ -121,7 +121,7 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
            ((applySing ((singFun2 @PairSym0) SPair))
               ((applySing ((singFun1 @SuccSym0) SSucc)) SZero)))
           ((applySing ((applySing ((singFun2 @(:@#@$)) SCons)) SZero)) SNil)
-    data SPair :: Pair a b -> GHC.Types.Type
+    data SPair :: forall a b. Pair a b -> GHC.Types.Type
       where
         SPair :: forall a b (n :: a) (n :: b).
                  (Sing (n :: a)) -> (Sing (n :: b)) -> SPair (Pair n n)

--- a/tests/compile-and-dump/Singletons/Empty.ghc88.template
+++ b/tests/compile-and-dump/Singletons/Empty.ghc88.template
@@ -2,8 +2,8 @@ Singletons/Empty.hs:(0,0)-(0,0): Splicing declarations
     singletons [d| data Empty |]
   ======>
     data Empty
-    data instance Sing :: Empty -> GHC.Types.Type
-    type SEmpty = Sing :: Empty -> GHC.Types.Type
+    data SEmpty :: Empty -> GHC.Types.Type
+    type instance Sing @Empty = SEmpty
     instance SingKind Empty where
       type Demote Empty = Empty
       fromSing x = case x of

--- a/tests/compile-and-dump/Singletons/EmptyShowDeriving.ghc88.template
+++ b/tests/compile-and-dump/Singletons/EmptyShowDeriving.ghc88.template
@@ -43,8 +43,8 @@ Singletons/EmptyShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
     instance PShow Foo where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
-    data instance Sing :: Foo -> GHC.Types.Type
-    type SFoo = Sing :: Foo -> GHC.Types.Type
+    data SFoo :: Foo -> GHC.Types.Type
+    type instance Sing @Foo = SFoo
     instance SingKind Foo where
       type Demote Foo = Foo
       fromSing x = case x of
@@ -66,4 +66,5 @@ Singletons/EmptyShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                  @(Sing (Case_0123456789876543210 v_0123456789876543210 a_0123456789876543210 v_0123456789876543210)))
                 (case sV_0123456789876543210 of)))
             sA_0123456789876543210
-    deriving instance Show (Sing (z :: Foo))
+    instance Show (SFoo (z :: Foo)) where
+      showsPrec _ v_0123456789876543210 = case v_0123456789876543210 of

--- a/tests/compile-and-dump/Singletons/EnumDeriving.ghc88.template
+++ b/tests/compile-and-dump/Singletons/EnumDeriving.ghc88.template
@@ -54,12 +54,12 @@ Singletons/EnumDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance PEnum Foo where
       type ToEnum a = Apply ToEnum_0123456789876543210Sym0 a
       type FromEnum a = Apply FromEnum_0123456789876543210Sym0 a
-    data instance Sing :: Foo -> GHC.Types.Type
+    data SFoo :: Foo -> GHC.Types.Type
       where
-        SBar :: Sing Bar
-        SBaz :: Sing Baz
-        SBum :: Sing Bum
-    type SFoo = Sing :: Foo -> GHC.Types.Type
+        SBar :: SFoo Bar
+        SBaz :: SFoo Baz
+        SBum :: SFoo Bum
+    type instance Sing @Foo = SFoo
     instance SingKind Foo where
       type Demote Foo = Foo
       fromSing SBar = Bar
@@ -68,11 +68,11 @@ Singletons/EnumDeriving.hs:(0,0)-(0,0): Splicing declarations
       toSing Bar = SomeSing SBar
       toSing Baz = SomeSing SBaz
       toSing Bum = SomeSing SBum
-    data instance Sing :: Quux -> GHC.Types.Type
+    data SQuux :: Quux -> GHC.Types.Type
       where
-        SQ1 :: Sing Q1
-        SQ2 :: Sing Q2
-    type SQuux = Sing :: Quux -> GHC.Types.Type
+        SQ1 :: SQuux Q1
+        SQ2 :: SQuux Q2
+    type instance Sing @Quux = SQuux
     instance SingKind Quux where
       type Demote Quux = Quux
       fromSing SQ1 = Q1

--- a/tests/compile-and-dump/Singletons/FunctorLikeDeriving.ghc88.template
+++ b/tests/compile-and-dump/Singletons/FunctorLikeDeriving.ghc88.template
@@ -1240,7 +1240,7 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply Traverse_0123456789876543210Sym0 a0123456789876543210 = Traverse_0123456789876543210Sym1 a0123456789876543210
     instance PTraversable Empty where
       type Traverse a a = Apply (Apply Traverse_0123456789876543210Sym0 a) a
-    data instance Sing :: T x a -> Type
+    data ST :: T x a -> Type
       where
         SMkT1 :: forall x
                         a
@@ -1251,10 +1251,10 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
                  (Sing (n :: x))
                  -> (Sing (n :: a))
                     -> (Sing (n :: Maybe a))
-                       -> (Sing (n :: Maybe (Maybe a))) -> Sing (MkT1 n n n n)
+                       -> (Sing (n :: Maybe (Maybe a))) -> ST (MkT1 n n n n)
         SMkT2 :: forall x (n :: Maybe x).
-                 (Sing (n :: Maybe x)) -> Sing (MkT2 n)
-    type ST = Sing :: T x a -> Type
+                 (Sing (n :: Maybe x)) -> ST (MkT2 n)
+    type instance Sing @(T x a) = ST
     instance (SingKind x, SingKind a) => SingKind (T x a) where
       type Demote (T x a) = T (Demote x) (Demote a)
       fromSing (SMkT1 b b b b)
@@ -1275,8 +1275,8 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
       toSing (MkT2 (b :: Demote (Maybe x)))
         = case toSing b :: SomeSing (Maybe x) of {
             SomeSing c -> SomeSing (SMkT2 c) }
-    data instance Sing :: Empty a -> Type
-    type SEmpty = Sing :: Empty a -> Type
+    data SEmpty :: Empty a -> Type
+    type instance Sing @(Empty a) = SEmpty
     instance SingKind a => SingKind (Empty a) where
       type Demote (Empty a) = Empty (Demote a)
       fromSing x = case x of

--- a/tests/compile-and-dump/Singletons/FunctorLikeDeriving.ghc88.template
+++ b/tests/compile-and-dump/Singletons/FunctorLikeDeriving.ghc88.template
@@ -1240,7 +1240,7 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply Traverse_0123456789876543210Sym0 a0123456789876543210 = Traverse_0123456789876543210Sym1 a0123456789876543210
     instance PTraversable Empty where
       type Traverse a a = Apply (Apply Traverse_0123456789876543210Sym0 a) a
-    data ST :: T x a -> Type
+    data ST :: forall x a. T x a -> Type
       where
         SMkT1 :: forall x
                         a
@@ -1275,7 +1275,7 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
       toSing (MkT2 (b :: Demote (Maybe x)))
         = case toSing b :: SomeSing (Maybe x) of {
             SomeSing c -> SomeSing (SMkT2 c) }
-    data SEmpty :: Empty a -> Type
+    data SEmpty :: forall a. Empty a -> Type
     type instance Sing @(Empty a) = SEmpty
     instance SingKind a => SingKind (Empty a) where
       type Demote (Empty a) = Empty (Demote a)

--- a/tests/compile-and-dump/Singletons/HigherOrder.ghc88.template
+++ b/tests/compile-and-dump/Singletons/HigherOrder.ghc88.template
@@ -452,11 +452,11 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     instance SingI d =>
              SingI (MapSym1 (d :: (~>) a b) :: (~>) [a] [b]) where
       sing = (singFun1 @(MapSym1 (d :: (~>) a b))) (sMap (sing @d))
-    data instance Sing :: Either a b -> GHC.Types.Type
+    data SEither :: Either a b -> GHC.Types.Type
       where
-        SLeft :: forall a (n :: a). (Sing (n :: a)) -> Sing (Left n)
-        SRight :: forall b (n :: b). (Sing (n :: b)) -> Sing (Right n)
-    type SEither = Sing :: Either a b -> GHC.Types.Type
+        SLeft :: forall a (n :: a). (Sing (n :: a)) -> SEither (Left n)
+        SRight :: forall b (n :: b). (Sing (n :: b)) -> SEither (Right n)
+    type instance Sing @(Either a b) = SEither
     instance (SingKind a, SingKind b) => SingKind (Either a b) where
       type Demote (Either a b) = Either (Demote a) (Demote b)
       fromSing (SLeft b) = Left (fromSing b)

--- a/tests/compile-and-dump/Singletons/HigherOrder.ghc88.template
+++ b/tests/compile-and-dump/Singletons/HigherOrder.ghc88.template
@@ -452,7 +452,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     instance SingI d =>
              SingI (MapSym1 (d :: (~>) a b) :: (~>) [a] [b]) where
       sing = (singFun1 @(MapSym1 (d :: (~>) a b))) (sMap (sing @d))
-    data SEither :: Either a b -> GHC.Types.Type
+    data SEither :: forall a b. Either a b -> GHC.Types.Type
       where
         SLeft :: forall a (n :: a). (Sing (n :: a)) -> SEither (Left n)
         SRight :: forall b (n :: b). (Sing (n :: b)) -> SEither (Right n)

--- a/tests/compile-and-dump/Singletons/Lambdas.ghc88.template
+++ b/tests/compile-and-dump/Singletons/Lambdas.ghc88.template
@@ -812,11 +812,11 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @Foo0Sym0) sFoo0
     instance SingI d => SingI (Foo0Sym1 (d :: a) :: (~>) b a) where
       sing = (singFun1 @(Foo0Sym1 (d :: a))) (sFoo0 (sing @d))
-    data instance Sing :: Foo a b -> GHC.Types.Type
+    data SFoo :: Foo a b -> GHC.Types.Type
       where
         SFoo :: forall a b (n :: a) (n :: b).
-                (Sing (n :: a)) -> (Sing (n :: b)) -> Sing (Foo n n)
-    type SFoo = Sing :: Foo a b -> GHC.Types.Type
+                (Sing (n :: a)) -> (Sing (n :: b)) -> SFoo (Foo n n)
+    type instance Sing @(Foo a b) = SFoo
     instance (SingKind a, SingKind b) => SingKind (Foo a b) where
       type Demote (Foo a b) = Foo (Demote a) (Demote b)
       fromSing (SFoo b b) = (Foo (fromSing b)) (fromSing b)

--- a/tests/compile-and-dump/Singletons/Lambdas.ghc88.template
+++ b/tests/compile-and-dump/Singletons/Lambdas.ghc88.template
@@ -812,7 +812,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @Foo0Sym0) sFoo0
     instance SingI d => SingI (Foo0Sym1 (d :: a) :: (~>) b a) where
       sing = (singFun1 @(Foo0Sym1 (d :: a))) (sFoo0 (sing @d))
-    data SFoo :: Foo a b -> GHC.Types.Type
+    data SFoo :: forall a b. Foo a b -> GHC.Types.Type
       where
         SFoo :: forall a b (n :: a) (n :: b).
                 (Sing (n :: a)) -> (Sing (n :: b)) -> SFoo (Foo n n)

--- a/tests/compile-and-dump/Singletons/Maybe.ghc88.template
+++ b/tests/compile-and-dump/Singletons/Maybe.ghc88.template
@@ -64,7 +64,7 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
       Equals_0123456789876543210 (_ :: Maybe a) (_ :: Maybe a) = FalseSym0
     instance PEq (Maybe a) where
       type (==) a b = Equals_0123456789876543210 a b
-    data SMaybe :: Maybe a -> GHC.Types.Type
+    data SMaybe :: forall a. Maybe a -> GHC.Types.Type
       where
         SNothing :: SMaybe Nothing
         SJust :: forall a (n :: a). (Sing (n :: a)) -> SMaybe (Just n)

--- a/tests/compile-and-dump/Singletons/Maybe.ghc88.template
+++ b/tests/compile-and-dump/Singletons/Maybe.ghc88.template
@@ -64,11 +64,11 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
       Equals_0123456789876543210 (_ :: Maybe a) (_ :: Maybe a) = FalseSym0
     instance PEq (Maybe a) where
       type (==) a b = Equals_0123456789876543210 a b
-    data instance Sing :: Maybe a -> GHC.Types.Type
+    data SMaybe :: Maybe a -> GHC.Types.Type
       where
-        SNothing :: Sing Nothing
-        SJust :: forall a (n :: a). (Sing (n :: a)) -> Sing (Just n)
-    type SMaybe = Sing :: Maybe a -> GHC.Types.Type
+        SNothing :: SMaybe Nothing
+        SJust :: forall a (n :: a). (Sing (n :: a)) -> SMaybe (Just n)
+    type instance Sing @(Maybe a) = SMaybe
     instance SingKind a => SingKind (Maybe a) where
       type Demote (Maybe a) = Maybe (Demote a)
       fromSing SNothing = Nothing
@@ -128,8 +128,27 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
             Proved Refl -> Proved Refl
             Disproved contra
               -> Disproved (\ refl -> case refl of { Refl -> contra Refl })
-    deriving instance Data.Singletons.ShowSing.ShowSing a =>
-                      Show (Sing (z :: Maybe a))
+    instance SDecide a =>
+             Data.Type.Equality.TestEquality (SMaybe :: Maybe a
+                                                        -> GHC.Types.Type) where
+      Data.Type.Equality.testEquality
+        = Data.Singletons.Decide.decideEquality
+    instance SDecide a =>
+             Data.Type.Coercion.TestCoercion (SMaybe :: Maybe a
+                                                        -> GHC.Types.Type) where
+      Data.Type.Coercion.testCoercion
+        = Data.Singletons.Decide.decideCoercion
+    instance Data.Singletons.ShowSing.ShowSing a =>
+             Show (SMaybe (z :: Maybe a)) where
+      showsPrec _ SNothing = showString "SNothing"
+      showsPrec
+        p_0123456789876543210
+        (SJust (arg_0123456789876543210 :: Sing argTy_0123456789876543210))
+        = (showParen (((>) p_0123456789876543210) 10))
+            (((.) (showString "SJust "))
+               ((showsPrec 11) arg_0123456789876543210)) ::
+            Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210 =>
+            ShowS
     instance SingI Nothing where
       sing = SNothing
     instance SingI n => SingI (Just (n :: a)) where

--- a/tests/compile-and-dump/Singletons/Nat.ghc88.template
+++ b/tests/compile-and-dump/Singletons/Nat.ghc88.template
@@ -159,11 +159,11 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
     instance SingI d =>
              SingI (PlusSym1 (d :: Nat) :: (~>) Nat Nat) where
       sing = (singFun1 @(PlusSym1 (d :: Nat))) (sPlus (sing @d))
-    data instance Sing :: Nat -> GHC.Types.Type
+    data SNat :: Nat -> GHC.Types.Type
       where
-        SZero :: Sing Zero
-        SSucc :: forall (n :: Nat). (Sing (n :: Nat)) -> Sing (Succ n)
-    type SNat = Sing :: Nat -> GHC.Types.Type
+        SZero :: SNat Zero
+        SSucc :: forall (n :: Nat). (Sing (n :: Nat)) -> SNat (Succ n)
+    type instance Sing @Nat = SNat
     instance SingKind Nat where
       type Demote Nat = Nat
       fromSing SZero = Zero
@@ -254,8 +254,27 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
             Proved Refl -> Proved Refl
             Disproved contra
               -> Disproved (\ refl -> case refl of { Refl -> contra Refl })
-    deriving instance Data.Singletons.ShowSing.ShowSing Nat =>
-                      Show (Sing (z :: Nat))
+    instance SDecide Nat =>
+             Data.Type.Equality.TestEquality (SNat :: Nat
+                                                      -> GHC.Types.Type) where
+      Data.Type.Equality.testEquality
+        = Data.Singletons.Decide.decideEquality
+    instance SDecide Nat =>
+             Data.Type.Coercion.TestCoercion (SNat :: Nat
+                                                      -> GHC.Types.Type) where
+      Data.Type.Coercion.testCoercion
+        = Data.Singletons.Decide.decideCoercion
+    instance Data.Singletons.ShowSing.ShowSing Nat =>
+             Show (SNat (z :: Nat)) where
+      showsPrec _ SZero = showString "SZero"
+      showsPrec
+        p_0123456789876543210
+        (SSucc (arg_0123456789876543210 :: Sing argTy_0123456789876543210))
+        = (showParen (((>) p_0123456789876543210) 10))
+            (((.) (showString "SSucc "))
+               ((showsPrec 11) arg_0123456789876543210)) ::
+            Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210 =>
+            ShowS
     instance SingI Zero where
       sing = SZero
     instance SingI n => SingI (Succ (n :: Nat)) where

--- a/tests/compile-and-dump/Singletons/Operators.ghc88.template
+++ b/tests/compile-and-dump/Singletons/Operators.ghc88.template
@@ -95,12 +95,12 @@ Singletons/Operators.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun1 @((+@#@$$) (d :: Nat))) ((%+) (sing @d))
     instance SingI (ChildSym0 :: (~>) Foo Foo) where
       sing = (singFun1 @ChildSym0) sChild
-    data instance Sing :: Foo -> GHC.Types.Type
+    data SFoo :: Foo -> GHC.Types.Type
       where
-        SFLeaf :: Sing FLeaf
+        SFLeaf :: SFoo FLeaf
         (:%+:) :: forall (n :: Foo) (n :: Foo).
-                  (Sing (n :: Foo)) -> (Sing (n :: Foo)) -> Sing ((:+:) n n)
-    type SFoo = Sing :: Foo -> GHC.Types.Type
+                  (Sing (n :: Foo)) -> (Sing (n :: Foo)) -> SFoo ((:+:) n n)
+    type instance Sing @Foo = SFoo
     instance SingKind Foo where
       type Demote Foo = Foo
       fromSing SFLeaf = FLeaf

--- a/tests/compile-and-dump/Singletons/OrdDeriving.ghc88.template
+++ b/tests/compile-and-dump/Singletons/OrdDeriving.ghc88.template
@@ -455,7 +455,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       toSing (Succ (b :: Demote Nat))
         = case toSing b :: SomeSing Nat of {
             SomeSing c -> SomeSing (SSucc c) }
-    data SFoo :: Foo a b c d -> GHC.Types.Type
+    data SFoo :: forall a b c d. Foo a b c d -> GHC.Types.Type
       where
         SA :: forall a b c d (n :: a) (n :: b) (n :: c) (n :: d).
               (Sing (n :: a))

--- a/tests/compile-and-dump/Singletons/OrdDeriving.ghc88.template
+++ b/tests/compile-and-dump/Singletons/OrdDeriving.ghc88.template
@@ -442,11 +442,11 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       Equals_0123456789876543210 (_ :: Foo a b c d) (_ :: Foo a b c d) = FalseSym0
     instance PEq (Foo a b c d) where
       type (==) a b = Equals_0123456789876543210 a b
-    data instance Sing :: Nat -> GHC.Types.Type
+    data SNat :: Nat -> GHC.Types.Type
       where
-        SZero :: Sing Zero
-        SSucc :: forall (n :: Nat). (Sing (n :: Nat)) -> Sing (Succ n)
-    type SNat = Sing :: Nat -> GHC.Types.Type
+        SZero :: SNat Zero
+        SSucc :: forall (n :: Nat). (Sing (n :: Nat)) -> SNat (Succ n)
+    type instance Sing @Nat = SNat
     instance SingKind Nat where
       type Demote Nat = Nat
       fromSing SZero = Zero
@@ -455,33 +455,33 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       toSing (Succ (b :: Demote Nat))
         = case toSing b :: SomeSing Nat of {
             SomeSing c -> SomeSing (SSucc c) }
-    data instance Sing :: Foo a b c d -> GHC.Types.Type
+    data SFoo :: Foo a b c d -> GHC.Types.Type
       where
         SA :: forall a b c d (n :: a) (n :: b) (n :: c) (n :: d).
               (Sing (n :: a))
               -> (Sing (n :: b))
-                 -> (Sing (n :: c)) -> (Sing (n :: d)) -> Sing (A n n n n)
+                 -> (Sing (n :: c)) -> (Sing (n :: d)) -> SFoo (A n n n n)
         SB :: forall a b c d (n :: a) (n :: b) (n :: c) (n :: d).
               (Sing (n :: a))
               -> (Sing (n :: b))
-                 -> (Sing (n :: c)) -> (Sing (n :: d)) -> Sing (B n n n n)
+                 -> (Sing (n :: c)) -> (Sing (n :: d)) -> SFoo (B n n n n)
         SC :: forall a b c d (n :: a) (n :: b) (n :: c) (n :: d).
               (Sing (n :: a))
               -> (Sing (n :: b))
-                 -> (Sing (n :: c)) -> (Sing (n :: d)) -> Sing (C n n n n)
+                 -> (Sing (n :: c)) -> (Sing (n :: d)) -> SFoo (C n n n n)
         SD :: forall a b c d (n :: a) (n :: b) (n :: c) (n :: d).
               (Sing (n :: a))
               -> (Sing (n :: b))
-                 -> (Sing (n :: c)) -> (Sing (n :: d)) -> Sing (D n n n n)
+                 -> (Sing (n :: c)) -> (Sing (n :: d)) -> SFoo (D n n n n)
         SE :: forall a b c d (n :: a) (n :: b) (n :: c) (n :: d).
               (Sing (n :: a))
               -> (Sing (n :: b))
-                 -> (Sing (n :: c)) -> (Sing (n :: d)) -> Sing (E n n n n)
+                 -> (Sing (n :: c)) -> (Sing (n :: d)) -> SFoo (E n n n n)
         SF :: forall a b c d (n :: a) (n :: b) (n :: c) (n :: d).
               (Sing (n :: a))
               -> (Sing (n :: b))
-                 -> (Sing (n :: c)) -> (Sing (n :: d)) -> Sing (F n n n n)
-    type SFoo = Sing :: Foo a b c d -> GHC.Types.Type
+                 -> (Sing (n :: c)) -> (Sing (n :: d)) -> SFoo (F n n n n)
+    type instance Sing @(Foo a b c d) = SFoo
     instance (SingKind a, SingKind b, SingKind c, SingKind d) =>
              SingKind (Foo a b c d) where
       type Demote (Foo a b c d) = Foo (Demote a) (Demote b) (Demote c) (Demote d)
@@ -868,6 +868,16 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
             Proved Refl -> Proved Refl
             Disproved contra
               -> Disproved (\ refl -> case refl of { Refl -> contra Refl })
+    instance SDecide Nat =>
+             Data.Type.Equality.TestEquality (SNat :: Nat
+                                                      -> GHC.Types.Type) where
+      Data.Type.Equality.testEquality
+        = Data.Singletons.Decide.decideEquality
+    instance SDecide Nat =>
+             Data.Type.Coercion.TestCoercion (SNat :: Nat
+                                                      -> GHC.Types.Type) where
+      Data.Type.Coercion.testCoercion
+        = Data.Singletons.Decide.decideCoercion
     instance (SEq a, SEq b, SEq c, SEq d) => SEq (Foo a b c d) where
       (%==) (SA a a a a) (SA b b b b)
         = ((%&&) (((%==) a) b))
@@ -1033,6 +1043,16 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
               -> Disproved (\ refl -> case refl of { Refl -> contra Refl })
             (,,,) _ _ _ (Disproved contra)
               -> Disproved (\ refl -> case refl of { Refl -> contra Refl })
+    instance (SDecide a, SDecide b, SDecide c, SDecide d) =>
+             Data.Type.Equality.TestEquality (SFoo :: Foo a b c d
+                                                      -> GHC.Types.Type) where
+      Data.Type.Equality.testEquality
+        = Data.Singletons.Decide.decideEquality
+    instance (SDecide a, SDecide b, SDecide c, SDecide d) =>
+             Data.Type.Coercion.TestCoercion (SFoo :: Foo a b c d
+                                                      -> GHC.Types.Type) where
+      Data.Type.Coercion.testCoercion
+        = Data.Singletons.Decide.decideCoercion
     instance SingI Zero where
       sing = SZero
     instance SingI n => SingI (Succ (n :: Nat)) where

--- a/tests/compile-and-dump/Singletons/PatternMatching.ghc88.template
+++ b/tests/compile-and-dump/Singletons/PatternMatching.ghc88.template
@@ -121,7 +121,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
            ((applySing ((singFun2 @PairSym0) SPair))
               ((applySing ((singFun1 @SuccSym0) SSucc)) SZero)))
           ((applySing ((applySing ((singFun2 @(:@#@$)) SCons)) SZero)) SNil)
-    data SPair :: Pair a b -> GHC.Types.Type
+    data SPair :: forall a b. Pair a b -> GHC.Types.Type
       where
         SPair :: forall a b (n :: a) (n :: b).
                  (Sing (n :: a)) -> (Sing (n :: b)) -> SPair (Pair n n)

--- a/tests/compile-and-dump/Singletons/PatternMatching.ghc88.template
+++ b/tests/compile-and-dump/Singletons/PatternMatching.ghc88.template
@@ -121,11 +121,11 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
            ((applySing ((singFun2 @PairSym0) SPair))
               ((applySing ((singFun1 @SuccSym0) SSucc)) SZero)))
           ((applySing ((applySing ((singFun2 @(:@#@$)) SCons)) SZero)) SNil)
-    data instance Sing :: Pair a b -> GHC.Types.Type
+    data SPair :: Pair a b -> GHC.Types.Type
       where
         SPair :: forall a b (n :: a) (n :: b).
-                 (Sing (n :: a)) -> (Sing (n :: b)) -> Sing (Pair n n)
-    type SPair = Sing :: Pair a b -> GHC.Types.Type
+                 (Sing (n :: a)) -> (Sing (n :: b)) -> SPair (Pair n n)
+    type instance Sing @(Pair a b) = SPair
     instance (SingKind a, SingKind b) => SingKind (Pair a b) where
       type Demote (Pair a b) = Pair (Demote a) (Demote b)
       fromSing (SPair b b) = (Pair (fromSing b)) (fromSing b)
@@ -169,9 +169,21 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
                                 (sFromInteger (sing :: Sing 11))))
                             sArg_0123456789876543210))))))
             sA_0123456789876543210
-    deriving instance (Data.Singletons.ShowSing.ShowSing a,
-                       Data.Singletons.ShowSing.ShowSing b) =>
-                      Show (Sing (z :: Pair a b))
+    instance (Data.Singletons.ShowSing.ShowSing a,
+              Data.Singletons.ShowSing.ShowSing b) =>
+             Show (SPair (z :: Pair a b)) where
+      showsPrec
+        p_0123456789876543210
+        (SPair (arg_0123456789876543210 :: Sing argTy_0123456789876543210)
+               (arg_0123456789876543210 :: Sing argTy_0123456789876543210))
+        = (showParen (((>) p_0123456789876543210) 10))
+            (((.) (showString "SPair "))
+               (((.) ((showsPrec 11) arg_0123456789876543210))
+                  (((.) GHC.Show.showSpace)
+                     ((showsPrec 11) arg_0123456789876543210)))) ::
+            (Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210,
+             Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210) =>
+            ShowS
     instance (SingI n, SingI n) => SingI (Pair (n :: a) (n :: b)) where
       sing = (SPair sing) sing
     instance SingI (PairSym0 :: (~>) a ((~>) b (Pair a b))) where

--- a/tests/compile-and-dump/Singletons/Records.ghc88.template
+++ b/tests/compile-and-dump/Singletons/Records.ghc88.template
@@ -49,7 +49,7 @@ Singletons/Records.hs:(0,0)-(0,0): Splicing declarations
                                             arg. SameKind (Apply MkRecordSym0 arg) (MkRecordSym1 arg) =>
                                      MkRecordSym0 t0123456789876543210
     type instance Apply MkRecordSym0 t0123456789876543210 = MkRecordSym1 t0123456789876543210
-    data SRecord :: Record a -> GHC.Types.Type
+    data SRecord :: forall a. Record a -> GHC.Types.Type
       where
         SMkRecord :: forall a (n :: a) (n :: Bool).
                      {sField1 :: (Sing (n :: a)), sField2 :: (Sing (n :: Bool))}

--- a/tests/compile-and-dump/Singletons/Records.ghc88.template
+++ b/tests/compile-and-dump/Singletons/Records.ghc88.template
@@ -49,12 +49,12 @@ Singletons/Records.hs:(0,0)-(0,0): Splicing declarations
                                             arg. SameKind (Apply MkRecordSym0 arg) (MkRecordSym1 arg) =>
                                      MkRecordSym0 t0123456789876543210
     type instance Apply MkRecordSym0 t0123456789876543210 = MkRecordSym1 t0123456789876543210
-    data instance Sing :: Record a -> GHC.Types.Type
+    data SRecord :: Record a -> GHC.Types.Type
       where
         SMkRecord :: forall a (n :: a) (n :: Bool).
                      {sField1 :: (Sing (n :: a)), sField2 :: (Sing (n :: Bool))}
-                     -> Sing (MkRecord n n)
-    type SRecord = Sing :: Record a -> GHC.Types.Type
+                     -> SRecord (MkRecord n n)
+    type instance Sing @(Record a) = SRecord
     instance SingKind a => SingKind (Record a) where
       type Demote (Record a) = Record (Demote a)
       fromSing (SMkRecord b b) = (MkRecord (fromSing b)) (fromSing b)

--- a/tests/compile-and-dump/Singletons/ShowDeriving.ghc88.template
+++ b/tests/compile-and-dump/Singletons/ShowDeriving.ghc88.template
@@ -270,24 +270,23 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     infixl 5 :%&:
     infixl 5 :%*:
     infixl 5 `SMkFoo2b`
-    data instance Sing :: Foo1 -> GHC.Types.Type
-      where SMkFoo1 :: Sing MkFoo1
-    type SFoo1 = Sing :: Foo1 -> GHC.Types.Type
+    data SFoo1 :: Foo1 -> GHC.Types.Type where SMkFoo1 :: SFoo1 MkFoo1
+    type instance Sing @Foo1 = SFoo1
     instance SingKind Foo1 where
       type Demote Foo1 = Foo1
       fromSing SMkFoo1 = MkFoo1
       toSing MkFoo1 = SomeSing SMkFoo1
-    data instance Sing :: Foo2 a -> GHC.Types.Type
+    data SFoo2 :: Foo2 a -> GHC.Types.Type
       where
         SMkFoo2a :: forall a (n :: a) (n :: a).
-                    (Sing (n :: a)) -> (Sing (n :: a)) -> Sing (MkFoo2a n n)
+                    (Sing (n :: a)) -> (Sing (n :: a)) -> SFoo2 (MkFoo2a n n)
         SMkFoo2b :: forall a (n :: a) (n :: a).
-                    (Sing (n :: a)) -> (Sing (n :: a)) -> Sing (MkFoo2b n n)
+                    (Sing (n :: a)) -> (Sing (n :: a)) -> SFoo2 (MkFoo2b n n)
         (:%*:) :: forall a (n :: a) (n :: a).
-                  (Sing (n :: a)) -> (Sing (n :: a)) -> Sing ((:*:) n n)
+                  (Sing (n :: a)) -> (Sing (n :: a)) -> SFoo2 ((:*:) n n)
         (:%&:) :: forall a (n :: a) (n :: a).
-                  (Sing (n :: a)) -> (Sing (n :: a)) -> Sing ((:&:) n n)
-    type SFoo2 = Sing :: Foo2 a -> GHC.Types.Type
+                  (Sing (n :: a)) -> (Sing (n :: a)) -> SFoo2 ((:&:) n n)
+    type instance Sing @(Foo2 a) = SFoo2
     instance SingKind a => SingKind (Foo2 a) where
       type Demote (Foo2 a) = Foo2 (Demote a)
       fromSing (SMkFoo2a b b) = (MkFoo2a (fromSing b)) (fromSing b)
@@ -306,12 +305,12 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
       toSing ((:&:) (b :: Demote a) (b :: Demote a))
         = case ((,) (toSing b :: SomeSing a)) (toSing b :: SomeSing a) of {
             (,) (SomeSing c) (SomeSing c) -> SomeSing (((:%&:) c) c) }
-    data instance Sing :: Foo3 -> GHC.Types.Type
+    data SFoo3 :: Foo3 -> GHC.Types.Type
       where
         SMkFoo3 :: forall (n :: Bool) (n :: Bool).
                    {sGetFoo3a :: (Sing (n :: Bool)), %*** :: (Sing (n :: Bool))}
-                   -> Sing (MkFoo3 n n)
-    type SFoo3 = Sing :: Foo3 -> GHC.Types.Type
+                   -> SFoo3 (MkFoo3 n n)
+    type instance Sing @Foo3 = SFoo3
     instance SingKind Foo3 where
       type Demote Foo3 = Foo3
       fromSing (SMkFoo3 b b) = (MkFoo3 (fromSing b)) (fromSing b)
@@ -507,11 +506,74 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                                      ((applySing ((singFun2 @ShowCharSym0) sShowChar))
                                         (sing :: Sing "}")))))))))))
             sA_0123456789876543210
-    deriving instance Show (Sing (z :: Foo1))
-    deriving instance Data.Singletons.ShowSing.ShowSing a =>
-                      Show (Sing (z :: Foo2 a))
-    deriving instance Data.Singletons.ShowSing.ShowSing Bool =>
-                      Show (Sing (z :: Foo3))
+    instance Show (SFoo1 (z :: Foo1)) where
+      showsPrec _ SMkFoo1 = showString "SMkFoo1"
+    instance Data.Singletons.ShowSing.ShowSing a =>
+             Show (SFoo2 (z :: Foo2 a)) where
+      showsPrec
+        p_0123456789876543210
+        (SMkFoo2a (arg_0123456789876543210 :: Sing argTy_0123456789876543210)
+                  (arg_0123456789876543210 :: Sing argTy_0123456789876543210))
+        = (showParen (((>) p_0123456789876543210) 10))
+            (((.) (showString "SMkFoo2a "))
+               (((.) ((showsPrec 11) arg_0123456789876543210))
+                  (((.) GHC.Show.showSpace)
+                     ((showsPrec 11) arg_0123456789876543210)))) ::
+            (Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210,
+             Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210) =>
+            ShowS
+      showsPrec
+        p_0123456789876543210
+        (SMkFoo2b (argL_0123456789876543210 :: Sing argTyL_0123456789876543210)
+                  (argR_0123456789876543210 :: Sing argTyR_0123456789876543210))
+        = (showParen (((>) p_0123456789876543210) 9))
+            (((.) ((showsPrec 10) argL_0123456789876543210))
+               (((.) (showString " `SMkFoo2b` "))
+                  ((showsPrec 10) argR_0123456789876543210))) ::
+            (Data.Singletons.ShowSing.ShowSing' argTyL_0123456789876543210,
+             Data.Singletons.ShowSing.ShowSing' argTyR_0123456789876543210) =>
+            ShowS
+      showsPrec
+        p_0123456789876543210
+        ((:%*:) (arg_0123456789876543210 :: Sing argTy_0123456789876543210)
+                (arg_0123456789876543210 :: Sing argTy_0123456789876543210))
+        = (showParen (((>) p_0123456789876543210) 10))
+            (((.) (showString "(:%*:) "))
+               (((.) ((showsPrec 11) arg_0123456789876543210))
+                  (((.) GHC.Show.showSpace)
+                     ((showsPrec 11) arg_0123456789876543210)))) ::
+            (Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210,
+             Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210) =>
+            ShowS
+      showsPrec
+        p_0123456789876543210
+        ((:%&:) (argL_0123456789876543210 :: Sing argTyL_0123456789876543210)
+                (argR_0123456789876543210 :: Sing argTyR_0123456789876543210))
+        = (showParen (((>) p_0123456789876543210) 9))
+            (((.) ((showsPrec 10) argL_0123456789876543210))
+               (((.) (showString " :%&: "))
+                  ((showsPrec 10) argR_0123456789876543210))) ::
+            (Data.Singletons.ShowSing.ShowSing' argTyL_0123456789876543210,
+             Data.Singletons.ShowSing.ShowSing' argTyR_0123456789876543210) =>
+            ShowS
+    instance Data.Singletons.ShowSing.ShowSing Bool =>
+             Show (SFoo3 (z :: Foo3)) where
+      showsPrec
+        p_0123456789876543210
+        (SMkFoo3 (arg_0123456789876543210 :: Sing argTy_0123456789876543210)
+                 (arg_0123456789876543210 :: Sing argTy_0123456789876543210))
+        = (showParen (((>) p_0123456789876543210) 10))
+            (((.) (showString "SMkFoo3 "))
+               (((.) (showChar '{'))
+                  (((.) (showString "sGetFoo3a = "))
+                     (((.) ((showsPrec 0) arg_0123456789876543210))
+                        (((.) GHC.Show.showCommaSpace)
+                           (((.) (showString "(%***) = "))
+                              (((.) ((showsPrec 0) arg_0123456789876543210))
+                                 (showChar '}')))))))) ::
+            (Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210,
+             Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210) =>
+            ShowS
     instance SingI MkFoo1 where
       sing = SMkFoo1
     instance (SingI n, SingI n) =>

--- a/tests/compile-and-dump/Singletons/ShowDeriving.ghc88.template
+++ b/tests/compile-and-dump/Singletons/ShowDeriving.ghc88.template
@@ -276,7 +276,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
       type Demote Foo1 = Foo1
       fromSing SMkFoo1 = MkFoo1
       toSing MkFoo1 = SomeSing SMkFoo1
-    data SFoo2 :: Foo2 a -> GHC.Types.Type
+    data SFoo2 :: forall a. Foo2 a -> GHC.Types.Type
       where
         SMkFoo2a :: forall a (n :: a) (n :: a).
                     (Sing (n :: a)) -> (Sing (n :: a)) -> SFoo2 (MkFoo2a n n)

--- a/tests/compile-and-dump/Singletons/StandaloneDeriving.ghc88.template
+++ b/tests/compile-and-dump/Singletons/StandaloneDeriving.ghc88.template
@@ -238,22 +238,22 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance PEq S where
       type (==) a b = Equals_0123456789876543210 a b
     infixl 6 :%*:
-    data instance Sing :: T a b -> GHC.Types.Type
+    data ST :: T a b -> GHC.Types.Type
       where
         (:%*:) :: forall a b (n :: a) (n :: b).
-                  (Sing (n :: a)) -> (Sing (n :: b)) -> Sing ((:*:) n n)
-    type ST = Sing :: T a b -> GHC.Types.Type
+                  (Sing (n :: a)) -> (Sing (n :: b)) -> ST ((:*:) n n)
+    type instance Sing @(T a b) = ST
     instance (SingKind a, SingKind b) => SingKind (T a b) where
       type Demote (T a b) = T (Demote a) (Demote b)
       fromSing ((:%*:) b b) = ((:*:) (fromSing b)) (fromSing b)
       toSing ((:*:) (b :: Demote a) (b :: Demote b))
         = case ((,) (toSing b :: SomeSing a)) (toSing b :: SomeSing b) of {
             (,) (SomeSing c) (SomeSing c) -> SomeSing (((:%*:) c) c) }
-    data instance Sing :: S -> GHC.Types.Type
+    data SS :: S -> GHC.Types.Type
       where
-        SS1 :: Sing S1
-        SS2 :: Sing S2
-    type SS = Sing :: S -> GHC.Types.Type
+        SS1 :: SS S1
+        SS2 :: SS S2
+    type instance Sing @S = SS
     instance SingKind S where
       type Demote S = S
       fromSing SS1 = S1
@@ -417,6 +417,16 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
               -> Disproved (\ refl -> case refl of { Refl -> contra Refl })
             (,) _ (Disproved contra)
               -> Disproved (\ refl -> case refl of { Refl -> contra Refl })
+    instance SDecide a =>
+             Data.Type.Equality.TestEquality (ST :: T a ()
+                                                    -> GHC.Types.Type) where
+      Data.Type.Equality.testEquality
+        = Data.Singletons.Decide.decideEquality
+    instance SDecide a =>
+             Data.Type.Coercion.TestCoercion (ST :: T a ()
+                                                    -> GHC.Types.Type) where
+      Data.Type.Coercion.testCoercion
+        = Data.Singletons.Decide.decideCoercion
     instance SEq S where
       (%==) SS1 SS1 = STrue
       (%==) SS1 SS2 = SFalse
@@ -427,9 +437,30 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
       (%~) SS1 SS2 = Disproved (\ x -> case x of)
       (%~) SS2 SS1 = Disproved (\ x -> case x of)
       (%~) SS2 SS2 = Proved Refl
-    deriving instance Data.Singletons.ShowSing.ShowSing a =>
-                      Show (Sing (z :: T a ()))
-    deriving instance Show (Sing (z :: S))
+    instance Data.Type.Equality.TestEquality (SS :: S
+                                                    -> GHC.Types.Type) where
+      Data.Type.Equality.testEquality
+        = Data.Singletons.Decide.decideEquality
+    instance Data.Type.Coercion.TestCoercion (SS :: S
+                                                    -> GHC.Types.Type) where
+      Data.Type.Coercion.testCoercion
+        = Data.Singletons.Decide.decideCoercion
+    instance Data.Singletons.ShowSing.ShowSing a =>
+             Show (ST (z :: T a ())) where
+      showsPrec
+        p_0123456789876543210
+        ((:%*:) (argL_0123456789876543210 :: Sing argTyL_0123456789876543210)
+                (argR_0123456789876543210 :: Sing argTyR_0123456789876543210))
+        = (showParen (((>) p_0123456789876543210) 9))
+            (((.) ((showsPrec 10) argL_0123456789876543210))
+               (((.) (showString " :%*: "))
+                  ((showsPrec 10) argR_0123456789876543210))) ::
+            (Data.Singletons.ShowSing.ShowSing' argTyL_0123456789876543210,
+             Data.Singletons.ShowSing.ShowSing' argTyR_0123456789876543210) =>
+            ShowS
+    instance Show (SS (z :: S)) where
+      showsPrec _ SS1 = showString "SS1"
+      showsPrec _ SS2 = showString "SS2"
     instance (SingI n, SingI n) =>
              SingI ((:*:) (n :: a) (n :: b)) where
       sing = ((:%*:) sing) sing

--- a/tests/compile-and-dump/Singletons/StandaloneDeriving.ghc88.template
+++ b/tests/compile-and-dump/Singletons/StandaloneDeriving.ghc88.template
@@ -238,7 +238,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance PEq S where
       type (==) a b = Equals_0123456789876543210 a b
     infixl 6 :%*:
-    data ST :: T a b -> GHC.Types.Type
+    data ST :: forall a b. T a b -> GHC.Types.Type
       where
         (:%*:) :: forall a b (n :: a) (n :: b).
                   (Sing (n :: a)) -> (Sing (n :: b)) -> ST ((:*:) n n)

--- a/tests/compile-and-dump/Singletons/Star.ghc88.template
+++ b/tests/compile-and-dump/Singletons/Star.ghc88.template
@@ -139,15 +139,15 @@ Singletons/Star.hs:0:0:: Splicing declarations
     type instance Apply ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
     instance PShow Type where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
-    data instance Sing :: Type -> Type
+    data SRep :: Type -> Type
       where
-        SNat :: Sing Nat
-        SInt :: Sing Int
-        SString :: Sing String
-        SMaybe :: forall (n :: Type). (Sing (n :: Type)) -> Sing (Maybe n)
+        SNat :: SRep Nat
+        SInt :: SRep Int
+        SString :: SRep String
+        SMaybe :: forall (n :: Type). (Sing (n :: Type)) -> SRep (Maybe n)
         SVec :: forall (n :: Type) (n :: Nat).
-                (Sing (n :: Type)) -> (Sing (n :: Nat)) -> Sing (Vec n n)
-    type SRep = Sing :: Type -> Type
+                (Sing (n :: Type)) -> (Sing (n :: Nat)) -> SRep (Vec n n)
+    type instance Sing @Type = SRep
     instance SingKind Type where
       type Demote Type = Rep
       fromSing SNat = Singletons.Star.Nat
@@ -229,6 +229,12 @@ Singletons/Star.hs:0:0:: Splicing declarations
               -> Disproved (\ refl -> case refl of { Refl -> contra Refl })
             (,) _ (Disproved contra)
               -> Disproved (\ refl -> case refl of { Refl -> contra Refl })
+    instance (SDecide Type, SDecide Nat) =>
+             Data.Type.Equality.TestEquality (SRep :: Type -> Type) where
+      Data.Type.Equality.testEquality = decideEquality
+    instance (SDecide Type, SDecide Nat) =>
+             Data.Type.Coercion.TestCoercion (SRep :: Type -> Type) where
+      Data.Type.Coercion.testCoercion = decideCoercion
     instance (SOrd Type, SOrd Nat) => SOrd Type where
       sCompare ::
         forall (t1 :: Type) (t2 :: Type).

--- a/tests/compile-and-dump/Singletons/T159.ghc88.template
+++ b/tests/compile-and-dump/Singletons/T159.ghc88.template
@@ -7,15 +7,15 @@ Singletons/T159.hs:0:0:: Splicing declarations
     type DSym0 = 'D
     type ESym0 = 'E
     type FSym0 = 'F
-    data instance Sing :: T0 -> GHC.Types.Type
+    data ST0 :: T0 -> GHC.Types.Type
       where
-        SA :: Sing 'A
-        SB :: Sing 'B
-        SC :: Sing 'C
-        SD :: Sing 'D
-        SE :: Sing 'E
-        SF :: Sing 'F
-    type ST0 = Sing :: T0 -> GHC.Types.Type
+        SA :: ST0 'A
+        SB :: ST0 'B
+        SC :: ST0 'C
+        SD :: ST0 'D
+        SE :: ST0 'E
+        SF :: ST0 'F
+    type instance Sing @T0 = ST0
     instance SingKind T0 where
       type Demote T0 = T0
       fromSing SA = A
@@ -85,14 +85,14 @@ Singletons/T159.hs:0:0:: Splicing declarations
                          (:&&@#@$) t0123456789876543210
     type instance Apply (:&&@#@$) t0123456789876543210 = (:&&@#@$$) t0123456789876543210
     infixr 5 :&&@#@$
-    data instance Sing :: T1 -> GHC.Types.Type
+    data ST1 :: T1 -> GHC.Types.Type
       where
-        SN1 :: Sing 'N1
+        SN1 :: ST1 'N1
         SC1 :: forall (n :: T0) (n :: T1).
-               (Sing (n :: T0)) -> (Sing (n :: T1)) -> Sing ('C1 n n)
+               (Sing (n :: T0)) -> (Sing (n :: T1)) -> ST1 ('C1 n n)
         (:%&&) :: forall (n :: T0) (n :: T1).
-                  (Sing (n :: T0)) -> (Sing (n :: T1)) -> Sing ('(:&&) n n)
-    type ST1 = Sing :: T1 -> GHC.Types.Type
+                  (Sing (n :: T0)) -> (Sing (n :: T1)) -> ST1 ('(:&&) n n)
+    type instance Sing @T1 = ST1
     instance SingKind T1 where
       type Demote T1 = T1
       fromSing SN1 = N1
@@ -183,14 +183,14 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
     infixr 5 :||@#@$
     infixr 5 :%||
     infixr 5 `SC2`
-    data instance Sing :: T2 -> GHC.Types.Type
+    data ST2 :: T2 -> GHC.Types.Type
       where
-        SN2 :: Sing N2
+        SN2 :: ST2 N2
         SC2 :: forall (n :: T0) (n :: T2).
-               (Sing (n :: T0)) -> (Sing (n :: T2)) -> Sing (C2 n n)
+               (Sing (n :: T0)) -> (Sing (n :: T2)) -> ST2 (C2 n n)
         (:%||) :: forall (n :: T0) (n :: T2).
-                  (Sing (n :: T0)) -> (Sing (n :: T2)) -> Sing ((:||) n n)
-    type ST2 = Sing :: T2 -> GHC.Types.Type
+                  (Sing (n :: T0)) -> (Sing (n :: T2)) -> ST2 ((:||) n n)
+    type instance Sing @T2 = ST2
     instance SingKind T2 where
       type Demote T2 = T2
       fromSing SN2 = N2

--- a/tests/compile-and-dump/Singletons/T163.ghc88.template
+++ b/tests/compile-and-dump/Singletons/T163.ghc88.template
@@ -24,7 +24,7 @@ Singletons/T163.hs:0:0:: Splicing declarations
                                      arg. SameKind (Apply RSym0 arg) (RSym1 arg) =>
                               RSym0 t0123456789876543210
     type instance Apply RSym0 t0123456789876543210 = R t0123456789876543210
-    data (%+) :: (+) a b -> GHC.Types.Type
+    data (%+) :: forall a b. (+) a b -> GHC.Types.Type
       where
         SL :: forall a (n :: a). (Sing (n :: a)) -> (%+) (L n)
         SR :: forall b (n :: b). (Sing (n :: b)) -> (%+) (R n)

--- a/tests/compile-and-dump/Singletons/T163.ghc88.template
+++ b/tests/compile-and-dump/Singletons/T163.ghc88.template
@@ -24,11 +24,11 @@ Singletons/T163.hs:0:0:: Splicing declarations
                                      arg. SameKind (Apply RSym0 arg) (RSym1 arg) =>
                               RSym0 t0123456789876543210
     type instance Apply RSym0 t0123456789876543210 = R t0123456789876543210
-    data instance Sing :: (+) a b -> GHC.Types.Type
+    data (%+) :: (+) a b -> GHC.Types.Type
       where
-        SL :: forall a (n :: a). (Sing (n :: a)) -> Sing (L n)
-        SR :: forall b (n :: b). (Sing (n :: b)) -> Sing (R n)
-    type (%+) = Sing :: (+) a b -> GHC.Types.Type
+        SL :: forall a (n :: a). (Sing (n :: a)) -> (%+) (L n)
+        SR :: forall b (n :: b). (Sing (n :: b)) -> (%+) (R n)
+    type instance Sing @((+) a b) = (%+)
     instance (SingKind a, SingKind b) => SingKind ((+) a b) where
       type Demote ((+) a b) = (+) (Demote a) (Demote b)
       fromSing (SL b) = L (fromSing b)

--- a/tests/compile-and-dump/Singletons/T178.ghc88.template
+++ b/tests/compile-and-dump/Singletons/T178.ghc88.template
@@ -101,12 +101,12 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
       type (==) a b = Equals_0123456789876543210 a b
     sEmpty :: Sing (EmptySym0 :: [(Symbol, Occ)])
     sEmpty = Data.Singletons.Prelude.Instances.SNil
-    data instance Sing :: Occ -> GHC.Types.Type
+    data SOcc :: Occ -> GHC.Types.Type
       where
-        SStr :: Sing Str
-        SOpt :: Sing Opt
-        SMany :: Sing Many
-    type SOcc = Sing :: Occ -> GHC.Types.Type
+        SStr :: SOcc Str
+        SOpt :: SOcc Opt
+        SMany :: SOcc Many
+    type instance Sing @Occ = SOcc
     instance SingKind Occ where
       type Demote Occ = Occ
       fromSing SStr = Str
@@ -201,7 +201,18 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
       (%~) SMany SStr = Disproved (\ x -> case x of)
       (%~) SMany SOpt = Disproved (\ x -> case x of)
       (%~) SMany SMany = Proved Refl
-    deriving instance Show (Sing (z :: Occ))
+    instance Data.Type.Equality.TestEquality (SOcc :: Occ
+                                                      -> GHC.Types.Type) where
+      Data.Type.Equality.testEquality
+        = Data.Singletons.Decide.decideEquality
+    instance Data.Type.Coercion.TestCoercion (SOcc :: Occ
+                                                      -> GHC.Types.Type) where
+      Data.Type.Coercion.testCoercion
+        = Data.Singletons.Decide.decideCoercion
+    instance Show (SOcc (z :: Occ)) where
+      showsPrec _ SStr = showString "SStr"
+      showsPrec _ SOpt = showString "SOpt"
+      showsPrec _ SMany = showString "SMany"
     instance SingI Str where
       sing = SStr
     instance SingI Opt where

--- a/tests/compile-and-dump/Singletons/T187.ghc88.template
+++ b/tests/compile-and-dump/Singletons/T187.ghc88.template
@@ -37,8 +37,8 @@ Singletons/T187.hs:(0,0)-(0,0): Splicing declarations
       Equals_0123456789876543210 (_ :: Empty) (_ :: Empty) = TrueSym0
     instance PEq Empty where
       type (==) a b = Equals_0123456789876543210 a b
-    data instance Sing :: Empty -> GHC.Types.Type
-    type SEmpty = Sing :: Empty -> GHC.Types.Type
+    data SEmpty :: Empty -> GHC.Types.Type
+    type instance Sing @Empty = SEmpty
     instance SingKind Empty where
       type Demote Empty = Empty
       fromSing x = case x of
@@ -55,3 +55,11 @@ Singletons/T187.hs:(0,0)-(0,0): Splicing declarations
       (%==) _ _ = STrue
     instance SDecide Empty where
       (%~) x _ = Proved (case x of)
+    instance Data.Type.Equality.TestEquality (SEmpty :: Empty
+                                                        -> GHC.Types.Type) where
+      Data.Type.Equality.testEquality
+        = Data.Singletons.Decide.decideEquality
+    instance Data.Type.Coercion.TestCoercion (SEmpty :: Empty
+                                                        -> GHC.Types.Type) where
+      Data.Type.Coercion.testCoercion
+        = Data.Singletons.Decide.decideCoercion

--- a/tests/compile-and-dump/Singletons/T190.ghc88.template
+++ b/tests/compile-and-dump/Singletons/T190.ghc88.template
@@ -117,8 +117,8 @@ Singletons/T190.hs:0:0:: Splicing declarations
       Equals_0123456789876543210 (_ :: T) (_ :: T) = FalseSym0
     instance PEq T where
       type (==) a b = Equals_0123456789876543210 a b
-    data instance Sing :: T -> GHC.Types.Type where ST :: Sing T
-    type ST = Sing :: T -> GHC.Types.Type
+    data ST :: T -> GHC.Types.Type where ST :: ST T
+    type instance Sing @T = ST
     instance SingKind T where
       type Demote T = T
       fromSing ST = T
@@ -184,6 +184,15 @@ Singletons/T190.hs:0:0:: Splicing declarations
       (%==) ST ST = STrue
     instance SDecide T where
       (%~) ST ST = Proved Refl
-    deriving instance Show (Sing (z :: T))
+    instance Data.Type.Equality.TestEquality (ST :: T
+                                                    -> GHC.Types.Type) where
+      Data.Type.Equality.testEquality
+        = Data.Singletons.Decide.decideEquality
+    instance Data.Type.Coercion.TestCoercion (ST :: T
+                                                    -> GHC.Types.Type) where
+      Data.Type.Coercion.testCoercion
+        = Data.Singletons.Decide.decideCoercion
+    instance Show (ST (z :: T)) where
+      showsPrec _ ST = showString "ST"
     instance SingI T where
       sing = ST

--- a/tests/compile-and-dump/Singletons/T197b.ghc88.template
+++ b/tests/compile-and-dump/Singletons/T197b.ghc88.template
@@ -56,22 +56,22 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
     infixr 9 `MkPairSym0`
     infixr 9 `SMkPair`
     infixr 9 `SPair`
-    data instance Sing :: (:*:) a b -> GHC.Types.Type
+    data (%:*:) :: (:*:) a b -> GHC.Types.Type
       where
         (:%*:) :: forall a b (n :: a) (n :: b).
-                  (Sing (n :: a)) -> (Sing (n :: b)) -> Sing ((:*:) n n)
-    type (%:*:) = Sing :: (:*:) a b -> GHC.Types.Type
+                  (Sing (n :: a)) -> (Sing (n :: b)) -> (%:*:) ((:*:) n n)
+    type instance Sing @((:*:) a b) = (%:*:)
     instance (SingKind a, SingKind b) => SingKind ((:*:) a b) where
       type Demote ((:*:) a b) = (:*:) (Demote a) (Demote b)
       fromSing ((:%*:) b b) = ((:*:) (fromSing b)) (fromSing b)
       toSing ((:*:) (b :: Demote a) (b :: Demote b))
         = case ((,) (toSing b :: SomeSing a)) (toSing b :: SomeSing b) of {
             (,) (SomeSing c) (SomeSing c) -> SomeSing (((:%*:) c) c) }
-    data instance Sing :: Pair a b -> GHC.Types.Type
+    data SPair :: Pair a b -> GHC.Types.Type
       where
         SMkPair :: forall a b (n :: a) (n :: b).
-                   (Sing (n :: a)) -> (Sing (n :: b)) -> Sing (MkPair n n)
-    type SPair = Sing :: Pair a b -> GHC.Types.Type
+                   (Sing (n :: a)) -> (Sing (n :: b)) -> SPair (MkPair n n)
+    type instance Sing @(Pair a b) = SPair
     instance (SingKind a, SingKind b) => SingKind (Pair a b) where
       type Demote (Pair a b) = Pair (Demote a) (Demote b)
       fromSing (SMkPair b b) = (MkPair (fromSing b)) (fromSing b)

--- a/tests/compile-and-dump/Singletons/T197b.ghc88.template
+++ b/tests/compile-and-dump/Singletons/T197b.ghc88.template
@@ -56,7 +56,7 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
     infixr 9 `MkPairSym0`
     infixr 9 `SMkPair`
     infixr 9 `SPair`
-    data (%:*:) :: (:*:) a b -> GHC.Types.Type
+    data (%:*:) :: forall a b. (:*:) a b -> GHC.Types.Type
       where
         (:%*:) :: forall a b (n :: a) (n :: b).
                   (Sing (n :: a)) -> (Sing (n :: b)) -> (%:*:) ((:*:) n n)
@@ -67,7 +67,7 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
       toSing ((:*:) (b :: Demote a) (b :: Demote b))
         = case ((,) (toSing b :: SomeSing a)) (toSing b :: SomeSing b) of {
             (,) (SomeSing c) (SomeSing c) -> SomeSing (((:%*:) c) c) }
-    data SPair :: Pair a b -> GHC.Types.Type
+    data SPair :: forall a b. Pair a b -> GHC.Types.Type
       where
         SMkPair :: forall a b (n :: a) (n :: b).
                    (Sing (n :: a)) -> (Sing (n :: b)) -> SPair (MkPair n n)

--- a/tests/compile-and-dump/Singletons/T200.ghc88.template
+++ b/tests/compile-and-dump/Singletons/T200.ghc88.template
@@ -132,16 +132,17 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
              SingI (($$:@#@$$) (d :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage) where
       sing
         = (singFun1 @(($$:@#@$$) (d :: ErrorMessage))) ((%$$:) (sing @d))
-    data instance Sing :: ErrorMessage -> GHC.Types.Type
+    data SErrorMessage :: ErrorMessage -> GHC.Types.Type
       where
         (:%$$:) :: forall (n :: ErrorMessage) (n :: ErrorMessage).
                    (Sing (n :: ErrorMessage))
-                   -> (Sing (n :: ErrorMessage)) -> Sing ((:$$:) n n)
+                   -> (Sing (n :: ErrorMessage)) -> SErrorMessage ((:$$:) n n)
         (:%<>:) :: forall (n :: ErrorMessage) (n :: ErrorMessage).
                    (Sing (n :: ErrorMessage))
-                   -> (Sing (n :: ErrorMessage)) -> Sing ((:<>:) n n)
-        SEM :: forall (n :: [Bool]). (Sing (n :: [Bool])) -> Sing (EM n)
-    type SErrorMessage = Sing :: ErrorMessage -> GHC.Types.Type
+                   -> (Sing (n :: ErrorMessage)) -> SErrorMessage ((:<>:) n n)
+        SEM :: forall (n :: [Bool]).
+               (Sing (n :: [Bool])) -> SErrorMessage (EM n)
+    type instance Sing @ErrorMessage = SErrorMessage
     instance SingKind ErrorMessage where
       type Demote ErrorMessage = ErrorMessage
       fromSing ((:%$$:) b b) = ((:$$:) (fromSing b)) (fromSing b)

--- a/tests/compile-and-dump/Singletons/T209.ghc88.template
+++ b/tests/compile-and-dump/Singletons/T209.ghc88.template
@@ -69,8 +69,8 @@ Singletons/T209.hs:(0,0)-(0,0): Splicing declarations
              SingI (MSym2 (d :: a) (d :: b) :: (~>) Bool Bool) where
       sing
         = (singFun1 @(MSym2 (d :: a) (d :: b))) ((sM (sing @d)) (sing @d))
-    data instance Sing :: Hm -> GHC.Types.Type where SHm :: Sing Hm
-    type SHm = Sing :: Hm -> GHC.Types.Type
+    data SHm :: Hm -> GHC.Types.Type where SHm :: SHm Hm
+    type instance Sing @Hm = SHm
     instance SingKind Hm where
       type Demote Hm = Hm
       fromSing SHm = Hm

--- a/tests/compile-and-dump/Singletons/T249.ghc88.template
+++ b/tests/compile-and-dump/Singletons/T249.ghc88.template
@@ -40,30 +40,30 @@ Singletons/T249.hs:(0,0)-(0,0): Splicing declarations
                                           arg. SameKind (Apply MkFoo3Sym0 arg) (MkFoo3Sym1 arg) =>
                                    MkFoo3Sym0 t0123456789876543210
     type instance Apply MkFoo3Sym0 t0123456789876543210 = MkFoo3 t0123456789876543210
-    data instance Sing :: Foo1 a -> Type
+    data SFoo1 :: Foo1 a -> Type
       where
-        SMkFoo1 :: forall a (n :: a). (Sing (n :: a)) -> Sing (MkFoo1 n)
-    type SFoo1 = Sing :: Foo1 a -> Type
+        SMkFoo1 :: forall a (n :: a). (Sing (n :: a)) -> SFoo1 (MkFoo1 n)
+    type instance Sing @(Foo1 a) = SFoo1
     instance SingKind a => SingKind (Foo1 a) where
       type Demote (Foo1 a) = Foo1 (Demote a)
       fromSing (SMkFoo1 b) = MkFoo1 (fromSing b)
       toSing (MkFoo1 (b :: Demote a))
         = case toSing b :: SomeSing a of {
             SomeSing c -> SomeSing (SMkFoo1 c) }
-    data instance Sing :: Foo2 a -> Type
+    data SFoo2 :: Foo2 a -> Type
       where
-        SMkFoo2 :: forall x (n :: x). (Sing (n :: x)) -> Sing (MkFoo2 n)
-    type SFoo2 = Sing :: Foo2 a -> Type
+        SMkFoo2 :: forall x (n :: x). (Sing (n :: x)) -> SFoo2 (MkFoo2 n)
+    type instance Sing @(Foo2 a) = SFoo2
     instance SingKind a => SingKind (Foo2 a) where
       type Demote (Foo2 a) = Foo2 (Demote a)
       fromSing (SMkFoo2 b) = MkFoo2 (fromSing b)
       toSing (MkFoo2 (b :: Demote x))
         = case toSing b :: SomeSing x of {
             SomeSing c -> SomeSing (SMkFoo2 c) }
-    data instance Sing :: Foo3 a -> Type
+    data SFoo3 :: Foo3 a -> Type
       where
-        SMkFoo3 :: forall x (n :: x). (Sing (n :: x)) -> Sing (MkFoo3 n)
-    type SFoo3 = Sing :: Foo3 a -> Type
+        SMkFoo3 :: forall x (n :: x). (Sing (n :: x)) -> SFoo3 (MkFoo3 n)
+    type instance Sing @(Foo3 a) = SFoo3
     instance SingKind a => SingKind (Foo3 a) where
       type Demote (Foo3 a) = Foo3 (Demote a)
       fromSing (SMkFoo3 b) = MkFoo3 (fromSing b)

--- a/tests/compile-and-dump/Singletons/T249.ghc88.template
+++ b/tests/compile-and-dump/Singletons/T249.ghc88.template
@@ -40,7 +40,7 @@ Singletons/T249.hs:(0,0)-(0,0): Splicing declarations
                                           arg. SameKind (Apply MkFoo3Sym0 arg) (MkFoo3Sym1 arg) =>
                                    MkFoo3Sym0 t0123456789876543210
     type instance Apply MkFoo3Sym0 t0123456789876543210 = MkFoo3 t0123456789876543210
-    data SFoo1 :: Foo1 a -> Type
+    data SFoo1 :: forall a. Foo1 a -> Type
       where
         SMkFoo1 :: forall a (n :: a). (Sing (n :: a)) -> SFoo1 (MkFoo1 n)
     type instance Sing @(Foo1 a) = SFoo1
@@ -50,7 +50,7 @@ Singletons/T249.hs:(0,0)-(0,0): Splicing declarations
       toSing (MkFoo1 (b :: Demote a))
         = case toSing b :: SomeSing a of {
             SomeSing c -> SomeSing (SMkFoo1 c) }
-    data SFoo2 :: Foo2 a -> Type
+    data SFoo2 :: forall a. Foo2 a -> Type
       where
         SMkFoo2 :: forall x (n :: x). (Sing (n :: x)) -> SFoo2 (MkFoo2 n)
     type instance Sing @(Foo2 a) = SFoo2
@@ -60,7 +60,7 @@ Singletons/T249.hs:(0,0)-(0,0): Splicing declarations
       toSing (MkFoo2 (b :: Demote x))
         = case toSing b :: SomeSing x of {
             SomeSing c -> SomeSing (SMkFoo2 c) }
-    data SFoo3 :: Foo3 a -> Type
+    data SFoo3 :: forall a. Foo3 a -> Type
       where
         SMkFoo3 :: forall x (n :: x). (Sing (n :: x)) -> SFoo3 (MkFoo3 n)
     type instance Sing @(Foo3 a) = SFoo3

--- a/tests/compile-and-dump/Singletons/T271.ghc88.template
+++ b/tests/compile-and-dump/Singletons/T271.ghc88.template
@@ -99,7 +99,7 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
       Equals_0123456789876543210 (_ :: Identity a) (_ :: Identity a) = FalseSym0
     instance PEq (Identity a) where
       type (==) a b = Equals_0123456789876543210 a b
-    data SConstant :: Constant a b -> Type
+    data SConstant :: forall a b. Constant a b -> Type
       where
         SConstant :: forall a (n :: a).
                      (Sing (n :: a)) -> SConstant (Constant n)
@@ -110,7 +110,7 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
       toSing (Constant (b :: Demote a))
         = case toSing b :: SomeSing a of {
             SomeSing c -> SomeSing (SConstant c) }
-    data SIdentity :: Identity a -> Type
+    data SIdentity :: forall a. Identity a -> Type
       where
         SIdentity :: forall a (n :: a).
                      (Sing (n :: a)) -> SIdentity (Identity n)

--- a/tests/compile-and-dump/Singletons/T271.ghc88.template
+++ b/tests/compile-and-dump/Singletons/T271.ghc88.template
@@ -99,22 +99,22 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
       Equals_0123456789876543210 (_ :: Identity a) (_ :: Identity a) = FalseSym0
     instance PEq (Identity a) where
       type (==) a b = Equals_0123456789876543210 a b
-    data instance Sing :: Constant a b -> Type
+    data SConstant :: Constant a b -> Type
       where
         SConstant :: forall a (n :: a).
-                     (Sing (n :: a)) -> Sing (Constant n)
-    type SConstant = Sing :: Constant a b -> Type
+                     (Sing (n :: a)) -> SConstant (Constant n)
+    type instance Sing @(Constant a b) = SConstant
     instance (SingKind a, SingKind b) => SingKind (Constant a b) where
       type Demote (Constant a b) = Constant (Demote a) (Demote b)
       fromSing (SConstant b) = Constant (fromSing b)
       toSing (Constant (b :: Demote a))
         = case toSing b :: SomeSing a of {
             SomeSing c -> SomeSing (SConstant c) }
-    data instance Sing :: Identity a -> Type
+    data SIdentity :: Identity a -> Type
       where
         SIdentity :: forall a (n :: a).
-                     (Sing (n :: a)) -> Sing (Identity n)
-    type SIdentity = Sing :: Identity a -> Type
+                     (Sing (n :: a)) -> SIdentity (Identity n)
+    type instance Sing @(Identity a) = SIdentity
     instance SingKind a => SingKind (Identity a) where
       type Demote (Identity a) = Identity (Demote a)
       fromSing (SIdentity b) = Identity (fromSing b)
@@ -177,6 +177,16 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
             Proved Refl -> Proved Refl
             Disproved contra
               -> Disproved (\ refl -> case refl of { Refl -> contra Refl })
+    instance SDecide a =>
+             Data.Type.Equality.TestEquality (SConstant :: Constant a b
+                                                           -> Type) where
+      Data.Type.Equality.testEquality
+        = Data.Singletons.Decide.decideEquality
+    instance SDecide a =>
+             Data.Type.Coercion.TestCoercion (SConstant :: Constant a b
+                                                           -> Type) where
+      Data.Type.Coercion.testCoercion
+        = Data.Singletons.Decide.decideCoercion
     instance SEq a => SEq (Identity a) where
       (%==) (SIdentity a) (SIdentity b) = ((%==) a) b
     instance SDecide a => SDecide (Identity a) where
@@ -185,6 +195,16 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
             Proved Refl -> Proved Refl
             Disproved contra
               -> Disproved (\ refl -> case refl of { Refl -> contra Refl })
+    instance SDecide a =>
+             Data.Type.Equality.TestEquality (SIdentity :: Identity a
+                                                           -> Type) where
+      Data.Type.Equality.testEquality
+        = Data.Singletons.Decide.decideEquality
+    instance SDecide a =>
+             Data.Type.Coercion.TestCoercion (SIdentity :: Identity a
+                                                           -> Type) where
+      Data.Type.Coercion.testCoercion
+        = Data.Singletons.Decide.decideCoercion
     instance SingI n => SingI (Constant (n :: a)) where
       sing = SConstant sing
     instance SingI (ConstantSym0 :: (~>) a (Constant (a :: Type) (b :: Type))) where

--- a/tests/compile-and-dump/Singletons/T297.ghc88.template
+++ b/tests/compile-and-dump/Singletons/T297.ghc88.template
@@ -48,9 +48,9 @@ Singletons/T297.hs:(0,0)-(0,0): Splicing declarations
         in sX
     instance SingI FSym0 where
       sing = (singFun1 @FSym0) sF
-    data instance Sing :: MyProxy a -> Type
-      where SMyProxy :: Sing MyProxy
-    type SMyProxy = Sing :: MyProxy a -> Type
+    data SMyProxy :: MyProxy a -> Type
+      where SMyProxy :: SMyProxy MyProxy
+    type instance Sing @(MyProxy a) = SMyProxy
     instance SingKind a => SingKind (MyProxy a) where
       type Demote (MyProxy a) = MyProxy (Demote a)
       fromSing SMyProxy = MyProxy

--- a/tests/compile-and-dump/Singletons/T297.ghc88.template
+++ b/tests/compile-and-dump/Singletons/T297.ghc88.template
@@ -48,7 +48,7 @@ Singletons/T297.hs:(0,0)-(0,0): Splicing declarations
         in sX
     instance SingI FSym0 where
       sing = (singFun1 @FSym0) sF
-    data SMyProxy :: MyProxy a -> Type
+    data SMyProxy :: forall a. MyProxy a -> Type
       where SMyProxy :: SMyProxy MyProxy
     type instance Sing @(MyProxy a) = SMyProxy
     instance SingKind a => SingKind (MyProxy a) where

--- a/tests/compile-and-dump/Singletons/T332.ghc88.template
+++ b/tests/compile-and-dump/Singletons/T332.ghc88.template
@@ -46,9 +46,8 @@ Singletons/T332.hs:(0,0)-(0,0): Splicing declarations
     sB SMkBar = STuple0
     instance SingI (BSym0 :: (~>) Bar ()) where
       sing = (singFun1 @BSym0) sB
-    data instance Sing :: Bar -> GHC.Types.Type
-      where SMkBar :: Sing MkBar
-    type SBar = Sing :: Bar -> GHC.Types.Type
+    data SBar :: Bar -> GHC.Types.Type where SMkBar :: SBar MkBar
+    type instance Sing @Bar = SBar
     instance SingKind Bar where
       type Demote Bar = Bar
       fromSing SMkBar = MkBar

--- a/tests/compile-and-dump/Singletons/T371.ghc88.template
+++ b/tests/compile-and-dump/Singletons/T371.ghc88.template
@@ -115,11 +115,11 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
     instance PShow (Y a) where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
-    data instance Sing :: X a -> Type
+    data SX :: X a -> Type
       where
-        SX1 :: Sing X1
-        SX2 :: forall a (n :: Y a). (Sing (n :: Y a)) -> Sing (X2 n)
-    type SX = Sing :: X a -> Type
+        SX1 :: SX X1
+        SX2 :: forall a (n :: Y a). (Sing (n :: Y a)) -> SX (X2 n)
+    type instance Sing @(X a) = SX
     instance SingKind a => SingKind (X a) where
       type Demote (X a) = X (Demote a)
       fromSing SX1 = X1
@@ -128,11 +128,11 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
       toSing (X2 (b :: Demote (Y a)))
         = case toSing b :: SomeSing (Y a) of {
             SomeSing c -> SomeSing (SX2 c) }
-    data instance Sing :: Y a -> Type
+    data SY :: Y a -> Type
       where
-        SY1 :: Sing Y1
-        SY2 :: forall a (n :: X a). (Sing (n :: X a)) -> Sing (Y2 n)
-    type SY = Sing :: Y a -> Type
+        SY1 :: SY Y1
+        SY2 :: forall a (n :: X a). (Sing (n :: X a)) -> SY (Y2 n)
+    type instance Sing @(Y a) = SY
     instance SingKind a => SingKind (Y a) where
       type Demote (Y a) = Y (Demote a)
       fromSing SY1 = Y1
@@ -211,10 +211,28 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
                           (Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 11))))
                       sArg_0123456789876543210))))
             sA_0123456789876543210
-    deriving instance Data.Singletons.ShowSing.ShowSing (Y a) =>
-                      Show (Sing (z :: X a))
-    deriving instance Data.Singletons.ShowSing.ShowSing (X a) =>
-                      Show (Sing (z :: Y a))
+    instance Data.Singletons.ShowSing.ShowSing (Y a) =>
+             Show (SX (z :: X a)) where
+      showsPrec _ SX1 = showString "SX1"
+      showsPrec
+        p_0123456789876543210
+        (SX2 (arg_0123456789876543210 :: Sing argTy_0123456789876543210))
+        = (showParen (((>) p_0123456789876543210) 10))
+            (((.) (showString "SX2 "))
+               ((showsPrec 11) arg_0123456789876543210)) ::
+            Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210 =>
+            ShowS
+    instance Data.Singletons.ShowSing.ShowSing (X a) =>
+             Show (SY (z :: Y a)) where
+      showsPrec _ SY1 = showString "SY1"
+      showsPrec
+        p_0123456789876543210
+        (SY2 (arg_0123456789876543210 :: Sing argTy_0123456789876543210))
+        = (showParen (((>) p_0123456789876543210) 10))
+            (((.) (showString "SY2 "))
+               ((showsPrec 11) arg_0123456789876543210)) ::
+            Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210 =>
+            ShowS
     instance SingI X1 where
       sing = SX1
     instance SingI n => SingI (X2 (n :: Y a)) where

--- a/tests/compile-and-dump/Singletons/T371.ghc88.template
+++ b/tests/compile-and-dump/Singletons/T371.ghc88.template
@@ -115,7 +115,7 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
     instance PShow (Y a) where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
-    data SX :: X a -> Type
+    data SX :: forall a. X a -> Type
       where
         SX1 :: SX X1
         SX2 :: forall a (n :: Y a). (Sing (n :: Y a)) -> SX (X2 n)
@@ -128,7 +128,7 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
       toSing (X2 (b :: Demote (Y a)))
         = case toSing b :: SomeSing (Y a) of {
             SomeSing c -> SomeSing (SX2 c) }
-    data SY :: Y a -> Type
+    data SY :: forall a. Y a -> Type
       where
         SY1 :: SY Y1
         SY2 :: forall a (n :: X a). (Sing (n :: X a)) -> SY (Y2 n)

--- a/tests/compile-and-dump/Singletons/TopLevelPatterns.ghc88.template
+++ b/tests/compile-and-dump/Singletons/TopLevelPatterns.ghc88.template
@@ -28,22 +28,22 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
                                        arg. SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
                                 BarSym0 t0123456789876543210
     type instance Apply BarSym0 t0123456789876543210 = BarSym1 t0123456789876543210
-    data instance Sing :: Bool -> GHC.Types.Type
+    data SBool :: Bool -> GHC.Types.Type
       where
-        SFalse :: Sing False
-        STrue :: Sing True
-    type SBool = Sing :: Bool -> GHC.Types.Type
+        SFalse :: SBool False
+        STrue :: SBool True
+    type instance Sing @Bool = SBool
     instance SingKind Bool where
       type Demote Bool = Bool
       fromSing SFalse = False
       fromSing STrue = True
       toSing False = SomeSing SFalse
       toSing True = SomeSing STrue
-    data instance Sing :: Foo -> GHC.Types.Type
+    data SFoo :: Foo -> GHC.Types.Type
       where
         SBar :: forall (n :: Bool) (n :: Bool).
-                (Sing (n :: Bool)) -> (Sing (n :: Bool)) -> Sing (Bar n n)
-    type SFoo = Sing :: Foo -> GHC.Types.Type
+                (Sing (n :: Bool)) -> (Sing (n :: Bool)) -> SFoo (Bar n n)
+    type instance Sing @Foo = SFoo
     instance SingKind Foo where
       type Demote Foo = Foo
       fromSing (SBar b b) = (Bar (fromSing b)) (fromSing b)

--- a/tests/compile-and-dump/Singletons/TopLevelPatterns.hs
+++ b/tests/compile-and-dump/Singletons/TopLevelPatterns.hs
@@ -6,7 +6,7 @@ module Singletons.TopLevelPatterns where
 import Data.Singletons
 import Data.Singletons.Prelude.List
 import Data.Singletons.SuppressUnusedWarnings
-import Data.Singletons.TH hiding (STrue, SFalse, TrueSym0, FalseSym0)
+import Data.Singletons.TH hiding (SBool(..), TrueSym0, FalseSym0)
 
 $(singletons [d|
   data Bool = False | True

--- a/tests/compile-and-dump/Singletons/TypeRepTYPE.hs
+++ b/tests/compile-and-dump/Singletons/TypeRepTYPE.hs
@@ -37,4 +37,4 @@ g tr
   = NothingWordRep
 
 h :: forall (rep :: RuntimeRep) (a :: TYPE rep). Typeable a => Sing a
-h = STypeRep (typeRep @a)
+h = typeRep @a


### PR DESCRIPTION
This fixes #318 by switching `Sing` from a data family to a type family. There are several knock-on changes as a result of this switch—refer to `CHANGES.md` for an overview.