### PR TITLE
Add genQuotedDecs option, generate fixity decs for infix names if False

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,10 +8,10 @@ Changelog for singletons project
   the way of an `Options` data type, which lives in the new
   `Data.Singletons.TH.Options` module. Besides `Options`, this module also
   contains:
-    * `Options`' record selectors. Currently, these include ways to toggle
-      generating `SingKind` instances and configure how `singletons` generates
-      the names of promoted or singled types. In the future, there may be
-      additional options.
+    * `Options`' record selectors. Currently, these include options to toggle
+      generating quoted declarations, toggle generating `SingKind` instances,
+      and configure how `singletons` generates the names of promoted or singled
+      types. In the future, there may be additional options.
     * A `defaultOptions` value.
     * An `mtl`-like `OptionsMonad` class for monads that support carrying
       `Option`s. This includes `Q`, which uses `defaultOptions` if it is the
@@ -45,6 +45,8 @@ Changelog for singletons project
     for type synonym or type family names.
   * A bug that caused fixity declarations for certain defunctionalization
     symbols not to be generated has been fixed.
+  * `promoteOnly` and `singletonsOnly` will now produce fixity declarations
+    for values with infix names.
 
 2.6
 ---

--- a/src/Data/Singletons/Prelude/Base.hs
+++ b/src/Data/Singletons/Prelude/Base.hs
@@ -108,9 +108,3 @@ $(singletonsOnly [d|
   seq _ x = x
   infixr 0 `seq`
  |])
-
--- Workaround for #326
-infixr 5 ++
-infixr 9 .
-infixr 0 $
-infixr 0 $!

--- a/src/Data/Singletons/Prelude/Function.hs
+++ b/src/Data/Singletons/Prelude/Function.hs
@@ -114,6 +114,3 @@ $(singletonsOnly [d|
   x & f = f x
   infixl 1 &
   |])
-
--- Workaround for #326
-infixl 1 &

--- a/src/Data/Singletons/Prelude/Functor.hs
+++ b/src/Data/Singletons/Prelude/Functor.hs
@@ -200,8 +200,3 @@ $(singletonsOnly [d|
   deriving instance Functor ((,) a)
   deriving instance Functor Down
   |])
-
--- Workaround for #326
-infixl 4 <$>
-infixl 4 $>
-infixl 1 <&>

--- a/src/Data/Singletons/Prelude/List/Internal.hs
+++ b/src/Data/Singletons/Prelude/List/Internal.hs
@@ -588,10 +588,6 @@ $(singletonsOnly [d|
 
   |])
 
--- Workaround for #326
-infix 5 \\      -- This comment is necessary so CPP doesn't treat the
-infixl 9 !!
-
 -- The following functions are supported for promotion only.
 $(promoteOnly [d|
 

--- a/src/Data/Singletons/Prelude/Monad.hs
+++ b/src/Data/Singletons/Prelude/Monad.hs
@@ -292,7 +292,3 @@ $(singletonsOnly [d|
   instance Monad Down where
     Down a >>= k = k a
   |])
-
--- Workaround for #326
-infixr 1 <=<, >=>
-infixl 4 <$!>

--- a/src/Data/Singletons/Prelude/Monad/Internal.hs
+++ b/src/Data/Singletons/Prelude/Monad/Internal.hs
@@ -425,13 +425,6 @@ $(singletonsOnly [d|
      mplus = (<|>)
   |])
 
--- Workaround for #326
-infixl 4 <$
-infixl 4 <*>, <*, *>, <**>
-infixl 1 >>, >>=
-infixr 1 =<<
-infixl 3 <|>
-
 $(singletonsOnly [d|
   -------------------------------------------------------------------------------
   -- Instances

--- a/src/Data/Singletons/Prelude/Num.hs
+++ b/src/Data/Singletons/Prelude/Num.hs
@@ -73,6 +73,9 @@ $(singletonsOnly [d|
 
       negate x            = 0 - x
 
+  subtract :: Num a => a -> a -> a
+  subtract x y = y - x
+
   -- deriving newtype instance Num a => Num (Down a)
   instance Num a => Num (Down a) where
       Down a + Down b = Down (a + b)
@@ -83,11 +86,6 @@ $(singletonsOnly [d|
       signum (Down a) = Down (signum a)
       fromInteger n   = Down (fromInteger n)
   |])
-
--- Workaround for #326
-infixl 6 +
-infixl 6 -
-infixl 7 *
 
 -- PNum instance
 type family SignumNat (a :: Nat) :: Nat where
@@ -139,8 +137,3 @@ instance SNum Nat where
       Disproved _ -> unsafeCoerce (sing :: Sing 1)
 
   sFromInteger x = x
-
-$(singletonsOnly [d|
-  subtract :: Num a => a -> a -> a
-  subtract x y = y - x
-  |])

--- a/src/Data/Singletons/Prelude/Ord.hs
+++ b/src/Data/Singletons/Prelude/Ord.hs
@@ -88,12 +88,6 @@ $(singletonsOnly [d|
   comparing p x y = compare (p x) (p y)
   |])
 
--- Workaround for #326
-infix 4 <=
-infix 4 <
-infix 4 >
-infix 4 >=
-
 $(genSingletons [''Down])
 
 $(singletonsOnly [d|

--- a/src/Data/Singletons/Prelude/Semigroup/Internal.hs
+++ b/src/Data/Singletons/Prelude/Semigroup/Internal.hs
@@ -147,9 +147,6 @@ $(singletonsOnly [d|
     Down a <> Down b = Down (a <> b)
   |])
 
--- Workaround for #326
-infixr 6 <>
-
 $(genSingletons       $ ''Option : semigroupBasicTypes)
 $(singBoundedInstances             semigroupBasicTypes)
 $(singEqInstances     $ ''Option : semigroupBasicTypes)

--- a/src/Data/Singletons/TH/Options.hs
+++ b/src/Data/Singletons/TH/Options.hs
@@ -20,6 +20,7 @@ module Data.Singletons.TH.Options
   ( -- * Options
     Options, defaultOptions
     -- ** Options record selectors
+  , genQuotedDecs
   , genSingKindInsts
   , promotedClassName
   , promotedValueName
@@ -56,7 +57,11 @@ import Language.Haskell.TH.Syntax hiding (Lift(..))
 -- | Options that control the finer details of how @singletons@' Template
 -- Haskell machinery works.
 data Options = Options
-  { genSingKindInsts        :: Bool
+  { genQuotedDecs        :: Bool
+    -- ^ If 'True', then quoted declarations will be generated alongside their
+    --   promoted and singled counterparts. If 'False', then quoted
+    --   declarations will be discarded.
+  , genSingKindInsts     :: Bool
     -- ^ If 'True', then 'SingKind' instances will be generated. If 'False',
     --   they will be omitted entirely. This can be useful in scenarios where
     --   TH-generated 'SingKind' instances do not typecheck (for instance,
@@ -98,6 +103,10 @@ data Options = Options
 
 -- | Sensible default 'Options'.
 --
+-- 'genQuotedDecs' defaults to 'True'.
+-- That is, quoted declarations are generated alongside their promoted and
+-- singled counterparts.
+--
 -- 'genSingKindInsts' defaults to 'True'.
 -- That is, 'SingKind' instances are generated.
 --
@@ -107,7 +116,8 @@ data Options = Options
 -- \"On names\" section of the @singletons@ @README@.
 defaultOptions :: Options
 defaultOptions = Options
-  { genSingKindInsts     = True
+  { genQuotedDecs        = True
+  , genSingKindInsts     = True
   , promotedClassName    = promoteClassName
   , promotedValueName    = promoteValNameLhs
   , singledDataTypeName  = singTyConName

--- a/src/Data/Singletons/Util.hs
+++ b/src/Data/Singletons/Util.hs
@@ -466,12 +466,6 @@ multiCase [] [] body = body
 multiCase scruts pats body =
   DCaseE (mkTupleDExp scruts) [DMatch (mkTupleDPat pats) body]
 
--- Make a desugar function into a TH function.
-wrapDesugar :: (Desugar th ds, DsMonad q) => (th -> ds -> q ds) -> th -> q th
-wrapDesugar f th = do
-  ds <- desugar th
-  fmap sweeten $ f th ds
-
 -- a monad transformer for writing a monoid alongside returning a Q
 newtype QWithAux m q a = QWA { runQWA :: WriterT m q a }
   deriving ( Functor, Applicative, Monad, MonadTrans

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -110,6 +110,7 @@ tests =
     , compileAndDumpStdTest "T313"
     , compileAndDumpStdTest "T316"
     , compileAndDumpStdTest "T322"
+    , compileAndDumpStdTest "T326"
     , compileAndDumpStdTest "NatSymbolReflexive"
     , compileAndDumpStdTest "T323"
     , compileAndDumpStdTest "T332"

--- a/tests/compile-and-dump/Singletons/T326.golden
+++ b/tests/compile-and-dump/Singletons/T326.golden
@@ -1,0 +1,68 @@
+Singletons/T326.hs:0:0:: Splicing declarations
+    genPromotions [''C1]
+  ======>
+    instance SuppressUnusedWarnings (<%>@#@$) where
+      suppressUnusedWarnings = snd (((,) (:<%>@#@$###)) ())
+    data (<%>@#@$) :: forall a0123456789876543210.
+                      (~>) a0123456789876543210 ((~>) a0123456789876543210 a0123456789876543210)
+      where
+        (:<%>@#@$###) :: forall arg0123456789876543210
+                                arg. SameKind (Apply (<%>@#@$) arg) ((<%>@#@$$) arg) =>
+                         (<%>@#@$) arg0123456789876543210
+    type instance Apply (<%>@#@$) arg0123456789876543210 = (<%>@#@$$) arg0123456789876543210
+    infixl 9 <%>@#@$
+    instance SuppressUnusedWarnings ((<%>@#@$$) arg0123456789876543210) where
+      suppressUnusedWarnings = snd (((,) (:<%>@#@$$###)) ())
+    data (<%>@#@$$) (arg0123456789876543210 :: a0123456789876543210) :: (~>) a0123456789876543210 a0123456789876543210
+      where
+        (:<%>@#@$$###) :: forall arg0123456789876543210
+                                 arg0123456789876543210
+                                 arg. SameKind (Apply ((<%>@#@$$) arg0123456789876543210) arg) ((<%>@#@$$$) arg0123456789876543210 arg) =>
+                          (<%>@#@$$) arg0123456789876543210 arg0123456789876543210
+    type instance Apply ((<%>@#@$$) arg0123456789876543210) arg0123456789876543210 = (<%>@#@$$$) arg0123456789876543210 arg0123456789876543210
+    infixl 9 <%>@#@$$
+    type (<%>@#@$$$) (arg0123456789876543210 :: a0123456789876543210) (arg0123456789876543210 :: a0123456789876543210) =
+        (<%>) arg0123456789876543210 arg0123456789876543210
+    infixl 9 <%>@#@$$$
+    class PC1 (a :: GHC.Types.Type) where
+      type (<%>) (arg :: a) (arg :: a) :: a
+    infixl 9 <%>
+Singletons/T326.hs:0:0:: Splicing declarations
+    genSingletons [''C2]
+  ======>
+    instance SuppressUnusedWarnings (<%%>@#@$) where
+      suppressUnusedWarnings = snd (((,) (:<%%>@#@$###)) ())
+    data (<%%>@#@$) :: forall a0123456789876543210.
+                       (~>) a0123456789876543210 ((~>) a0123456789876543210 a0123456789876543210)
+      where
+        (:<%%>@#@$###) :: forall arg0123456789876543210
+                                 arg. SameKind (Apply (<%%>@#@$) arg) ((<%%>@#@$$) arg) =>
+                          (<%%>@#@$) arg0123456789876543210
+    type instance Apply (<%%>@#@$) arg0123456789876543210 = (<%%>@#@$$) arg0123456789876543210
+    infixl 9 <%%>@#@$
+    instance SuppressUnusedWarnings ((<%%>@#@$$) arg0123456789876543210) where
+      suppressUnusedWarnings = snd (((,) (:<%%>@#@$$###)) ())
+    data (<%%>@#@$$) (arg0123456789876543210 :: a0123456789876543210) :: (~>) a0123456789876543210 a0123456789876543210
+      where
+        (:<%%>@#@$$###) :: forall arg0123456789876543210
+                                  arg0123456789876543210
+                                  arg. SameKind (Apply ((<%%>@#@$$) arg0123456789876543210) arg) ((<%%>@#@$$$) arg0123456789876543210 arg) =>
+                           (<%%>@#@$$) arg0123456789876543210 arg0123456789876543210
+    type instance Apply ((<%%>@#@$$) arg0123456789876543210) arg0123456789876543210 = (<%%>@#@$$$) arg0123456789876543210 arg0123456789876543210
+    infixl 9 <%%>@#@$$
+    type (<%%>@#@$$$) (arg0123456789876543210 :: a0123456789876543210) (arg0123456789876543210 :: a0123456789876543210) =
+        (<%%>) arg0123456789876543210 arg0123456789876543210
+    infixl 9 <%%>@#@$$$
+    class PC2 (a :: GHC.Types.Type) where
+      type (<%%>) (arg :: a) (arg :: a) :: a
+    infixl 9 <%%>
+    class SC2 (a :: GHC.Types.Type) where
+      (%<%%>) ::
+        forall (t :: a) (t :: a).
+        Sing t -> Sing t -> Sing (Apply (Apply (<%%>@#@$) t) t :: a)
+    infixl 9 %<%%>
+    instance SC2 a => SingI ((<%%>@#@$) :: (~>) a ((~>) a a)) where
+      sing = (singFun2 @(<%%>@#@$)) (%<%%>)
+    instance (SC2 a, SingI d) =>
+             SingI ((<%%>@#@$$) (d :: a) :: (~>) a a) where
+      sing = (singFun1 @((<%%>@#@$$) (d :: a))) ((%<%%>) (sing @d))

--- a/tests/compile-and-dump/Singletons/T326.hs
+++ b/tests/compile-and-dump/Singletons/T326.hs
@@ -1,0 +1,23 @@
+module T326 where
+
+import Data.Singletons.TH
+import Data.Type.Equality
+
+class C1 a where
+  infixl 9 <%>
+  (<%>) :: a -> a -> a
+
+class C2 a where
+  infixl 9 <%%>
+  (<%%>) :: a -> a -> a
+
+$(genPromotions [''C1])
+$(genSingletons [''C2])
+
+test1 :: Proxy f -> Proxy g -> Proxy h
+      -> (f <%> g) <%> h :~: f <%> g <%> h
+test1 _ _ _ = Refl
+
+test2 :: Proxy f -> Proxy g -> Proxy h
+      -> (f <%%> g) <%%> h :~: f <%%> g <%%> h
+test2 _ _ _ = Refl


### PR DESCRIPTION
This patch:

* Introduces a `genQuotedDecs :: Bool` option that controls whether the `q [Dec]` arguments in the `promote` and `singletons` functions should be generated as part of their output.
* Refactor `promote{Only}` and `singletons{Only}` to use `genQuotedDecs`.
* Changes `D.S.Promote.promoteInfixDecl` so that it _does_ promote fixity declarations for infix names when `genQuotedDecs` is `False`. (See the updated `Note [singletons and fixity declarations]` in `D.S.Single.Fixity`, wrinkle 1, for a more detailed explanation.) This fixes #326 in a much more robust way than the previous hacky workaround in commit 40c736ffc3b3a4954d5e44f759344690424ab449.