### PR TITLE
Fix #410

### DIFF
--- a/src/Data/Singletons/CustomStar.hs
+++ b/src/Data/Singletons/CustomStar.hs
@@ -93,7 +93,7 @@ singletonStar names = do
     showInst <- mkShowInstance ForPromotion Nothing (DConT repName) dataDecl
     (pInsts, promDecls) <- promoteM [] $ do promoteDataDec dataDecl
                                             promoteDerivedEqDec dataDeclEqInst
-                                            traverse (promoteInstanceDec mempty)
+                                            traverse (promoteInstanceDec mempty mempty)
                                               [ordInst, showInst]
     singletonDecls <- singDecsM [] $ do decs1 <- singDataD dataDecl
                                         decs2 <- singDerivedEqDecs dataDeclEqInst

--- a/src/Data/Singletons/Prelude/Monad/Zip.hs
+++ b/src/Data/Singletons/Prelude/Monad/Zip.hs
@@ -33,7 +33,6 @@ module Data.Singletons.Prelude.Monad.Zip (
   MunzipSym0, MunzipSym1,
   ) where
 
-import Control.Monad.Zip
 import Data.Functor.Identity
 import Data.Kind
 import Data.Monoid

--- a/src/Data/Singletons/Promote/Defun.hs
+++ b/src/Data/Singletons/Promote/Defun.hs
@@ -67,11 +67,7 @@ buildDefunSymsClosedTypeFamilyD :: DTypeFamilyHead -> PrM [DDec]
 buildDefunSymsClosedTypeFamilyD = buildDefunSymsTypeFamilyHead id id
 
 buildDefunSymsOpenTypeFamilyD :: DTypeFamilyHead -> PrM [DDec]
-buildDefunSymsOpenTypeFamilyD = buildDefunSymsTypeFamilyHead cuskify default_to_star
-  where
-    default_to_star :: Maybe DKind -> Maybe DKind
-    default_to_star Nothing  = Just $ DConT typeKindName
-    default_to_star (Just k) = Just k
+buildDefunSymsOpenTypeFamilyD = buildDefunSymsTypeFamilyHead cuskify (Just . defaultToTypeKind)
 
 buildDefunSymsTypeFamilyHead
   :: (DTyVarBndr -> DTyVarBndr)

--- a/src/Data/Singletons/Single.hs
+++ b/src/Data/Singletons/Single.hs
@@ -279,7 +279,7 @@ singInstance mk_inst inst_name name = do
   let data_decl = DataDecl name dtvbs dcons
   raw_inst <- mk_inst Nothing data_ty data_decl
   (a_inst, decs) <- promoteM [] $
-                    promoteInstanceDec OMap.empty raw_inst
+                    promoteInstanceDec OMap.empty Map.empty raw_inst
   decs' <- singDecsM [] $ (:[]) <$> singInstD a_inst
   return $ decsToTH (decs ++ decs')
 
@@ -313,8 +313,9 @@ singTopLevelDecs locals raw_decls = withLocalDeclarations locals $ do
     promoteDataDecs datas
     (_, letDecEnv) <- promoteLetDecs noPrefix letDecls
     classes' <- mapM promoteClassDec classes
-    let meth_sigs = foldMap (lde_types . cd_lde) classes
-    insts' <- mapM (promoteInstanceDec meth_sigs) insts
+    let meth_sigs    = foldMap (lde_types . cd_lde) classes
+        cls_tvbs_map = Map.fromList $ map (\cd -> (cd_name cd, cd_tvbs cd)) classes
+    insts' <- mapM (promoteInstanceDec meth_sigs cls_tvbs_map) insts
     mapM_ promoteDerivedEqDec derivedEqDecs
     return (letDecEnv, classes', insts')
 

--- a/src/Data/Singletons/Util.hs
+++ b/src/Data/Singletons/Util.hs
@@ -239,6 +239,10 @@ extractTvbName (DKindedTV n _) = n
 tvbToType :: DTyVarBndr -> DType
 tvbToType = DVarT . extractTvbName
 
+defaultToTypeKind :: Maybe DKind -> DKind
+defaultToTypeKind (Just k) = k
+defaultToTypeKind Nothing  = DConT typeKindName
+
 inferMaybeKindTV :: Name -> Maybe DKind -> DTyVarBndr
 inferMaybeKindTV n Nothing =  DPlainTV n
 inferMaybeKindTV n (Just k) = DKindedTV n k

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -120,6 +120,7 @@ tests =
     , compileAndDumpStdTest "T378a"
     , compileAndDumpStdTest "T401"
     , compileAndDumpStdTest "T402"
+    , compileAndDumpStdTest "T410"
     ],
     testCompileAndDumpGroup "Promote"
     [ compileAndDumpStdTest "Constructors"

--- a/tests/compile-and-dump/Singletons/T410.ghc88.template
+++ b/tests/compile-and-dump/Singletons/T410.ghc88.template
@@ -1,0 +1,61 @@
+Singletons/T410.hs:(0,0)-(0,0): Splicing declarations
+    promote
+      [d| class Eq a where
+            equals :: a -> a -> Bool
+          
+          instance Eq () where
+            equals () () = True |]
+  ======>
+    class Eq a where
+      equals :: a -> a -> Bool
+    instance Eq () where
+      equals () () = True
+    type EqualsSym2 (arg0123456789876543210 :: a0123456789876543210) (arg0123456789876543210 :: a0123456789876543210) =
+        Equals arg0123456789876543210 arg0123456789876543210
+    instance Data.Singletons.SuppressUnusedWarnings.SuppressUnusedWarnings (EqualsSym1 arg0123456789876543210) where
+      Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings
+        = snd (((,) EqualsSym1KindInference) ())
+    data EqualsSym1 (arg0123456789876543210 :: a0123456789876543210) :: (~>) a0123456789876543210 Bool
+      where
+        EqualsSym1KindInference :: forall arg0123456789876543210
+                                          arg0123456789876543210
+                                          arg. SameKind (Apply (EqualsSym1 arg0123456789876543210) arg) (EqualsSym2 arg0123456789876543210 arg) =>
+                                   EqualsSym1 arg0123456789876543210 arg0123456789876543210
+    type instance Apply (EqualsSym1 arg0123456789876543210) arg0123456789876543210 = Equals arg0123456789876543210 arg0123456789876543210
+    instance Data.Singletons.SuppressUnusedWarnings.SuppressUnusedWarnings EqualsSym0 where
+      Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings
+        = snd (((,) EqualsSym0KindInference) ())
+    data EqualsSym0 :: forall a0123456789876543210.
+                       (~>) a0123456789876543210 ((~>) a0123456789876543210 Bool)
+      where
+        EqualsSym0KindInference :: forall arg0123456789876543210
+                                          arg. SameKind (Apply EqualsSym0 arg) (EqualsSym1 arg) =>
+                                   EqualsSym0 arg0123456789876543210
+    type instance Apply EqualsSym0 arg0123456789876543210 = EqualsSym1 arg0123456789876543210
+    class PEq (a :: GHC.Types.Type) where
+      type Equals (arg :: a) (arg :: a) :: Bool
+    type family Equals_0123456789876543210 (a :: ()) (a :: ()) :: Bool where
+      Equals_0123456789876543210 '() '() = TrueSym0
+    type Equals_0123456789876543210Sym2 (a0123456789876543210 :: ()) (a0123456789876543210 :: ()) =
+        Equals_0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance Data.Singletons.SuppressUnusedWarnings.SuppressUnusedWarnings (Equals_0123456789876543210Sym1 a0123456789876543210) where
+      Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings
+        = snd (((,) Equals_0123456789876543210Sym1KindInference) ())
+    data Equals_0123456789876543210Sym1 (a0123456789876543210 :: ()) :: (~>) () Bool
+      where
+        Equals_0123456789876543210Sym1KindInference :: forall a0123456789876543210
+                                                              a0123456789876543210
+                                                              arg. SameKind (Apply (Equals_0123456789876543210Sym1 a0123456789876543210) arg) (Equals_0123456789876543210Sym2 a0123456789876543210 arg) =>
+                                                       Equals_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (Equals_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Equals_0123456789876543210 a0123456789876543210 a0123456789876543210
+    instance Data.Singletons.SuppressUnusedWarnings.SuppressUnusedWarnings Equals_0123456789876543210Sym0 where
+      Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings
+        = snd (((,) Equals_0123456789876543210Sym0KindInference) ())
+    data Equals_0123456789876543210Sym0 :: (~>) () ((~>) () Bool)
+      where
+        Equals_0123456789876543210Sym0KindInference :: forall a0123456789876543210
+                                                              arg. SameKind (Apply Equals_0123456789876543210Sym0 arg) (Equals_0123456789876543210Sym1 arg) =>
+                                                       Equals_0123456789876543210Sym0 a0123456789876543210
+    type instance Apply Equals_0123456789876543210Sym0 a0123456789876543210 = Equals_0123456789876543210Sym1 a0123456789876543210
+    instance PEq () where
+      type Equals a a = Apply (Apply Equals_0123456789876543210Sym0 a) a

--- a/tests/compile-and-dump/Singletons/T410.hs
+++ b/tests/compile-and-dump/Singletons/T410.hs
@@ -1,0 +1,12 @@
+module T410 where
+
+import Data.Singletons
+import Data.Singletons.Prelude.Bool
+import Data.Singletons.TH (promote)
+
+$(promote [d|
+  class Eq a where
+    equals :: a -> a -> Bool
+  instance Eq () where
+    equals () () = True
+  |])


### PR DESCRIPTION
The only part of this patch that actually changes the behavior of `singletons` is the new `Map Name [DTyVarBndr]` argument of `promoteInstanceDec`, which maps names of type classes to the type variable binders in their class heads. This map is consulted first when constructing a substitution from class variables to instance types so as to avoid imported classes from shadowing them, as observed in #410.

The rest of this patch simply refactors some of the structure of the related functions `promoteMethod` and `promoteLetDecRHS`, both of which have arguments that are only used in certain code paths depending on what sort of thing is being promoted. To make this clearer, I introduced auxiliary data types `MethodSort` and `LetDecRHSSort` that describe the various code paths.

Fixes #410.