### PR TITLE
Make SomeSing's Enum efficient more efficient and general

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -87,6 +87,9 @@ Changelog for singletons project
   would fail to single.
 * The infix names `(.)` and `(!)` are no longer mapped to `(:.)` and `(:!)`,
   as GHC 8.8 learned to parse them at the type level.
+* The `Enum` instance for `SomeSing` now uses more efficient implementations of
+  `enumFromTo` and `enumFromThenTo` that no longer require a `SingKind`
+  constraint.
 
 2.5.1
 -----


### PR DESCRIPTION
It turns out that we don't need the `Enum` instance for `SomeSing` to have a `SingKind` constraint, as we can get away without needing the use of `fromSing` in the implementations of `enumFromTo` and `enumFromThenTo` if we convert an `SList @a` directly into a list of `SomeSing a`s without recursively invoking `fromSing`. As an added bonus, this will likely make the code more efficient at runtime as well.