### PR TITLE
Single record selectors as top-level functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,7 +592,6 @@ The following constructs are fully supported:
 * class constraints (though these sometimes fail with `let`, `lambda`, and `case`)
 * literals (for `Nat` and `Symbol`), including overloaded number literals
 * unboxed tuples (which are treated as normal tuples)
-* records
 * pattern guards
 * case
 * let
@@ -604,6 +603,7 @@ The following constructs are fully supported:
 * `InstanceSigs`
 * higher-kinded type variables (see below)
 * finite arithmetic sequences (see below)
+* records (with limitations -- see below)
 * functional dependencies (with limitations -- see below)
 * type families (with limitations -- see below)
 
@@ -622,6 +622,16 @@ methods from the `Enum` class under the hood). _Finite_ sequences (e.g.,
 [0..42]) are fully supported. However, _infinite_ sequences (e.g., [0..]),
 which desugar to calls to `enumFromTo` or `enumFromThenTo`, are not supported,
 as these would require using infinite lists at the type level.
+
+Record selectors are promoted to top-level functions, as there is no record
+syntax at the type level. Record selectors are also singled to top-level
+functions because embedding records directly into singleton data constructors
+can result in surprising behavior (see
+[this bug report](https://github.com/goldfirere/singletons/issues/364) for more
+details on this point). TH-generated code is not affected by this limitation
+since `singletons` desugars away most uses of record syntax. On the other hand,
+it is not possible to write out code like
+`SIdentity { sRunIdentity = SIdentity STrue }` by hand.
 
 The following constructs are supported for promotion but not singleton generation:
 
@@ -864,7 +874,6 @@ for the following constructs:
 Known bugs
 ----------
 
-* Record updates don't singletonize
 * Inference dependent on functional dependencies is unpredictably bad. The
   problem is that a use of an associated type family tied to a class with
   fundeps doesn't provoke the fundep to kick in. This is GHC's problem, in

--- a/src/Data/Singletons/CustomStar.hs
+++ b/src/Data/Singletons/CustomStar.hs
@@ -92,7 +92,7 @@ singletonStar names = do
     let dataDeclEqInst = DerivedDecl (Just dataDeclEqCxt) (DConT repName) repName dataDecl
     ordInst  <- mkOrdInstance Nothing (DConT repName) dataDecl
     showInst <- mkShowInstance ForPromotion Nothing (DConT repName) dataDecl
-    (pInsts, promDecls) <- promoteM [] $ do promoteDataDec dataDecl
+    (pInsts, promDecls) <- promoteM [] $ do _ <- promoteDataDec dataDecl
                                             promoteDerivedEqDec dataDeclEqInst
                                             traverse (promoteInstanceDec mempty mempty)
                                               [ordInst, showInst]

--- a/src/Data/Singletons/Prelude/Applicative.hs
+++ b/src/Data/Singletons/Prelude/Applicative.hs
@@ -29,7 +29,7 @@
 module Data.Singletons.Prelude.Applicative (
   PApplicative(..), SApplicative(..),
   PAlternative(..), SAlternative(..),
-  Sing, SConst(..), Const, GetConst,
+  Sing, SConst(..), Const, GetConst, sGetConst,
   type (<$>), (%<$>), type (<$), (%<$), type (<**>), (%<**>),
   LiftA, sLiftA, LiftA3, sLiftA3, Optional, sOptional,
 

--- a/src/Data/Singletons/Prelude/Const.hs
+++ b/src/Data/Singletons/Prelude/Const.hs
@@ -27,7 +27,7 @@
 
 module Data.Singletons.Prelude.Const (
   -- * The 'Const' singleton
-  Sing, SConst(..), GetConst,
+  Sing, SConst(..), GetConst, sGetConst,
 
   -- * Defunctionalization symbols
   ConstSym0, ConstSym1,
@@ -73,7 +73,7 @@ hand.
 -}
 type SConst :: Const a b -> Type
 data SConst c where
-  SConst :: { sGetConst :: Sing a } -> SConst ('Const a)
+  SConst :: Sing a -> SConst ('Const a)
 type instance Sing = SConst
 instance SingKind a => SingKind (Const a b) where
   type Demote (Const a b) = Const (Demote a) b
@@ -86,13 +86,10 @@ $(genDefunSymbols [''Const])
 instance SingI ConstSym0 where
   sing = singFun1 SConst
 
-$(singletons [d|
-  type GetConst :: Const a b -> a
-  type family GetConst x where
-    GetConst ('Const x) = x
-  |])
-
 $(singletonsOnly [d|
+  getConst :: Const a b -> a
+  getConst (Const x) = x
+
   deriving instance Bounded a => Bounded (Const a b)
   deriving instance Eq      a => Eq      (Const a b)
   deriving instance Ord     a => Ord     (Const a b)

--- a/src/Data/Singletons/Prelude/Identity.hs
+++ b/src/Data/Singletons/Prelude/Identity.hs
@@ -27,7 +27,7 @@
 
 module Data.Singletons.Prelude.Identity (
   -- * The 'Identity' singleton
-  Sing, SIdentity(..), RunIdentity,
+  Sing, SIdentity(..), RunIdentity, sRunIdentity,
 
   -- * Defunctionalization symbols
   IdentitySym0, IdentitySym1,

--- a/src/Data/Singletons/Prelude/Monoid.hs
+++ b/src/Data/Singletons/Prelude/Monoid.hs
@@ -34,6 +34,7 @@ module Data.Singletons.Prelude.Monoid (
   Sing, SDual(..), SAll(..), SAny(..),
   SSum(..), SProduct(..), SFirst(..), SLast(..),
   GetDual, GetAll, GetAny, GetSum, GetProduct, GetFirst, GetLast,
+  sGetDual, sGetAll, sGetAny, sGetSum, sGetProduct, sGetFirst, sGetLast,
 
   -- ** Defunctionalization symbols
   MemptySym0,
@@ -61,8 +62,8 @@ import Data.Singletons.Prelude.Semigroup.Internal hiding
        (SFirst, SLast,
         FirstSym0, FirstSym1, FirstSym0KindInference,
         LastSym0,  LastSym1,  LastSym0KindInference,
-        GetFirst,  GetFirstSym0, GetFirstSym1, GetFirstSym0KindInference,
-        GetLast,   GetLastSym0,  GetLastSym1, GetLastSym0KindInference)
+        GetFirst, sGetFirst, GetFirstSym0, GetFirstSym1, GetFirstSym0KindInference,
+        GetLast,  sGetLast,  GetLastSym0,  GetLastSym1, GetLastSym0KindInference)
 import Data.Singletons.Prelude.Show
 import Data.Singletons.Single
 import Data.Singletons.Util

--- a/src/Data/Singletons/Prelude/Ord.hs
+++ b/src/Data/Singletons/Prelude/Ord.hs
@@ -28,7 +28,7 @@ module Data.Singletons.Prelude.Ord (
   -- it returns its first argument.
   thenCmp, ThenCmp, sThenCmp,
 
-  Sing, SOrdering(..), SDown(..),
+  Sing, SOrdering(..), SDown(..), GetDown, sGetDown,
 
   -- ** Defunctionalization symbols
   ThenCmpSym0, ThenCmpSym1, ThenCmpSym2,
@@ -41,7 +41,8 @@ module Data.Singletons.Prelude.Ord (
   MaxSym0, MaxSym1, MaxSym2,
   MinSym0, MinSym1, MinSym2,
   ComparingSym0, ComparingSym1, ComparingSym2, ComparingSym3,
-  DownSym0, DownSym1
+  DownSym0, DownSym1,
+  GetDownSym0, GetDownSym1
   ) where
 
 import Data.Ord (Down(..))

--- a/src/Data/Singletons/Prelude/Semigroup.hs
+++ b/src/Data/Singletons/Prelude/Semigroup.hs
@@ -36,6 +36,8 @@ module Data.Singletons.Prelude.Semigroup (
   SSum(..), SProduct(..), SOption(..), SArg(..),
   GetMin, GetMax, GetFirst, GetLast, UnwrapMonoid, GetDual,
   GetAll, GetAny, GetSum, GetProduct, GetOption,
+  sGetMin, sGetMax, sGetFirst, sGetLast, sUnwrapMonoid, sGetDual,
+  sGetAll, sGetAny, sGetSum, sGetProduct, sGetOption,
 
   option_, sOption_, Option_,
 
@@ -76,8 +78,8 @@ import Data.Singletons.Prelude.Monad.Internal
 import Data.Singletons.Prelude.Monoid hiding
        (SFirst(..), SLast(..),
         FirstSym0, FirstSym1, LastSym0, LastSym1,
-        GetFirst,  GetFirstSym0, GetFirstSym1,
-        GetLast,   GetLastSym0,  GetLastSym1)
+        GetFirst, sGetFirst, GetFirstSym0, GetFirstSym1,
+        GetLast,  sGetLast,  GetLastSym0,  GetLastSym1)
 import Data.Singletons.Prelude.Num
 import Data.Singletons.Prelude.Ord hiding
        (MinSym0, MinSym1, MaxSym0, MaxSym1)

--- a/src/Data/Singletons/Prelude/Traversable.hs
+++ b/src/Data/Singletons/Prelude/Traversable.hs
@@ -86,6 +86,14 @@ data StateRSym0 z
 type instance Apply StateRSym0 x = 'StateR x
 
 $(singletonsOnly [d|
+  runStateL :: StateL s a -> (s -> (s, a))
+  runStateL (StateL x) = x
+
+  runStateR :: StateR s a -> (s -> (s, a))
+  runStateR (StateR x) = x
+  |])
+
+$(singletonsOnly [d|
   -- -| Functors representing data structures that can be traversed from
   -- left to right.
   --
@@ -266,16 +274,14 @@ $(singletonsOnly [d|
   -- a final value of this accumulator together with the new structure.
   mapAccumL :: forall t a b c. Traversable t
             => (a -> b -> (a, c)) -> a -> t b -> (a, t c)
-  mapAccumL f s t = case traverse (StateL . flip f) t of
-                      StateL g -> g s
+  mapAccumL f s t = runStateL (traverse (StateL . flip f) t) s
 
   -- -|The 'mapAccumR' function behaves like a combination of 'fmap'
   -- and 'foldr'; it applies a function to each element of a structure,
   -- passing an accumulating parameter from right to left, and returning
   -- a final value of this accumulator together with the new structure.
   mapAccumR :: Traversable t => (a -> b -> (a, c)) -> a -> t b -> (a, t c)
-  mapAccumR f s t = case traverse (StateR . flip f) t of
-                      StateR g -> g s
+  mapAccumR f s t = runStateR (traverse (StateR . flip f) t) s
 
   -- -| This function may be used as a value for `fmap` in a `Functor`
   --   instance, provided that 'traverse' is defined. (Using

--- a/src/Data/Singletons/Single.hs
+++ b/src/Data/Singletons/Single.hs
@@ -328,8 +328,8 @@ singTopLevelDecs locals raw_decls = withLocalDeclarations locals $ do
 
   ((letDecEnv, classes', insts'), promDecls) <- promoteM locals $ do
     defunTopLevelTypeDecls ty_syns c_tyfams o_tyfams
-    promoteDataDecs datas
-    (_, letDecEnv) <- promoteLetDecs Nothing letDecls
+    recSelLetDecls <- promoteDataDecs datas
+    (_, letDecEnv) <- promoteLetDecs Nothing $ recSelLetDecls ++ letDecls
     classes' <- mapM promoteClassDec classes
     let meth_sigs    = foldMap (lde_types . cd_lde) classes
         cls_tvbs_map = Map.fromList $ map (\cd -> (cd_name cd, cd_tvbs cd)) classes

--- a/src/Data/Singletons/Util.hs
+++ b/src/Data/Singletons/Util.hs
@@ -115,12 +115,21 @@ tysOfConFields :: DConFields -> [DType]
 tysOfConFields (DNormalC _ stys) = map snd stys
 tysOfConFields (DRecC vstys)   = map (\(_,_,ty) -> ty) vstys
 
--- extract the name and number of arguments to a constructor
+recSelsOfConFields :: DConFields -> [Name]
+recSelsOfConFields DNormalC{}    = []
+recSelsOfConFields (DRecC vstys) = map (\(n,_,_) -> n) vstys
+
+-- Extract a data constructor's name and the number of arguments it accepts.
 extractNameArgs :: DCon -> (Name, Int)
 extractNameArgs (DCon _ _ n fields _) = (n, length (tysOfConFields fields))
 
+-- Extract a data constructor's name.
 extractName :: DCon -> Name
 extractName (DCon _ _ n _ _) = n
+
+-- Extract the names of a data constructor's record selectors.
+extractRecSelNames :: DCon -> [Name]
+extractRecSelNames (DCon _ _ _ fields _) = recSelsOfConFields fields
 
 -- | is a valid Haskell infix data constructor (i.e., does it begin with a colon?)
 isInfixDataCon :: String -> Bool

--- a/tests/compile-and-dump/Promote/Newtypes.golden
+++ b/tests/compile-and-dump/Promote/Newtypes.golden
@@ -9,25 +9,6 @@ Promote/Newtypes.hs:(0,0)-(0,0): Splicing declarations
       = Foo Nat
       deriving Eq
     newtype Bar = Bar {unBar :: Nat}
-    type Equals_0123456789876543210 :: Foo -> Foo -> Bool
-    type family Equals_0123456789876543210 a b where
-      Equals_0123456789876543210 (Foo a) (Foo b) = (==) a b
-      Equals_0123456789876543210 (_ :: Foo) (_ :: Foo) = FalseSym0
-    instance PEq Foo where
-      type (==) a b = Equals_0123456789876543210 a b
-    type UnBarSym0 :: (~>) Bar Nat
-    data UnBarSym0 a0123456789876543210
-      where
-        UnBarSym0KindInference :: SameKind (Apply UnBarSym0 arg) (UnBarSym1 arg) =>
-                                  UnBarSym0 a0123456789876543210
-    type instance Apply UnBarSym0 a0123456789876543210 = UnBarSym1 a0123456789876543210
-    instance SuppressUnusedWarnings UnBarSym0 where
-      suppressUnusedWarnings = snd (((,) UnBarSym0KindInference) ())
-    type UnBarSym1 (a0123456789876543210 :: Bar) =
-        UnBar a0123456789876543210 :: Nat
-    type UnBar :: Bar -> Nat
-    type family UnBar a where
-      UnBar (Bar field) = field
     type FooSym0 :: (~>) Nat Foo
     data FooSym0 a0123456789876543210
       where
@@ -48,3 +29,22 @@ Promote/Newtypes.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) BarSym0KindInference) ())
     type BarSym1 (a0123456789876543210 :: Nat) =
         Bar a0123456789876543210 :: Bar
+    type UnBarSym0 :: (~>) Bar Nat
+    data UnBarSym0 a0123456789876543210
+      where
+        UnBarSym0KindInference :: SameKind (Apply UnBarSym0 arg) (UnBarSym1 arg) =>
+                                  UnBarSym0 a0123456789876543210
+    type instance Apply UnBarSym0 a0123456789876543210 = UnBarSym1 a0123456789876543210
+    instance SuppressUnusedWarnings UnBarSym0 where
+      suppressUnusedWarnings = snd (((,) UnBarSym0KindInference) ())
+    type UnBarSym1 (a0123456789876543210 :: Bar) =
+        UnBar a0123456789876543210 :: Nat
+    type UnBar :: Bar -> Nat
+    type family UnBar a where
+      UnBar (Bar field) = field
+    type Equals_0123456789876543210 :: Foo -> Foo -> Bool
+    type family Equals_0123456789876543210 a b where
+      Equals_0123456789876543210 (Foo a) (Foo b) = (==) a b
+      Equals_0123456789876543210 (_ :: Foo) (_ :: Foo) = FalseSym0
+    instance PEq Foo where
+      type (==) a b = Equals_0123456789876543210 a b

--- a/tests/compile-and-dump/Promote/T180.golden
+++ b/tests/compile-and-dump/Promote/T180.golden
@@ -8,31 +8,6 @@ Promote/T180.hs:(0,0)-(0,0): Splicing declarations
     data X = X1 {y :: Symbol} | X2 {y :: Symbol}
     z (X1 x) = x
     z (X2 x) = x
-    data ZSym0 a0123456789876543210
-      where
-        ZSym0KindInference :: SameKind (Apply ZSym0 arg) (ZSym1 arg) =>
-                              ZSym0 a0123456789876543210
-    type instance Apply ZSym0 a0123456789876543210 = ZSym1 a0123456789876543210
-    instance SuppressUnusedWarnings ZSym0 where
-      suppressUnusedWarnings = snd (((,) ZSym0KindInference) ())
-    type ZSym1 a0123456789876543210 = Z a0123456789876543210
-    type family Z a where
-      Z (X1 x) = x
-      Z (X2 x) = x
-    type YSym0 :: (~>) X Symbol
-    data YSym0 a0123456789876543210
-      where
-        YSym0KindInference :: SameKind (Apply YSym0 arg) (YSym1 arg) =>
-                              YSym0 a0123456789876543210
-    type instance Apply YSym0 a0123456789876543210 = YSym1 a0123456789876543210
-    instance SuppressUnusedWarnings YSym0 where
-      suppressUnusedWarnings = snd (((,) YSym0KindInference) ())
-    type YSym1 (a0123456789876543210 :: X) =
-        Y a0123456789876543210 :: Symbol
-    type Y :: X -> Symbol
-    type family Y a where
-      Y (X1 field) = field
-      Y (X2 field) = field
     type X1Sym0 :: (~>) Symbol X
     data X1Sym0 a0123456789876543210
       where
@@ -53,3 +28,28 @@ Promote/T180.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) X2Sym0KindInference) ())
     type X2Sym1 (a0123456789876543210 :: Symbol) =
         X2 a0123456789876543210 :: X
+    data ZSym0 a0123456789876543210
+      where
+        ZSym0KindInference :: SameKind (Apply ZSym0 arg) (ZSym1 arg) =>
+                              ZSym0 a0123456789876543210
+    type instance Apply ZSym0 a0123456789876543210 = ZSym1 a0123456789876543210
+    instance SuppressUnusedWarnings ZSym0 where
+      suppressUnusedWarnings = snd (((,) ZSym0KindInference) ())
+    type ZSym1 a0123456789876543210 = Z a0123456789876543210
+    type YSym0 :: (~>) X Symbol
+    data YSym0 a0123456789876543210
+      where
+        YSym0KindInference :: SameKind (Apply YSym0 arg) (YSym1 arg) =>
+                              YSym0 a0123456789876543210
+    type instance Apply YSym0 a0123456789876543210 = YSym1 a0123456789876543210
+    instance SuppressUnusedWarnings YSym0 where
+      suppressUnusedWarnings = snd (((,) YSym0KindInference) ())
+    type YSym1 (a0123456789876543210 :: X) =
+        Y a0123456789876543210 :: Symbol
+    type family Z a where
+      Z (X1 x) = x
+      Z (X2 x) = x
+    type Y :: X -> Symbol
+    type family Y a where
+      Y (X1 field) = field
+      Y (X2 field) = field

--- a/tests/compile-and-dump/Singletons/Records.golden
+++ b/tests/compile-and-dump/Singletons/Records.golden
@@ -3,6 +3,24 @@ Singletons/Records.hs:(0,0)-(0,0): Splicing declarations
       [d| data Record a = MkRecord {field1 :: a, field2 :: Bool} |]
   ======>
     data Record a = MkRecord {field1 :: a, field2 :: Bool}
+    type MkRecordSym0 :: forall a. (~>) a ((~>) Bool (Record a))
+    data MkRecordSym0 a0123456789876543210
+      where
+        MkRecordSym0KindInference :: SameKind (Apply MkRecordSym0 arg) (MkRecordSym1 arg) =>
+                                     MkRecordSym0 a0123456789876543210
+    type instance Apply MkRecordSym0 a0123456789876543210 = MkRecordSym1 a0123456789876543210
+    instance SuppressUnusedWarnings MkRecordSym0 where
+      suppressUnusedWarnings = snd (((,) MkRecordSym0KindInference) ())
+    type MkRecordSym1 :: forall a. a -> (~>) Bool (Record a)
+    data MkRecordSym1 a0123456789876543210 a0123456789876543210
+      where
+        MkRecordSym1KindInference :: SameKind (Apply (MkRecordSym1 a0123456789876543210) arg) (MkRecordSym2 a0123456789876543210 arg) =>
+                                     MkRecordSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (MkRecordSym1 a0123456789876543210) a0123456789876543210 = MkRecordSym2 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (MkRecordSym1 a0123456789876543210) where
+      suppressUnusedWarnings = snd (((,) MkRecordSym1KindInference) ())
+    type MkRecordSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: Bool) =
+        MkRecord a0123456789876543210 a0123456789876543210 :: Record a
     type Field2Sym0 :: forall a. (~>) (Record a) Bool
     data Field2Sym0 a0123456789876543210
       where
@@ -29,29 +47,21 @@ Singletons/Records.hs:(0,0)-(0,0): Splicing declarations
     type Field1 :: forall a. Record a -> a
     type family Field1 a where
       Field1 (MkRecord field _) = field
-    type MkRecordSym0 :: forall a. (~>) a ((~>) Bool (Record a))
-    data MkRecordSym0 a0123456789876543210
-      where
-        MkRecordSym0KindInference :: SameKind (Apply MkRecordSym0 arg) (MkRecordSym1 arg) =>
-                                     MkRecordSym0 a0123456789876543210
-    type instance Apply MkRecordSym0 a0123456789876543210 = MkRecordSym1 a0123456789876543210
-    instance SuppressUnusedWarnings MkRecordSym0 where
-      suppressUnusedWarnings = snd (((,) MkRecordSym0KindInference) ())
-    type MkRecordSym1 :: forall a. a -> (~>) Bool (Record a)
-    data MkRecordSym1 a0123456789876543210 a0123456789876543210
-      where
-        MkRecordSym1KindInference :: SameKind (Apply (MkRecordSym1 a0123456789876543210) arg) (MkRecordSym2 a0123456789876543210 arg) =>
-                                     MkRecordSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply (MkRecordSym1 a0123456789876543210) a0123456789876543210 = MkRecordSym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (MkRecordSym1 a0123456789876543210) where
-      suppressUnusedWarnings = snd (((,) MkRecordSym1KindInference) ())
-    type MkRecordSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: Bool) =
-        MkRecord a0123456789876543210 a0123456789876543210 :: Record a
+    sField2 ::
+      forall a (t :: Record a).
+      Sing t -> Sing (Apply Field2Sym0 t :: Bool)
+    sField1 ::
+      forall a (t :: Record a). Sing t -> Sing (Apply Field1Sym0 t :: a)
+    sField2 (SMkRecord _ (sField :: Sing field)) = sField
+    sField1 (SMkRecord (sField :: Sing field) _) = sField
+    instance SingI (Field2Sym0 :: (~>) (Record a) Bool) where
+      sing = (singFun1 @Field2Sym0) sField2
+    instance SingI (Field1Sym0 :: (~>) (Record a) a) where
+      sing = (singFun1 @Field1Sym0) sField1
     data SRecord :: forall a. Record a -> GHC.Types.Type
       where
         SMkRecord :: forall a (n :: a) (n :: Bool).
-                     {sField1 :: (Sing n), sField2 :: (Sing n)}
-                     -> SRecord (MkRecord n n :: Record a)
+                     (Sing n) -> (Sing n) -> SRecord (MkRecord n n :: Record a)
     type instance Sing @(Record a) = SRecord
     instance SingKind a => SingKind (Record a) where
       type Demote (Record a) = Record (Demote a)

--- a/tests/compile-and-dump/Singletons/ShowDeriving.golden
+++ b/tests/compile-and-dump/Singletons/ShowDeriving.golden
@@ -24,32 +24,6 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     data Foo3
       = MkFoo3 {getFoo3a :: Bool, *** :: Bool}
       deriving Show
-    type (***@#@$) :: (~>) Foo3 Bool
-    data (***@#@$) a0123456789876543210
-      where
-        (:***@#@$###) :: SameKind (Apply (***@#@$) arg) ((***@#@$$) arg) =>
-                         (***@#@$) a0123456789876543210
-    type instance Apply (***@#@$) a0123456789876543210 = (***@#@$$) a0123456789876543210
-    instance SuppressUnusedWarnings (***@#@$) where
-      suppressUnusedWarnings = snd (((,) (:***@#@$###)) ())
-    type (***@#@$$) (a0123456789876543210 :: Foo3) =
-        (***) a0123456789876543210 :: Bool
-    type GetFoo3aSym0 :: (~>) Foo3 Bool
-    data GetFoo3aSym0 a0123456789876543210
-      where
-        GetFoo3aSym0KindInference :: SameKind (Apply GetFoo3aSym0 arg) (GetFoo3aSym1 arg) =>
-                                     GetFoo3aSym0 a0123456789876543210
-    type instance Apply GetFoo3aSym0 a0123456789876543210 = GetFoo3aSym1 a0123456789876543210
-    instance SuppressUnusedWarnings GetFoo3aSym0 where
-      suppressUnusedWarnings = snd (((,) GetFoo3aSym0KindInference) ())
-    type GetFoo3aSym1 (a0123456789876543210 :: Foo3) =
-        GetFoo3a a0123456789876543210 :: Bool
-    type (***) :: Foo3 -> Bool
-    type family (***) a where
-      (***) (MkFoo3 _ field) = field
-    type GetFoo3a :: Foo3 -> Bool
-    type family GetFoo3a a where
-      GetFoo3a (MkFoo3 field _) = field
     type MkFoo1Sym0 = MkFoo1 :: Foo1
     type MkFoo2aSym0 :: forall a. (~>) a ((~>) a (Foo2 a))
     data MkFoo2aSym0 a0123456789876543210
@@ -150,6 +124,32 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) MkFoo3Sym1KindInference) ())
     type MkFoo3Sym2 (a0123456789876543210 :: Bool) (a0123456789876543210 :: Bool) =
         MkFoo3 a0123456789876543210 a0123456789876543210 :: Foo3
+    type (***@#@$) :: (~>) Foo3 Bool
+    data (***@#@$) a0123456789876543210
+      where
+        (:***@#@$###) :: SameKind (Apply (***@#@$) arg) ((***@#@$$) arg) =>
+                         (***@#@$) a0123456789876543210
+    type instance Apply (***@#@$) a0123456789876543210 = (***@#@$$) a0123456789876543210
+    instance SuppressUnusedWarnings (***@#@$) where
+      suppressUnusedWarnings = snd (((,) (:***@#@$###)) ())
+    type (***@#@$$) (a0123456789876543210 :: Foo3) =
+        (***) a0123456789876543210 :: Bool
+    type GetFoo3aSym0 :: (~>) Foo3 Bool
+    data GetFoo3aSym0 a0123456789876543210
+      where
+        GetFoo3aSym0KindInference :: SameKind (Apply GetFoo3aSym0 arg) (GetFoo3aSym1 arg) =>
+                                     GetFoo3aSym0 a0123456789876543210
+    type instance Apply GetFoo3aSym0 a0123456789876543210 = GetFoo3aSym1 a0123456789876543210
+    instance SuppressUnusedWarnings GetFoo3aSym0 where
+      suppressUnusedWarnings = snd (((,) GetFoo3aSym0KindInference) ())
+    type GetFoo3aSym1 (a0123456789876543210 :: Foo3) =
+        GetFoo3a a0123456789876543210 :: Bool
+    type (***) :: Foo3 -> Bool
+    type family (***) a where
+      (***) (MkFoo3 _ field) = field
+    type GetFoo3a :: Foo3 -> Bool
+    type family GetFoo3a a where
+      GetFoo3a (MkFoo3 field _) = field
     type ShowsPrec_0123456789876543210 :: GHC.Types.Nat
                                           -> Foo1 -> Symbol -> Symbol
     type family ShowsPrec_0123456789876543210 a a a where
@@ -267,6 +267,16 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     infixl 5 :%&:
     infixl 5 :%*:
     infixl 5 `SMkFoo2b`
+    (%***) ::
+      forall (t :: Foo3). Sing t -> Sing (Apply (***@#@$) t :: Bool)
+    sGetFoo3a ::
+      forall (t :: Foo3). Sing t -> Sing (Apply GetFoo3aSym0 t :: Bool)
+    (%***) (SMkFoo3 _ (sField :: Sing field)) = sField
+    sGetFoo3a (SMkFoo3 (sField :: Sing field) _) = sField
+    instance SingI ((***@#@$) :: (~>) Foo3 Bool) where
+      sing = (singFun1 @(***@#@$)) (%***)
+    instance SingI (GetFoo3aSym0 :: (~>) Foo3 Bool) where
+      sing = (singFun1 @GetFoo3aSym0) sGetFoo3a
     data SFoo1 :: Foo1 -> GHC.Types.Type
       where SMkFoo1 :: SFoo1 (MkFoo1 :: Foo1)
     type instance Sing @Foo1 = SFoo1
@@ -306,8 +316,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     data SFoo3 :: Foo3 -> GHC.Types.Type
       where
         SMkFoo3 :: forall (n :: Bool) (n :: Bool).
-                   {sGetFoo3a :: (Sing n), %*** :: (Sing n)}
-                   -> SFoo3 (MkFoo3 n n :: Foo3)
+                   (Sing n) -> (Sing n) -> SFoo3 (MkFoo3 n n :: Foo3)
     type instance Sing @Foo3 = SFoo3
     instance SingKind Foo3 where
       type Demote Foo3 = Foo3

--- a/tests/compile-and-dump/Singletons/T332.golden
+++ b/tests/compile-and-dump/Singletons/T332.golden
@@ -8,6 +8,7 @@ Singletons/T332.hs:(0,0)-(0,0): Splicing declarations
     data Foo = MkFoo
     f :: Foo -> ()
     f MkFoo {} = ()
+    type MkFooSym0 = MkFoo :: Foo
     type FSym0 :: (~>) Foo ()
     data FSym0 a0123456789876543210
       where
@@ -21,7 +22,6 @@ Singletons/T332.hs:(0,0)-(0,0): Splicing declarations
     type F :: Foo -> ()
     type family F a where
       F MkFoo = Tuple0Sym0
-    type MkFooSym0 = MkFoo :: Foo
 Singletons/T332.hs:(0,0)-(0,0): Splicing declarations
     singletons
       [d| b :: Bar -> ()

--- a/tests/compile-and-dump/Singletons/T412.golden
+++ b/tests/compile-and-dump/Singletons/T412.golden
@@ -1,6 +1,6 @@
 Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
     singletons
-      [d| infixr 5 `D1`, `MkD1`
+      [d| infixr 5 `D1`, `MkD1`, `d1A`, `d1B`
           infixl 5 `T1a`, `T1b`
           infix 6 `m1`
           infix 5 `C1`
@@ -11,7 +11,7 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
           type T1a a b = Either a b
           type family T1b a b where
             T1b a b = Either a b
-          data D1 a b = MkD1 a b |]
+          data D1 a b = MkD1 {d1A :: a, d1B :: b} |]
   ======>
     infix 5 `C1`
     class C1 a b where
@@ -24,7 +24,9 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
       T1b a b = Either a b
     infixr 5 `D1`
     infixr 5 `MkD1`
-    data D1 a b = MkD1 a b
+    infixr 5 `d1A`
+    infixr 5 `d1B`
+    data D1 a b = MkD1 {d1A :: a, d1B :: b}
     data T1aSym0 a0123456789876543210
       where
         T1aSym0KindInference :: SameKind (Apply T1aSym0 arg) (T1aSym1 arg) =>
@@ -84,6 +86,38 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
     type MkD1Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) =
         MkD1 a0123456789876543210 a0123456789876543210 :: D1 a b
     infixr 5 `MkD1Sym2`
+    type D1BSym0 :: forall a b. (~>) (D1 a b) b
+    data D1BSym0 a0123456789876543210
+      where
+        D1BSym0KindInference :: SameKind (Apply D1BSym0 arg) (D1BSym1 arg) =>
+                                D1BSym0 a0123456789876543210
+    type instance Apply D1BSym0 a0123456789876543210 = D1BSym1 a0123456789876543210
+    instance SuppressUnusedWarnings D1BSym0 where
+      suppressUnusedWarnings = snd (((,) D1BSym0KindInference) ())
+    infixr 5 `D1BSym0`
+    type D1BSym1 (a0123456789876543210 :: D1 a b) =
+        D1B a0123456789876543210 :: b
+    infixr 5 `D1BSym1`
+    type D1ASym0 :: forall a b. (~>) (D1 a b) a
+    data D1ASym0 a0123456789876543210
+      where
+        D1ASym0KindInference :: SameKind (Apply D1ASym0 arg) (D1ASym1 arg) =>
+                                D1ASym0 a0123456789876543210
+    type instance Apply D1ASym0 a0123456789876543210 = D1ASym1 a0123456789876543210
+    instance SuppressUnusedWarnings D1ASym0 where
+      suppressUnusedWarnings = snd (((,) D1ASym0KindInference) ())
+    infixr 5 `D1ASym0`
+    type D1ASym1 (a0123456789876543210 :: D1 a b) =
+        D1A a0123456789876543210 :: a
+    infixr 5 `D1ASym1`
+    type D1B :: forall a b. D1 a b -> b
+    type family D1B a where
+      D1B (MkD1 _ field) = field
+    type D1A :: forall a b. D1 a b -> a
+    type family D1A a where
+      D1A (MkD1 field _) = field
+    infixr 5 `D1B`
+    infixr 5 `D1A`
     infix 6 `M1`
     infix 5 `PC1`
     type M1Sym0 :: forall a b. (~>) a ((~>) b Bool)
@@ -109,9 +143,21 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
     infix 6 `M1Sym2`
     class PC1 a b where
       type M1 (arg :: a) (arg :: b) :: Bool
+    infixr 5 `sD1B`
+    infixr 5 `sD1A`
     infixr 5 `SMkD1`
     infix 6 `sM1`
     infix 5 `SC1`
+    sD1B ::
+      forall a b (t :: D1 a b). Sing t -> Sing (Apply D1BSym0 t :: b)
+    sD1A ::
+      forall a b (t :: D1 a b). Sing t -> Sing (Apply D1ASym0 t :: a)
+    sD1B (SMkD1 _ (sField :: Sing field)) = sField
+    sD1A (SMkD1 (sField :: Sing field) _) = sField
+    instance SingI (D1BSym0 :: (~>) (D1 a b) b) where
+      sing = (singFun1 @D1BSym0) sD1B
+    instance SingI (D1ASym0 :: (~>) (D1 a b) a) where
+      sing = (singFun1 @D1ASym0) sD1A
     data SD1 :: forall a b. D1 a b -> GHC.Types.Type
       where
         SMkD1 :: forall a b (n :: a) (n :: b).
@@ -249,6 +295,54 @@ Singletons/T412.hs:0:0:: Splicing declarations
     type MkD2Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) =
         'MkD2 a0123456789876543210 a0123456789876543210 :: D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type)
     infixr 5 `MkD2Sym2`
+    infixr 5 `D2A`
+    infixr 5 `D2B`
+    type D2BSym0 :: forall (a :: GHC.Types.Type) (b :: GHC.Types.Type).
+                    (~>) (D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type)) b
+    data D2BSym0 a0123456789876543210
+      where
+        D2BSym0KindInference :: SameKind (Apply D2BSym0 arg) (D2BSym1 arg) =>
+                                D2BSym0 a0123456789876543210
+    type instance Apply D2BSym0 a0123456789876543210 = D2BSym1 a0123456789876543210
+    instance SuppressUnusedWarnings D2BSym0 where
+      suppressUnusedWarnings = snd (((,) D2BSym0KindInference) ())
+    type D2BSym1 (a0123456789876543210 :: D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type)) =
+        D2B a0123456789876543210 :: b
+    type D2ASym0 :: forall (a :: GHC.Types.Type) (b :: GHC.Types.Type).
+                    (~>) (D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type)) a
+    data D2ASym0 a0123456789876543210
+      where
+        D2ASym0KindInference :: SameKind (Apply D2ASym0 arg) (D2ASym1 arg) =>
+                                D2ASym0 a0123456789876543210
+    type instance Apply D2ASym0 a0123456789876543210 = D2ASym1 a0123456789876543210
+    instance SuppressUnusedWarnings D2ASym0 where
+      suppressUnusedWarnings = snd (((,) D2ASym0KindInference) ())
+    type D2ASym1 (a0123456789876543210 :: D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type)) =
+        D2A a0123456789876543210 :: a
+    type D2B :: forall (a :: GHC.Types.Type) (b :: GHC.Types.Type).
+                D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type) -> b
+    type family D2B a where
+      D2B ('MkD2 _ field) = field
+    type D2A :: forall (a :: GHC.Types.Type) (b :: GHC.Types.Type).
+                D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type) -> a
+    type family D2A a where
+      D2A ('MkD2 field _) = field
+    sD2B ::
+      forall (a :: GHC.Types.Type)
+             (b :: GHC.Types.Type)
+             (t :: D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type)).
+      Sing t -> Sing (Apply D2BSym0 t :: b)
+    sD2A ::
+      forall (a :: GHC.Types.Type)
+             (b :: GHC.Types.Type)
+             (t :: D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type)).
+      Sing t -> Sing (Apply D2ASym0 t :: a)
+    sD2B (SMkD2 _ (sField :: Sing field)) = sField
+    sD2A (SMkD2 (sField :: Sing field) _) = sField
+    instance SingI (D2BSym0 :: (~>) (D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type)) b) where
+      sing = (singFun1 @D2BSym0) sD2B
+    instance SingI (D2ASym0 :: (~>) (D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type)) a) where
+      sing = (singFun1 @D2ASym0) sD2A
     type SD2 :: forall (a :: GHC.Types.Type) (b :: GHC.Types.Type).
                 D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type) -> GHC.Types.Type
     data SD2 z
@@ -268,6 +362,8 @@ Singletons/T412.hs:0:0:: Splicing declarations
         = case ((,) (toSing b :: SomeSing a)) (toSing b :: SomeSing b) of {
             (,) (SomeSing c) (SomeSing c) -> SomeSing ((SMkD2 c) c) }
     infixr 5 `SMkD2`
+    infixr 5 `sD2A`
+    infixr 5 `sD2B`
     instance (SingI n, SingI n) =>
              SingI ('MkD2 (n :: a) (n :: b)) where
       sing = (SMkD2 sing) sing

--- a/tests/compile-and-dump/Singletons/T412.hs
+++ b/tests/compile-and-dump/Singletons/T412.hs
@@ -13,8 +13,8 @@ $(singletons [d|
   type family T1b a b where
     T1b a b = Either a b
 
-  infixr 5 `D1`, `MkD1`
-  data D1 a b = MkD1 a b
+  infixr 5 `D1`, `MkD1`, `d1A`, `d1B`
+  data D1 a b = MkD1 { d1A :: a, d1B :: b }
   |])
 
 infix 5 `C2`
@@ -27,7 +27,7 @@ type T2a a b = Either a b
 type family T2b a b where
   T2b a b = Either a b
 
-infixr 5 `D2`, `MkD2`
-data D2 a b = MkD2 a b
+infixr 5 `D2`, `MkD2`, `d2A`, `d2B`
+data D2 a b = MkD2 { d2A :: a, d2B :: b }
 
 $(genSingletons [''C2, ''T2a, ''T2b, ''D2])


### PR DESCRIPTION
`singletons` has traditionally singled record selectors "in-place".
For example, `data T = MkT { unT :: Bool }` would be singled as
`data ST :: T -> Type where SMkT :: { sUnT :: Sing b } -> ST (MkT b)`.
This may seem like a sensible choice, but it has some unfortunate
consequences:

* This function will not typecheck when singled:

  ```hs
  f :: T -> Bool
  f = unT
  ```

  This is because the type of `sUnT` is `Sing (MkT b) -> b`, which
  is not general enough for the type of `sF`, which is
  `Sing (t :: T) -> Sing (F t :: Bool)`.
* It is impossible to single a data type with multiple constructors
  that share a record name, since each occurrence of a record
  selector in a data type is required to have the same type.

For these reasons and more discussed in
`Note [singletons and record selectors]` in `D.S.Single.Data`, we
have decided in #364 to single record selectors as simple top-level
functions. That is, we would generate the following for `sUnT`:

```hs
data ST :: T -> Type where
  SMkT :: Sing b -> ST (MkT b)

sUnT :: Sing (t :: T) -> Sing (UnT t :: Bool)
sUnT (MkT x) = x
```

This brings the treatment of singled record selectors in line with
promoted record selectors (note that `UnT` is also a top-level type
family) and avoids the drawbacks mentioned above. The drawback is
that it is no longer possible to use record syntax in combination
with `SMkT`, although record selectors for singleton data constructors
are already quite buggy (see
https://github.com/goldfirere/singletons/issues/364#issuecomment-582476156),
so this is arguably not that huge of a loss.

This change allows `D.S.Prelude.*` to single code that is much closer
to the original code found in `base`. As one example, the changes in
`D.S.Prelude.Foldable` should give a pretty good idea of the kind of
code that can now be singled.

Fixes #364.