### PR TITLE
Remove the promoted versions of GenericTake et al.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,11 @@ Changelog for singletons project
 * Export `ApplyTyConAux1`, `ApplyTyConAux2`, as well as the record pattern
   synonyms selector `applySing2`, `applySing3`, etc. from `Data.Singletons`.
   These were unintentionally left out in previous releases.
+* Remove the promoted versions of `genericTake`, `genericDrop`,
+  `genericSplitAt`, `genericIndex`, and `genericReplicate` from
+  `Data.Singletons.Prelude.List`. These definitions were subtly wrong since
+  (1) they claim to work over any `Integral` type `i`, but in practice would
+  only work on `Nat`s, and (2) wouldn't even typecheck if they were singled.
 * Fix a slew of bugs related to fixity declarations:
   * Fixity declarations for data types are no longer singled, as fixity
     declarations do not serve any purpose for singled data type constructors,

--- a/src/Data/Singletons/Prelude/List.hs
+++ b/src/Data/Singletons/Prelude/List.hs
@@ -124,8 +124,6 @@ module Data.Singletons.Prelude.List (
   -- | The prefix \`@generic@\' indicates an overloaded function that
   -- is a generalized version of a "Prelude" function.
   GenericLength, sGenericLength,
-  GenericTake, GenericDrop,
-  GenericSplitAt, GenericIndex, GenericReplicate,
 
   -- * Defunctionalization symbols
   NilSym0,
@@ -245,12 +243,7 @@ module Data.Singletons.Prelude.List (
   MaximumBySym0, MaximumBySym1, MaximumBySym2,
   MinimumBySym0, MinimumBySym1, MinimumBySym2,
 
-  GenericLengthSym0, GenericLengthSym1,
-  GenericTakeSym0, GenericTakeSym1, GenericTakeSym2,
-  GenericDropSym0, GenericDropSym1, GenericDropSym2,
-  GenericSplitAtSym0, GenericSplitAtSym1, GenericSplitAtSym2,
-  GenericIndexSym0, GenericIndexSym1, GenericIndexSym2,
-  GenericReplicateSym0, GenericReplicateSym1, GenericReplicateSym2,
+  GenericLengthSym0, GenericLengthSym1
   ) where
 
 import Data.Singletons.Prelude.Base

--- a/src/Data/Singletons/Prelude/List/Internal.hs
+++ b/src/Data/Singletons/Prelude/List/Internal.hs
@@ -637,26 +637,4 @@ $(promoteOnly [d|
   zipWith7 z (a:as) (b:bs) (c:cs) (d:ds) (e:es) (f:fs) (g:gs)
                      =  z a b c d e f g : zipWith7 z as bs cs ds es fs gs
   zipWith7 _ _ _ _ _ _ _ _ = []
-
--- These functions use Integral or Num typeclass instead of Int.
---
---  genericLength, genericTake, genericDrop, genericSplitAt, genericIndex
---  genericReplicate
---
--- We provide aliases below to improve compatibility
-
-  genericTake :: (Integral i) => i -> [a] -> [a]
-  genericTake = take
-
-  genericDrop :: (Integral i) => i -> [a] -> [a]
-  genericDrop = drop
-
-  genericSplitAt :: (Integral i) => i -> [a] -> ([a], [a])
-  genericSplitAt = splitAt
-
-  genericIndex :: (Integral i) => [a] -> i -> a
-  genericIndex = (!!)
-
-  genericReplicate :: (Integral i) => i -> a -> [a]
-  genericReplicate = replicate
  |])


### PR DESCRIPTION
Per the discussion in https://github.com/goldfirere/singletons/issues/433#issuecomment-582912446, these definitions are subtly bogus. Let's just remove them.