### PR TITLE
Handle associated types properly in D.S.Promote.Defun

### DIFF
--- a/src/Data/Singletons/Partition.hs
+++ b/src/Data/Singletons/Partition.hs
@@ -99,8 +99,8 @@ partitionDec (DClassD cxt name tvbs fds decs) = do
                                                , cd_name      = name
                                                , cd_tvbs      = tvbs
                                                , cd_fds       = fds
-                                               , cd_lde       = lde }]
-                  , pd_open_type_family_decs = otfs }
+                                               , cd_lde       = lde
+                                               , cd_atfs      = otfs}] }
 partitionDec (DInstanceD _ _ cxt ty decs) = do
   (defns, sigs) <- liftM (bimap catMaybes mconcat) $
                    mapAndUnzipM partitionInstanceDec decs
@@ -312,4 +312,9 @@ Also note that:
 1. Other uses of type synonyms in singled code will be expanded away.
 2. Other uses of type families in singled code are unlikely to work at present
    due to Trac #12564.
+3. We track open type families, closed type families, and associated type
+   families separately, as each form of type family has different kind
+   inference behavior. See defunTopLevelTypeDecls and
+   defunAssociatedTypeFamilies in D.S.Promote.Defun for how these differences
+   manifest.
 -}

--- a/src/Data/Singletons/Promote.hs
+++ b/src/Data/Singletons/Promote.hs
@@ -229,7 +229,7 @@ promoteDecs raw_decls = do
         , pd_closed_type_family_decs = c_tyfams
         , pd_derived_eq_decs         = derived_eq_decs } <- partitionDecs decls
 
-  defunTypeDecls ty_syns c_tyfams o_tyfams
+  defunTopLevelTypeDecls ty_syns c_tyfams o_tyfams
     -- promoteLetDecs returns LetBinds, which we don't need at top level
   _ <- promoteLetDecs noPrefix let_decs
   mapM_ promoteClassDec classes
@@ -289,6 +289,7 @@ promoteClassDec :: UClassDecl
 promoteClassDec decl@(ClassDecl { cd_name = cls_name
                                 , cd_tvbs = tvbs
                                 , cd_fds  = fundeps
+                                , cd_atfs = atfs
                                 , cd_lde  = lde@LetDecEnv
                                     { lde_defns = defaults
                                     , lde_types = meth_sigs
@@ -302,6 +303,7 @@ promoteClassDec decl@(ClassDecl { cd_name = cls_name
     sig_decs <- mapM (uncurry promote_sig) meth_sigs_list
     (default_decs, ann_rhss, prom_rhss)
       <- mapAndUnzip3M (promoteMethod DefaultMethods meth_sigs) defaults_list
+    defunAssociatedTypeFamilies tvbs atfs
 
     infix_decls' <- mapMaybeM (uncurry promoteInfixDecl) $ OMap.assocs infix_decls
     cls_infix_decls <- promoteReifiedInfixDecls $ cls_name:meth_names

--- a/src/Data/Singletons/Single.hs
+++ b/src/Data/Singletons/Single.hs
@@ -309,7 +309,7 @@ singTopLevelDecs locals raw_decls = withLocalDeclarations locals $ do
         , pd_derived_show_decs       = derivedShowDecs } <- partitionDecs decls
 
   ((letDecEnv, classes', insts'), promDecls) <- promoteM locals $ do
-    defunTypeDecls ty_syns c_tyfams o_tyfams
+    defunTopLevelTypeDecls ty_syns c_tyfams o_tyfams
     promoteDataDecs datas
     (_, letDecEnv) <- promoteLetDecs noPrefix letDecls
     classes' <- mapM promoteClassDec classes

--- a/src/Data/Singletons/Syntax.hs
+++ b/src/Data/Singletons/Syntax.hs
@@ -62,12 +62,18 @@ newtype TypeFamilyDecl (info :: FamilyInfo)
 -- Whether a type family is open or closed.
 data FamilyInfo = Open | Closed
 
-data ClassDecl ann = ClassDecl { cd_cxt  :: DCxt
-                               , cd_name :: Name
-                               , cd_tvbs :: [DTyVarBndr]
-                               , cd_fds  :: [FunDep]
-                               , cd_lde  :: LetDecEnv ann
-                               }
+data ClassDecl ann
+  = ClassDecl { cd_cxt  :: DCxt
+              , cd_name :: Name
+              , cd_tvbs :: [DTyVarBndr]
+              , cd_fds  :: [FunDep]
+              , cd_lde  :: LetDecEnv ann
+              , cd_atfs :: [OpenTypeFamilyDecl]
+                  -- Associated type families. Only recorded for
+                  -- defunctionalization purposes.
+                  -- See Note [Partitioning, type synonyms, and type families]
+                  -- in D.S.Partition.
+              }
 
 data InstDecl  ann = InstDecl { id_cxt     :: DCxt
                               , id_name    :: Name

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -122,6 +122,7 @@ tests =
     , compileAndDumpStdTest "T402"
     , compileAndDumpStdTest "T410"
     , compileAndDumpStdTest "T412"
+    , compileAndDumpStdTest "T414"
     ],
     testCompileAndDumpGroup "Promote"
     [ compileAndDumpStdTest "Constructors"

--- a/tests/compile-and-dump/Singletons/T414.ghc88.template
+++ b/tests/compile-and-dump/Singletons/T414.ghc88.template
@@ -1,0 +1,53 @@
+Singletons/T414.hs:(0,0)-(0,0): Splicing declarations
+    singletons
+      [d| class C1 (a :: Bool) where
+            type T1 a b
+          class C2 a where
+            type T2 a b |]
+  ======>
+    class C1 (a :: Bool) where
+      type T1 a b
+    class C2 a where
+      type T2 a b
+    type T1Sym2 (a0123456789876543210 :: Bool) (b0123456789876543210 :: GHC.Types.Type) =
+        T1 a0123456789876543210 b0123456789876543210
+    instance SuppressUnusedWarnings (T1Sym1 a0123456789876543210) where
+      suppressUnusedWarnings = snd (((,) T1Sym1KindInference) ())
+    data T1Sym1 (a0123456789876543210 :: Bool) :: (~>) GHC.Types.Type GHC.Types.Type
+      where
+        T1Sym1KindInference :: forall a0123456789876543210
+                                      b0123456789876543210
+                                      arg. SameKind (Apply (T1Sym1 a0123456789876543210) arg) (T1Sym2 a0123456789876543210 arg) =>
+                               T1Sym1 a0123456789876543210 b0123456789876543210
+    type instance Apply (T1Sym1 a0123456789876543210) b0123456789876543210 = T1 a0123456789876543210 b0123456789876543210
+    instance SuppressUnusedWarnings T1Sym0 where
+      suppressUnusedWarnings = snd (((,) T1Sym0KindInference) ())
+    data T1Sym0 :: (~>) Bool ((~>) GHC.Types.Type GHC.Types.Type)
+      where
+        T1Sym0KindInference :: forall a0123456789876543210
+                                      arg. SameKind (Apply T1Sym0 arg) (T1Sym1 arg) =>
+                               T1Sym0 a0123456789876543210
+    type instance Apply T1Sym0 a0123456789876543210 = T1Sym1 a0123456789876543210
+    class PC1 (a :: Bool)
+    type T2Sym2 a0123456789876543210 b0123456789876543210 =
+        T2 a0123456789876543210 b0123456789876543210
+    instance SuppressUnusedWarnings (T2Sym1 a0123456789876543210) where
+      suppressUnusedWarnings = snd (((,) T2Sym1KindInference) ())
+    data T2Sym1 a0123456789876543210 b0123456789876543210
+      where
+        T2Sym1KindInference :: forall a0123456789876543210
+                                      b0123456789876543210
+                                      arg. SameKind (Apply (T2Sym1 a0123456789876543210) arg) (T2Sym2 a0123456789876543210 arg) =>
+                               T2Sym1 a0123456789876543210 b0123456789876543210
+    type instance Apply (T2Sym1 a0123456789876543210) b0123456789876543210 = T2 a0123456789876543210 b0123456789876543210
+    instance SuppressUnusedWarnings T2Sym0 where
+      suppressUnusedWarnings = snd (((,) T2Sym0KindInference) ())
+    data T2Sym0 a0123456789876543210
+      where
+        T2Sym0KindInference :: forall a0123456789876543210
+                                      arg. SameKind (Apply T2Sym0 arg) (T2Sym1 arg) =>
+                               T2Sym0 a0123456789876543210
+    type instance Apply T2Sym0 a0123456789876543210 = T2Sym1 a0123456789876543210
+    class PC2 a
+    class SC1 (a :: Bool)
+    class SC2 a

--- a/tests/compile-and-dump/Singletons/T414.hs
+++ b/tests/compile-and-dump/Singletons/T414.hs
@@ -1,0 +1,11 @@
+module T414 where
+
+import Data.Singletons.TH
+
+$(singletons [d|
+  class C1 (a :: Bool) where
+    type T1 a b
+
+  class C2 a where
+    type T2 a b
+  |])


### PR DESCRIPTION
Associated type families were going through the same code path as top-level open type families during defunctionalization. But top-level open type families always default any type variable binders without explicit kinds to be of kind `Type`. This approach does not always work for associated type families, leading to the bug observed in #414.

This fixes the issue by partitioning associated type families separately from other open type families in `D.S.Partition` and introducing a new `defunAssociatedTypeFamilies` function in `D.S.Promote.Defun` to handle them. I've also added some more comments in various places to make things a bit clearer.

Fixes #414.