### PR TITLE
Really fix ghcjs th conflict

### DIFF
--- a/src/Data/Singletons/Util.hs
+++ b/src/Data/Singletons/Util.hs
@@ -91,11 +91,11 @@ qReportError :: Quasi q => String -> q ()
 qReportError = qReport True
 
 -- | Generate a new Unique
-qNewUnique :: DsMonad q => q Int
+qNewUnique :: DsMonad q => q Uniq
 qNewUnique = do
   Name _ flav <- qNewName "x"
   case flav of
-    NameU n -> return $ fromIntegral n
+    NameU n -> return n
     _       -> error "Internal error: `qNewName` didn't return a NameU"
 
 checkForRep :: Quasi q => [Name] -> q ()
@@ -202,7 +202,7 @@ suffixName ident symb n =
 -- convert a number into both alphanumeric and symoblic forms
 uniquePrefixes :: String   -- alphanumeric prefix
                -> String   -- symbolic prefix
-               -> Int
+               -> Uniq
                -> (String, String)  -- (alphanum, symbolic)
 uniquePrefixes alpha symb n = (alpha ++ n_str, symb ++ convert n_str)
   where


### PR DESCRIPTION
My previous fix in https://github.com/goldfirere/singletons/pull/389
was not complete. Compiling for 32-bit on 64-bit machines means that
we get truncated when the template identifier exceeds 2,147,483,647.
This leads to hitting an error when actually using singletons (as
opposed to just building):

- https://github.com/ghcjs/ghcjs/issues/617

To fix, we need to use Uniq to preserve identifier uniqueness in
template haskell. This allows GHCJS to use its own Uniq type here:

- https://github.com/ghcjs/ghc/commit/f1a393ae03d7310159d27e146197d1fd99242aac

This should have the side effect of also fixing singletons for ghc
8.8.1 now that this has been merged:

- https://gitlab.haskell.org/ghc/ghc/merge_requests/948