### PR TITLE
Adapt to simplified subsumption in GHC

### DIFF
--- a/src/Data/Singletons/Internal.hs
+++ b/src/Data/Singletons/Internal.hs
@@ -436,37 +436,49 @@ singFun1 :: forall f. SingFunction1 f -> Sing f
 singFun1 f = SLambda f
 
 type SingFunction2 :: (a1 ~> a2 ~> b) -> Type
-type SingFunction2 f = forall t. Sing t -> SingFunction1 (f @@ t)
+type SingFunction2 f = forall t1 t2. Sing t1 -> Sing t2 -> Sing (f @@ t1 @@ t2)
 singFun2 :: forall f. SingFunction2 f -> Sing f
 singFun2 f = SLambda (\x -> singFun1 (f x))
 
 type SingFunction3 :: (a1 ~> a2 ~> a3 ~> b) -> Type
-type SingFunction3 f = forall t. Sing t -> SingFunction2 (f @@ t)
+type SingFunction3 f = forall t1 t2 t3.
+                       Sing t1 -> Sing t2 -> Sing t3
+                    -> Sing (f @@ t1 @@ t2 @@ t3)
 singFun3 :: forall f. SingFunction3 f -> Sing f
 singFun3 f = SLambda (\x -> singFun2 (f x))
 
 type SingFunction4 :: (a1 ~> a2 ~> a3 ~> a4 ~> b) -> Type
-type SingFunction4 f = forall t. Sing t -> SingFunction3 (f @@ t)
+type SingFunction4 f = forall t1 t2 t3 t4.
+                       Sing t1 -> Sing t2 -> Sing t3 -> Sing t4
+                    -> Sing (f @@ t1 @@ t2 @@ t3 @@ t4)
 singFun4 :: forall f. SingFunction4 f -> Sing f
 singFun4 f = SLambda (\x -> singFun3 (f x))
 
 type SingFunction5 :: (a1 ~> a2 ~> a3 ~> a4 ~> a5 ~> b) -> Type
-type SingFunction5 f = forall t. Sing t -> SingFunction4 (f @@ t)
+type SingFunction5 f = forall t1 t2 t3 t4 t5.
+                       Sing t1 -> Sing t2 -> Sing t3 -> Sing t4 -> Sing t5
+                    -> Sing (f @@ t1 @@ t2 @@ t3 @@ t4 @@ t5)
 singFun5 :: forall f. SingFunction5 f -> Sing f
 singFun5 f = SLambda (\x -> singFun4 (f x))
 
 type SingFunction6 :: (a1 ~> a2 ~> a3 ~> a4 ~> a5 ~> a6 ~> b) -> Type
-type SingFunction6 f = forall t. Sing t -> SingFunction5 (f @@ t)
+type SingFunction6 f = forall t1 t2 t3 t4 t5 t6.
+                       Sing t1 -> Sing t2 -> Sing t3 -> Sing t4 -> Sing t5 -> Sing t6
+                    -> Sing (f @@ t1 @@ t2 @@ t3 @@ t4 @@ t5 @@ t6)
 singFun6 :: forall f. SingFunction6 f -> Sing f
 singFun6 f = SLambda (\x -> singFun5 (f x))
 
 type SingFunction7 :: (a1 ~> a2 ~> a3 ~> a4 ~> a5 ~> a6 ~> a7 ~> b) -> Type
-type SingFunction7 f = forall t. Sing t -> SingFunction6 (f @@ t)
+type SingFunction7 f = forall t1 t2 t3 t4 t5 t6 t7.
+                       Sing t1 -> Sing t2 -> Sing t3 -> Sing t4 -> Sing t5 -> Sing t6 -> Sing t7
+                    -> Sing (f @@ t1 @@ t2 @@ t3 @@ t4 @@ t5 @@ t6 @@ t7)
 singFun7 :: forall f. SingFunction7 f -> Sing f
 singFun7 f = SLambda (\x -> singFun6 (f x))
 
 type SingFunction8 :: (a1 ~> a2 ~> a3 ~> a4 ~> a5 ~> a6 ~> a7 ~> a8 ~> b) -> Type
-type SingFunction8 f = forall t. Sing t -> SingFunction7 (f @@ t)
+type SingFunction8 f = forall t1 t2 t3 t4 t5 t6 t7 t8.
+                       Sing t1 -> Sing t2 -> Sing t3 -> Sing t4 -> Sing t5 -> Sing t6 -> Sing t7 -> Sing t8
+                    -> Sing (f @@ t1 @@ t2 @@ t3 @@ t4 @@ t5 @@ t6 @@ t7 @@ t8)
 singFun8 :: forall f. SingFunction8 f -> Sing f
 singFun8 f = SLambda (\x -> singFun7 (f x))
 

--- a/tests/ByHand.hs
+++ b/tests/ByHand.hs
@@ -861,8 +861,8 @@ sFindIndices :: forall a (t1 :: a ~> Bool) (t2 :: (List a)).
              -> Sing t2
              -> Sing (FindIndicesSym0 @@ t1 @@ t2)
 sFindIndices sP sLs =
-  let sLoop :: forall (u1 :: Nat). Sing u1
-            -> forall (u2 :: List a). Sing u2
+  let sLoop :: forall (u1 :: Nat) (u2 :: List a).
+               Sing u1 -> Sing u2
             -> Sing ((Let123LoopSym2 t1 t2) @@ u1 @@ u2)
       sLoop _ SNil = SNil
       sLoop sN (sX `SCons` sXs) = case sP @@ sX of


### PR DESCRIPTION
GHC's [simplified subsumption proposal](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0287-simplify-subsumption.rst) removes deep skolemization, which `singletons`' TH machinery relied on in order to typecheck the uses of `singFun1` _et al._ that it generates. The reason it relied on deep skolemization is because `SingFunction1` _et al._ were defined with `forall`s nested underneath arrow types. In this patch, we redefine `SingFunction1` _et al._ so that all of the `forall`s are up front, making deep skolemization unnecessary when applying `singFun1` _et al._

...well, unnecessary 99% of the time. It turns out there is one place in `ByHand` that defines a singled function with nested `forall`s that no longer works with the new version of `singFun2`. But `singletons` would never generate a function with nested `forall`s like this in the first place, so let's just change it to use prenex `forall`s.

Fixes #438.