### PR TITLE
Properly reject higher-rank types during promotion/singling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,7 @@ install:
     echo "source-repository-package"                            >> cabal.project
     echo "  type:     git"                                      >> cabal.project
     echo "  location: https://github.com/goldfirere/th-desugar" >> cabal.project
-    echo "  tag:      35cdb6c294651c5b55733cb3348f7722300c92a7" >> cabal.project
+    echo "  tag:      3a1eadc51049bfae66fcb7873428fdb06f3040c3" >> cabal.project
     echo ""                                                     >> cabal.project
     echo "package th-desugar"                                   >> cabal.project
     echo "  tests:      False"                                  >> cabal.project
@@ -146,7 +146,7 @@ script:
     echo "source-repository-package"                            >> cabal.project
     echo "  type:     git"                                      >> cabal.project
     echo "  location: https://github.com/goldfirere/th-desugar" >> cabal.project
-    echo "  tag:      35cdb6c294651c5b55733cb3348f7722300c92a7" >> cabal.project
+    echo "  tag:      3a1eadc51049bfae66fcb7873428fdb06f3040c3" >> cabal.project
     echo ""                                                     >> cabal.project
     echo "package th-desugar"                                   >> cabal.project
     echo "  tests:      False"                                  >> cabal.project

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.3.20190815
+# version: 0.4
 #
 language: c
 dist: xenial
@@ -111,7 +111,7 @@ install:
     echo "source-repository-package"                            >> cabal.project
     echo "  type:     git"                                      >> cabal.project
     echo "  location: https://github.com/goldfirere/th-desugar" >> cabal.project
-    echo "  tag:      d8d00ea8dd19dac3628435cac7a31ab0f214db9b" >> cabal.project
+    echo "  tag:      35cdb6c294651c5b55733cb3348f7722300c92a7" >> cabal.project
     echo ""                                                     >> cabal.project
     echo "package th-desugar"                                   >> cabal.project
     echo "  tests:      False"                                  >> cabal.project
@@ -146,7 +146,7 @@ script:
     echo "source-repository-package"                            >> cabal.project
     echo "  type:     git"                                      >> cabal.project
     echo "  location: https://github.com/goldfirere/th-desugar" >> cabal.project
-    echo "  tag:      d8d00ea8dd19dac3628435cac7a31ab0f214db9b" >> cabal.project
+    echo "  tag:      35cdb6c294651c5b55733cb3348f7722300c92a7" >> cabal.project
     echo ""                                                     >> cabal.project
     echo "package th-desugar"                                   >> cabal.project
     echo "  tests:      False"                                  >> cabal.project

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,14 @@
 Changelog for singletons project
 ================================
 
+next
+----
+* Require GHC 8.10.
+* `singletons` now does a more much thorough job of rejecting higher-rank types
+  during promotion or singling, as they cannot support them. (Previously,
+  `singletons` would sometimes accept them, often changing rank-2 types to
+  rank-1 types incorrectly in the process.)
+
 2.6
 ---
 * Require GHC 8.8.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,9 +5,9 @@ next
 ----
 * Require GHC 8.10.
 * `singletons` now does a more much thorough job of rejecting higher-rank types
-  during promotion or singling, as they cannot support them. (Previously,
-  `singletons` would sometimes accept them, often changing rank-2 types to
-  rank-1 types incorrectly in the process.)
+  during promotion or singling, as `singletons` cannot support them.
+  (Previously, `singletons` would sometimes accept them, often changing rank-2
+  types to rank-1 types incorrectly in the process.)
 
 2.6
 ---

--- a/cabal.project
+++ b/cabal.project
@@ -4,4 +4,4 @@ packages: .
 source-repository-package
   type: git
   location: https://github.com/goldfirere/th-desugar
-  tag: 35cdb6c294651c5b55733cb3348f7722300c92a7
+  tag: 3a1eadc51049bfae66fcb7873428fdb06f3040c3

--- a/cabal.project
+++ b/cabal.project
@@ -4,4 +4,4 @@ packages: .
 source-repository-package
   type: git
   location: https://github.com/goldfirere/th-desugar
-  tag: d8d00ea8dd19dac3628435cac7a31ab0f214db9b
+  tag: 35cdb6c294651c5b55733cb3348f7722300c92a7

--- a/singletons.cabal
+++ b/singletons.cabal
@@ -59,7 +59,7 @@ library
                       ghc-boot-th,
                       template-haskell,
                       containers >= 0.5,
-                      th-desugar >= 1.10 && < 1.11,
+                      th-desugar >= 1.11 && < 1.12,
                       pretty,
                       syb >= 0.4,
                       text >= 1.2,

--- a/src/Data/Singletons/CustomStar.hs
+++ b/src/Data/Singletons/CustomStar.hs
@@ -133,7 +133,8 @@ singletonStar names = do
 
         -- demote a kind back to a type, accumulating any unbound parameters
         kindToType :: DsMonad q => [DTypeArg] -> DKind -> QWithAux [Name] q DType
-        kindToType _    (DForallT _ _ _) = fail "Explicit forall encountered in kind"
+        kindToType _    (DForallT _ _ _)    = fail "Explicit forall encountered in kind"
+        kindToType _    (DConstrainedT _ _) = fail "Explicit constraint encountered in kind"
         kindToType args (DAppT f a) = do
           a' <- kindToType [] a
           kindToType (DTANormal a' : args) f

--- a/src/Data/Singletons/Deriving/Show.hs
+++ b/src/Data/Singletons/Deriving/Show.hs
@@ -241,5 +241,5 @@ mk_Show_arg_pat ForShowSing{} arg arg_ty =
 mk_Show_rhs_sig :: ShowMode -> [Name] -> DExp -> DExp
 mk_Show_rhs_sig ForPromotion  _            e = e
 mk_Show_rhs_sig ForShowSing{} arg_ty_names e =
-  e `DSigE` DForallT [] (map (DAppT (DConT showSing'Name) . DVarT) arg_ty_names)
-                        (DConT showSName)
+  e `DSigE` DConstrainedT (map (DAppT (DConT showSing'Name) . DVarT) arg_ty_names)
+                          (DConT showSName)

--- a/src/Data/Singletons/Deriving/Util.hs
+++ b/src/Data/Singletons/Deriving/Util.hs
@@ -137,14 +137,15 @@ functorLikeTraverse var (FT { ft_triv = caseTrivial, ft_var = caseVar
                                       -- error if we encounter one here.
                                   then pure (caseWrongArg, True)
                                   else tyApp
-                             inspect (DForallT _ _ t) = inspect t
-                             inspect (DSigT t _)      = inspect t
-                             inspect (DAppT t _)      = inspect t
-                             inspect (DAppKindT t _)  = inspect t
-                             inspect (DVarT {})       = tyApp
-                             inspect DArrowT          = tyApp
-                             inspect (DLitT {})       = tyApp
-                             inspect DWildCardT       = tyApp
+                             inspect (DForallT _ _ t)    = inspect t
+                             inspect (DConstrainedT _ t) = inspect t
+                             inspect (DSigT t _)         = inspect t
+                             inspect (DAppT t _)         = inspect t
+                             inspect (DAppKindT t _)     = inspect t
+                             inspect (DVarT {})          = tyApp
+                             inspect DArrowT             = tyApp
+                             inspect (DLitT {})          = tyApp
+                             inspect DWildCardT          = tyApp
 
                          in case unfoldDType f of
                               (f_head, _) -> inspect f_head
@@ -162,11 +163,12 @@ functorLikeTraverse var (FT { ft_triv = caseTrivial, ft_var = caseVar
     go (DVarT v)
       | v == var = pure (caseVar, True)
       | otherwise = trivial
-    go (DForallT tvbs _ t) = do
+    go (DForallT _ tvbs t) = do
       (tr, tc) <- go t
       if var `notElem` map extractTvbName tvbs && tc
          then pure (caseForAll tvbs tr, True)
          else trivial
+    go (DConstrainedT _ t) =  go t
     go (DConT {}) = trivial
     go DArrowT    = trivial
     go (DLitT {}) = trivial

--- a/src/Data/Singletons/Names.hs
+++ b/src/Data/Singletons/Names.hs
@@ -320,7 +320,9 @@ splitUnderscores s = case span (== '_') s of
 modifyConNameDType :: (Name -> Name) -> DType -> DType
 modifyConNameDType mod_con_name = go
   where
-    go (DForallT tvbs cxt p) = DForallT tvbs (map go cxt) (go p)
+    go :: DType -> DType
+    go (DForallT fvf tvbs p) = DForallT fvf tvbs (go p)
+    go (DConstrainedT cxt p) = DConstrainedT (map go cxt) (go p)
     go (DAppT     p t)       = DAppT     (go p) t
     go (DAppKindT p k)       = DAppKindT (go p) k
     go (DSigT     p k)       = DSigT     (go p) k

--- a/src/Data/Singletons/Promote/Type.hs
+++ b/src/Data/Singletons/Promote/Type.hs
@@ -7,26 +7,37 @@ This file implements promotion of types into kinds.
 -}
 
 module Data.Singletons.Promote.Type
-  ( promoteType, promoteTypeArg, promoteUnraveled
+  ( promoteType, promoteType_NC
+  , promoteTypeArg_NC, promoteUnraveled
   ) where
 
 import Language.Haskell.TH.Desugar
 import Data.Singletons.Names
+import Data.Singletons.Util
 import Language.Haskell.TH
 
--- the only monadic thing we do here is fail. This allows the function
--- to be used from the Singletons module
+-- Promote a DType to the kind level.
+--
+-- NB: the only monadic thing we do here is fail. This allows the function
+-- to be used from the Singletons module.
 promoteType :: MonadFail m => DType -> m DKind
-promoteType = go []
+promoteType ty = do
+  checkVanillaDType ty
+  promoteType_NC ty
+
+-- Promote a DType to the kind level. This is suffixed with "_NC" because
+-- we do not invoke checkVanillaDType here.
+-- See [Vanilla-type validity checking during promotion].
+promoteType_NC :: MonadFail m => DType -> m DKind
+promoteType_NC = go []
   where
     go :: MonadFail m => [DTypeArg] -> DType -> m DKind
+    go []       (DForallT _fvf _tvbs ty) = go [] ty
     -- We don't need to worry about constraints: they are used to express
     -- static guarantees at runtime. But, because we don't need to do
     -- anything special to keep static guarantees at compile time, we don't
     -- need to promote them.
-    go []       (DForallT _tvbs _cxt ty) = go [] ty
-    go []       (DAppT (DAppT DArrowT (DForallT (_:_) _ _)) _) =
-      fail "Cannot promote types of rank above 1."
+    go []       (DConstrainedT _cxt ty) = go [] ty
     go args     (DAppT t1 t2) = do
       k2 <- go [] t2
       go (DTANormal k2 : args) t1
@@ -60,14 +71,49 @@ promoteType = go []
                             "headed by: " ++ show hd ++ "\n" ++
                             "applied to: " ++ show args
 
-promoteTypeArg :: MonadFail m => DTypeArg -> m DTypeArg
-promoteTypeArg (DTANormal t) = DTANormal <$> promoteType t
-promoteTypeArg ta@(DTyArg _) = pure ta -- Kinds are already promoted
+-- | Promote a DTypeArg to the kind level. This is suffixed with "_NC" because
+-- we do not invoke checkVanillaDType here.
+-- See [Vanilla-type validity checking during promotion].
+promoteTypeArg_NC :: MonadFail m => DTypeArg -> m DTypeArg
+promoteTypeArg_NC (DTANormal t) = DTANormal <$> promoteType_NC t
+promoteTypeArg_NC ta@(DTyArg _) = pure ta -- Kinds are already promoted
 
+-- | Promote a DType to the kind level, splitting it into its argument and
+-- result types in the process.
 promoteUnraveled :: MonadFail m => DType -> m ([DKind], DKind)
 promoteUnraveled ty = do
-  arg_kis <- mapM promoteType arg_tys
-  res_ki  <- promoteType res_ty
+  checkVanillaDType ty
+  arg_kis <- mapM promoteType_NC arg_tys
+  res_ki  <- promoteType_NC res_ty
   return (arg_kis, res_ki)
   where
-    (_, _, arg_tys, res_ty) = unravel ty
+    (_, _, arg_tys, res_ty) = unravelVanillaDType ty
+
+{-
+Note [Vanilla-type validity checking during promotion]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+We only support promoting (and singling) vanilla types, where a vanilla
+function type is a type that:
+
+1. Only uses a @forall@ at the top level, if used at all. That is to say, it
+   does not contain any nested or higher-rank @forall@s.
+
+2. Only uses a context (e.g., @c => ...@) at the top level, if used at all,
+   and only after the top-level @forall@ if one is present. That is to say,
+   it does not contain any nested or higher-rank contexts.
+
+3. Contains no visible dependent quantification.
+
+The checkVanillaDType function checks if a type is vanilla. Note that it is
+crucial to call checkVanillaDType on the /entire/ type. For instance, it would
+be incorrect to call unravelVanillaDType and then check each argument type
+individually, since that loses information about which @forall@s/constraints
+are higher-rank.
+
+We make an effort to avoiding calling checkVanillaDType on the same type twice,
+since checkVanillaDType must traverse the entire type. (It would not be
+incorrect to do so, just wasteful.) For this certain, certain functions are
+suffixed with "_NC" (short for "no checking") to indicate that they do not
+invoke checkVanillaDType. These functions are used on types that have already
+been validity-checked.
+-}

--- a/src/Data/Singletons/Promote/Type.hs
+++ b/src/Data/Singletons/Promote/Type.hs
@@ -32,7 +32,9 @@ promoteType_NC :: MonadFail m => DType -> m DKind
 promoteType_NC = go []
   where
     go :: MonadFail m => [DTypeArg] -> DType -> m DKind
-    go []       (DForallT _fvf _tvbs ty) = go [] ty
+    go []       (DForallT fvf tvbs ty) = do
+      ty' <- go [] ty
+      pure $ DForallT fvf tvbs ty'
     -- We don't need to worry about constraints: they are used to express
     -- static guarantees at runtime. But, because we don't need to do
     -- anything special to keep static guarantees at compile time, we don't

--- a/src/Data/Singletons/Single/Data.hs
+++ b/src/Data/Singletons/Single/Data.hs
@@ -66,7 +66,7 @@ singDataD (DataDecl name tvbs ctors) = do
         DTySynInstD $ DTySynEqn Nothing
                                 (DConT singFamilyName `DAppKindT` k)
                                 (DConT singDataName)
-      kindedSingTy = DForallT (map DPlainTV tvbNames) [] $
+      kindedSingTy = DForallT ForallInvis (map DPlainTV tvbNames) $
                      DArrowT `DAppT` k `DAppT` DConT typeKindName
 
   return $ (DDataD Data [] singDataName [] (Just kindedSingTy) ctors' []) :

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -117,6 +117,7 @@ tests =
     , compileAndDumpStdTest "T367"
     , compileAndDumpStdTest "T371"
     , compileAndDumpStdTest "T376"
+    , compileAndDumpStdTest "T401"
     , compileAndDumpStdTest "T402"
     ],
     testCompileAndDumpGroup "Promote"

--- a/tests/compile-and-dump/Singletons/T401.ghc88.template
+++ b/tests/compile-and-dump/Singletons/T401.ghc88.template
@@ -1,0 +1,13 @@
+
+Singletons/T401.hs:0:0: error:
+    `singletons` does not support higher-rank `forall`s
+In the type: (forall a_0 . a_0 -> a_0) -> b_1 -> b_1
+
+  |
+5 | $(singletons [d|
+  |   ^^^^^^^^^^^^^^...
+
+Singletons/T401.hs:0:0: error: Q monad failure
+  |
+5 | $(singletons [d|
+  |   ^^^^^^^^^^^^^^...

--- a/tests/compile-and-dump/Singletons/T401.hs
+++ b/tests/compile-and-dump/Singletons/T401.hs
@@ -1,0 +1,8 @@
+module T401 where
+
+import Data.Singletons.TH
+
+$(singletons [d|
+  f :: (forall a. a -> a) -> b -> b
+  f _ x = x
+  |])


### PR DESCRIPTION
`singletons` can't handle higher-rank types. You might think that these sorts of types would naturally be rejected when promoting or singling them, but that actually turns out not to be the case! (See #401 for examples of higher-rank types that squeeze through the cracks.)

Luckily, the additional machinery that `th-desuguar` adds in goldfirere/th-desugar#125 makes it much easier to detect these. Instead of using `unravelDType` to decompose a function type (which permits all sorts of higher-rank gubbins), we use a restricted version called `unravelVanillaDType`, which throws an error if anything higher-rank is detected. See `Note [Vanilla-type validity checking during promotion]` in `D.S.Promote.Type` for a full explanation of what a "vanilla" type is.

Fixes #401.