### PR TITLE
Fix #402

### DIFF
--- a/src/Data/Singletons/Partition.hs
+++ b/src/Data/Singletons/Partition.hs
@@ -116,9 +116,9 @@ partitionDec (DInstanceD _ _ cxt ty decs) = do
     split_app_tys acc (DSigT t _)   = split_app_tys acc t
     split_app_tys _ _ = fail $ "Illegal instance head: " ++ show ty
 partitionDec (DRoleAnnotD {}) = return mempty  -- ignore these
-partitionDec (DTySynD name tvbs _type) =
+partitionDec (DTySynD name tvbs rhs) =
   -- See Note [Partitioning, type synonyms, and type families]
-  pure $ mempty { pd_ty_syn_decs = [TySynDecl name tvbs] }
+  pure $ mempty { pd_ty_syn_decs = [TySynDecl name tvbs rhs] }
 partitionDec (DClosedTypeFamilyD tf_head _) =
   -- See Note [Partitioning, type synonyms, and type families]
   pure $ mempty { pd_closed_type_family_decs = [TypeFamilyDecl tf_head] }

--- a/src/Data/Singletons/Syntax.hs
+++ b/src/Data/Singletons/Syntax.hs
@@ -48,7 +48,7 @@ type SingDSigPaInfos = [(DExp, DType)]
 data DataDecl = DataDecl Name [DTyVarBndr] [DCon]
 
 -- The parts of type synonyms that are relevant to singletons.
-data TySynDecl = TySynDecl Name [DTyVarBndr]
+data TySynDecl = TySynDecl Name [DTyVarBndr] DType
 
 -- The parts of open type families that are relevant to singletons.
 type OpenTypeFamilyDecl = TypeFamilyDecl 'Open

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -117,6 +117,7 @@ tests =
     , compileAndDumpStdTest "T367"
     , compileAndDumpStdTest "T371"
     , compileAndDumpStdTest "T376"
+    , compileAndDumpStdTest "T402"
     ],
     testCompileAndDumpGroup "Promote"
     [ compileAndDumpStdTest "Constructors"

--- a/tests/compile-and-dump/Singletons/T402.ghc88.template
+++ b/tests/compile-and-dump/Singletons/T402.ghc88.template
@@ -1,0 +1,15 @@
+Singletons/T402.hs:0:0:: Splicing declarations
+    singletons [d| type AnyOfKind (k :: Type) = Any :: k |]
+  ======>
+    type AnyOfKind (k :: Type) = Any :: k
+    type AnyOfKindSym1 (k0123456789876543210 :: Type) =
+        AnyOfKind k0123456789876543210
+    instance SuppressUnusedWarnings AnyOfKindSym0 where
+      suppressUnusedWarnings = snd (((,) AnyOfKindSym0KindInference) ())
+    data AnyOfKindSym0 :: forall (k0123456789876543210 :: Type).
+                          (~>) Type k0123456789876543210
+      where
+        AnyOfKindSym0KindInference :: forall k0123456789876543210
+                                             arg. SameKind (Apply AnyOfKindSym0 arg) (AnyOfKindSym1 arg) =>
+                                      AnyOfKindSym0 k0123456789876543210
+    type instance Apply AnyOfKindSym0 k0123456789876543210 = AnyOfKind k0123456789876543210

--- a/tests/compile-and-dump/Singletons/T402.hs
+++ b/tests/compile-and-dump/Singletons/T402.hs
@@ -1,0 +1,7 @@
+module T402 where
+
+import Data.Kind
+import Data.Singletons.TH
+
+type family Any :: k
+$(singletons [d| type AnyOfKind (k :: Type) = Any :: k |])


### PR DESCRIPTION
Have `D.S.Promote.Defun.buildDefunSymsTySynD` make use of an explicit kind annotation on the right-hand side of a type synonym when one is available.