### PR TITLE
Introduce Options and OptionsMonad

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,25 @@ Changelog for singletons project
 2.7
 ---
 * Require GHC 8.10.
+* The Template Haskell machinery now supports fine-grained configuration in
+  the way of an `Options` data type, which lives in the new
+  `Data.Singletons.TH.Options` module. Besides `Options`, this module also
+  contains:
+    * `Options`' record selectors. Currently, these include ways to toggle
+      generating `SingKind` instances and configure how `singletons` generates
+      the names of promoted or singled types. In the future, there may be
+      additional options.
+    * A `defaultOptions` value.
+    * An `mtl`-like `OptionsMonad` class for monads that support carrying
+      `Option`s. This includes `Q`, which uses `defaultOptions` if it is the
+      top of the monad transformer stack.
+    * An `OptionM` monad transformer that turns any `DsMonad` into an
+      `OptionsMonad`.
+    * A `withOptions` function which allows passing `Options` to TH functions
+      (e.g., `promote` or `singletons`). See the `README` for a full example
+      of how to use `withOptions`.
+  Most TH functions are now polymorphic over `OptionsMonad` instead of
+  `DsMonad`.
 * `singletons` now does a much better job of preserving the order of type
   variables when singling the type signatures of top-level functions and data
   constructors. See the `Support for TypeApplications` section of the `README`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,8 @@
 Changelog for singletons project
 ================================
 
-next
-----
+2.7
+---
 * Require GHC 8.10.
 * `singletons` now does a much better job of preserving the order of type
   variables when singling the type signatures of top-level functions and data

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-version=2.6
+version=2.7
 source=src/Data/Singletons.hs src/Data/Singletons/*.hs src/Data/Singletons/Prelude/* src/Data/Singletons/Promote/* src/Data/Singletons/Single/* src/Data/Promotion/* src/Data/Promotion/Prelude/*
 test-suite=tests/SingletonsTestSuite.hs tests/SingletonsTestSuiteUtils.hs
 test-byhand=tests/ByHand.hs tests/ByHandAux.hs

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-singletons 2.6
+singletons 2.7
 ==============
 
 [![Hackage](https://img.shields.io/hackage/v/singletons.svg)](http://hackage.haskell.org/package/singletons)

--- a/README.md
+++ b/README.md
@@ -545,6 +545,23 @@ treatment):
 
    All functions that begin with leading underscores are treated similarly.
 
+If desired, you can pick your own naming conventions by using the
+`Data.Singletons.TH.Options` module. Here is an example of how this module can
+be used to prefix a singled data constructor with `MyS` instead of `S`:
+
+```hs
+import Control.Monad.Trans.Class
+import Data.Singletons.TH
+import Data.Singletons.TH.Options
+import Language.Haskell.TH (Name, mkName, nameBase)
+
+$(let myPrefix :: Name -> Name
+      myPrefix name = mkName ("MyS" ++ nameBase name) in
+
+      withOptions defaultOptions{singledDataConName = myPrefix} $
+      singletons $ lift [d| data T = MkT |])
+```
+
 Supported Haskell constructs
 ----------------------------
 
@@ -780,3 +797,9 @@ Known bugs
     method :: [a]
     method = []
   ```
+* Singling GADTs is likely to fail due to the generated `SingKind` instances
+  not typechecking. (See
+  [#150](https://github.com/goldfirere/singletons/issues/150)).
+  However, one can often work around the issue by suppressing the generation
+  of `SingKind` instances by using custom `Options`. See the `T150` test case
+  for an example.

--- a/singletons.cabal
+++ b/singletons.cabal
@@ -73,6 +73,7 @@ library
                       Data.Singletons.CustomStar
                       Data.Singletons.TypeRepTYPE
                       Data.Singletons.TH
+                      Data.Singletons.TH.Options
                       Data.Singletons.Prelude
                       Data.Singletons.Prelude.Applicative
                       Data.Singletons.Prelude.Base

--- a/singletons.cabal
+++ b/singletons.cabal
@@ -1,5 +1,5 @@
 name:           singletons
-version:        2.6
+version:        2.7
                 -- Remember to bump version in the Makefile as well
 cabal-version:  >= 1.10
 synopsis:       A framework for generating singleton types
@@ -38,7 +38,7 @@ description:
 source-repository this
   type:     git
   location: https://github.com/goldfirere/singletons.git
-  tag:      v2.6
+  tag:      v2.7
 
 source-repository head
   type:     git

--- a/src/Data/Singletons/CustomStar.hs
+++ b/src/Data/Singletons/CustomStar.hs
@@ -37,6 +37,7 @@ import Data.Singletons.Single
 import Data.Singletons.Syntax
 import Data.Singletons.Names
 import Data.Singletons.TH
+import Data.Singletons.TH.Options
 import Control.Monad
 import Data.Maybe
 import Language.Haskell.TH.Desugar
@@ -70,7 +71,7 @@ import Data.Singletons.Prelude.Bool
 -- @Bool@, and @Maybe@, not just promoted data constructors.
 --
 -- Please note that this function is /very/ experimental. Use at your own risk.
-singletonStar :: DsMonad q
+singletonStar :: OptionsMonad q
               => [Name]        -- ^ A list of Template Haskell @Name@s for types
               -> q [Dec]
 singletonStar names = do

--- a/src/Data/Singletons/Partition.hs
+++ b/src/Data/Singletons/Partition.hs
@@ -27,6 +27,7 @@ import Data.Singletons.Deriving.Show
 import Data.Singletons.Deriving.Traversable
 import Data.Singletons.Deriving.Util
 import Data.Singletons.Names
+import Data.Singletons.TH.Options
 import Language.Haskell.TH.Syntax hiding (showName)
 import Language.Haskell.TH.Ppr
 import Language.Haskell.TH.Desugar
@@ -63,10 +64,10 @@ instance Monoid PartitionedDecs where
 
 -- | Split up a @[DDec]@ into its pieces, extracting 'Ord' instances
 -- from deriving clauses
-partitionDecs :: DsMonad m => [DDec] -> m PartitionedDecs
+partitionDecs :: OptionsMonad m => [DDec] -> m PartitionedDecs
 partitionDecs = concatMapM partitionDec
 
-partitionDec :: DsMonad m => DDec -> m PartitionedDecs
+partitionDec :: OptionsMonad m => DDec -> m PartitionedDecs
 partitionDec (DLetDec (DPragmaD {})) = return mempty
 partitionDec (DLetDec letdec) = return $ mempty { pd_let_decs = [letdec] }
 
@@ -194,7 +195,7 @@ partitionInstanceDec _ =
   fail "Only method bodies can be promoted within an instance."
 
 partitionDeriving
-  :: forall m. DsMonad m
+  :: forall m. OptionsMonad m
   => Maybe DDerivStrategy
                 -- ^ The deriving strategy, if present.
   -> DPred      -- ^ The class being derived (e.g., 'Eq'), possibly applied to

--- a/src/Data/Singletons/Promote.hs
+++ b/src/Data/Singletons/Promote.hs
@@ -13,7 +13,7 @@ type level. It is an internal module to the singletons package.
 module Data.Singletons.Promote where
 
 import Language.Haskell.TH hiding ( Q, cxt )
-import Language.Haskell.TH.Syntax ( NameSpace(..), Quasi(..) )
+import Language.Haskell.TH.Syntax ( NameSpace(..), Quasi(..), Uniq )
 import Language.Haskell.TH.Desugar
 import qualified Language.Haskell.TH.Desugar.OMap.Strict as OMap
 import Language.Haskell.TH.Desugar.OMap.Strict (OMap)
@@ -30,6 +30,7 @@ import Data.Singletons.Deriving.Enum
 import Data.Singletons.Deriving.Show
 import Data.Singletons.Deriving.Util
 import Data.Singletons.Partition
+import Data.Singletons.TH.Options
 import Data.Singletons.Util
 import Data.Singletons.Syntax
 import Prelude hiding (exp)
@@ -44,7 +45,7 @@ import qualified GHC.LanguageExtensions.Type as LangExt
 
 -- | Generate promoted definitions from a type that is already defined.
 -- This is generally only useful with classes.
-genPromotions :: DsMonad q => [Name] -> q [Dec]
+genPromotions :: OptionsMonad q => [Name] -> q [Dec]
 genPromotions names = do
   checkForRep names
   infos <- mapM reifyWithLocals names
@@ -53,7 +54,7 @@ genPromotions names = do
   return $ decsToTH ddecs
 
 -- | Promote every declaration given to the type level, retaining the originals.
-promote :: DsMonad q => q [Dec] -> q [Dec]
+promote :: OptionsMonad q => q [Dec] -> q [Dec]
 promote qdec = do
   decls <- qdec
   ddecls <- withLocalDeclarations decls $ dsDecs decls
@@ -63,7 +64,7 @@ promote qdec = do
 -- | Promote each declaration, discarding the originals. Note that a promoted
 -- datatype uses the same definition as an original datatype, so this will
 -- not work with datatypes. Classes, instances, and functions are all fine.
-promoteOnly :: DsMonad q => q [Dec] -> q [Dec]
+promoteOnly :: OptionsMonad q => q [Dec] -> q [Dec]
 promoteOnly qdec = do
   decls  <- qdec
   ddecls <- dsDecs decls
@@ -101,7 +102,7 @@ promoteOnly qdec = do
 -- @MyProxySym0@ will be slightly more general, which means that under rare
 -- circumstances, you may have to provide extra type signatures if you write
 -- code which exploits the dependency in @MyProxy@'s kind.
-genDefunSymbols :: DsMonad q => [Name] -> q [Dec]
+genDefunSymbols :: OptionsMonad q => [Name] -> q [Dec]
 genDefunSymbols names = do
   checkForRep names
   infos <- mapM (dsInfo <=< reifyWithLocals) names
@@ -109,43 +110,43 @@ genDefunSymbols names = do
   return $ decsToTH decs
 
 -- | Produce instances for @(==)@ (type-level equality) from the given types
-promoteEqInstances :: DsMonad q => [Name] -> q [Dec]
+promoteEqInstances :: OptionsMonad q => [Name] -> q [Dec]
 promoteEqInstances = concatMapM promoteEqInstance
 
 -- | Produce instances for 'POrd' from the given types
-promoteOrdInstances :: DsMonad q => [Name] -> q [Dec]
+promoteOrdInstances :: OptionsMonad q => [Name] -> q [Dec]
 promoteOrdInstances = concatMapM promoteOrdInstance
 
 -- | Produce an instance for 'POrd' from the given type
-promoteOrdInstance :: DsMonad q => Name -> q [Dec]
+promoteOrdInstance :: OptionsMonad q => Name -> q [Dec]
 promoteOrdInstance = promoteInstance mkOrdInstance "Ord"
 
 -- | Produce instances for 'PBounded' from the given types
-promoteBoundedInstances :: DsMonad q => [Name] -> q [Dec]
+promoteBoundedInstances :: OptionsMonad q => [Name] -> q [Dec]
 promoteBoundedInstances = concatMapM promoteBoundedInstance
 
 -- | Produce an instance for 'PBounded' from the given type
-promoteBoundedInstance :: DsMonad q => Name -> q [Dec]
+promoteBoundedInstance :: OptionsMonad q => Name -> q [Dec]
 promoteBoundedInstance = promoteInstance mkBoundedInstance "Bounded"
 
 -- | Produce instances for 'PEnum' from the given types
-promoteEnumInstances :: DsMonad q => [Name] -> q [Dec]
+promoteEnumInstances :: OptionsMonad q => [Name] -> q [Dec]
 promoteEnumInstances = concatMapM promoteEnumInstance
 
 -- | Produce an instance for 'PEnum' from the given type
-promoteEnumInstance :: DsMonad q => Name -> q [Dec]
+promoteEnumInstance :: OptionsMonad q => Name -> q [Dec]
 promoteEnumInstance = promoteInstance mkEnumInstance "Enum"
 
 -- | Produce instances for 'PShow' from the given types
-promoteShowInstances :: DsMonad q => [Name] -> q [Dec]
+promoteShowInstances :: OptionsMonad q => [Name] -> q [Dec]
 promoteShowInstances = concatMapM promoteShowInstance
 
 -- | Produce an instance for 'PShow' from the given type
-promoteShowInstance :: DsMonad q => Name -> q [Dec]
+promoteShowInstance :: OptionsMonad q => Name -> q [Dec]
 promoteShowInstance = promoteInstance (mkShowInstance ForPromotion) "Show"
 
 -- | Produce an instance for @(==)@ (type-level equality) from the given type
-promoteEqInstance :: DsMonad q => Name -> q [Dec]
+promoteEqInstance :: OptionsMonad q => Name -> q [Dec]
 promoteEqInstance name = do
   (tvbs, cons) <- getDataD "I cannot make an instance of (==) for it." name
   tvbs' <- mapM dsTvb tvbs
@@ -155,7 +156,7 @@ promoteEqInstance name = do
   inst_decs <- mkEqTypeInstance kind cons'
   return $ decsToTH inst_decs
 
-promoteInstance :: DsMonad q => DerivDesc q -> String -> Name -> q [Dec]
+promoteInstance :: OptionsMonad q => DerivDesc q -> String -> Name -> q [Dec]
 promoteInstance mk_inst class_name name = do
   (tvbs, cons) <- getDataD ("I cannot make an instance of " ++ class_name
                             ++ " for it.") name
@@ -231,7 +232,7 @@ promoteDecs raw_decls = do
 
   defunTopLevelTypeDecls ty_syns c_tyfams o_tyfams
     -- promoteLetDecs returns LetBinds, which we don't need at top level
-  _ <- promoteLetDecs noPrefix let_decs
+  _ <- promoteLetDecs Nothing let_decs
   mapM_ promoteClassDec classes
   let orig_meth_sigs = foldMap (lde_types . cd_lde) classes
       cls_tvbs_map   = Map.fromList $ map (\cd -> (cd_name cd, cd_tvbs cd)) classes
@@ -242,7 +243,7 @@ promoteDecs raw_decls = do
 promoteDataDecs :: [DataDecl] -> PrM ()
 promoteDataDecs data_decs = do
   rec_selectors <- concatMapM extract_rec_selectors data_decs
-  _ <- promoteLetDecs noPrefix rec_selectors
+  _ <- promoteLetDecs Nothing rec_selectors
   mapM_ promoteDataDec data_decs
   where
     extract_rec_selectors :: DataDecl -> PrM [DLetDec]
@@ -252,17 +253,18 @@ promoteDataDecs data_decs = do
       getRecordSelectors arg_ty cons
 
 -- curious about ALetDecEnv? See the LetDecEnv module for an explanation.
-promoteLetDecs :: (String, String) -- (alpha, symb) prefixes to use
+promoteLetDecs :: Maybe Uniq -- let-binding unique (if locally bound)
                -> [DLetDec] -> PrM ([LetBind], ALetDecEnv)
   -- See Note [Promoting declarations in two stages]
-promoteLetDecs prefixes decls = do
+promoteLetDecs mb_let_uniq decls = do
+  opts <- getOptions
   let_dec_env <- buildLetDecEnv decls
   all_locals <- allLocals
   let binds = [ (name, foldType (DConT sym) (map DVarT all_locals))
               | (name, _) <- OMap.assocs $ lde_defns let_dec_env
-              , let proName = promoteValNameLhsPrefix prefixes name
-                    sym = promoteTySym proName (length all_locals) ]
-  (decs, let_dec_env') <- letBind binds $ promoteLetDecEnv prefixes let_dec_env
+              , let proName = promotedValueName opts name mb_let_uniq
+                    sym = defunctionalizedName opts proName (length all_locals) ]
+  (decs, let_dec_env') <- letBind binds $ promoteLetDecEnv mb_let_uniq let_dec_env
   emitDecs decs
   return (binds, let_dec_env' { lde_proms = OMap.fromList binds })
 
@@ -294,7 +296,8 @@ promoteClassDec decl@(ClassDecl { cd_name = cls_name
                                     { lde_defns = defaults
                                     , lde_types = meth_sigs
                                     , lde_infix = infix_decls } }) = do
-  let pClsName = promoteClassName cls_name
+  opts <- getOptions
+  let pClsName = promotedClassName opts cls_name
   forallBind cls_kvs_to_bind $ do
     let meth_sigs_list = OMap.assocs meth_sigs
         meth_names     = map fst meth_sigs_list
@@ -305,7 +308,8 @@ promoteClassDec decl@(ClassDecl { cd_name = cls_name
       <- mapAndUnzip3M (promoteMethod DefaultMethods meth_sigs) defaults_list
     defunAssociatedTypeFamilies tvbs atfs
 
-    infix_decls' <- mapMaybeM (uncurry promoteInfixDecl) $ OMap.assocs infix_decls
+    infix_decls' <- mapMaybeM (uncurry (promoteInfixDecl Nothing)) $
+                    OMap.assocs infix_decls
     cls_infix_decls <- promoteReifiedInfixDecls $ cls_name:meth_names
 
     -- no need to do anything to the fundeps. They work as is!
@@ -326,7 +330,8 @@ promoteClassDec decl@(ClassDecl { cd_name = cls_name
 
     promote_sig :: Name -> DType -> PrM DDec
     promote_sig name ty = do
-      let proName = promoteValNameLhs name
+      opts <- getOptions
+      let proName = promotedTopLevelValueName opts name
       (argKs, resK) <- promoteUnraveled ty
       args <- mapM (const $ qNewName "arg") argKs
       let proTvbs = zipWith DKindedTV args argKs
@@ -350,9 +355,11 @@ promoteInstanceDec orig_meth_sigs cls_tvbs_map
                                   , id_arg_tys  = inst_tys
                                   , id_sigs     = inst_sigs
                                   , id_meths    = meths }) = do
+  opts <- getOptions
   cls_tvb_names <- lookup_cls_tvb_names
   inst_kis <- mapM promoteType inst_tys
-  let kvs_to_bind = foldMap fvDType inst_kis
+  let pClsName    = promotedClassName opts cls_name
+      kvs_to_bind = foldMap fvDType inst_kis
   forallBind kvs_to_bind $ do
     let subst     = Map.fromList $ zip cls_tvb_names inst_kis
         meth_impl = InstanceMethods inst_sigs subst
@@ -362,8 +369,6 @@ promoteInstanceDec orig_meth_sigs cls_tvbs_map
                                               inst_kis) meths']
     return (decl { id_meths = zip (map fst meths) ann_rhss })
   where
-    pClsName = promoteClassName cls_name
-
     lookup_cls_tvb_names :: PrM [Name]
     lookup_cls_tvb_names =
       -- First, try consulting the map of class names to their type variables.
@@ -378,7 +383,9 @@ promoteInstanceDec orig_meth_sigs cls_tvbs_map
 
     reify_cls_tvb_names :: PrM [Name]
     reify_cls_tvb_names = do
-      let mk_tvb_names = extract_tvb_names (dsReifyTypeNameInfo pClsName)
+      opts <- getOptions
+      let pClsName     = promotedClassName opts cls_name
+          mk_tvb_names = extract_tvb_names (dsReifyTypeNameInfo pClsName)
                      <|> extract_tvb_names (dsReifyTypeNameInfo cls_name)
                       -- See Note [Using dsReifyTypeNameInfo when promoting instances]
       mb_tvb_names <- runMaybeT mk_tvb_names
@@ -444,9 +451,11 @@ promoteMethod :: MethodSort
               -> PrM (DDec, ALetDecRHS, DType)
                  -- returns (type instance, ALetDecRHS, promoted RHS)
 promoteMethod meth_sort orig_sigs_map (meth_name, meth_rhs) = do
+  opts <- getOptions
   (meth_arg_kis, meth_res_ki) <- promote_meth_ty
   meth_arg_tvs <- mapM (const $ qNewName "a") meth_arg_kis
-  let helperNameBase = case nameBase proName of
+  let proName = promotedTopLevelValueName opts meth_name
+      helperNameBase = case nameBase proName of
                          first:_ | not (isHsLetter first) -> "TFHelper"
                          alpha                            -> alpha
 
@@ -464,19 +473,18 @@ promoteMethod meth_sort orig_sigs_map (meth_name, meth_rhs) = do
       -- strictly necessary, as kind inference can figure them out just as well.
       family_args = map DVarT meth_arg_tvs
   helperName <- newUniqueName helperNameBase
+  let helperDefunName = defunctionalizedName0 opts helperName
   (pro_dec, defun_decs, ann_rhs)
     <- promoteLetDecRHS (ClassMethodRHS meth_arg_kis meth_res_ki) OMap.empty OMap.empty
-                        noPrefix helperName meth_rhs
+                        Nothing helperName meth_rhs
   emitDecs (pro_dec:defun_decs)
   return ( DTySynInstD
              (DTySynEqn Nothing
                         (foldType (DConT proName) family_args)
-                        (foldApply (promoteValRhs helperName) (map DVarT meth_arg_tvs)))
+                        (foldApply (DConT helperDefunName) (map DVarT meth_arg_tvs)))
          , ann_rhs
-         , DConT (promoteTySym helperName 0) )
+         , DConT helperDefunName )
   where
-    proName = promoteValNameLhs meth_name
-
     -- Promote the type of a class method. For a default method, "the type" is
     -- simply the type of the original method. For an instance method,
     -- "the type" is like the type of the original method, but substituted for
@@ -510,7 +518,9 @@ promoteMethod meth_sort orig_sigs_map (meth_name, meth_rhs) = do
 
     -- Attempt to look up a class method's original type.
     lookup_meth_ty :: PrM ([DKind], DKind)
-    lookup_meth_ty =
+    lookup_meth_ty = do
+      opts <- getOptions
+      let proName = promotedTopLevelValueName opts meth_name
       case OMap.lookup meth_name orig_sigs_map of
         Just ty ->
           -- The type of the method is in scope, so promote that.
@@ -559,17 +569,19 @@ substitute in the kinds of the instance itself to determine the kinds of
 promoted method implementations like MHelper2.
 -}
 
-promoteLetDecEnv :: (String, String) -> ULetDecEnv -> PrM ([DDec], ALetDecEnv)
-promoteLetDecEnv prefixes (LetDecEnv { lde_defns = value_env
-                                     , lde_types = type_env
-                                     , lde_infix = fix_env }) = do
-  infix_decls <- mapMaybeM (uncurry promoteInfixDecl) $ OMap.assocs fix_env
+promoteLetDecEnv :: Maybe Uniq -> ULetDecEnv -> PrM ([DDec], ALetDecEnv)
+promoteLetDecEnv mb_let_uniq (LetDecEnv { lde_defns = value_env
+                                        , lde_types = type_env
+                                        , lde_infix = fix_env }) = do
+  infix_decls <- mapMaybeM (uncurry (promoteInfixDecl mb_let_uniq)) $
+                 OMap.assocs fix_env
 
     -- promote all the declarations, producing annotated declarations
   let (names, rhss) = unzip $ OMap.assocs value_env
   (pro_decs, defun_decss, ann_rhss)
     <- fmap unzip3 $
-       zipWithM (promoteLetDecRHS LetBindingRHS type_env fix_env prefixes) names rhss
+       zipWithM (promoteLetDecRHS LetBindingRHS type_env fix_env mb_let_uniq)
+                names rhss
 
   emitDecs $ concat defun_decss
   bound_kvs <- allBoundKindVars
@@ -585,8 +597,10 @@ promoteLetDecEnv prefixes (LetDecEnv { lde_defns = value_env
   return (decs, let_dec_env')
 
 -- Promote a fixity declaration.
-promoteInfixDecl :: forall q. DsMonad q => Name -> Fixity -> q (Maybe DDec)
-promoteInfixDecl name fixity = do
+promoteInfixDecl :: forall q. OptionsMonad q
+                 => Maybe Uniq -> Name -> Fixity -> q (Maybe DDec)
+promoteInfixDecl mb_let_uniq name fixity = do
+  opts  <- getOptions
   mb_ns <- reifyNameSpace name
   case mb_ns of
     -- If we can't find the Name for some odd reason,
@@ -598,7 +612,7 @@ promoteInfixDecl name fixity = do
       mb_info <- dsReify name
       case mb_info of
         Just (DTyConI DClassD{} _)
-          -> finish $ promoteClassName name
+          -> finish $ promotedClassName opts name
         _ -> never_mind
   where
     -- Produce the fixity declaration.
@@ -615,20 +629,19 @@ promoteInfixDecl name fixity = do
     -- Certain function names do not change when promoted (e.g., infix names),
     -- so don't bother with them.
     promote_infix_val :: q (Maybe DDec)
-    promote_infix_val
-      | nameBase name == nameBase promoted_name
-      = never_mind
-      | otherwise
-      = finish promoted_name
-
-    promoted_name :: Name
-    promoted_name = promoteValNameLhs name
+    promote_infix_val = do
+      opts <- getOptions
+      let promoted_name :: Name
+          promoted_name = promotedValueName opts name mb_let_uniq
+      if nameBase name == nameBase promoted_name
+         then never_mind
+         else finish promoted_name
 
 -- Try producing promoted fixity declarations for Names by reifying them
 -- /without/ consulting quoted declarations. If reification fails, recover and
 -- return the empty list.
 -- See [singletons and fixity declarations] in D.S.Single.Fixity, wrinkle 2.
-promoteReifiedInfixDecls :: forall q. DsMonad q => [Name] -> q [DDec]
+promoteReifiedInfixDecls :: forall q. OptionsMonad q => [Name] -> q [DDec]
 promoteReifiedInfixDecls = mapMaybeM tryPromoteFixityDeclaration
   where
     tryPromoteFixityDeclaration :: Name -> q (Maybe DDec)
@@ -637,7 +650,7 @@ promoteReifiedInfixDecls = mapMaybeM tryPromoteFixityDeclaration
         mFixity <- qReifyFixity name
         case mFixity of
           Nothing     -> pure Nothing
-          Just fixity -> promoteInfixDecl name fixity
+          Just fixity -> promoteInfixDecl Nothing name fixity
 
 -- Which sort of let-bound declaration's right-hand side is being promoted?
 data LetDecRHSSort
@@ -655,20 +668,22 @@ data LetDecRHSSort
 promoteLetDecRHS :: LetDecRHSSort
                  -> OMap Name DType      -- local type env't
                  -> OMap Name Fixity     -- local fixity env't
-                 -> (String, String)     -- let-binding prefixes
+                 -> Maybe Uniq           -- let-binding unique (if locally bound)
                  -> Name                 -- name of the thing being promoted
                  -> ULetDecRHS           -- body of the thing
                  -> PrM ( DDec          -- "type family"
                         , [DDec]        -- defunctionalization
                         , ALetDecRHS )  -- annotated RHS
-promoteLetDecRHS rhs_sort type_env fix_env prefixes name let_dec_rhs = do
+promoteLetDecRHS rhs_sort type_env fix_env mb_let_uniq name let_dec_rhs = do
+  opts <- getOptions
   all_locals <- allLocals
   case let_dec_rhs of
     UValue exp -> do
       (m_argKs, m_resK, ty_num_args) <- promote_let_dec_ty 0
       if ty_num_args == 0
       then
-        let prom_fun_lhs = foldType (DConT proName) $ map DVarT all_locals in
+        let proName = promotedValueName opts name mb_let_uniq
+            prom_fun_lhs = foldType (DConT proName) $ map DVarT all_locals in
         promote_let_dec_rhs all_locals m_argKs m_resK 0
                             (promoteExp exp)
                             (\exp' -> [DTySynEqn Nothing prom_fun_lhs exp'])
@@ -684,8 +699,10 @@ promoteLetDecRHS rhs_sort type_env fix_env prefixes name let_dec_rhs = do
     promote_function_rhs :: [Name]
                          -> [DClause] -> PrM (DDec, [DDec], ALetDecRHS)
     promote_function_rhs all_locals clauses = do
+      opts <- getOptions
       numArgs <- count_args clauses
-      let prom_fun_lhs = foldType (DConT proName) $ map DVarT all_locals
+      let proName = promotedValueName opts name mb_let_uniq
+          prom_fun_lhs = foldType (DConT proName) $ map DVarT all_locals
       (m_argKs, m_resK, ty_num_args) <- promote_let_dec_ty numArgs
       expClauses <- mapM (etaContractOrExpand ty_num_args numArgs) clauses
       promote_let_dec_rhs all_locals m_argKs m_resK ty_num_args
@@ -709,8 +726,10 @@ promoteLetDecRHS rhs_sort type_env fix_env prefixes name let_dec_rhs = do
       -> PrM (DDec, [DDec], ALetDecRHS)
     promote_let_dec_rhs all_locals m_argKs m_resK ty_num_args
                         promote_thing mk_prom_eqns mk_alet_dec_rhs = do
+      opts <- getOptions
       tyvarNames <- mapM (const $ qNewName "a") m_argKs
-      let local_tvbs      = map DPlainTV all_locals
+      let proName         = promotedValueName opts name mb_let_uniq
+          local_tvbs      = map DPlainTV all_locals
           m_fixity        = OMap.lookup name fix_env
           args            = zipWith inferMaybeKindTV tyvarNames m_argKs
           all_args        = local_tvbs ++ args
@@ -723,9 +742,6 @@ promoteLetDecRHS rhs_sort type_env fix_env prefixes name let_dec_rhs = do
                  (mk_prom_eqns prom_thing)
              , defun_decs
              , mk_alet_dec_rhs prom_fun_rhs ty_num_args thing )
-
-    proName :: Name
-    proName = promoteValNameLhsPrefix prefixes name
 
     promote_let_dec_ty :: Int -- The number of arguments to default to if the
                               -- type cannot be inferred. This is 0 for UValues
@@ -836,7 +852,9 @@ promotePat DWildP = return (DWildCardT, ADWildP)
 
 promoteExp :: DExp -> PrM (DType, ADExp)
 promoteExp (DVarE name) = fmap (, ADVarE name) $ lookupVarE name
-promoteExp (DConE name) = return $ (promoteValRhs name, ADConE name)
+promoteExp (DConE name) = do
+  opts <- getOptions
+  return (DConT $ defunctionalizedName0 opts name, ADConE name)
 promoteExp (DLitE lit)  = fmap (, ADLitE lit) $ promoteLitExp lit
 promoteExp (DAppE exp1 exp2) = do
   (exp1', ann_exp1) <- promoteExp exp1
@@ -847,6 +865,7 @@ promoteExp (DAppTypeE exp _) = do
   qReportWarning "Visible type applications are ignored by `singletons`."
   promoteExp exp
 promoteExp (DLamE names exp) = do
+  opts <- getOptions
   lambdaName <- newUniqueName "Lambda"
   tyNames <- mapM mkTyName names
   let var_proms = zip names tyNames
@@ -865,7 +884,7 @@ promoteExp (DLamE names exp) = do
                                            map DVarT (all_locals ++ tyNames))
                                           rhs]]
   emitDecsM $ defunctionalize lambdaName Nothing tvbs Nothing
-  let promLambda = foldl apply (DConT (promoteTySym lambdaName 0))
+  let promLambda = foldl apply (DConT (defunctionalizedName opts lambdaName 0))
                                (map DVarT all_locals)
   return (promLambda, ADLamE tyNames promLambda names ann_exp)
 promoteExp (DCaseE exp matches) = do
@@ -884,8 +903,7 @@ promoteExp (DCaseE exp matches) = do
          , ADCaseE ann_exp ann_matches applied_case )
 promoteExp (DLetE decs exp) = do
   unique <- qNewUnique
-  let letPrefixes = uniquePrefixes "Let" "<<<" unique
-  (binds, ann_env) <- promoteLetDecs letPrefixes decs
+  (binds, ann_env) <- promoteLetDecs (Just unique) decs
   (exp', ann_exp) <- letBind binds $ promoteExp exp
   return (exp', ADLetE ann_env ann_exp)
 promoteExp (DSigE exp ty) = do

--- a/src/Data/Singletons/Single/Type.hs
+++ b/src/Data/Singletons/Single/Type.hs
@@ -14,6 +14,7 @@ import Language.Haskell.TH.Syntax
 import Data.Singletons.Names
 import Data.Singletons.Single.Monad
 import Data.Singletons.Promote.Type
+import Data.Singletons.TH.Options
 import Data.Singletons.Util
 import Control.Monad
 import Data.Foldable
@@ -106,8 +107,9 @@ singPredRec ctx (DConT n)
   | n == equalityName
   = fail "Singling of type equality constraints not yet supported"
   | otherwise = do
+    opts <- getOptions
     kis <- mapM promoteTypeArg_NC ctx
-    let sName = singClassName n
+    let sName = singledClassName opts n
     return $ applyDType (DConT sName) kis
 singPredRec _ctx DWildCardT = return DWildCardT  -- it just might work
 singPredRec _ctx DArrowT =

--- a/src/Data/Singletons/TH/Options.hs
+++ b/src/Data/Singletons/TH/Options.hs
@@ -1,0 +1,259 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Singletons.TH.Options
+-- Copyright   :  (C) 2019 Ryan Scott
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Ryan Scott
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- This module defines 'Options' that control finer details of how the Template
+-- Haskell machinery works, as well as an @mtl@-like 'OptionsMonad' class
+-- and an 'OptionsM' monad transformer.
+--
+----------------------------------------------------------------------------
+
+module Data.Singletons.TH.Options
+  ( -- * Options
+    Options, defaultOptions
+    -- ** Options record selectors
+  , genSingKindInsts
+  , promotedClassName
+  , promotedValueName
+  , singledDataTypeName
+  , singledClassName
+  , singledDataConName
+  , singledValueName
+  , defunctionalizedName
+    -- ** Derived functions over Options
+  , promotedTopLevelValueName
+  , promotedLetBoundValueName
+  , defunctionalizedName0
+
+    -- * OptionsMonad
+  , OptionsMonad(..), OptionsM, withOptions
+  ) where
+
+import Control.Applicative
+import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Reader (ReaderT(..), ask)
+import Control.Monad.RWS (RWST)
+import Control.Monad.State (StateT)
+import Control.Monad.Trans.Class (MonadTrans(..))
+import Control.Monad.Writer (WriterT)
+import Data.Singletons.Names ( consName, listName, nilName
+                             , mk_name_tc, mkTupleDataName, mkTupleTypeName
+                             , sconsName, sListName, snilName
+                             , splitUnderscores
+                             )
+import Data.Singletons.Util
+import Language.Haskell.TH.Desugar
+import Language.Haskell.TH.Syntax hiding (Lift(..))
+
+-- | Options that control the finer details of how @singletons@' Template
+-- Haskell machinery works.
+data Options = Options
+  { genSingKindInsts        :: Bool
+    -- ^ If 'True', then 'SingKind' instances will be generated. If 'False',
+    --   they will be omitted entirely. This can be useful in scenarios where
+    --   TH-generated 'SingKind' instances do not typecheck (for instance,
+    --   when generating singletons for GADTs).
+  , promotedClassName    :: Name -> Name
+    -- ^ Given the name of the original, unrefined class, produces the name of
+    --   the promoted equivalent of the class.
+  , promotedValueName    :: Name -> Maybe Uniq -> Name
+    -- ^ Given the name of the original, unrefined value, produces the name of
+    --   the promoted equivalent of the value. This is used for both top-level
+    --   and @let@-bound names, and the difference is encoded in the
+    --   @'Maybe' 'Uniq'@ argument. If promoting a top-level name, the argument
+    --   is 'Nothing'. If promoting a @let@-bound name, the argument is
+    --   @Just uniq@, where @uniq@ is a globally unique number that can be used
+    --   to distinguish the name from other local definitions of the same name
+    --   (e.g., if two functions both use @let x = ... in x@).
+  , singledDataTypeName  :: Name -> Name
+    -- ^ Given the name of the original, unrefined data type, produces the name
+    --   of the corresponding singleton type.
+  , singledClassName     :: Name -> Name
+    -- ^ Given the name of the original, unrefined class, produces the name of
+    --   the singled equivalent of the class.
+  , singledDataConName   :: Name -> Name
+    -- ^ Given the name of the original, unrefined data constructor, produces
+    --   the name of the corresponding singleton data constructor.
+  , singledValueName     :: Name -> Name
+    -- ^ Given the name of the original, unrefined value, produces the name of
+    --   the singled equivalent of the value.
+  , defunctionalizedName :: Name -> Int -> Name
+    -- ^ Given the original name and the number of parameters it is applied to
+    --   (the 'Int' argument), produces a type-level function name that can be
+    --   partially applied when given the same number of parameters.
+    --
+    --   Note that defunctionalization works over both term-level names
+    --   (producing symbols for the promoted name) and type-level names
+    --   (producing symbols directly for the name itself). As a result, this
+    --   callback is used for names in both the term and type namespaces.
+  }
+
+-- | Sensible default 'Options'.
+--
+-- 'genSingKindInsts' defaults to 'True'.
+-- That is, 'SingKind' instances are generated.
+--
+-- The default behaviors for 'promotedClassName', 'promotedValueNamePrefix',
+-- 'singledDataTypeName', 'singledClassName', 'singledDataConName',
+-- 'singledValueName', and 'defunctionalizedName' are described in the
+-- \"On names\" section of the @singletons@ @README@.
+defaultOptions :: Options
+defaultOptions = Options
+  { genSingKindInsts     = True
+  , promotedClassName    = promoteClassName
+  , promotedValueName    = promoteValNameLhs
+  , singledDataTypeName  = singTyConName
+  , singledClassName     = singClassName
+  , singledDataConName   = singDataConName
+  , singledValueName     = singValName
+  , defunctionalizedName = promoteTySym
+  }
+
+-- | Given the name of the original, unrefined, top-level value, produces the
+-- name of the promoted equivalent of the value.
+promotedTopLevelValueName :: Options -> Name -> Name
+promotedTopLevelValueName opts name = promotedValueName opts name Nothing
+
+-- | Given the name of the original, unrefined, @let@-bound value and its
+-- globally unique number, produces the name of the promoted equivalent of the
+-- value.
+promotedLetBoundValueName :: Options -> Name -> Uniq -> Name
+promotedLetBoundValueName opts name = promotedValueName opts name . Just
+
+-- | Given the original name of a function (term- or type-level), produces a
+-- type-level function name that can be partially applied even without being
+-- given any arguments (i.e., @0@ arguments).
+defunctionalizedName0 :: Options -> Name -> Name
+defunctionalizedName0 opts name = defunctionalizedName opts name 0
+
+-- | Class that describes monads that contain 'Options'.
+class DsMonad m => OptionsMonad m where
+  getOptions :: m Options
+
+instance OptionsMonad Q where
+  getOptions = pure defaultOptions
+
+instance OptionsMonad m => OptionsMonad (DsM m) where
+  getOptions = lift getOptions
+
+instance (OptionsMonad q, Monoid m) => OptionsMonad (QWithAux m q) where
+  getOptions = lift getOptions
+
+instance OptionsMonad m => OptionsMonad (ReaderT r m) where
+  getOptions = lift getOptions
+
+instance OptionsMonad m => OptionsMonad (StateT s m) where
+  getOptions = lift getOptions
+
+instance (OptionsMonad m, Monoid w) => OptionsMonad (WriterT w m) where
+  getOptions = lift getOptions
+
+instance (OptionsMonad m, Monoid w) => OptionsMonad (RWST r w s m) where
+  getOptions = lift getOptions
+
+-- | A convenient implementation of the 'OptionsMonad' class. Use by calling
+-- 'withOptions'.
+newtype OptionsM m a = OptionsM (ReaderT Options m a)
+  deriving ( Functor, Applicative, Monad, MonadTrans
+           , Quasi, MonadFail, MonadIO, DsMonad )
+
+-- | Turn any 'DsMonad' into an 'OptionsMonad'.
+instance DsMonad m => OptionsMonad (OptionsM m) where
+  getOptions = OptionsM ask
+
+-- | Declare the 'Options' that a TH computation should use.
+withOptions :: Options -> OptionsM m a -> m a
+withOptions opts (OptionsM x) = runReaderT x opts
+
+-- Used when a value name appears in a pattern context.
+-- Works only for proper variables (lower-case names).
+--
+-- If the Maybe Uniq argument is Nothing, then the name is top-level (and
+-- thus globally unique on its own).
+-- If the Maybe Uniq argument is `Just uniq`, then the name is let-bound and
+-- should use `uniq` to make the promoted name globally unique.
+promoteValNameLhs :: Name -> Maybe Uniq -> Name
+promoteValNameLhs n mb_let_uniq
+    -- We can't promote promote idenitifers beginning with underscores to
+    -- type names, so we work around the issue by prepending "US" at the
+    -- front of the name (#229).
+  | Just (us, rest) <- splitUnderscores (nameBase n)
+  = mkName $ alpha ++ "US" ++ us ++ rest
+
+  | otherwise
+  = mkName $ toUpcaseStr pres n
+  where
+    pres = maybe noPrefix (uniquePrefixes "Let" "<<<") mb_let_uniq
+    (alpha, _) = pres
+
+-- generates type-level symbol for a given name. Int parameter represents
+-- saturation: 0 - no parameters passed to the symbol, 1 - one parameter
+-- passed to the symbol, and so on. Works on both promoted and unpromoted
+-- names.
+promoteTySym :: Name -> Int -> Name
+promoteTySym name sat
+      -- We can't promote promote idenitifers beginning with underscores to
+      -- type names, so we work around the issue by prepending "US" at the
+      -- front of the name (#229).
+    | Just (us, rest) <- splitUnderscores (nameBase name)
+    = default_case (mkName $ "US" ++ us ++ rest)
+
+    | name == nilName
+    = mkName $ "NilSym" ++ (show sat)
+
+       -- treat unboxed tuples like tuples
+    | Just degree <- tupleNameDegree_maybe name <|>
+                     unboxedTupleNameDegree_maybe name
+    = mk_name_tc "Data.Singletons.Prelude.Instances" $
+                 "Tuple" ++ show degree ++ "Sym" ++ (show sat)
+
+    | otherwise
+    = default_case name
+  where
+    default_case :: Name -> Name
+    default_case name' =
+      let capped = toUpcaseStr noPrefix name' in
+      if isHsLetter (head capped)
+      then mkName (capped ++ "Sym" ++ (show sat))
+      else mkName (capped ++ "@#@" -- See Note [Defunctionalization symbol suffixes]
+                          ++ (replicate (sat + 1) '$'))
+
+promoteClassName :: Name -> Name
+promoteClassName = prefixName "P" "#"
+
+-- Singletons
+
+singDataConName :: Name -> Name
+singDataConName nm
+  | nm == nilName                                  = snilName
+  | nm == consName                                 = sconsName
+  | Just degree <- tupleNameDegree_maybe nm        = mkTupleDataName degree
+  | Just degree <- unboxedTupleNameDegree_maybe nm = mkTupleDataName degree
+  | otherwise                                      = prefixConName "S" "%" nm
+
+singTyConName :: Name -> Name
+singTyConName name
+  | name == listName                                 = sListName
+  | Just degree <- tupleNameDegree_maybe name        = mkTupleTypeName degree
+  | Just degree <- unboxedTupleNameDegree_maybe name = mkTupleTypeName degree
+  | otherwise                                        = prefixName "S" "%" name
+
+singClassName :: Name -> Name
+singClassName = singTyConName
+
+singValName :: Name -> Name
+singValName n
+     -- Push the 's' past the underscores, as this lets us avoid some unused
+     -- variable warnings (#229).
+  | Just (us, rest) <- splitUnderscores (nameBase n)
+  = prefixName (us ++ "s") "%" $ mkName rest
+  | otherwise
+  = prefixName "s" "%" $ upcase n

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -75,6 +75,8 @@ tests =
     , compileAndDumpStdTest "T145"
     , compileAndDumpStdTest "PolyKinds"
     , compileAndDumpStdTest "PolyKindsApp"
+    , afterSingletonsNat .
+      compileAndDumpStdTest "T150"
     , compileAndDumpStdTest "T160"
     , compileAndDumpStdTest "T163"
     , compileAndDumpStdTest "T166"
@@ -92,6 +94,7 @@ tests =
     , compileAndDumpStdTest "T197"
     , compileAndDumpStdTest "T197b"
     , compileAndDumpStdTest "T200"
+    , compileAndDumpStdTest "T204"
     , compileAndDumpStdTest "T206"
     , compileAndDumpStdTest "T209"
     , compileAndDumpStdTest "T216"

--- a/tests/compile-and-dump/Singletons/T150.golden
+++ b/tests/compile-and-dump/Singletons/T150.golden
@@ -1,0 +1,384 @@
+Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
+    withOptions defaultOptions {genSingKindInsts = False}
+      $ singletons
+          $ lift
+              [d| headVec :: Vec (Succ n) a -> a
+                  headVec (VCons x _) = x
+                  tailVec :: Vec (Succ n) a -> Vec n a
+                  tailVec (VCons _ xs) = xs
+                  (!) :: Vec n a -> Fin n -> a
+                  VCons x _ ! FZ = x
+                  VCons _ xs ! FS n = xs ! n
+                  VNil ! n = case n of
+                  mapVec :: (a -> b) -> Vec n a -> Vec n b
+                  mapVec _ VNil = VNil
+                  mapVec f (VCons x xs) = VCons (f x) (mapVec f xs)
+                  symmetry :: Equal a b -> Equal b a
+                  symmetry Reflexive = Reflexive
+                  transitivity :: Equal a b -> Equal b c -> Equal a c
+                  transitivity Reflexive Reflexive = Reflexive
+                  
+                  data Fin :: Nat -> Type
+                    where
+                      FZ :: Fin (Succ n)
+                      FS :: Fin n -> Fin (Succ n)
+                  data Foo :: Type -> Type
+                    where
+                      MkFoo1 :: Foo Bool
+                      MkFoo2 :: Foo Ordering
+                  data Vec :: Nat -> Type -> Type
+                    where
+                      VNil :: Vec Zero a
+                      VCons :: a -> Vec n a -> Vec (Succ n) a
+                  data Equal :: Type -> Type -> Type where Reflexive :: Equal a a
+                  data HList :: [Type] -> Type
+                    where
+                      HNil :: HList '[]
+                      HCons :: x -> HList xs -> HList (x : xs)
+                  data Obj :: Type where Obj :: a -> Obj |]
+  ======>
+    data Fin :: Nat -> Type
+      where
+        FZ :: Fin ('Succ n)
+        FS :: (Fin n) -> Fin ('Succ n)
+    data Foo :: Type -> Type
+      where
+        MkFoo1 :: Foo Bool
+        MkFoo2 :: Foo Ordering
+    data Vec :: Nat -> Type -> Type
+      where
+        VNil :: Vec 'Zero a
+        VCons :: a -> (Vec n a) -> Vec ('Succ n) a
+    headVec :: Vec ('Succ n) a -> a
+    headVec (VCons x _) = x
+    tailVec :: Vec ('Succ n) a -> Vec n a
+    tailVec (VCons _ xs) = xs
+    (!) :: Vec n a -> Fin n -> a
+    (!) (VCons x _) FZ = x
+    (!) (VCons _ xs) (FS n) = (xs ! n)
+    (!) VNil n = case n of
+    mapVec :: (a -> b) -> Vec n a -> Vec n b
+    mapVec _ VNil = VNil
+    mapVec f (VCons x xs) = (VCons (f x)) ((mapVec f) xs)
+    data Equal :: Type -> Type -> Type where Reflexive :: Equal a a
+    symmetry :: Equal a b -> Equal b a
+    symmetry Reflexive = Reflexive
+    transitivity :: Equal a b -> Equal b c -> Equal a c
+    transitivity Reflexive Reflexive = Reflexive
+    data HList :: [Type] -> Type
+      where
+        HNil :: HList '[]
+        HCons :: x -> (HList xs) -> HList ('(:) x xs)
+    data Obj :: Type where Obj :: a -> Obj
+    type FZSym0 = FZ
+    instance SuppressUnusedWarnings FSSym0 where
+      suppressUnusedWarnings = snd (((,) FSSym0KindInference) ())
+    data FSSym0 :: forall n0123456789876543210.
+                   (~>) (Fin n0123456789876543210) (Fin ('Succ n0123456789876543210))
+      where
+        FSSym0KindInference :: forall t0123456789876543210
+                                      arg. SameKind (Apply FSSym0 arg) (FSSym1 arg) =>
+                               FSSym0 t0123456789876543210
+    type instance Apply FSSym0 t0123456789876543210 = FSSym1 t0123456789876543210
+    type FSSym1 (t0123456789876543210 :: Fin n0123456789876543210) =
+        FS t0123456789876543210
+    type MkFoo1Sym0 = MkFoo1
+    type MkFoo2Sym0 = MkFoo2
+    type VNilSym0 = VNil
+    instance SuppressUnusedWarnings VConsSym0 where
+      suppressUnusedWarnings = snd (((,) VConsSym0KindInference) ())
+    data VConsSym0 :: forall a0123456789876543210 n0123456789876543210.
+                      (~>) a0123456789876543210 ((~>) (Vec n0123456789876543210 a0123456789876543210) (Vec ('Succ n0123456789876543210) a0123456789876543210))
+      where
+        VConsSym0KindInference :: forall t0123456789876543210
+                                         arg. SameKind (Apply VConsSym0 arg) (VConsSym1 arg) =>
+                                  VConsSym0 t0123456789876543210
+    type instance Apply VConsSym0 t0123456789876543210 = VConsSym1 t0123456789876543210
+    instance SuppressUnusedWarnings (VConsSym1 t0123456789876543210) where
+      suppressUnusedWarnings = snd (((,) VConsSym1KindInference) ())
+    data VConsSym1 (t0123456789876543210 :: a0123456789876543210) :: forall n0123456789876543210.
+                                                                     (~>) (Vec n0123456789876543210 a0123456789876543210) (Vec ('Succ n0123456789876543210) a0123456789876543210)
+      where
+        VConsSym1KindInference :: forall t0123456789876543210
+                                         t0123456789876543210
+                                         arg. SameKind (Apply (VConsSym1 t0123456789876543210) arg) (VConsSym2 t0123456789876543210 arg) =>
+                                  VConsSym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (VConsSym1 t0123456789876543210) t0123456789876543210 = VConsSym2 t0123456789876543210 t0123456789876543210
+    type VConsSym2 (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: Vec n0123456789876543210 a0123456789876543210) =
+        VCons t0123456789876543210 t0123456789876543210
+    type ReflexiveSym0 = Reflexive
+    type HNilSym0 = HNil
+    instance SuppressUnusedWarnings HConsSym0 where
+      suppressUnusedWarnings = snd (((,) HConsSym0KindInference) ())
+    data HConsSym0 :: forall x0123456789876543210
+                             xs0123456789876543210.
+                      (~>) x0123456789876543210 ((~>) (HList xs0123456789876543210) (HList ('(:) x0123456789876543210 xs0123456789876543210)))
+      where
+        HConsSym0KindInference :: forall t0123456789876543210
+                                         arg. SameKind (Apply HConsSym0 arg) (HConsSym1 arg) =>
+                                  HConsSym0 t0123456789876543210
+    type instance Apply HConsSym0 t0123456789876543210 = HConsSym1 t0123456789876543210
+    instance SuppressUnusedWarnings (HConsSym1 t0123456789876543210) where
+      suppressUnusedWarnings = snd (((,) HConsSym1KindInference) ())
+    data HConsSym1 (t0123456789876543210 :: x0123456789876543210) :: forall xs0123456789876543210.
+                                                                     (~>) (HList xs0123456789876543210) (HList ('(:) x0123456789876543210 xs0123456789876543210))
+      where
+        HConsSym1KindInference :: forall t0123456789876543210
+                                         t0123456789876543210
+                                         arg. SameKind (Apply (HConsSym1 t0123456789876543210) arg) (HConsSym2 t0123456789876543210 arg) =>
+                                  HConsSym1 t0123456789876543210 t0123456789876543210
+    type instance Apply (HConsSym1 t0123456789876543210) t0123456789876543210 = HConsSym2 t0123456789876543210 t0123456789876543210
+    type HConsSym2 (t0123456789876543210 :: x0123456789876543210) (t0123456789876543210 :: HList xs0123456789876543210) =
+        HCons t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings ObjSym0 where
+      suppressUnusedWarnings = snd (((,) ObjSym0KindInference) ())
+    data ObjSym0 :: forall a0123456789876543210.
+                    (~>) a0123456789876543210 Obj
+      where
+        ObjSym0KindInference :: forall t0123456789876543210
+                                       arg. SameKind (Apply ObjSym0 arg) (ObjSym1 arg) =>
+                                ObjSym0 t0123456789876543210
+    type instance Apply ObjSym0 t0123456789876543210 = ObjSym1 t0123456789876543210
+    type ObjSym1 (t0123456789876543210 :: a0123456789876543210) =
+        Obj t0123456789876543210
+    type family Case_0123456789876543210 n t where
+    instance SuppressUnusedWarnings TransitivitySym0 where
+      suppressUnusedWarnings
+        = snd (((,) TransitivitySym0KindInference) ())
+    data TransitivitySym0 :: forall a0123456789876543210
+                                    b0123456789876543210
+                                    c0123456789876543210.
+                             (~>) (Equal a0123456789876543210 b0123456789876543210) ((~>) (Equal b0123456789876543210 c0123456789876543210) (Equal a0123456789876543210 c0123456789876543210))
+      where
+        TransitivitySym0KindInference :: forall a0123456789876543210
+                                                arg. SameKind (Apply TransitivitySym0 arg) (TransitivitySym1 arg) =>
+                                         TransitivitySym0 a0123456789876543210
+    type instance Apply TransitivitySym0 a0123456789876543210 = TransitivitySym1 a0123456789876543210
+    instance SuppressUnusedWarnings (TransitivitySym1 a0123456789876543210) where
+      suppressUnusedWarnings
+        = snd (((,) TransitivitySym1KindInference) ())
+    data TransitivitySym1 (a0123456789876543210 :: Equal a0123456789876543210 b0123456789876543210) :: forall c0123456789876543210.
+                                                                                                       (~>) (Equal b0123456789876543210 c0123456789876543210) (Equal a0123456789876543210 c0123456789876543210)
+      where
+        TransitivitySym1KindInference :: forall a0123456789876543210
+                                                a0123456789876543210
+                                                arg. SameKind (Apply (TransitivitySym1 a0123456789876543210) arg) (TransitivitySym2 a0123456789876543210 arg) =>
+                                         TransitivitySym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (TransitivitySym1 a0123456789876543210) a0123456789876543210 = TransitivitySym2 a0123456789876543210 a0123456789876543210
+    type TransitivitySym2 (a0123456789876543210 :: Equal a0123456789876543210 b0123456789876543210) (a0123456789876543210 :: Equal b0123456789876543210 c0123456789876543210) =
+        Transitivity a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings SymmetrySym0 where
+      suppressUnusedWarnings = snd (((,) SymmetrySym0KindInference) ())
+    data SymmetrySym0 :: forall a0123456789876543210
+                                b0123456789876543210.
+                         (~>) (Equal a0123456789876543210 b0123456789876543210) (Equal b0123456789876543210 a0123456789876543210)
+      where
+        SymmetrySym0KindInference :: forall a0123456789876543210
+                                            arg. SameKind (Apply SymmetrySym0 arg) (SymmetrySym1 arg) =>
+                                     SymmetrySym0 a0123456789876543210
+    type instance Apply SymmetrySym0 a0123456789876543210 = SymmetrySym1 a0123456789876543210
+    type SymmetrySym1 (a0123456789876543210 :: Equal a0123456789876543210 b0123456789876543210) =
+        Symmetry a0123456789876543210
+    instance SuppressUnusedWarnings MapVecSym0 where
+      suppressUnusedWarnings = snd (((,) MapVecSym0KindInference) ())
+    data MapVecSym0 :: forall a0123456789876543210
+                              b0123456789876543210
+                              n0123456789876543210.
+                       (~>) ((~>) a0123456789876543210 b0123456789876543210) ((~>) (Vec n0123456789876543210 a0123456789876543210) (Vec n0123456789876543210 b0123456789876543210))
+      where
+        MapVecSym0KindInference :: forall a0123456789876543210
+                                          arg. SameKind (Apply MapVecSym0 arg) (MapVecSym1 arg) =>
+                                   MapVecSym0 a0123456789876543210
+    type instance Apply MapVecSym0 a0123456789876543210 = MapVecSym1 a0123456789876543210
+    instance SuppressUnusedWarnings (MapVecSym1 a0123456789876543210) where
+      suppressUnusedWarnings = snd (((,) MapVecSym1KindInference) ())
+    data MapVecSym1 (a0123456789876543210 :: (~>) a0123456789876543210 b0123456789876543210) :: forall n0123456789876543210.
+                                                                                                (~>) (Vec n0123456789876543210 a0123456789876543210) (Vec n0123456789876543210 b0123456789876543210)
+      where
+        MapVecSym1KindInference :: forall a0123456789876543210
+                                          a0123456789876543210
+                                          arg. SameKind (Apply (MapVecSym1 a0123456789876543210) arg) (MapVecSym2 a0123456789876543210 arg) =>
+                                   MapVecSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (MapVecSym1 a0123456789876543210) a0123456789876543210 = MapVecSym2 a0123456789876543210 a0123456789876543210
+    type MapVecSym2 (a0123456789876543210 :: (~>) a0123456789876543210 b0123456789876543210) (a0123456789876543210 :: Vec n0123456789876543210 a0123456789876543210) =
+        MapVec a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (!@#@$) where
+      suppressUnusedWarnings = snd (((,) (:!@#@$###)) ())
+    data (!@#@$) :: forall n0123456789876543210 a0123456789876543210.
+                    (~>) (Vec n0123456789876543210 a0123456789876543210) ((~>) (Fin n0123456789876543210) a0123456789876543210)
+      where
+        (:!@#@$###) :: forall a0123456789876543210
+                              arg. SameKind (Apply (!@#@$) arg) ((!@#@$$) arg) =>
+                       (!@#@$) a0123456789876543210
+    type instance Apply (!@#@$) a0123456789876543210 = (!@#@$$) a0123456789876543210
+    instance SuppressUnusedWarnings ((!@#@$$) a0123456789876543210) where
+      suppressUnusedWarnings = snd (((,) (:!@#@$$###)) ())
+    data (!@#@$$) (a0123456789876543210 :: Vec n0123456789876543210 a0123456789876543210) :: (~>) (Fin n0123456789876543210) a0123456789876543210
+      where
+        (:!@#@$$###) :: forall a0123456789876543210
+                               a0123456789876543210
+                               arg. SameKind (Apply ((!@#@$$) a0123456789876543210) arg) ((!@#@$$$) a0123456789876543210 arg) =>
+                        (!@#@$$) a0123456789876543210 a0123456789876543210
+    type instance Apply ((!@#@$$) a0123456789876543210) a0123456789876543210 = (!@#@$$$) a0123456789876543210 a0123456789876543210
+    type (!@#@$$$) (a0123456789876543210 :: Vec n0123456789876543210 a0123456789876543210) (a0123456789876543210 :: Fin n0123456789876543210) =
+        (!) a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings TailVecSym0 where
+      suppressUnusedWarnings = snd (((,) TailVecSym0KindInference) ())
+    data TailVecSym0 :: forall n0123456789876543210
+                               a0123456789876543210.
+                        (~>) (Vec ('Succ n0123456789876543210) a0123456789876543210) (Vec n0123456789876543210 a0123456789876543210)
+      where
+        TailVecSym0KindInference :: forall a0123456789876543210
+                                           arg. SameKind (Apply TailVecSym0 arg) (TailVecSym1 arg) =>
+                                    TailVecSym0 a0123456789876543210
+    type instance Apply TailVecSym0 a0123456789876543210 = TailVecSym1 a0123456789876543210
+    type TailVecSym1 (a0123456789876543210 :: Vec ('Succ n0123456789876543210) a0123456789876543210) =
+        TailVec a0123456789876543210
+    instance SuppressUnusedWarnings HeadVecSym0 where
+      suppressUnusedWarnings = snd (((,) HeadVecSym0KindInference) ())
+    data HeadVecSym0 :: forall n0123456789876543210
+                               a0123456789876543210.
+                        (~>) (Vec ('Succ n0123456789876543210) a0123456789876543210) a0123456789876543210
+      where
+        HeadVecSym0KindInference :: forall a0123456789876543210
+                                           arg. SameKind (Apply HeadVecSym0 arg) (HeadVecSym1 arg) =>
+                                    HeadVecSym0 a0123456789876543210
+    type instance Apply HeadVecSym0 a0123456789876543210 = HeadVecSym1 a0123456789876543210
+    type HeadVecSym1 (a0123456789876543210 :: Vec ('Succ n0123456789876543210) a0123456789876543210) =
+        HeadVec a0123456789876543210
+    type family Transitivity (a :: Equal a b) (a :: Equal b c) :: Equal a c where
+      Transitivity Reflexive Reflexive = ReflexiveSym0
+    type family Symmetry (a :: Equal a b) :: Equal b a where
+      Symmetry Reflexive = ReflexiveSym0
+    type family MapVec (a :: (~>) a b) (a :: Vec n a) :: Vec n b where
+      MapVec _ VNil = VNilSym0
+      MapVec f (VCons x xs) = Apply (Apply VConsSym0 (Apply f x)) (Apply (Apply MapVecSym0 f) xs)
+    type family (!) (a :: Vec n a) (a :: Fin n) :: a where
+      (!) (VCons x _) FZ = x
+      (!) (VCons _ xs) (FS n) = Apply (Apply (!@#@$) xs) n
+      (!) VNil n = Case_0123456789876543210 n n
+    type family TailVec (a :: Vec ('Succ n) a) :: Vec n a where
+      TailVec (VCons _ xs) = xs
+    type family HeadVec (a :: Vec ('Succ n) a) :: a where
+      HeadVec (VCons x _) = x
+    sTransitivity ::
+      forall a b c (t :: Equal a b) (t :: Equal b c).
+      Sing t
+      -> Sing t -> Sing (Apply (Apply TransitivitySym0 t) t :: Equal a c)
+    sSymmetry ::
+      forall a b (t :: Equal a b).
+      Sing t -> Sing (Apply SymmetrySym0 t :: Equal b a)
+    sMapVec ::
+      forall a b n (t :: (~>) a b) (t :: Vec n a).
+      Sing t -> Sing t -> Sing (Apply (Apply MapVecSym0 t) t :: Vec n b)
+    (%!) ::
+      forall n a (t :: Vec n a) (t :: Fin n).
+      Sing t -> Sing t -> Sing (Apply (Apply (!@#@$) t) t :: a)
+    sTailVec ::
+      forall n a (t :: Vec ('Succ n) a).
+      Sing t -> Sing (Apply TailVecSym0 t :: Vec n a)
+    sHeadVec ::
+      forall n a (t :: Vec ('Succ n) a).
+      Sing t -> Sing (Apply HeadVecSym0 t :: a)
+    sTransitivity SReflexive SReflexive = SReflexive
+    sSymmetry SReflexive = SReflexive
+    sMapVec _ SVNil = SVNil
+    sMapVec (sF :: Sing f) (SVCons (sX :: Sing x) (sXs :: Sing xs))
+      = (applySing
+           ((applySing ((singFun2 @VConsSym0) SVCons)) ((applySing sF) sX)))
+          ((applySing ((applySing ((singFun2 @MapVecSym0) sMapVec)) sF)) sXs)
+    (%!) (SVCons (sX :: Sing x) _) SFZ = sX
+    (%!) (SVCons _ (sXs :: Sing xs)) (SFS (sN :: Sing n))
+      = (applySing ((applySing ((singFun2 @(!@#@$)) (%!))) sXs)) sN
+    (%!) SVNil (sN :: Sing n)
+      = (id @(Sing (Case_0123456789876543210 n n :: a))) (case sN of)
+    sTailVec (SVCons _ (sXs :: Sing xs)) = sXs
+    sHeadVec (SVCons (sX :: Sing x) _) = sX
+    instance SingI (TransitivitySym0 :: (~>) (Equal a b) ((~>) (Equal b c) (Equal a c))) where
+      sing = (singFun2 @TransitivitySym0) sTransitivity
+    instance SingI d =>
+             SingI (TransitivitySym1 (d :: Equal a b) :: (~>) (Equal b c) (Equal a c)) where
+      sing
+        = (singFun1 @(TransitivitySym1 (d :: Equal a b)))
+            (sTransitivity (sing @d))
+    instance SingI (SymmetrySym0 :: (~>) (Equal a b) (Equal b a)) where
+      sing = (singFun1 @SymmetrySym0) sSymmetry
+    instance SingI (MapVecSym0 :: (~>) ((~>) a b) ((~>) (Vec n a) (Vec n b))) where
+      sing = (singFun2 @MapVecSym0) sMapVec
+    instance SingI d =>
+             SingI (MapVecSym1 (d :: (~>) a b) :: (~>) (Vec n a) (Vec n b)) where
+      sing = (singFun1 @(MapVecSym1 (d :: (~>) a b))) (sMapVec (sing @d))
+    instance SingI ((!@#@$) :: (~>) (Vec n a) ((~>) (Fin n) a)) where
+      sing = (singFun2 @(!@#@$)) (%!)
+    instance SingI d =>
+             SingI ((!@#@$$) (d :: Vec n a) :: (~>) (Fin n) a) where
+      sing = (singFun1 @((!@#@$$) (d :: Vec n a))) ((%!) (sing @d))
+    instance SingI (TailVecSym0 :: (~>) (Vec ('Succ n) a) (Vec n a)) where
+      sing = (singFun1 @TailVecSym0) sTailVec
+    instance SingI (HeadVecSym0 :: (~>) (Vec ('Succ n) a) a) where
+      sing = (singFun1 @HeadVecSym0) sHeadVec
+    data SFin :: forall a. Fin a -> Type
+      where
+        SFZ :: forall n. SFin (FZ :: Fin ('Succ n))
+        SFS :: forall n (n :: Fin n).
+               (Sing n) -> SFin (FS n :: Fin ('Succ n))
+    type instance Sing @(Fin a) = SFin
+    data SFoo :: forall a. Foo a -> Type
+      where
+        SMkFoo1 :: SFoo (MkFoo1 :: Foo Bool)
+        SMkFoo2 :: SFoo (MkFoo2 :: Foo Ordering)
+    type instance Sing @(Foo a) = SFoo
+    data SVec :: forall a a. Vec a a -> Type
+      where
+        SVNil :: forall a. SVec (VNil :: Vec 'Zero a)
+        SVCons :: forall a n (n :: a) (n :: Vec n a).
+                  (Sing n) -> (Sing n) -> SVec (VCons n n :: Vec ('Succ n) a)
+    type instance Sing @(Vec a a) = SVec
+    data SEqual :: forall a a. Equal a a -> Type
+      where SReflexive :: forall a. SEqual (Reflexive :: Equal a a)
+    type instance Sing @(Equal a a) = SEqual
+    data SHList :: forall a. HList a -> Type
+      where
+        SHNil :: SHList (HNil :: HList '[])
+        SHCons :: forall x xs (n :: x) (n :: HList xs).
+                  (Sing n) -> (Sing n) -> SHList (HCons n n :: HList ('(:) x xs))
+    type instance Sing @(HList a) = SHList
+    data SObj :: Obj -> Type
+      where SObj :: forall a (n :: a). (Sing n) -> SObj (Obj n :: Obj)
+    type instance Sing @Obj = SObj
+    instance SingI FZ where
+      sing = SFZ
+    instance SingI n => SingI (FS (n :: Fin n)) where
+      sing = SFS sing
+    instance SingI (FSSym0 :: (~>) (Fin n) (Fin ('Succ n))) where
+      sing = (singFun1 @FSSym0) SFS
+    instance SingI MkFoo1 where
+      sing = SMkFoo1
+    instance SingI MkFoo2 where
+      sing = SMkFoo2
+    instance SingI VNil where
+      sing = SVNil
+    instance (SingI n, SingI n) =>
+             SingI (VCons (n :: a) (n :: Vec n a)) where
+      sing = (SVCons sing) sing
+    instance SingI (VConsSym0 :: (~>) a ((~>) (Vec n a) (Vec ('Succ n) a))) where
+      sing = (singFun2 @VConsSym0) SVCons
+    instance SingI d =>
+             SingI (VConsSym1 (d :: a) :: (~>) (Vec n a) (Vec ('Succ n) a)) where
+      sing = (singFun1 @(VConsSym1 (d :: a))) (SVCons (sing @d))
+    instance SingI Reflexive where
+      sing = SReflexive
+    instance SingI HNil where
+      sing = SHNil
+    instance (SingI n, SingI n) =>
+             SingI (HCons (n :: x) (n :: HList xs)) where
+      sing = (SHCons sing) sing
+    instance SingI (HConsSym0 :: (~>) x ((~>) (HList xs) (HList ('(:) x xs)))) where
+      sing = (singFun2 @HConsSym0) SHCons
+    instance SingI d =>
+             SingI (HConsSym1 (d :: x) :: (~>) (HList xs) (HList ('(:) x xs))) where
+      sing = (singFun1 @(HConsSym1 (d :: x))) (SHCons (sing @d))
+    instance SingI n => SingI (Obj (n :: a)) where
+      sing = SObj sing
+    instance SingI (ObjSym0 :: (~>) a Obj) where
+      sing = (singFun1 @ObjSym0) SObj

--- a/tests/compile-and-dump/Singletons/T150.hs
+++ b/tests/compile-and-dump/Singletons/T150.hs
@@ -1,0 +1,53 @@
+module T150 where
+
+import Control.Monad.Trans.Class
+import Data.Kind
+import Data.Singletons.TH
+import Data.Singletons.TH.Options
+import Singletons.Nat
+
+$(withOptions defaultOptions{genSingKindInsts = False} $
+    singletons $ lift
+    [d| data Fin :: Nat -> Type where
+          FZ :: Fin (Succ n)
+          FS :: Fin n -> Fin (Succ n)
+
+        data Foo :: Type -> Type where
+          MkFoo1 :: Foo Bool
+          MkFoo2 :: Foo Ordering
+
+        data Vec :: Nat -> Type -> Type where
+          VNil  :: Vec Zero a
+          VCons :: a -> Vec n a -> Vec (Succ n) a
+
+        headVec :: Vec (Succ n) a -> a
+        headVec (VCons x _) = x
+
+        tailVec :: Vec (Succ n) a -> Vec n a
+        tailVec (VCons _ xs) = xs
+
+        (!) :: Vec n a -> Fin n -> a
+        VCons x _  ! FZ   = x
+        VCons _ xs ! FS n = xs ! n
+        VNil       ! n    = case n of {}
+
+        mapVec :: (a -> b) -> Vec n a -> Vec n b
+        mapVec _ VNil         = VNil
+        mapVec f (VCons x xs) = VCons (f x) (mapVec f xs)
+
+        data Equal :: Type -> Type -> Type where
+          Reflexive :: Equal a a
+
+        symmetry :: Equal a b -> Equal b a
+        symmetry Reflexive = Reflexive
+
+        transitivity :: Equal a b -> Equal b c -> Equal a c
+        transitivity Reflexive Reflexive = Reflexive
+
+        data HList :: [Type] -> Type where
+          HNil  :: HList '[]
+          HCons :: x -> HList xs -> HList (x:xs)
+
+        data Obj :: Type where
+          Obj :: a -> Obj
+    |])

--- a/tests/compile-and-dump/Singletons/T204.golden
+++ b/tests/compile-and-dump/Singletons/T204.golden
@@ -1,0 +1,94 @@
+Singletons/T204.hs:(0,0)-(0,0): Splicing declarations
+    let
+      sing_data_con_name :: Name -> Name
+      sing_data_con_name n
+        = case nameBase n of
+            ':' : '%' : rest -> mkName $ ":^%" ++ rest
+            _ -> singledDataConName defaultOptions n
+    in
+      withOptions
+        defaultOptions {singledDataConName = sing_data_con_name}
+        $ singletons
+            $ lift
+                [d| data Ratio1 a = a :% a
+                    data Ratio2 a = a :%% a |]
+  ======>
+    data Ratio1 a = a :% a
+    data Ratio2 a = a :%% a
+    instance SuppressUnusedWarnings (:%@#@$) where
+      suppressUnusedWarnings = snd (((,) (::%@#@$###)) ())
+    data (:%@#@$) :: forall a0123456789876543210.
+                     (~>) a0123456789876543210 ((~>) a0123456789876543210 (Ratio1 a0123456789876543210))
+      where
+        (::%@#@$###) :: forall t0123456789876543210
+                               arg. SameKind (Apply (:%@#@$) arg) ((:%@#@$$) arg) =>
+                        (:%@#@$) t0123456789876543210
+    type instance Apply (:%@#@$) t0123456789876543210 = (:%@#@$$) t0123456789876543210
+    instance SuppressUnusedWarnings ((:%@#@$$) t0123456789876543210) where
+      suppressUnusedWarnings = snd (((,) (::%@#@$$###)) ())
+    data (:%@#@$$) (t0123456789876543210 :: a0123456789876543210) :: (~>) a0123456789876543210 (Ratio1 a0123456789876543210)
+      where
+        (::%@#@$$###) :: forall t0123456789876543210
+                                t0123456789876543210
+                                arg. SameKind (Apply ((:%@#@$$) t0123456789876543210) arg) ((:%@#@$$$) t0123456789876543210 arg) =>
+                         (:%@#@$$) t0123456789876543210 t0123456789876543210
+    type instance Apply ((:%@#@$$) t0123456789876543210) t0123456789876543210 = (:%@#@$$$) t0123456789876543210 t0123456789876543210
+    type (:%@#@$$$) (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: a0123456789876543210) =
+        (:%) t0123456789876543210 t0123456789876543210
+    instance SuppressUnusedWarnings (:%%@#@$) where
+      suppressUnusedWarnings = snd (((,) (::%%@#@$###)) ())
+    data (:%%@#@$) :: forall a0123456789876543210.
+                      (~>) a0123456789876543210 ((~>) a0123456789876543210 (Ratio2 a0123456789876543210))
+      where
+        (::%%@#@$###) :: forall t0123456789876543210
+                                arg. SameKind (Apply (:%%@#@$) arg) ((:%%@#@$$) arg) =>
+                         (:%%@#@$) t0123456789876543210
+    type instance Apply (:%%@#@$) t0123456789876543210 = (:%%@#@$$) t0123456789876543210
+    instance SuppressUnusedWarnings ((:%%@#@$$) t0123456789876543210) where
+      suppressUnusedWarnings = snd (((,) (::%%@#@$$###)) ())
+    data (:%%@#@$$) (t0123456789876543210 :: a0123456789876543210) :: (~>) a0123456789876543210 (Ratio2 a0123456789876543210)
+      where
+        (::%%@#@$$###) :: forall t0123456789876543210
+                                 t0123456789876543210
+                                 arg. SameKind (Apply ((:%%@#@$$) t0123456789876543210) arg) ((:%%@#@$$$) t0123456789876543210 arg) =>
+                          (:%%@#@$$) t0123456789876543210 t0123456789876543210
+    type instance Apply ((:%%@#@$$) t0123456789876543210) t0123456789876543210 = (:%%@#@$$$) t0123456789876543210 t0123456789876543210
+    type (:%%@#@$$$) (t0123456789876543210 :: a0123456789876543210) (t0123456789876543210 :: a0123456789876543210) =
+        (:%%) t0123456789876543210 t0123456789876543210
+    data SRatio1 :: forall a. Ratio1 a -> GHC.Types.Type
+      where
+        (:^%) :: forall a (n :: a) (n :: a).
+                 (Sing n) -> (Sing n) -> SRatio1 ((:%) n n :: Ratio1 a)
+    type instance Sing @(Ratio1 a) = SRatio1
+    instance SingKind a => SingKind (Ratio1 a) where
+      type Demote (Ratio1 a) = Ratio1 (Demote a)
+      fromSing ((:^%) b b) = ((:%) (fromSing b)) (fromSing b)
+      toSing ((:%) (b :: Demote a) (b :: Demote a))
+        = case ((,) (toSing b :: SomeSing a)) (toSing b :: SomeSing a) of {
+            (,) (SomeSing c) (SomeSing c) -> SomeSing (((:^%) c) c) }
+    data SRatio2 :: forall a. Ratio2 a -> GHC.Types.Type
+      where
+        (:^%%) :: forall a (n :: a) (n :: a).
+                  (Sing n) -> (Sing n) -> SRatio2 ((:%%) n n :: Ratio2 a)
+    type instance Sing @(Ratio2 a) = SRatio2
+    instance SingKind a => SingKind (Ratio2 a) where
+      type Demote (Ratio2 a) = Ratio2 (Demote a)
+      fromSing ((:^%%) b b) = ((:%%) (fromSing b)) (fromSing b)
+      toSing ((:%%) (b :: Demote a) (b :: Demote a))
+        = case ((,) (toSing b :: SomeSing a)) (toSing b :: SomeSing a) of {
+            (,) (SomeSing c) (SomeSing c) -> SomeSing (((:^%%) c) c) }
+    instance (SingI n, SingI n) => SingI ((:%) (n :: a) (n :: a)) where
+      sing = ((:^%) sing) sing
+    instance SingI ((:%@#@$) :: (~>) a ((~>) a (Ratio1 a))) where
+      sing = (singFun2 @(:%@#@$)) (:^%)
+    instance SingI d =>
+             SingI ((:%@#@$$) (d :: a) :: (~>) a (Ratio1 a)) where
+      sing = (singFun1 @((:%@#@$$) (d :: a))) ((:^%) (sing @d))
+    instance (SingI n, SingI n) =>
+             SingI ((:%%) (n :: a) (n :: a)) where
+      sing = ((:^%%) sing) sing
+    instance SingI ((:%%@#@$) :: (~>) a ((~>) a (Ratio2 a))) where
+      sing = (singFun2 @(:%%@#@$)) (:^%%)
+    instance SingI d =>
+             SingI ((:%%@#@$$) (d :: a) :: (~>) a (Ratio2 a)) where
+      sing = (singFun1 @((:%%@#@$$) (d :: a))) ((:^%%) (sing @d))

--- a/tests/compile-and-dump/Singletons/T204.hs
+++ b/tests/compile-and-dump/Singletons/T204.hs
@@ -1,0 +1,17 @@
+module T204 where
+
+import Control.Monad.Trans.Class
+import Data.Singletons.TH
+import Data.Singletons.TH.Options
+import Language.Haskell.TH
+
+$(let sing_data_con_name :: Name -> Name
+      sing_data_con_name n =
+        case nameBase n of
+          ':':'%':rest -> mkName $ ":^%" ++ rest
+          _            -> singledDataConName defaultOptions n in
+  withOptions defaultOptions{singledDataConName = sing_data_con_name} $
+    singletons $ lift
+    [d| data Ratio1 a = a :%  a
+        data Ratio2 a = a :%% a
+      |])


### PR DESCRIPTION
This patch introduces an `Options` data type and an `mtl`-like `OptionsMonad` class for monads that carry `Options`. At present, the only things one can do with `Options` are:

* Toggle the generation of `SingKind` instances. Suppressing `SingKind` instances provides an effective workaround for #150.
* Hook into the TH machinery's naming conventions for promoted and singled names. This fixes #204.

The vast majority of this patch simply adds plumbing by using `OptionsMonad` in places that need it. See the `D.S.TH.Options` module for where most of the new code is housed, as well as the `T150` and `T204` test cases for examples of how to use it.