### PR TITLE
Implement Refun for refunctionalising a defunctionalisation symbol

### DIFF
--- a/src/Data/Singletons.hs
+++ b/src/Data/Singletons.hs
@@ -60,6 +60,7 @@ module Data.Singletons (
 
   -- ** Defunctionalization
   TyFun, type (~>),
+  Refun, Refun0, Refun1,
   TyCon1, TyCon2, TyCon3, TyCon4, TyCon5, TyCon6, TyCon7, TyCon8,
   TyCon, Apply, type (@@), ApplyTyCon, ApplyTyConAux1, ApplyTyConAux2,
 

--- a/src/Data/Singletons/Internal.hs
+++ b/src/Data/Singletons/Internal.hs
@@ -288,6 +288,14 @@ type (@@) :: (k1 ~> k2) -> k1 -> k2
 type a @@ b = Apply a b
 infixl 9 @@
 
+-- | Refunctionalise a defunctionalised type function back to its type.
+type family Refun f where
+   Refun (a ~> b) = a -> b
+
+data Refun0 :: Type ~> Type
+type instance Apply Refun0 f = Refun1 f
+type Refun1 f = Refun f
+
 -- | Workhorse for the 'TyCon1', etc., types. This can be used directly
 -- in place of any of the @TyConN@ types, but it will work only with
 -- /monomorphic/ types. When GHC#14645 is fixed, this should fully supersede


### PR DESCRIPTION
I wanted to, at the type-level, do `fmap (\v -> (x -> v)) vv` for some fixed but parameterised `x`.

After some poring through the docs I came up with `Fmap (FlipSym2 (~>@#@$) x) vv`, however this has the wrong kind:

```haskell
Prelude
Data.Kind
Data.Singletons
Data.Singletons.Prelude.Function
Data.Singletons.Prelude.Functor
> :kind! Fmap (FlipSym2 (~>@#@$) Int) '[Bool]
Fmap (FlipSym2 (~>@#@$) Int) '[Bool] :: [*]
= '[TyFun Bool Int -> *]
```

I tried searching through the existing docs and code for what I needed but it seems it's not implemented, so here is a PR for it. It works for my use-case:

```haskell
> :kind! Fmap (Refun0 .@#@$$$ (FlipSym2 (~>@#@$) Int)) '[Bool]
Fmap (Refun0 .@#@$$$ (FlipSym2 (~>@#@$) Int)) '[Bool] :: [*]
= '[Bool -> Int]
```

Apologies if it already exists. I thought it should already exist, but couldn't find it. I even ran `egrep -R '=\s*\w+\s*->'` but couldn't find anything obvious.