### PR TITLE
Fix #453 by always explicitly quantifying SAK kind variables

### DIFF
--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -133,6 +133,7 @@ tests =
     , compileAndDumpStdTest "T414"
     , afterSingletonsNat .
       compileAndDumpStdTest "T445"
+    , compileAndDumpStdTest "T453"
     ],
     testCompileAndDumpGroup "Promote"
     [ compileAndDumpStdTest "Constructors"

--- a/tests/compile-and-dump/Singletons/BoundedDeriving.golden
+++ b/tests/compile-and-dump/Singletons/BoundedDeriving.golden
@@ -198,7 +198,7 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
       toSing (Foo3 (b :: Demote a))
         = case toSing b :: SomeSing a of {
             SomeSing c -> SomeSing (SFoo3 c) }
-    data SFoo4 :: forall a b. Foo4 (a :: Type) (b :: Type) -> Type
+    data SFoo4 :: forall (a :: Type) (b :: Type). Foo4 a b -> Type
       where
         SFoo41 :: forall (a :: Type) (b :: Type).
                   SFoo4 (Foo41 :: Foo4 (a :: Type) (b :: Type))

--- a/tests/compile-and-dump/Singletons/FunctorLikeDeriving.golden
+++ b/tests/compile-and-dump/Singletons/FunctorLikeDeriving.golden
@@ -977,7 +977,7 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
       toSing (MkT2 (b :: Demote (Maybe x)))
         = case toSing b :: SomeSing (Maybe x) of {
             SomeSing c -> SomeSing (SMkT2 c) }
-    data SEmpty :: forall a. Empty (a :: Type) -> Type
+    data SEmpty :: forall (a :: Type). Empty a -> Type
     type instance Sing @(Empty a) = SEmpty
     instance SingKind a => SingKind (Empty a) where
       type Demote (Empty a) = Empty (Demote a)

--- a/tests/compile-and-dump/Singletons/T150.golden
+++ b/tests/compile-and-dump/Singletons/T150.golden
@@ -318,27 +318,27 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun1 @TailVecSym0) sTailVec
     instance SingI (HeadVecSym0 :: (~>) (Vec ('Succ n) a) a) where
       sing = (singFun1 @HeadVecSym0) sHeadVec
-    data SFin :: forall a. Fin (a :: Nat) -> Type
+    data SFin :: forall (a :: Nat). Fin a -> Type
       where
         SFZ :: forall n. SFin (FZ :: Fin ('Succ n))
         SFS :: forall n (n :: Fin n).
                (Sing n) -> SFin (FS n :: Fin ('Succ n))
     type instance Sing @(Fin a) = SFin
-    data SFoo :: forall a. Foo (a :: Type) -> Type
+    data SFoo :: forall (a :: Type). Foo a -> Type
       where
         SMkFoo1 :: SFoo (MkFoo1 :: Foo Bool)
         SMkFoo2 :: SFoo (MkFoo2 :: Foo Ordering)
     type instance Sing @(Foo a) = SFoo
-    data SVec :: forall a a. Vec (a :: Nat) (a :: Type) -> Type
+    data SVec :: forall (a :: Nat) (a :: Type). Vec a a -> Type
       where
         SVNil :: forall a. SVec (VNil :: Vec 'Zero a)
         SVCons :: forall a n (n :: a) (n :: Vec n a).
                   (Sing n) -> (Sing n) -> SVec (VCons n n :: Vec ('Succ n) a)
     type instance Sing @(Vec a a) = SVec
-    data SEqual :: forall a a. Equal (a :: Type) (a :: Type) -> Type
+    data SEqual :: forall (a :: Type) (a :: Type). Equal a a -> Type
       where SReflexive :: forall a. SEqual (Reflexive :: Equal a a)
     type instance Sing @(Equal a a) = SEqual
-    data SHList :: forall a. HList (a :: [Type]) -> Type
+    data SHList :: forall (a :: [Type]). HList a -> Type
       where
         SHNil :: SHList (HNil :: HList '[])
         SHCons :: forall x xs (n :: x) (n :: HList xs).

--- a/tests/compile-and-dump/Singletons/T271.golden
+++ b/tests/compile-and-dump/Singletons/T271.golden
@@ -108,8 +108,8 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
       Equals_0123456789876543210 (_ :: Identity a) (_ :: Identity a) = FalseSym0
     instance PEq (Identity a) where
       type (==) a b = Equals_0123456789876543210 a b
-    data SConstant :: forall a b.
-                      Constant (a :: Type) (b :: Type) -> Type
+    data SConstant :: forall (a :: Type) (b :: Type).
+                      Constant a b -> Type
       where
         SConstant :: forall (a :: Type) (b :: Type) (n :: a).
                      (Sing n)
@@ -121,7 +121,7 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
       toSing (Constant (b :: Demote a))
         = case toSing b :: SomeSing a of {
             SomeSing c -> SomeSing (SConstant c) }
-    data SIdentity :: forall a. Identity (a :: Type) -> Type
+    data SIdentity :: forall (a :: Type). Identity a -> Type
       where
         SIdentity :: forall a (n :: a).
                      (Sing n) -> SIdentity (Identity n :: Identity a)

--- a/tests/compile-and-dump/Singletons/T296.golden
+++ b/tests/compile-and-dump/Singletons/T296.golden
@@ -61,7 +61,7 @@ Singletons/T296.hs:(0,0)-(0,0): Splicing declarations
         in sX
     instance SingI (FSym0 :: (~>) (MyProxy a) (MyProxy a)) where
       sing = (singFun1 @FSym0) sF
-    data SMyProxy :: forall a. MyProxy (a :: Type) -> Type
+    data SMyProxy :: forall (a :: Type). MyProxy a -> Type
       where
         SMyProxy :: forall (a :: Type).
                     SMyProxy (MyProxy :: MyProxy (a :: Type))

--- a/tests/compile-and-dump/Singletons/T297.golden
+++ b/tests/compile-and-dump/Singletons/T297.golden
@@ -54,7 +54,7 @@ Singletons/T297.hs:(0,0)-(0,0): Splicing declarations
         in sX
     instance SingI FSym0 where
       sing = (singFun1 @FSym0) sF
-    data SMyProxy :: forall a. MyProxy (a :: Type) -> Type
+    data SMyProxy :: forall (a :: Type). MyProxy a -> Type
       where
         SMyProxy :: forall (a :: Type).
                     SMyProxy (MyProxy :: MyProxy (a :: Type))

--- a/tests/compile-and-dump/Singletons/T371.golden
+++ b/tests/compile-and-dump/Singletons/T371.golden
@@ -121,7 +121,7 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
       ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow (Y a) where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
-    data SX :: forall a. X (a :: Type) -> Type
+    data SX :: forall (a :: Type). X a -> Type
       where
         SX1 :: forall (a :: Type). SX (X1 :: X (a :: Type))
         SX2 :: forall (a :: Type) (n :: Y a).
@@ -135,7 +135,7 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
       toSing (X2 (b :: Demote (Y a)))
         = case toSing b :: SomeSing (Y a) of {
             SomeSing c -> SomeSing (SX2 c) }
-    data SY :: forall a. Y (a :: Type) -> Type
+    data SY :: forall (a :: Type). Y a -> Type
       where
         SY1 :: forall (a :: Type). SY (Y1 :: Y (a :: Type))
         SY2 :: forall (a :: Type) (n :: X a).

--- a/tests/compile-and-dump/Singletons/T378a.golden
+++ b/tests/compile-and-dump/Singletons/T378a.golden
@@ -60,7 +60,7 @@ Singletons/T378a.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @ConstBASym0) sConstBA
     instance SingI d => SingI (ConstBASym1 (d :: a) :: (~>) b a) where
       sing = (singFun1 @(ConstBASym1 (d :: a))) (sConstBA (sing @d))
-    data SProxy :: forall a. Proxy (a :: k) -> Type
+    data SProxy :: forall k (a :: k). Proxy a -> Type
       where
         SProxy1 :: forall a. SProxy (Proxy1 :: Proxy a)
         SProxy2 :: forall k (a :: k). SProxy (Proxy2 :: Proxy (a :: k))

--- a/tests/compile-and-dump/Singletons/T378b.golden
+++ b/tests/compile-and-dump/Singletons/T378b.golden
@@ -113,8 +113,7 @@ Singletons/T378b.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @FSym0) sF
     instance SingI d => SingI (FSym1 (d :: a) :: (~>) b ()) where
       sing = (singFun1 @(FSym1 (d :: a))) (sF (sing @d))
-    type SD :: forall b a (x :: a) (y :: b).
-               D (x :: a) (y :: b) -> Type
+    type SD :: forall b a (x :: a) (y :: b). D x y -> Type
     data SD z
     type instance Sing @(D x y) = SD
     instance (SingKind x, SingKind y) => SingKind (D x y) where

--- a/tests/compile-and-dump/Singletons/T412.golden
+++ b/tests/compile-and-dump/Singletons/T412.golden
@@ -358,7 +358,7 @@ Singletons/T412.hs:0:0:: Splicing declarations
     instance SingI (D2ASym0 :: (~>) (D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type)) a) where
       sing = (singFun1 @D2ASym0) sD2A
     type SD2 :: forall (a :: GHC.Types.Type) (b :: GHC.Types.Type).
-                D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type) -> GHC.Types.Type
+                D2 a b -> GHC.Types.Type
     data SD2 z
       where
         SMkD2 :: forall (a :: GHC.Types.Type)

--- a/tests/compile-and-dump/Singletons/T453.golden
+++ b/tests/compile-and-dump/Singletons/T453.golden
@@ -1,0 +1,20 @@
+Singletons/T453.hs:(0,0)-(0,0): Splicing declarations
+    withOptions defaultOptions {genSingKindInsts = False}
+      $ singletons
+          $ lift
+              [d| type T1 :: forall k. k -> Type
+                  type T2 :: k -> Type
+                  
+                  data T1 a
+                  data T2 a |]
+  ======>
+    type T1 :: forall k. k -> Type
+    data T1 a
+    type T2 :: k -> Type
+    data T2 a
+    type ST1 :: forall k (a :: k). T1 a -> Type
+    data ST1 z
+    type instance Sing @(T1 a) = ST1
+    type ST2 :: forall k (a :: k). T2 a -> Type
+    data ST2 z
+    type instance Sing @(T2 a) = ST2

--- a/tests/compile-and-dump/Singletons/T453.hs
+++ b/tests/compile-and-dump/Singletons/T453.hs
@@ -1,0 +1,15 @@
+module T453 where
+
+import Control.Monad.Trans.Class
+import Data.Kind
+import Data.Singletons.TH
+import Data.Singletons.TH.Options
+
+$(withOptions defaultOptions{genSingKindInsts = False} $
+  singletons $ lift [d|
+    type T1 :: forall k. k -> Type
+    data T1 a
+
+    type T2 :: k -> Type
+    data T2 a
+  |])


### PR DESCRIPTION
If a data declaration's SAK were to use an explicit `forall`, then `singletons` would have no issues singling it. If it didn't use an explicit `forall`, however, then it would topple over. The fix: quantify the kind variables in a SAK ourselves when a SAK lacks an explicit `forall`. The `D.S.Single.Type.singTypeKVBs` function does the exact same thing, as it turns out, but I somehow overlooked this before.

While I was in town, I took the liberty of cleaning up a couple of code smells:

* There were a couple of invocations of `promoteType` that were completely unnecessary.
* In the case where a data declaration lacks a SAK, I now explicitly quantify over kind variables as well as type variables. Not quantifying over kind variables in a data declaration's return kind is not an error per se (since the forall-or-nothing rule doesn't apply there), but it is more consistent with what happens with data declarations that do have SAKs.