### PR TITLE
Add Data.Singletons.Prelude.Proxy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,7 @@ Changelog for singletons project
 * Export `ApplyTyConAux1`, `ApplyTyConAux2`, as well as the record pattern
   synonyms selector `applySing2`, `applySing3`, etc. from `Data.Singletons`.
   These were unintentionally left out in previous releases.
+* Add the `Data.Singletons.Prelude.Proxy` module.
 * Remove the promoted versions of `genericTake`, `genericDrop`,
   `genericSplitAt`, `genericIndex`, and `genericReplicate` from
   `Data.Singletons.Prelude.List`. These definitions were subtly wrong since

--- a/singletons.cabal
+++ b/singletons.cabal
@@ -95,6 +95,7 @@ library
                       Data.Singletons.Prelude.Monad.Zip
                       Data.Singletons.Prelude.Monoid
                       Data.Singletons.Prelude.Num
+                      Data.Singletons.Prelude.Proxy
                       Data.Singletons.Prelude.Semigroup
                       Data.Singletons.Prelude.Show
                       Data.Singletons.Prelude.Traversable

--- a/src/Data/Singletons/Prelude/Foldable.hs
+++ b/src/Data/Singletons/Prelude/Foldable.hs
@@ -454,6 +454,36 @@ $(singletonsOnly [d|
 
       null             = isLeft
 
+  instance Foldable Proxy where
+      foldMap _ _ = mempty
+      fold _ = mempty
+      foldr _ z _ = z
+      foldl _ z _ = z
+      foldl1 _ _ = errorWithoutStackTrace "foldl1: Proxy"
+      foldr1 _ _ = errorWithoutStackTrace "foldr1: Proxy"
+
+      -- Why do we give length (and null) an instance signature here? If we
+      -- didn't, singletons would generate one for us when singling it:
+      --
+      --    instance SFoldable Proxy where
+      --      sLength :: forall a (x :: Proxy a). Sing x -> Sing (Length x)
+      --      sLength = ...
+      --
+      -- If you squint, you'll notice that that instance signature is actually
+      -- /too/ general. This is because GHC will infer that `a` should be
+      -- kind-polymorphic, but Length is only defined when `a` is of kind
+      -- `Type`! Ugh. To force GHC to come to its senses, we explicitly inform
+      -- it that `a :: Type` through our own instance signature.
+      length :: forall (a :: Type). Proxy a -> Nat
+      length _   = 0
+
+      null :: forall (a :: Type). Proxy a -> Bool
+      null _     = True
+
+      elem _ _   = False
+      sum _      = 0
+      product _  = 1
+
   instance Foldable Dual where
       foldMap f (Dual x)  = f x
 

--- a/src/Data/Singletons/Prelude/Monad/Zip.hs
+++ b/src/Data/Singletons/Prelude/Monad/Zip.hs
@@ -36,6 +36,7 @@ module Data.Singletons.Prelude.Monad.Zip (
 
 import Data.Functor.Identity
 import Data.Monoid
+import Data.Proxy
 import Data.Singletons.Prelude.Identity
 import Data.Singletons.Prelude.Instances
 import Data.Singletons.Prelude.List
@@ -43,6 +44,7 @@ import Data.Singletons.Prelude.List
        , sZip,    sZipWith,    sUnzip )
 import Data.Singletons.Prelude.Monad.Internal
 import Data.Singletons.Prelude.Monoid ()
+import Data.Singletons.Prelude.Proxy
 import Data.Singletons.Prelude.Tuple
 import Data.Singletons.Single
 
@@ -103,4 +105,7 @@ $(singletonsOnly [d|
 
   instance MonadZip Last where
       mzipWith = liftM2
+
+  instance MonadZip Proxy where
+      mzipWith _ _ _ = Proxy
   |])

--- a/src/Data/Singletons/Prelude/Proxy.hs
+++ b/src/Data/Singletons/Prelude/Proxy.hs
@@ -1,0 +1,162 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Singletons.Prelude.Proxy
+-- Copyright   :  (C) 2020 Ryan Scott
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Richard Eisenberg (rae@cs.brynmawr.edu)
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Exports promoted and singled versions of the definitions in "Data.Proxy".
+--
+-----------------------------------------------------------------------------
+
+module Data.Singletons.Prelude.Proxy (
+    -- * The 'Proxy' singleton
+    Sing, SProxy(..)
+  , AsProxyTypeOf, sAsProxyTypeOf
+
+    -- * Defunctionalization symbols
+  , ProxySym0
+  , AsProxyTypeOfSym0, AsProxyTypeOfSym1, AsProxyTypeOfSym2
+  ) where
+
+import Control.Applicative
+import Control.Monad
+import Data.Kind
+import Data.Proxy
+import Data.Semigroup (Semigroup(..))
+import Data.Singletons.Decide
+import Data.Singletons.Internal
+import Data.Singletons.Prelude.Base
+import Data.Singletons.Prelude.Enum
+import Data.Singletons.Prelude.Eq
+import Data.Singletons.Prelude.Instances
+import Data.Singletons.Prelude.Monad.Internal
+import Data.Singletons.Prelude.Monoid
+import Data.Singletons.Prelude.Ord
+import Data.Singletons.Prelude.Semigroup.Internal
+import Data.Singletons.Prelude.Show
+import Data.Singletons.Promote
+import Data.Singletons.Single
+import Data.Singletons.TypeLits.Internal
+import Data.Type.Coercion
+import Data.Type.Equality hiding (type (==))
+
+{-
+In order to keep the type argument to Proxy poly-kinded, we define the
+singleton version of Proxy by hand. This is very much in the spirit of the
+code in D.S.Prelude.Const. (See the comments above SConst in that module
+for more details on this choice.)
+-}
+data SProxy :: forall t. Proxy t -> Type where
+  SProxy :: forall t. SProxy ('Proxy @t)
+type instance Sing = SProxy
+instance SingKind (Proxy t) where
+  type Demote (Proxy t) = Proxy t
+  fromSing SProxy = Proxy
+  toSing Proxy = SomeSing SProxy
+instance SingI 'Proxy where
+  sing = SProxy
+
+$(genDefunSymbols [''Proxy])
+
+instance SDecide (Proxy t) where
+  SProxy %~ SProxy = Proved Refl
+
+instance TestEquality SProxy where
+  testEquality = decideEquality
+
+instance TestCoercion SProxy where
+  testCoercion = decideCoercion
+
+instance Show (SProxy z) where
+  showsPrec _ _ = showString "SProxy"
+
+$(singletonsOnly [d|
+  deriving instance Bounded (Proxy s)
+
+  -- It's common to use (undefined :: Proxy t) and (Proxy :: Proxy t)
+  -- interchangeably, so all of these instances are hand-written to be
+  -- lazy in Proxy arguments.
+
+  instance Eq (Proxy s) where
+    _ == _ = True
+
+  instance Ord (Proxy s) where
+    compare _ _ = EQ
+
+  instance Show (Proxy s) where
+    showsPrec _ _ = showString "Proxy"
+
+  instance Enum (Proxy s) where
+      succ _               = errorWithoutStackTrace "Proxy.succ"
+      pred _               = errorWithoutStackTrace "Proxy.pred"
+      fromEnum _           = 0
+      -- toEnum 0             = Proxy
+      -- toEnum _             = errorWithoutStackTrace "Proxy.toEnum: 0 expected"
+      toEnum n             = if n == 0
+                             then Proxy
+                             else errorWithoutStackTrace "Proxy.toEnum: 0 expected"
+      -- enumFrom _           = [Proxy]
+      -- enumFromThen _ _     = [Proxy]
+      enumFromThenTo _ _ _ = [Proxy]
+      enumFromTo _ _       = [Proxy]
+
+  instance Semigroup (Proxy s) where
+      _ <> _ = Proxy
+      sconcat _ = Proxy
+      -- stimes _ _ = Proxy
+
+  instance Monoid (Proxy s) where
+      mempty = Proxy
+      mconcat _ = Proxy
+
+  instance Functor Proxy where
+      fmap _ _ = Proxy
+
+  instance Applicative Proxy where
+      pure _ = Proxy
+      _ <*> _ = Proxy
+
+  instance Alternative Proxy where
+      empty = Proxy
+      _ <|> _ = Proxy
+
+  instance Monad Proxy where
+      _ >>= _ = Proxy
+
+  instance MonadPlus Proxy
+
+  -- -| 'asProxyTypeOf' is a type-restricted version of 'const'.
+  -- It is usually used as an infix operator, and its typing forces its first
+  -- argument (which is usually overloaded) to have the same type as the tag
+  -- of the second.
+  --
+  -- >>> import Data.Word
+  -- >>> :type asProxyTypeOf 123 (Proxy :: Proxy Word8)
+  -- asProxyTypeOf 123 (Proxy :: Proxy Word8) :: Word8
+  --
+  -- Note the lower-case @proxy@ in the definition. This allows any type
+  -- constructor with just one argument to be passed to the function, for example
+  -- we could also write
+  --
+  -- >>> import Data.Word
+  -- >>> :type asProxyTypeOf 123 (Just (undefined :: Word8))
+  -- asProxyTypeOf 123 (Just (undefined :: Word8)) :: Word8
+  asProxyTypeOf :: a -> proxy a -> a
+  asProxyTypeOf = const
+  |])

--- a/src/Data/Singletons/Prelude/Traversable.hs
+++ b/src/Data/Singletons/Prelude/Traversable.hs
@@ -62,6 +62,7 @@ import Data.Singletons.Prelude.Identity
 import Data.Singletons.Prelude.Instances
 import Data.Singletons.Prelude.Monad.Internal
 import Data.Singletons.Prelude.Monoid
+import Data.Singletons.Prelude.Proxy
 import Data.Singletons.Single
 
 type StateL :: Type -> Type -> Type
@@ -204,7 +205,13 @@ $(singletonsOnly [d|
   deriving instance Traversable NonEmpty
   deriving instance Traversable (Either a)
   deriving instance Traversable ((,) a)
-  deriving instance Traversable (Const m)
+
+  instance Traversable Proxy where
+      traverse _ _ = pure Proxy
+      sequenceA _ = pure Proxy
+      mapM _ _ = pure Proxy
+      sequence _ = pure Proxy
+
   deriving instance Traversable Dual
   deriving instance Traversable Sum
   deriving instance Traversable Product


### PR DESCRIPTION
Even in a library as deeply entrenched in type-level trickery as
`singletons` is, there are still some situations that call for
proxies. See, for example, the use case in #435, which uses not only
the classic `Proxy` data type, but also the /singled/ version of
`Proxy`! The author of this use case requested that the singled
version of `Proxy` be made available in `singletons`, so this patch
accomplishes that.

Fixes #435.