### PR TITLE
Handle type constructors' fixity declarations more carefully

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,15 @@ next
   during promotion or singling, as `singletons` cannot support them.
   (Previously, `singletons` would sometimes accept them, often changing rank-2
   types to rank-1 types incorrectly in the process.)
+* Fix a slew of bugs related to fixity declarations:
+  * Fixity declarations for data types are no longer singled, as fixity
+    declarations do not serve any purpose for singled data type constructors,
+    which always have exactly one argument.
+  * `singletons` now promotes fixity declarations for class names.
+    `genPromotions`/`genSingletons` now also handle fixity declarations for
+    class names correctly.
+  * `singletons` will no longer erroneously try to single fixity declarations
+    for type synonym or type family names.
 
 2.6
 ---

--- a/src/Data/Singletons/Single.hs
+++ b/src/Data/Singletons/Single.hs
@@ -375,10 +375,11 @@ singClassD (ClassDecl { cd_cxt  = cls_cxt
                                             , lde_proms     = promoted_defaults
                                             , lde_bound_kvs = meth_bound_kvs } }) =
   bindContext [foldTypeTvbs (DConT cls_name) cls_tvbs] $ do
+    cls_infix_decl <- singReifiedInfixDecls [cls_name]
     (sing_sigs, _, tyvar_names, cxts, res_kis, singIDefunss)
       <- unzip6 <$> zipWithM (singTySig no_meth_defns meth_sigs meth_bound_kvs)
                              meth_names (map promoteValRhs meth_names)
-    emitDecs $ concat singIDefunss
+    emitDecs $ cls_infix_decl ++ concat singIDefunss
     let default_sigs = catMaybes $
                        zipWith4 mk_default_sig meth_names sing_sigs tyvar_names res_kis
         res_ki_map   = Map.fromList (zip meth_names
@@ -387,7 +388,7 @@ singClassD (ClassDecl { cd_cxt  = cls_cxt
                                                (Map.fromList cxts)
                                                res_ki_map))
                        (OMap.assocs default_defns)
-    fixities' <- traverse (uncurry singInfixDecl) $ OMap.assocs fixities
+    fixities' <- mapMaybeM (uncurry singInfixDecl) $ OMap.assocs fixities
     cls_cxt' <- mapM singPred cls_cxt
     return $ DClassD cls_cxt'
                      (singClassName cls_name)
@@ -539,7 +540,7 @@ singLetDecEnv (LetDecEnv { lde_defns     = defns
   let prom_list = OMap.assocs proms
   (typeSigs, letBinds, tyvarNames, cxts, res_kis, singIDefunss)
     <- unzip6 <$> mapM (uncurry (singTySig defns types bound_kvs)) prom_list
-  infix_decls' <- traverse (uncurry singInfixDecl) $ OMap.assocs infix_decls
+  infix_decls' <- mapMaybeM (uncurry singInfixDecl) $ OMap.assocs infix_decls
   let res_ki_map = Map.fromList [ (name, res_ki) | ((name, _), Just res_ki)
                                                      <- zip prom_list res_kis ]
   bindLets letBinds $ do

--- a/src/Data/Singletons/Single/Data.hs
+++ b/src/Data/Singletons/Single/Data.hs
@@ -29,17 +29,7 @@ singDataD (DataDecl name tvbs ctors) = do
   let tvbNames = map extractTvbName tvbs
   k <- promoteType (foldType (DConT name) (map DVarT tvbNames))
   ctors' <- mapM (singCtor name) ctors
-  ctorFixities <-
-    -- try to reify the fixity declarations for the constructors and then
-    -- singletonize them. In case the reification fails, we default to an
-    -- empty list of singletonized fixity declarations.
-    -- why this works:
-    -- 1. if we're in a call to 'genSingletons', the data type was defined
-    --    earlier and its constructors are in scope, the reification succeeds.
-    -- 2. if we're in a call to 'singletons', the reification will fail, but
-    --    the fixity declaration will get singletonized by itself (not from
-    --    here, look for other invocations of 'singInfixDecl')
-    singFixityDeclarations [ n | DCon _ _ n _ _ <- ctors ]
+  ctorFixities <- singReifiedInfixDecls [ n | DCon _ _ n _ _ <- ctors ]
   -- instance for SingKind
   fromSingClauses     <- mapM mkFromSingClause ctors
   emptyFromSingClause <- mkEmptyFromSingClause

--- a/src/Data/Singletons/Single/Fixity.hs
+++ b/src/Data/Singletons/Single/Fixity.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ScopedTypeVariables #-}
 module Data.Singletons.Single.Fixity where
 
 import Prelude hiding ( exp )
@@ -7,27 +8,128 @@ import Data.Singletons.Util
 import Data.Singletons.Names
 import Language.Haskell.TH.Desugar
 
-singInfixDecl :: DsMonad q => Name -> Fixity -> q DLetDec
+-- Single a fixity declaration.
+singInfixDecl :: forall q. DsMonad q => Name -> Fixity -> q (Maybe DLetDec)
 singInfixDecl name fixity = do
   mb_ns <- reifyNameSpace name
-  pure $ DInfixD fixity
-       $ case mb_ns of
-           Just TcClsName -> singTyConName name
-           Just DataName  -> singDataConName name
-           Just VarName   -> singValName name
-           -- If we can't find the Name for some odd reason,
-           -- fall back to singValName
-           Nothing        -> singValName name
-
-singFixityDeclaration :: DsMonad q => Name -> q [DDec]
-singFixityDeclaration name = do
-  mFixity <- qReifyFixity name
-  case mFixity of
-    Nothing     -> pure []
-    Just fixity -> sequenceA [DLetDec <$> singInfixDecl name fixity]
-
-singFixityDeclarations :: DsMonad q => [Name] -> q [DDec]
-singFixityDeclarations = concatMapM trySingFixityDeclaration
+  case mb_ns of
+    -- If we can't find the Name for some odd reason,
+    -- fall back to singValName
+    Nothing        -> finish $ singValName name
+    Just VarName   -> finish $ singValName name
+    Just DataName  -> finish $ singDataConName name
+    Just TcClsName -> do
+      mb_info <- dsReify name
+      case mb_info of
+        Just (DTyConI DClassD{} _)
+          -> finish $ singTyConName name
+        _ -> pure Nothing
+          -- Don't produce anything for other type constructors (type synonyms,
+          -- type families, data types, etc.).
+          -- See [singletons and fixity declarations], wrinkle 1.
   where
+    finish :: Name -> q (Maybe DLetDec)
+    finish = pure . Just . DInfixD fixity
+
+-- Try producing singled fixity declarations for Names by reifying them
+-- /without/ consulting quoted declarations. If reification fails, recover and
+-- return the empty list.
+-- See [singletons and fixity declarations], wrinkle 2.
+singReifiedInfixDecls :: forall q. DsMonad q => [Name] -> q [DDec]
+singReifiedInfixDecls = mapMaybeM trySingFixityDeclaration
+  where
+    trySingFixityDeclaration :: Name -> q (Maybe DDec)
     trySingFixityDeclaration name =
-      qRecover (return []) (singFixityDeclaration name)
+      qRecover (return Nothing) $ do
+        mFixity <- qReifyFixity name
+        case mFixity of
+          Nothing     -> pure Nothing
+          Just fixity -> fmap (fmap DLetDec) $ singInfixDecl name fixity
+
+{-
+Note [singletons and fixity declarations]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Promoting and singling fixity declarations is surprisingly tricky to get right.
+This Note serves as a place to document the insights learned after getting this
+wrong at various points.
+
+As a general rule, when promoting something with a fixity declaration like this
+one:
+
+  infixl 5 `foo`
+
+singletons will produce promoted and singled versions of them:
+
+  infixl 5 `Foo`
+  infixl 5 `sFoo`
+
+singletons will also produce fixity declarations for its defunctionalization
+symbols (see Note [Fixity declarations for defunctionalization symbols] in
+D.S.Promote.Defun):
+
+  infixl 5 `FooSym0`
+  infixl 5 `FooSym1`
+  ...
+
+-----
+-- Wrinkle 1: When not to promote/single fixity declarations
+-----
+
+Rules are meant to be broken, and the general rule above is no exception. There
+are certain cases where singletons does *not* produce promoted or singled
+versions of fixity declarations:
+
+* During promotion, fixity declarations for data types, type synonyms,
+  type families, data constructors, and infix functions will not receive a
+  promoted counterpart. This is because the promoted versions of these names
+  are the same as the originals, so generating an extra fixity declaration for
+  them would run the risk of having duplicates, which GHC would reject with an
+  error. (See #326 for the drawback to this approach.)
+
+* During singling, the following things will not have their fixity declarations
+  singled:
+
+  - Type synonyms or type families. This is because singletons does not
+    generate singled versions of them in the first place (they only receive
+    defunctionalization symbols).
+
+  - Data types. This is because the singled version of a data type T is
+    always of the form:
+
+      data ST :: forall a_1 ... a_n. T a_1 ... a_n -> Type where ...
+
+    Regardless of how many arguments T has, ST will have exactly one argument.
+    This makes is rather pointless to generate a fixity declaration for it.
+
+-----
+-- Wrinkle 2: Making sure fixity declarations are promoted/singled properly
+-----
+
+There are two situations where singletons must promote/single fixity
+declarations:
+
+1. When quoting code, i.e., with `promote` or `singletons`.
+2. When reifying code, i.e., with `genPromotions` or `genSingletons`.
+
+In the case of (1), singletons stores the quoted fixity declarations in the
+lde_infix field of LetDecEnv. Therefore, it suffices to call
+promoteInfixDecl/singleInfixDecl when processing LetDecEnvs.
+
+In the case of (2), there is no LetDecEnv to use, so we must instead reify
+the fixity declarations and promote/single those. See D.S.Single.Data.singDataD
+(which singles data constructors) for a place that does this—we will use
+singDataD as a running example for the rest of this section.
+
+One complication is that code paths like singDataD are invoked in both (1) and
+(2). This runs the risk that singletons will generate duplicate infix
+declarations for data constructors in situation (1), as it will try to single
+their fixity declarations once when processing them in LetDecEnvs and again
+when reifying them in singDataD.
+
+To avoid this pitfall, when reifying declarations in singDataD we take care
+*not* to consult any quoted declarations when reifying (i.e., we do not use
+reifyWithLocals for functions like it). Therefore, it we are in situation (1),
+then the reification in singDataD will fail (and recover gracefully), so it
+will not produce any singled fixity declarations. Therefore, the only singled
+fixity declarations will be produced by processing LetDecEnvs.
+-}

--- a/src/Data/Singletons/Util.hs
+++ b/src/Data/Singletons/Util.hs
@@ -559,6 +559,16 @@ concatMapM fn list = do
   bss <- mapM fn list
   return $ fold bss
 
+-- like GHC's
+mapMaybeM :: Monad m => (a -> m (Maybe b)) -> [a] -> m [b]
+mapMaybeM _ [] = return []
+mapMaybeM f (x:xs) = do
+  y <- f x
+  ys <- mapMaybeM f xs
+  return $ case y of
+    Nothing -> ys
+    Just z  -> z : ys
+
 -- make a one-element list
 listify :: a -> [a]
 listify = (:[])

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -121,6 +121,7 @@ tests =
     , compileAndDumpStdTest "T401"
     , compileAndDumpStdTest "T402"
     , compileAndDumpStdTest "T410"
+    , compileAndDumpStdTest "T412"
     ],
     testCompileAndDumpGroup "Promote"
     [ compileAndDumpStdTest "Constructors"

--- a/tests/compile-and-dump/Singletons/T197b.ghc88.template
+++ b/tests/compile-and-dump/Singletons/T197b.ghc88.template
@@ -55,7 +55,6 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply MkPairSym0 t0123456789876543210 = MkPairSym1 t0123456789876543210
     infixr 9 `MkPairSym0`
     infixr 9 `SMkPair`
-    infixr 9 `SPair`
     data (%:*:) :: forall a b. (:*:) a b -> GHC.Types.Type
       where
         (:%*:) :: forall a b (n :: a) (n :: b).

--- a/tests/compile-and-dump/Singletons/T412.ghc88.template
+++ b/tests/compile-and-dump/Singletons/T412.ghc88.template
@@ -1,0 +1,208 @@
+Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
+    singletons
+      [d| infixr 5 `D1`, `MkD1`
+          infixl 5 `T1a`, `T1b`
+          infix 5 `C1`
+          
+          class C1 a b
+          type T1a a b = Either a b
+          type family T1b a b where
+            T1b a b = Either a b
+          data D1 a b = MkD1 a b |]
+  ======>
+    infix 5 `C1`
+    class C1 a b
+    infixl 5 `T1a`
+    infixl 5 `T1b`
+    type T1a a b = Either a b
+    type family T1b a b where
+      T1b a b = Either a b
+    infixr 5 `D1`
+    infixr 5 `MkD1`
+    data D1 a b = MkD1 a b
+    type T1aSym2 a0123456789876543210 b0123456789876543210 =
+        T1a a0123456789876543210 b0123456789876543210
+    instance SuppressUnusedWarnings (T1aSym1 a0123456789876543210) where
+      suppressUnusedWarnings = snd (((,) T1aSym1KindInference) ())
+    data T1aSym1 a0123456789876543210 b0123456789876543210
+      where
+        T1aSym1KindInference :: forall a0123456789876543210
+                                       b0123456789876543210
+                                       arg. SameKind (Apply (T1aSym1 a0123456789876543210) arg) (T1aSym2 a0123456789876543210 arg) =>
+                                T1aSym1 a0123456789876543210 b0123456789876543210
+    type instance Apply (T1aSym1 a0123456789876543210) b0123456789876543210 = T1a a0123456789876543210 b0123456789876543210
+    infixl 5 `T1aSym1`
+    instance SuppressUnusedWarnings T1aSym0 where
+      suppressUnusedWarnings = snd (((,) T1aSym0KindInference) ())
+    data T1aSym0 a0123456789876543210
+      where
+        T1aSym0KindInference :: forall a0123456789876543210
+                                       arg. SameKind (Apply T1aSym0 arg) (T1aSym1 arg) =>
+                                T1aSym0 a0123456789876543210
+    type instance Apply T1aSym0 a0123456789876543210 = T1aSym1 a0123456789876543210
+    infixl 5 `T1aSym0`
+    type T1bSym2 a0123456789876543210 b0123456789876543210 =
+        T1b a0123456789876543210 b0123456789876543210
+    instance SuppressUnusedWarnings (T1bSym1 a0123456789876543210) where
+      suppressUnusedWarnings = snd (((,) T1bSym1KindInference) ())
+    data T1bSym1 a0123456789876543210 b0123456789876543210
+      where
+        T1bSym1KindInference :: forall a0123456789876543210
+                                       b0123456789876543210
+                                       arg. SameKind (Apply (T1bSym1 a0123456789876543210) arg) (T1bSym2 a0123456789876543210 arg) =>
+                                T1bSym1 a0123456789876543210 b0123456789876543210
+    type instance Apply (T1bSym1 a0123456789876543210) b0123456789876543210 = T1b a0123456789876543210 b0123456789876543210
+    infixl 5 `T1bSym1`
+    instance SuppressUnusedWarnings T1bSym0 where
+      suppressUnusedWarnings = snd (((,) T1bSym0KindInference) ())
+    data T1bSym0 a0123456789876543210
+      where
+        T1bSym0KindInference :: forall a0123456789876543210
+                                       arg. SameKind (Apply T1bSym0 arg) (T1bSym1 arg) =>
+                                T1bSym0 a0123456789876543210
+    type instance Apply T1bSym0 a0123456789876543210 = T1bSym1 a0123456789876543210
+    infixl 5 `T1bSym0`
+    type MkD1Sym2 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: b0123456789876543210) =
+        MkD1 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (MkD1Sym1 t0123456789876543210) where
+      suppressUnusedWarnings = snd (((,) MkD1Sym1KindInference) ())
+    data MkD1Sym1 (t0123456789876543210 :: a0123456789876543210) :: forall b0123456789876543210.
+                                                                    (~>) b0123456789876543210 (D1 a0123456789876543210 b0123456789876543210)
+      where
+        MkD1Sym1KindInference :: forall t0123456789876543210
+                                        t0123456789876543210
+                                        arg. SameKind (Apply (MkD1Sym1 t0123456789876543210) arg) (MkD1Sym2 t0123456789876543210 arg) =>
+                                 MkD1Sym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (MkD1Sym1 t0123456789876543210) t0123456789876543210 = MkD1 t0123456789876543210 t0123456789876543210
+    infixr 5 `MkD1Sym1`
+    instance SuppressUnusedWarnings MkD1Sym0 where
+      suppressUnusedWarnings = snd (((,) MkD1Sym0KindInference) ())
+    data MkD1Sym0 :: forall a0123456789876543210 b0123456789876543210.
+                     (~>) a0123456789876543210 ((~>) b0123456789876543210 (D1 a0123456789876543210 b0123456789876543210))
+      where
+        MkD1Sym0KindInference :: forall t0123456789876543210
+                                        arg. SameKind (Apply MkD1Sym0 arg) (MkD1Sym1 arg) =>
+                                 MkD1Sym0 t0123456789876543210
+    type instance Apply MkD1Sym0 t0123456789876543210 = MkD1Sym1 t0123456789876543210
+    infixr 5 `MkD1Sym0`
+    infix 5 `PC1`
+    class PC1 (a :: GHC.Types.Type) (b :: GHC.Types.Type)
+    infixr 5 `SMkD1`
+    infix 5 `SC1`
+    data SD1 :: forall a b. D1 a b -> GHC.Types.Type
+      where
+        SMkD1 :: forall a b (n :: a) (n :: b).
+                 (Sing n) -> (Sing n) -> SD1 (MkD1 n n :: D1 a b)
+    type instance Sing @(D1 a b) = SD1
+    instance (SingKind a, SingKind b) => SingKind (D1 a b) where
+      type Demote (D1 a b) = D1 (Demote a) (Demote b)
+      fromSing (SMkD1 b b) = (MkD1 (fromSing b)) (fromSing b)
+      toSing (MkD1 (b :: Demote a) (b :: Demote b))
+        = case ((,) (toSing b :: SomeSing a)) (toSing b :: SomeSing b) of {
+            (,) (SomeSing c) (SomeSing c) -> SomeSing ((SMkD1 c) c) }
+    class SC1 a b
+    instance (SingI n, SingI n) => SingI (MkD1 (n :: a) (n :: b)) where
+      sing = (SMkD1 sing) sing
+    instance SingI (MkD1Sym0 :: (~>) a ((~>) b (D1 a b))) where
+      sing = (singFun2 @MkD1Sym0) SMkD1
+    instance SingI d =>
+             SingI (MkD1Sym1 (d :: a) :: (~>) b (D1 a b)) where
+      sing = (singFun1 @(MkD1Sym1 (d :: a))) (SMkD1 (sing @d))
+Singletons/T412.hs:0:0:: Splicing declarations
+    genSingletons [''C2, ''T2a, ''T2b, ''D2]
+  ======>
+    class PC2 (a :: k) (b :: k)
+    infix 5 `PC2`
+    class SC2 (a :: k) (b :: k)
+    infix 5 `SC2`
+    type T2aSym2 (a0123456789876543210 :: GHC.Types.Type) (b0123456789876543210 :: GHC.Types.Type) =
+        T2a a0123456789876543210 b0123456789876543210
+    instance SuppressUnusedWarnings (T2aSym1 a0123456789876543210) where
+      suppressUnusedWarnings = snd (((,) T2aSym1KindInference) ())
+    data T2aSym1 (a0123456789876543210 :: GHC.Types.Type) b0123456789876543210
+      where
+        T2aSym1KindInference :: forall a0123456789876543210
+                                       b0123456789876543210
+                                       arg. SameKind (Apply (T2aSym1 a0123456789876543210) arg) (T2aSym2 a0123456789876543210 arg) =>
+                                T2aSym1 a0123456789876543210 b0123456789876543210
+    type instance Apply (T2aSym1 a0123456789876543210) b0123456789876543210 = T2a a0123456789876543210 b0123456789876543210
+    infixl 5 `T2aSym1`
+    instance SuppressUnusedWarnings T2aSym0 where
+      suppressUnusedWarnings = snd (((,) T2aSym0KindInference) ())
+    data T2aSym0 a0123456789876543210
+      where
+        T2aSym0KindInference :: forall a0123456789876543210
+                                       arg. SameKind (Apply T2aSym0 arg) (T2aSym1 arg) =>
+                                T2aSym0 a0123456789876543210
+    type instance Apply T2aSym0 a0123456789876543210 = T2aSym1 a0123456789876543210
+    infixl 5 `T2aSym0`
+    type T2bSym2 (a0123456789876543210 :: GHC.Types.Type) (b0123456789876543210 :: GHC.Types.Type) =
+        T2b a0123456789876543210 b0123456789876543210
+    instance SuppressUnusedWarnings (T2bSym1 a0123456789876543210) where
+      suppressUnusedWarnings = snd (((,) T2bSym1KindInference) ())
+    data T2bSym1 (a0123456789876543210 :: GHC.Types.Type) :: (~>) GHC.Types.Type GHC.Types.Type
+      where
+        T2bSym1KindInference :: forall a0123456789876543210
+                                       b0123456789876543210
+                                       arg. SameKind (Apply (T2bSym1 a0123456789876543210) arg) (T2bSym2 a0123456789876543210 arg) =>
+                                T2bSym1 a0123456789876543210 b0123456789876543210
+    type instance Apply (T2bSym1 a0123456789876543210) b0123456789876543210 = T2b a0123456789876543210 b0123456789876543210
+    infixl 5 `T2bSym1`
+    instance SuppressUnusedWarnings T2bSym0 where
+      suppressUnusedWarnings = snd (((,) T2bSym0KindInference) ())
+    data T2bSym0 :: (~>) GHC.Types.Type ((~>) GHC.Types.Type GHC.Types.Type)
+      where
+        T2bSym0KindInference :: forall a0123456789876543210
+                                       arg. SameKind (Apply T2bSym0 arg) (T2bSym1 arg) =>
+                                T2bSym0 a0123456789876543210
+    type instance Apply T2bSym0 a0123456789876543210 = T2bSym1 a0123456789876543210
+    infixl 5 `T2bSym0`
+    type MkD2Sym2 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: b0123456789876543210) =
+        'MkD2 t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (MkD2Sym1 t0123456789876543210) where
+      suppressUnusedWarnings = snd (((,) MkD2Sym1KindInference) ())
+    data MkD2Sym1 (t0123456789876543210 :: a0123456789876543210 :: GHC.Types.Type) :: forall (b0123456789876543210 :: GHC.Types.Type).
+                                                                                      (~>) b0123456789876543210 (D2 (a0123456789876543210 :: GHC.Types.Type) (b0123456789876543210 :: GHC.Types.Type))
+      where
+        MkD2Sym1KindInference :: forall t0123456789876543210
+                                        t0123456789876543210
+                                        arg. SameKind (Apply (MkD2Sym1 t0123456789876543210) arg) (MkD2Sym2 t0123456789876543210 arg) =>
+                                 MkD2Sym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (MkD2Sym1 t0123456789876543210) t0123456789876543210 = 'MkD2 t0123456789876543210 t0123456789876543210
+    infixr 5 `MkD2Sym1`
+    instance SuppressUnusedWarnings MkD2Sym0 where
+      suppressUnusedWarnings = snd (((,) MkD2Sym0KindInference) ())
+    data MkD2Sym0 :: forall (a0123456789876543210 :: GHC.Types.Type)
+                            (b0123456789876543210 :: GHC.Types.Type).
+                     (~>) a0123456789876543210 ((~>) b0123456789876543210 (D2 (a0123456789876543210 :: GHC.Types.Type) (b0123456789876543210 :: GHC.Types.Type)))
+      where
+        MkD2Sym0KindInference :: forall t0123456789876543210
+                                        arg. SameKind (Apply MkD2Sym0 arg) (MkD2Sym1 arg) =>
+                                 MkD2Sym0 t0123456789876543210
+    type instance Apply MkD2Sym0 t0123456789876543210 = MkD2Sym1 t0123456789876543210
+    infixr 5 `MkD2Sym0`
+    data SD2 :: forall a b. D2 a b -> GHC.Types.Type
+      where
+        SMkD2 :: forall (a :: GHC.Types.Type)
+                        (b :: GHC.Types.Type)
+                        (n :: a)
+                        (n :: b).
+                 (Sing n)
+                 -> (Sing n)
+                    -> SD2 ('MkD2 n n :: D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type))
+    type instance Sing @(D2 a b) = SD2
+    instance (SingKind a, SingKind b) => SingKind (D2 a b) where
+      type Demote (D2 a b) = D2 (Demote a) (Demote b)
+      fromSing (SMkD2 b b) = (MkD2 (fromSing b)) (fromSing b)
+      toSing (MkD2 (b :: Demote a) (b :: Demote b))
+        = case ((,) (toSing b :: SomeSing a)) (toSing b :: SomeSing b) of {
+            (,) (SomeSing c) (SomeSing c) -> SomeSing ((SMkD2 c) c) }
+    infixr 5 `SMkD2`
+    instance (SingI n, SingI n) =>
+             SingI ('MkD2 (n :: a) (n :: b)) where
+      sing = (SMkD2 sing) sing
+    instance SingI (MkD2Sym0 :: (~>) a ((~>) b (D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type)))) where
+      sing = (singFun2 @MkD2Sym0) SMkD2
+    instance SingI d =>
+             SingI (MkD2Sym1 (d :: a) :: (~>) b (D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type))) where
+      sing = (singFun1 @(MkD2Sym1 (d :: a))) (SMkD2 (sing @d))

--- a/tests/compile-and-dump/Singletons/T412.hs
+++ b/tests/compile-and-dump/Singletons/T412.hs
@@ -1,0 +1,29 @@
+module T412 where
+
+import Data.Singletons.TH
+
+$(singletons [d|
+  infix 5 `C1`
+  class C1 a b
+
+  infixl 5 `T1a`, `T1b`
+  type T1a a b = Either a b
+  type family T1b a b where
+    T1b a b = Either a b
+
+  infixr 5 `D1`, `MkD1`
+  data D1 a b = MkD1 a b
+  |])
+
+infix 5 `C2`
+class C2 a b
+
+infixl 5 `T2a`, `T2b`
+type T2a a b = Either a b
+type family T2b a b where
+  T2b a b = Either a b
+
+infixr 5 `D2`, `MkD2`
+data D2 a b = MkD2 a b
+
+$(genSingletons [''C2, ''T2a, ''T2b, ''D2])


### PR DESCRIPTION
Issue #412 revealed so many bugs in how `singletons` handles fixity declarations that it drove me to write `Note [singletons and fixity declarations]` to document that various wisdom one needs to handle them correctly:

* `singInfixDecl` now returns a `Maybe`, since the only type constructors that need to be singled are classes. `promoteInfixDecl` now also makes a similar special case when dealing with type constructors.
* The `promoteReifiedInfixDecls`/`singReifiedInfixDecls` functions are now used in the code that promotes/singles classes to ensure that their fixity declarations will be handled even if `genSingletons` is used instead of the `singletons` functions.

Fixes #412.