### PR TITLE
Don't pick up .ghc.environment files when running tests

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -47,7 +47,7 @@ generateBuildModule flags pkg lbi = do
                 | otherwise           = distPref
       -- Package DBs
       dbStack = withPackageDB lbi ++ [ SpecificPackageDB $ distPref' </> "package.conf.inplace" ]
-      dbFlags = "-hide-all-packages" : packageDbArgsDb dbStack
+      dbFlags = "-hide-all-packages" : "-package-env=-" : packageDbArgsDb dbStack
 
       ghc = case lookupProgram ghcProgram (withPrograms lbi) of
               Just fp -> locationPath $ programLocation fp


### PR DESCRIPTION
As observed in commercialhaskell/stackage#4646, newer versions of `stack` use `.ghc.environment` files in such a way that they are picked up while invoking the test suite, which causes a `Loaded package environment from ...` message to be printed and breaks the expected test output. To avoid this issue, we simply pass `-package-env=-` when shelling out to `ghc` in the test suite so that it never picks up any ambient `.ghc.environment` files.