### PR TITLE
Disable kind generalization when singling sig-less local functions

### DIFF
--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -105,6 +105,7 @@ tests =
     , compileAndDumpStdTest "T271"
     , compileAndDumpStdTest "T287"
     , compileAndDumpStdTest "TypeRepTYPE"
+    , compileAndDumpStdTest "T296"
     , compileAndDumpStdTest "T297"
     , compileAndDumpStdTest "T312"
     , compileAndDumpStdTest "T313"

--- a/tests/compile-and-dump/GradingClient/Database.golden
+++ b/tests/compile-and-dump/GradingClient/Database.golden
@@ -629,7 +629,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
                    (sAttrs :: Sing attrs)))
       = let
           sScrutinee_0123456789876543210 ::
-            Sing (Let0123456789876543210Scrutinee_0123456789876543210Sym4 name name' u attrs)
+            Sing @_ (Let0123456789876543210Scrutinee_0123456789876543210Sym4 name name' u attrs)
           sScrutinee_0123456789876543210
             = (applySing ((applySing ((singFun2 @(==@#@$)) (%==))) sName))
                 sName'

--- a/tests/compile-and-dump/InsertionSort/InsertionSortImp.golden
+++ b/tests/compile-and-dump/InsertionSort/InsertionSortImp.golden
@@ -175,7 +175,7 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
     sInsert (sN :: Sing n) (SCons (sH :: Sing h) (sT :: Sing t))
       = let
           sScrutinee_0123456789876543210 ::
-            Sing (Let0123456789876543210Scrutinee_0123456789876543210Sym3 n h t)
+            Sing @_ (Let0123456789876543210Scrutinee_0123456789876543210Sym3 n h t)
           sScrutinee_0123456789876543210
             = (applySing ((applySing ((singFun2 @LeqSym0) sLeq)) sN)) sH
         in

--- a/tests/compile-and-dump/Singletons/AsPattern.golden
+++ b/tests/compile-and-dump/Singletons/AsPattern.golden
@@ -256,14 +256,15 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
       Sing t -> Sing (Apply MaybePlusSym0 t :: Maybe Nat)
     sFoo SNil
       = let
-          sP :: Sing Let0123456789876543210PSym0
+          sP :: Sing @_ Let0123456789876543210PSym0
           sP = SNil
         in sP
     sFoo
       (SCons (sWild_0123456789876543210 :: Sing wild_0123456789876543210)
              SNil)
       = let
-          sP :: Sing (Let0123456789876543210PSym1 wild_0123456789876543210)
+          sP ::
+            Sing @_ (Let0123456789876543210PSym1 wild_0123456789876543210)
           sP
             = (applySing
                  ((applySing ((singFun2 @(:@#@$)) SCons))
@@ -276,7 +277,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
                     (sWild_0123456789876543210 :: Sing wild_0123456789876543210)))
       = let
           sP ::
-            Sing (Let0123456789876543210PSym3 wild_0123456789876543210 wild_0123456789876543210 wild_0123456789876543210)
+            Sing @_ (Let0123456789876543210PSym3 wild_0123456789876543210 wild_0123456789876543210 wild_0123456789876543210)
           sP
             = (applySing
                  ((applySing ((singFun2 @(:@#@$)) SCons))
@@ -291,7 +292,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
                (sWild_0123456789876543210 :: Sing wild_0123456789876543210))
       = let
           sP ::
-            Sing (Let0123456789876543210PSym2 wild_0123456789876543210 wild_0123456789876543210)
+            Sing @_ (Let0123456789876543210PSym2 wild_0123456789876543210 wild_0123456789876543210)
           sP
             = (applySing
                  ((applySing ((singFun2 @Tuple2Sym0) STuple2))
@@ -300,7 +301,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
         in sP
     sBaz_ SNothing
       = let
-          sP :: Sing Let0123456789876543210PSym0
+          sP :: Sing @_ Let0123456789876543210PSym0
           sP = SNothing
         in sP
     sBaz_
@@ -309,7 +310,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
                    (sWild_0123456789876543210 :: Sing wild_0123456789876543210)))
       = let
           sP ::
-            Sing (Let0123456789876543210PSym3 wild_0123456789876543210 wild_0123456789876543210 wild_0123456789876543210)
+            Sing @_ (Let0123456789876543210PSym3 wild_0123456789876543210 wild_0123456789876543210 wild_0123456789876543210)
           sP
             = (applySing ((singFun1 @JustSym0) SJust))
                 ((applySing
@@ -321,7 +322,8 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
     sBar
       (SJust (sWild_0123456789876543210 :: Sing wild_0123456789876543210))
       = let
-          sX :: Sing (Let0123456789876543210XSym1 wild_0123456789876543210)
+          sX ::
+            Sing @_ (Let0123456789876543210XSym1 wild_0123456789876543210)
           sX
             = (applySing ((singFun1 @JustSym0) SJust))
                 sWild_0123456789876543210
@@ -335,7 +337,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
              sN)
     sMaybePlus SNothing
       = let
-          sP :: Sing Let0123456789876543210PSym0
+          sP :: Sing @_ Let0123456789876543210PSym0
           sP = SNothing
         in sP
     instance SingI (FooSym0 :: (~>) [Nat] [Nat]) where

--- a/tests/compile-and-dump/Singletons/CaseExpressions.golden
+++ b/tests/compile-and-dump/Singletons/CaseExpressions.golden
@@ -263,7 +263,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
     sFoo3 (sA :: Sing a) (sB :: Sing b)
       = let
           sScrutinee_0123456789876543210 ::
-            Sing (Let0123456789876543210Scrutinee_0123456789876543210Sym2 a b)
+            Sing @_ (Let0123456789876543210Scrutinee_0123456789876543210Sym2 a b)
           sScrutinee_0123456789876543210
             = (applySing ((applySing ((singFun2 @Tuple2Sym0) STuple2)) sA)) sB
         in
@@ -274,7 +274,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
     sFoo2 (sD :: Sing d) _
       = let
           sScrutinee_0123456789876543210 ::
-            Sing (Let0123456789876543210Scrutinee_0123456789876543210Sym1 d)
+            Sing @_ (Let0123456789876543210Scrutinee_0123456789876543210Sym1 d)
           sScrutinee_0123456789876543210
             = (applySing ((singFun1 @JustSym0) SJust)) sD
         in

--- a/tests/compile-and-dump/Singletons/DataValues.golden
+++ b/tests/compile-and-dump/Singletons/DataValues.golden
@@ -83,10 +83,10 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
         ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 :: Symbol
     instance PShow (Pair a b) where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
-    sAList :: Sing AListSym0
-    sTuple :: Sing TupleSym0
-    sComplex :: Sing ComplexSym0
-    sPr :: Sing PrSym0
+    sAList :: Sing @_ AListSym0
+    sTuple :: Sing @_ TupleSym0
+    sComplex :: Sing @_ ComplexSym0
+    sPr :: Sing @_ PrSym0
     sAList
       = (applySing ((applySing ((singFun2 @(:@#@$)) SCons)) SZero))
           ((applySing

--- a/tests/compile-and-dump/Singletons/FunDeps.golden
+++ b/tests/compile-and-dump/Singletons/FunDeps.golden
@@ -77,7 +77,7 @@ Singletons/FunDeps.hs:(0,0)-(0,0): Splicing declarations
     instance PFD Bool Nat where
       type Meth a = Apply Meth_0123456789876543210Sym0 a
       type L2r a = Apply L2r_0123456789876543210Sym0 a
-    sT1 :: Sing T1Sym0
+    sT1 :: Sing @_ T1Sym0
     sT1 = (applySing ((singFun1 @MethSym0) sMeth)) STrue
     class SFD a b | a -> b where
       sMeth :: forall (t :: a). Sing t -> Sing (Apply MethSym0 t :: a)

--- a/tests/compile-and-dump/Singletons/LetStatements.golden
+++ b/tests/compile-and-dump/Singletons/LetStatements.golden
@@ -775,10 +775,10 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       forall (t :: Nat). Sing t -> Sing (Apply Foo1Sym0 t :: Nat)
     sFoo14 (sX :: Sing x)
       = let
-          sZ :: Sing (Let0123456789876543210ZSym1 x)
-          sY :: Sing (Let0123456789876543210YSym1 x)
+          sZ :: Sing @_ (Let0123456789876543210ZSym1 x)
+          sY :: Sing @_ (Let0123456789876543210YSym1 x)
           sX_0123456789876543210 ::
-            Sing (Let0123456789876543210X_0123456789876543210Sym1 x)
+            Sing @_ (Let0123456789876543210X_0123456789876543210Sym1 x)
           sZ
             = (id
                  @(Sing (Case_0123456789876543210 x (Let0123456789876543210X_0123456789876543210Sym1 x))))
@@ -925,8 +925,8 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         in sY
     sFoo2
       = let
-          sZ :: Sing Let0123456789876543210ZSym0
-          sY :: Sing Let0123456789876543210YSym0
+          sZ :: Sing @_ Let0123456789876543210ZSym0
+          sY :: Sing @_ Let0123456789876543210YSym0
           sZ = (applySing ((singFun1 @SuccSym0) SSucc)) sY
           sY = (applySing ((singFun1 @SuccSym0) SSucc)) SZero
         in sZ

--- a/tests/compile-and-dump/Singletons/PatternMatching.golden
+++ b/tests/compile-and-dump/Singletons/PatternMatching.golden
@@ -83,10 +83,10 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
         ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 :: Symbol
     instance PShow (Pair a b) where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
-    sAList :: Sing AListSym0
-    sTuple :: Sing TupleSym0
-    sComplex :: Sing ComplexSym0
-    sPr :: Sing PrSym0
+    sAList :: Sing @_ AListSym0
+    sTuple :: Sing @_ TupleSym0
+    sComplex :: Sing @_ ComplexSym0
+    sPr :: Sing @_ PrSym0
     sAList
       = (applySing ((applySing ((singFun2 @(:@#@$)) SCons)) SZero))
           ((applySing
@@ -434,26 +434,26 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
       forall a b (t :: (a, b)). Sing t -> Sing (Apply Foo2Sym0 t :: a)
     sFoo1 ::
       forall a b (t :: (a, b)). Sing t -> Sing (Apply Foo1Sym0 t :: a)
-    sBlimy :: Sing BlimySym0
+    sBlimy :: Sing @_ BlimySym0
     sLsz :: Sing (LszSym0 :: Nat)
-    sX_0123456789876543210 :: Sing X_0123456789876543210Sym0
-    sTt :: Sing TtSym0
-    sTjz :: Sing TjzSym0
-    sTf :: Sing TfSym0
-    sX_0123456789876543210 :: Sing X_0123456789876543210Sym0
+    sX_0123456789876543210 :: Sing @_ X_0123456789876543210Sym0
+    sTt :: Sing @_ TtSym0
+    sTjz :: Sing @_ TjzSym0
+    sTf :: Sing @_ TfSym0
+    sX_0123456789876543210 :: Sing @_ X_0123456789876543210Sym0
     sFls :: Sing (FlsSym0 :: Bool)
-    sZz :: Sing ZzSym0
-    sJz :: Sing JzSym0
-    sX_0123456789876543210 :: Sing X_0123456789876543210Sym0
-    sLz :: Sing LzSym0
-    sSz :: Sing SzSym0
-    sX_0123456789876543210 :: Sing X_0123456789876543210Sym0
+    sZz :: Sing @_ ZzSym0
+    sJz :: Sing @_ JzSym0
+    sX_0123456789876543210 :: Sing @_ X_0123456789876543210Sym0
+    sLz :: Sing @_ LzSym0
+    sSz :: Sing @_ SzSym0
+    sX_0123456789876543210 :: Sing @_ X_0123456789876543210Sym0
     sSilly (sX :: Sing x)
       = (id @(Sing (Case_0123456789876543210 x x :: ())))
           (case sX of { _ -> STuple0 })
     sFoo2 (STuple2 (sX :: Sing x) (sY :: Sing y))
       = let
-          sT :: Sing (Let0123456789876543210TSym2 x y)
+          sT :: Sing @_ (Let0123456789876543210TSym2 x y)
           sT
             = (applySing ((applySing ((singFun2 @Tuple2Sym0) STuple2)) sX)) sY
         in

--- a/tests/compile-and-dump/Singletons/T160.golden
+++ b/tests/compile-and-dump/Singletons/T160.golden
@@ -42,7 +42,7 @@ Singletons/T160.hs:(0,0)-(0,0): Splicing declarations
     sFoo (sX :: Sing x)
       = let
           sScrutinee_0123456789876543210 ::
-            Sing (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x)
+            Sing @_ (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x)
           sScrutinee_0123456789876543210
             = (applySing ((applySing ((singFun2 @(==@#@$)) (%==))) sX))
                 (sFromInteger (sing :: Sing 0))

--- a/tests/compile-and-dump/Singletons/T183.golden
+++ b/tests/compile-and-dump/Singletons/T183.golden
@@ -21,6 +21,7 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
           foo7 (x :: a) (_ :: b) = (x :: a)
           foo8 :: forall a. Maybe a -> Maybe a
           foo8 x@(Just (_ :: a) :: Maybe a) = x
+          foo8 x@(Nothing :: Maybe a) = x
           foo9 :: a -> a
           foo9 (x :: a)
             = let
@@ -51,6 +52,7 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
     foo7 (x :: a) (_ :: b) = x :: a
     foo8 :: forall a. Maybe a -> Maybe a
     foo8 x@(Just (_ :: a) :: Maybe a) = x
+    foo8 x@(Nothing :: Maybe a) = x
     foo9 :: a -> a
     foo9 (x :: a)
       = let
@@ -97,6 +99,9 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
         Let0123456789876543210X wild_01234567898765432100123456789876543210
     type family Let0123456789876543210X wild_0123456789876543210 where
       Let0123456789876543210X wild_0123456789876543210 = Apply JustSym0 (wild_0123456789876543210 :: a) :: Maybe a
+    type Let0123456789876543210XSym0 = Let0123456789876543210X
+    type family Let0123456789876543210X where
+      Let0123456789876543210X = NothingSym0 :: Maybe a
     data Let0123456789876543210Scrutinee_0123456789876543210Sym0 x0123456789876543210
       where
         Let0123456789876543210Scrutinee_0123456789876543210Sym0KindInference :: SameKind (Apply Let0123456789876543210Scrutinee_0123456789876543210Sym0 arg) (Let0123456789876543210Scrutinee_0123456789876543210Sym1 arg) =>
@@ -290,6 +295,7 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
     type Foo8 :: forall a. Maybe a -> Maybe a
     type family Foo8 a where
       Foo8 ('Just (wild_0123456789876543210 :: a) :: Maybe a) = Let0123456789876543210XSym1 wild_0123456789876543210
+      Foo8 ('Nothing :: Maybe a) = Let0123456789876543210XSym0
     type Foo7 :: a -> b -> a
     type family Foo7 a a where
       Foo7 (x :: a) (wild_0123456789876543210 :: b) = x :: a
@@ -369,12 +375,20 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
           (,) (_ :: Sing (wild_0123456789876543210 :: a))
               (_ :: Sing ('Just (wild_0123456789876543210 :: a) :: Maybe a))
             -> let
-                 sX :: Sing (Let0123456789876543210XSym1 wild_0123456789876543210)
+                 sX ::
+                   Sing @_ (Let0123456789876543210XSym1 wild_0123456789876543210)
                  sX
                    = (applySing ((singFun1 @JustSym0) SJust))
                        (sWild_0123456789876543210 ::
                           Sing (wild_0123456789876543210 :: a)) ::
                        Sing (Apply JustSym0 (wild_0123456789876543210 :: a) :: Maybe a)
+               in sX }
+    sFoo8 SNothing
+      = case SNothing of {
+          (_ :: Sing ('Nothing :: Maybe a))
+            -> let
+                 sX :: Sing @_ Let0123456789876543210XSym0
+                 sX = SNothing :: Sing (NothingSym0 :: Maybe a)
                in sX }
     sFoo7
       (sX :: Sing x)
@@ -391,7 +405,7 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
           (_ :: Sing ('Just x :: Maybe (Maybe a)))
             -> let
                  sScrutinee_0123456789876543210 ::
-                   Sing (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x)
+                   Sing @_ (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x)
                  sScrutinee_0123456789876543210 = sX :: Sing (x :: Maybe a)
                in
                  (id
@@ -443,7 +457,7 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
     sG (sX :: Sing x)
       = let
           sScrutinee_0123456789876543210 ::
-            Sing (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x)
+            Sing @_ (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x)
           sScrutinee_0123456789876543210
             = (applySing ((singFun1 @JustSym0) SJust)) sX
         in

--- a/tests/compile-and-dump/Singletons/T183.hs
+++ b/tests/compile-and-dump/Singletons/T183.hs
@@ -51,7 +51,7 @@ $(singletons [d|
 
   foo8 :: forall a. Maybe a -> Maybe a
   foo8 x@(Just (_ :: a) :: Maybe a) = x
-  -- foo8 x@(Nothing :: Maybe a)       = x -- #296
+  foo8 x@(Nothing :: Maybe a)       = x
 
   -----
   -- Type variable scoping (vis-à-vis #297)

--- a/tests/compile-and-dump/Singletons/T296.golden
+++ b/tests/compile-and-dump/Singletons/T296.golden
@@ -1,6 +1,7 @@
-Singletons/T297.hs:(0,0)-(0,0): Splicing declarations
+Singletons/T296.hs:(0,0)-(0,0): Splicing declarations
     singletons
-      [d| f MyProxy
+      [d| f :: forall a. MyProxy a -> MyProxy a
+          f MyProxy
             = let
                 x = let
                       z :: MyProxy a
@@ -11,6 +12,7 @@ Singletons/T297.hs:(0,0)-(0,0): Splicing declarations
           data MyProxy (a :: Type) = MyProxy |]
   ======>
     data MyProxy (a :: Type) = MyProxy
+    f :: forall a. MyProxy a -> MyProxy a
     f MyProxy
       = let
           x = let
@@ -27,6 +29,7 @@ Singletons/T297.hs:(0,0)-(0,0): Splicing declarations
     type Let0123456789876543210XSym0 = Let0123456789876543210X
     type family Let0123456789876543210X where
       Let0123456789876543210X = Let0123456789876543210ZSym0
+    type FSym0 :: forall a. (~>) (MyProxy a) (MyProxy a)
     data FSym0 a0123456789876543210
       where
         FSym0KindInference :: SameKind (Apply FSym0 arg) (FSym1 arg) =>
@@ -34,20 +37,24 @@ Singletons/T297.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply FSym0 a0123456789876543210 = FSym1 a0123456789876543210
     instance SuppressUnusedWarnings FSym0 where
       suppressUnusedWarnings = snd (((,) FSym0KindInference) ())
-    type FSym1 a0123456789876543210 = F a0123456789876543210
+    type FSym1 (a0123456789876543210 :: MyProxy a) =
+        F a0123456789876543210 :: MyProxy a
+    type F :: forall a. MyProxy a -> MyProxy a
     type family F a where
       F MyProxy = Let0123456789876543210XSym0
-    sF :: forall arg. Sing arg -> Sing (Apply FSym0 arg)
+    sF ::
+      forall a (t :: MyProxy a).
+      Sing t -> Sing (Apply FSym0 t :: MyProxy a)
     sF SMyProxy
       = let
           sX :: Sing @_ Let0123456789876543210XSym0
           sX
             = let
-                sZ :: forall a. Sing (Let0123456789876543210ZSym0 :: MyProxy a)
+                sZ :: Sing (Let0123456789876543210ZSym0 :: MyProxy a)
                 sZ = SMyProxy
               in sZ
         in sX
-    instance SingI FSym0 where
+    instance SingI (FSym0 :: (~>) (MyProxy a) (MyProxy a)) where
       sing = (singFun1 @FSym0) sF
     data SMyProxy :: forall a. MyProxy (a :: Type) -> Type
       where

--- a/tests/compile-and-dump/Singletons/T296.hs
+++ b/tests/compile-and-dump/Singletons/T296.hs
@@ -1,0 +1,14 @@
+module T296 where
+
+import Data.Kind
+import Data.Singletons.TH
+
+$(singletons [d|
+  data MyProxy (a :: Type) = MyProxy
+
+  f :: forall a. MyProxy a -> MyProxy a
+  f MyProxy =
+    let x = let z :: MyProxy a
+                z = MyProxy in z
+    in x
+  |])

--- a/tests/compile-and-dump/Singletons/T54.golden
+++ b/tests/compile-and-dump/Singletons/T54.golden
@@ -40,7 +40,7 @@ Singletons/T54.hs:(0,0)-(0,0): Splicing declarations
       = (applySing
            (let
               sScrutinee_0123456789876543210 ::
-                Sing (Let0123456789876543210Scrutinee_0123456789876543210Sym1 e)
+                Sing @_ (Let0123456789876543210Scrutinee_0123456789876543210Sym1 e)
               sScrutinee_0123456789876543210
                 = (applySing
                      ((applySing ((singFun2 @(:@#@$)) SCons))

--- a/tests/compile-and-dump/Singletons/TopLevelPatterns.golden
+++ b/tests/compile-and-dump/Singletons/TopLevelPatterns.golden
@@ -246,17 +246,17 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
       Otherwise = TrueSym0
     sM :: Sing (MSym0 :: Bool)
     sL :: Sing (LSym0 :: Bool)
-    sX_0123456789876543210 :: Sing X_0123456789876543210Sym0
+    sX_0123456789876543210 :: Sing @_ X_0123456789876543210Sym0
     sK :: Sing (KSym0 :: Bool)
     sJ :: Sing (JSym0 :: Bool)
-    sX_0123456789876543210 :: Sing X_0123456789876543210Sym0
+    sX_0123456789876543210 :: Sing @_ X_0123456789876543210Sym0
     sI :: forall (t :: Bool). Sing t -> Sing (Apply ISym0 t :: Bool)
     sH :: forall (t :: Bool). Sing t -> Sing (Apply HSym0 t :: Bool)
-    sX_0123456789876543210 :: Sing X_0123456789876543210Sym0
+    sX_0123456789876543210 :: Sing @_ X_0123456789876543210Sym0
     sG :: forall (t :: Bool). Sing t -> Sing (Apply GSym0 t :: Bool)
     sF :: forall (t :: Bool). Sing t -> Sing (Apply FSym0 t :: Bool)
-    sX_0123456789876543210 :: Sing X_0123456789876543210Sym0
-    sFalse_ :: Sing False_Sym0
+    sX_0123456789876543210 :: Sing @_ X_0123456789876543210Sym0
+    sFalse_ :: Sing @_ False_Sym0
     sNot ::
       forall (t :: Bool). Sing t -> Sing (Apply NotSym0 t :: Bool)
     sId :: forall a (t :: a). Sing t -> Sing (Apply IdSym0 t :: a)


### PR DESCRIPTION
When a local function (1) lacks a type signature, and (2) has no arguments, we single it such that its type signature has a return type of `Sing @_ Blah` instead of `Sing Blah`. This prevents kind generalization from mucking with the kind of `Blah`, which can be undesirable. For the complete story, refer to `Note [Disable kind generalization for local functions if possible]` in `D.S.Single`.

Aside from fixing #296, this allows us to finally uncomment a line of code in `T183` that relies on this fix.