### PR TITLE
Use simpler version of getRecordSelectors from th-desugar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ install:
     echo "source-repository-package"                            >> cabal.project
     echo "  type:     git"                                      >> cabal.project
     echo "  location: https://github.com/goldfirere/th-desugar" >> cabal.project
-    echo "  tag:      f075206882ce4e554c37537e624b4be7409d74a3" >> cabal.project
+    echo "  tag:      5eef50aad9a7db9ad284a427b791891398304fa8" >> cabal.project
     echo ""                                                     >> cabal.project
     echo "package th-desugar"                                   >> cabal.project
     echo "  tests:      False"                                  >> cabal.project
@@ -124,7 +124,7 @@ script:
     echo "source-repository-package"                            >> cabal.project
     echo "  type:     git"                                      >> cabal.project
     echo "  location: https://github.com/goldfirere/th-desugar" >> cabal.project
-    echo "  tag:      f075206882ce4e554c37537e624b4be7409d74a3" >> cabal.project
+    echo "  tag:      5eef50aad9a7db9ad284a427b791891398304fa8" >> cabal.project
     echo ""                                                     >> cabal.project
     echo "package th-desugar"                                   >> cabal.project
     echo "  tests:      False"                                  >> cabal.project

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,28 @@ Changelog for singletons project
       natMinus a@(S _) Z     = a
       |])
     ```
+* The specification for how `singletons` deals with record selectors has been
+  simplified. Previously, `singletons` would try to avoid promoting so-called
+  "naughty" selectors (those whose types mention existential type variables
+  that do not appear in the constructor's return type) to top-level functions.
+  Determing if a selector is naughty is quite challenging in practice, as
+  determining if a type variable is existential or not in the context of
+  Template Haskell is difficult in the general case. As a result, `singletons`
+  now adopts the dumb-but-predictable approach of always promoting record
+  selectors to top-level functions, naughty or not.
+
+  This means that attempting to promote code with a naughty record selector,
+  like in the example below, will no longer work:
+
+  ```hs
+  $(promote [d|
+    data Some :: (Type -> Type) -> Type where
+      MkSome :: { getSome :: f a } -> Some f
+      -- getSome is naughty due to mentioning the type variable `a`
+    |])
+  ```
+
+  Please open an issue if you find this restriction burdensome in practice.
 
 2.7
 ---

--- a/README.md
+++ b/README.md
@@ -794,6 +794,26 @@ since `singletons` desugars away most uses of record syntax. On the other hand,
 it is not possible to write out code like
 `SIdentity { sRunIdentity = SIdentity STrue }` by hand.
 
+Another caveat is that GHC allows defining so-called "naughty" record selectors
+that mention existential type variables that do not appear in the constructor's
+return type. Naughty record selectors can be used in pattern matching, but they
+cannot be used as top-level functions. Here is one example of a naughty
+record selector:
+
+```hs
+data Some :: (Type -> Type) -> Type where
+  MkSome :: { getSome :: f a } -> Some f
+```
+
+Because `singletons` promotes all records to top-level functions, however,
+attempting to promote `getSome` will result in an invalid definition. (It
+may typecheck, but it will not behave like you would expect.) Theoretically,
+`singletons` could refrain from promoting naughty record selectors, but this
+would require detecting which type variables in a data constructor are
+existentially quantified. This is very challenging in general, so we stick to
+the dumb-but-predictable approach of always promoting record selectors,
+regardless of whether they are naughty or not.
+
 ### Signatures in patterns
 
 `singletons` can promote basic pattern signatures, such as in the following

--- a/cabal.project
+++ b/cabal.project
@@ -3,4 +3,4 @@ packages: .
 source-repository-package
   type: git
   location: https://github.com/goldfirere/th-desugar
-  tag: f075206882ce4e554c37537e624b4be7409d74a3
+  tag: 5eef50aad9a7db9ad284a427b791891398304fa8

--- a/singletons.cabal
+++ b/singletons.cabal
@@ -58,7 +58,7 @@ library
                       ghc-boot-th,
                       template-haskell,
                       containers >= 0.5,
-                      th-desugar >= 1.11 && < 1.12,
+                      th-desugar >= 1.12 && < 1.13,
                       pretty,
                       syb >= 0.4,
                       text >= 1.2,

--- a/src/Data/Singletons/Promote.hs
+++ b/src/Data/Singletons/Promote.hs
@@ -287,12 +287,11 @@ promoteDataDecs = concatMapM promoteDataDec
 --    be promoted in a single location.
 --    See Note [singletons and record selectors] in D.S.Single.Data.
 promoteDataDec :: DataDecl -> PrM [DLetDec]
-promoteDataDec (DataDecl data_name tvbs ctors) = do
-  let arg_ty        = foldTypeTvbs (DConT data_name) tvbs
-      rec_sel_names = nub $ concatMap extractRecSelNames ctors
+promoteDataDec (DataDecl _ _ ctors) = do
+  let rec_sel_names = nub $ concatMap extractRecSelNames ctors
                       -- Note the use of nub: the same record selector name can
                       -- be used in multiple constructors!
-  rec_sel_let_decs <- getRecordSelectors arg_ty ctors
+  rec_sel_let_decs <- getRecordSelectors ctors
   ctorSyms         <- buildDefunSymsDataD ctors
   infix_decs       <- promoteReifiedInfixDecls rec_sel_names
   emitDecs $ ctorSyms ++ infix_decs

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -131,6 +131,7 @@ tests =
     , compileAndDumpStdTest "T410"
     , compileAndDumpStdTest "T412"
     , compileAndDumpStdTest "T414"
+    , compileAndDumpStdTest "T443"
     , afterSingletonsNat .
       compileAndDumpStdTest "T445"
     , compileAndDumpStdTest "T453"

--- a/tests/compile-and-dump/Singletons/T443.golden
+++ b/tests/compile-and-dump/Singletons/T443.golden
@@ -1,0 +1,118 @@
+Singletons/T443.hs:(0,0)-(0,0): Splicing declarations
+    withOptions defaultOptions {genSingKindInsts = False}
+      $ singletons
+          $ lift
+              [d| data Nat = Z | S Nat
+                  data Vec :: Nat -> Type -> Type
+                    where
+                      VNil :: Vec Z a
+                      (:>) :: {head :: a, tail :: Vec n a} -> Vec (S n) a |]
+  ======>
+    data Nat = Z | S Nat
+    data Vec :: Nat -> Type -> Type
+      where
+        VNil :: Vec 'Z a
+        (:>) :: {head :: a, tail :: (Vec n a)} -> Vec ('S n) a
+    type ZSym0 :: Nat
+    type family ZSym0 where
+      ZSym0 = Z
+    type SSym0 :: (~>) Nat Nat
+    data SSym0 a0123456789876543210
+      where
+        SSym0KindInference :: SameKind (Apply SSym0 arg) (SSym1 arg) =>
+                              SSym0 a0123456789876543210
+    type instance Apply SSym0 a0123456789876543210 = S a0123456789876543210
+    instance SuppressUnusedWarnings SSym0 where
+      suppressUnusedWarnings = snd (((,) SSym0KindInference) ())
+    type SSym1 :: Nat -> Nat
+    type family SSym1 a0123456789876543210 where
+      SSym1 a0123456789876543210 = S a0123456789876543210
+    type VNilSym0 :: Vec Z a
+    type family VNilSym0 where
+      VNilSym0 = VNil
+    type (:>@#@$) :: (~>) a ((~>) (Vec n a) (Vec (S n) a))
+    data (:>@#@$) a0123456789876543210
+      where
+        (::>@#@$###) :: SameKind (Apply (:>@#@$) arg) ((:>@#@$$) arg) =>
+                        (:>@#@$) a0123456789876543210
+    type instance Apply (:>@#@$) a0123456789876543210 = (:>@#@$$) a0123456789876543210
+    instance SuppressUnusedWarnings (:>@#@$) where
+      suppressUnusedWarnings = snd (((,) (::>@#@$###)) ())
+    type (:>@#@$$) :: a -> (~>) (Vec n a) (Vec (S n) a)
+    data (:>@#@$$) a0123456789876543210 a0123456789876543210
+      where
+        (::>@#@$$###) :: SameKind (Apply ((:>@#@$$) a0123456789876543210) arg) ((:>@#@$$$) a0123456789876543210 arg) =>
+                         (:>@#@$$) a0123456789876543210 a0123456789876543210
+    type instance Apply ((:>@#@$$) a0123456789876543210) a0123456789876543210 = (:>) a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings ((:>@#@$$) a0123456789876543210) where
+      suppressUnusedWarnings = snd (((,) (::>@#@$$###)) ())
+    type (:>@#@$$$) :: a -> Vec n a -> Vec (S n) a
+    type family (:>@#@$$$) a0123456789876543210 a0123456789876543210 where
+      (:>@#@$$$) a0123456789876543210 a0123456789876543210 = (:>) a0123456789876543210 a0123456789876543210
+    type TailSym0 :: (~>) (Vec (S n) a) (Vec n a)
+    data TailSym0 a0123456789876543210
+      where
+        TailSym0KindInference :: SameKind (Apply TailSym0 arg) (TailSym1 arg) =>
+                                 TailSym0 a0123456789876543210
+    type instance Apply TailSym0 a0123456789876543210 = Tail a0123456789876543210
+    instance SuppressUnusedWarnings TailSym0 where
+      suppressUnusedWarnings = snd (((,) TailSym0KindInference) ())
+    type TailSym1 :: Vec (S n) a -> Vec n a
+    type family TailSym1 a0123456789876543210 where
+      TailSym1 a0123456789876543210 = Tail a0123456789876543210
+    type HeadSym0 :: (~>) (Vec (S n) a) a
+    data HeadSym0 a0123456789876543210
+      where
+        HeadSym0KindInference :: SameKind (Apply HeadSym0 arg) (HeadSym1 arg) =>
+                                 HeadSym0 a0123456789876543210
+    type instance Apply HeadSym0 a0123456789876543210 = Head a0123456789876543210
+    instance SuppressUnusedWarnings HeadSym0 where
+      suppressUnusedWarnings = snd (((,) HeadSym0KindInference) ())
+    type HeadSym1 :: Vec (S n) a -> a
+    type family HeadSym1 a0123456789876543210 where
+      HeadSym1 a0123456789876543210 = Head a0123456789876543210
+    type Tail :: Vec (S n) a -> Vec n a
+    type family Tail a where
+      Tail ((:>) _ field) = field
+    type Head :: Vec (S n) a -> a
+    type family Head a where
+      Head ((:>) field _) = field
+    sTail ::
+      forall n a (t :: Vec (S n) a).
+      Sing t -> Sing (Apply TailSym0 t :: Vec n a)
+    sHead ::
+      forall n a (t :: Vec (S n) a).
+      Sing t -> Sing (Apply HeadSym0 t :: a)
+    sTail ((:%>) _ (sField :: Sing field)) = sField
+    sHead ((:%>) (sField :: Sing field) _) = sField
+    instance SingI (TailSym0 :: (~>) (Vec (S n) a) (Vec n a)) where
+      sing = (singFun1 @TailSym0) sTail
+    instance SingI (HeadSym0 :: (~>) (Vec (S n) a) a) where
+      sing = (singFun1 @HeadSym0) sHead
+    data SNat :: Nat -> Type
+      where
+        SZ :: SNat (Z :: Nat)
+        SS :: forall (n :: Nat). (Sing n) -> SNat (S n :: Nat)
+    type instance Sing @Nat = SNat
+    data SVec :: forall (a :: Nat) (a :: Type). Vec a a -> Type
+      where
+        SVNil :: forall a. SVec (VNil :: Vec Z a)
+        (:%>) :: forall a n (n :: a) (n :: Vec n a).
+                 (Sing n) -> (Sing n) -> SVec ((:>) n n :: Vec (S n) a)
+    type instance Sing @(Vec a a) = SVec
+    instance SingI Z where
+      sing = SZ
+    instance SingI n => SingI (S (n :: Nat)) where
+      sing = SS sing
+    instance SingI (SSym0 :: (~>) Nat Nat) where
+      sing = (singFun1 @SSym0) SS
+    instance SingI VNil where
+      sing = SVNil
+    instance (SingI n, SingI n) =>
+             SingI ((:>) (n :: a) (n :: Vec n a)) where
+      sing = ((:%>) sing) sing
+    instance SingI ((:>@#@$) :: (~>) a ((~>) (Vec n a) (Vec (S n) a))) where
+      sing = (singFun2 @(:>@#@$)) (:%>)
+    instance SingI d =>
+             SingI ((:>@#@$$) (d :: a) :: (~>) (Vec n a) (Vec (S n) a)) where
+      sing = (singFun1 @((:>@#@$$) (d :: a))) ((:%>) (sing @d))

--- a/tests/compile-and-dump/Singletons/T443.hs
+++ b/tests/compile-and-dump/Singletons/T443.hs
@@ -1,0 +1,15 @@
+module T443 where
+
+import Control.Monad.Trans.Class
+import Data.Kind
+import Data.Singletons.TH
+import Data.Singletons.TH.Options
+
+$(withOptions defaultOptions{genSingKindInsts = False} $
+  singletons $ lift [d|
+  data Nat = Z | S Nat
+
+  data Vec :: Nat -> Type -> Type where
+    VNil :: Vec Z a
+    (:>) :: { head :: a, tail :: Vec n a } -> Vec (S n) a
+  |])


### PR DESCRIPTION
This patch updates the `th-desugar` submodule to incorporate
goldfirere/th-desugar#139, which:

1. Removes the horribly buggy `conExistentialTvbs` function, and
2. Simplifies `getRecordSelectors` so that it does not bother trying
   to filter out naughty record selectors.

Incorporating (2) amounts to fixing #443, for which the test case was
rejected due to `conExistentialTvbs` being overly conservative with
GADTs. To adapt to (1), certain validity checks in `singletons` which
previously used `conExistentialTvbs` will now be less precise. This
isn't a huge deal—it just means that erroneous programs which
`singletons` used to give specialized error messages for will now
just go through, resulting in an error message on GHC's behalf.

Fixes #443.