### PR TITLE
Refactor internals of promoteMethod

### DIFF
--- a/src/Data/Singletons/Util.hs
+++ b/src/Data/Singletons/Util.hs
@@ -249,6 +249,9 @@ resultSigToMaybeKind (DKindSig k)                = Just k
 resultSigToMaybeKind (DTyVarSig (DPlainTV _))    = Nothing
 resultSigToMaybeKind (DTyVarSig (DKindedTV _ k)) = Just k
 
+maybeKindToResultSig :: Maybe DKind -> DFamilyResultSig
+maybeKindToResultSig = maybe DNoSig DKindSig
+
 -- Reconstruct arrow kind from the list of kinds
 ravel :: [DType] -> DType -> DType
 ravel []    res  = res


### PR DESCRIPTION
`promoteMethod` is unnecessarily complicated. It does a lot of work to construct a type family defintion and defunctionalization symbols for the method's default implementation. However, these definitions were actually computed earlier in the call to `promoteLetDecRHS`, but `promoteMethod` throws them away and recomputes them anyway!

Instead, we can simply reuse the results of `promoteLetDecRHS`, which this patch accomplishes. This also allows the return type of `promoteLetDecRHS` to be simplified slightly, as we no longer need to return a nested tuple of assorted things. Instead, we now have a flat tuple of assorted things :)

This commit is purely an internal refactor—no user-facing changes here.