### PR TITLE
Don't wire in promoted or singled Names

### DIFF
--- a/src/Data/Singletons/Deriving/Enum.hs
+++ b/src/Data/Singletons/Deriving/Enum.hs
@@ -53,11 +53,8 @@ mkEnumInstance mb_ctxt ty (DataDecl _ _ cons) = do
                                                         (DLitE (IntegerL i)))
                                      [0..] cons)
   return (InstDecl { id_cxt     = fromMaybe [] mb_ctxt
-                   , id_name    = singletonsEnumName
-                      -- need to use singletons's Enum class to get the types
-                      -- to use Nat instead of Int
-
+                   , id_name    = enumName
                    , id_arg_tys = [ty]
                    , id_sigs    = mempty
-                   , id_meths   = [ (singletonsToEnumName, to_enum)
-                                  , (singletonsFromEnumName, from_enum) ] })
+                   , id_meths   = [ (toEnumName, to_enum)
+                                  , (fromEnumName, from_enum) ] })

--- a/src/Data/Singletons/Prelude/Ord.hs
+++ b/src/Data/Singletons/Prelude/Ord.hs
@@ -50,6 +50,7 @@ import Data.Singletons.Single
 import Data.Singletons.Prelude.Eq
 import Data.Singletons.Prelude.Instances
 import Data.Singletons.Util
+import Language.Haskell.TH.Syntax (thenCmp)
 
 $(singletonsOnly [d|
   class  (Eq a) => Ord a  where
@@ -88,6 +89,11 @@ $(singletonsOnly [d|
   -- >   ... sortBy (comparing fst) ...
   comparing :: (Ord a) => (b -> a) -> b -> b -> Ordering
   comparing p x y = compare (p x) (p y)
+
+  thenCmp :: Ordering -> Ordering -> Ordering
+  thenCmp EQ x = x
+  thenCmp LT _ = LT
+  thenCmp GT _ = GT
   |])
 
 $(genSingletons [''Down])
@@ -97,13 +103,6 @@ $(singletonsOnly [d|
 
   instance Ord a => Ord (Down a) where
       compare (Down x) (Down y) = y `compare` x
-  |])
-
-$(singletons [d|
-  thenCmp :: Ordering -> Ordering -> Ordering
-  thenCmp EQ x = x
-  thenCmp LT _ = LT
-  thenCmp GT _ = GT
   |])
 
 $(singOrdInstances basicTypes)

--- a/src/Data/Singletons/Prelude/Proxy.hs
+++ b/src/Data/Singletons/Prelude/Proxy.hs
@@ -47,6 +47,7 @@ import Data.Singletons.Prelude.Eq
 import Data.Singletons.Prelude.Instances
 import Data.Singletons.Prelude.Monad.Internal
 import Data.Singletons.Prelude.Monoid
+import Data.Singletons.Prelude.Num
 import Data.Singletons.Prelude.Ord
 import Data.Singletons.Prelude.Semigroup.Internal
 import Data.Singletons.Prelude.Show

--- a/src/Data/Singletons/Prelude/Show.hs
+++ b/src/Data/Singletons/Prelude/Show.hs
@@ -60,6 +60,7 @@ import           Data.Singletons.Internal
 import           Data.Singletons.Prelude.Base
 import           Data.Singletons.Prelude.Instances
 import           Data.Singletons.Prelude.List.Internal
+import           Data.Singletons.Prelude.Num
 import           Data.Singletons.Prelude.Ord
 import           Data.Singletons.Prelude.Semigroup.Internal
 import           Data.Singletons.Promote

--- a/src/Data/Singletons/TH.hs
+++ b/src/Data/Singletons/TH.hs
@@ -48,7 +48,7 @@ module Data.Singletons.TH (
   cases, sCases,
 
   -- * Basic singleton definitions
-  SBool(..), STuple0(..), STuple2(..), STuple3(..), STuple4(..),
+  SList(..), SBool(..), STuple0(..), STuple2(..), STuple3(..), STuple4(..),
   STuple5(..), STuple6(..), STuple7(..), SOrdering(..),
   module Data.Singletons,
 
@@ -61,9 +61,10 @@ module Data.Singletons.TH (
   SDecide(..), (:~:)(..), Void, Refuted, Decision(..),
   PBounded(..), SBounded(..),
   PEnum(FromEnum, ToEnum), SEnum(sFromEnum, sToEnum),
-  PShow(..), SShow(..),
+  PShow(..), SShow(..), PIsString(..), SIsString(..),
   ShowString, sShowString, ShowParen, sShowParen, ShowSpace, sShowSpace,
   ShowChar, sShowChar, ShowCommaSpace, sShowCommaSpace,
+  FromInteger, sFromInteger, Negate, sNegate,
   PFunctor(..), SFunctor(..),
   PFoldable(..), SFoldable(..), PMonoid(..), SMonoid(..),
   PTraversable(..), STraversable(..), PApplicative(..), SApplicative(..),
@@ -93,6 +94,9 @@ module Data.Singletons.TH (
   ShowSpaceSym0, ShowSpaceSym1,
   ShowCharSym0, ShowCharSym1, ShowCharSym2,
   ShowCommaSpaceSym0, ShowCommaSpaceSym1,
+  FromIntegerSym0, FromIntegerSym1,
+  NegateSym0, NegateSym1,
+  FromStringSym0, FromStringSym1,
   FmapSym0, FmapSym1, FmapSym2,
   type (<$@#@$),  type (<$@#@$$),  type (<$@#@$$$),
   FoldMapSym0, FoldMapSym1, FoldMapSym2,
@@ -123,7 +127,9 @@ import Data.Singletons.Prelude.Enum
 import Data.Singletons.Prelude.Eq
 import Data.Singletons.Prelude.Foldable
 import Data.Singletons.Prelude.Functor hiding (Void)
+import Data.Singletons.Prelude.IsString
 import Data.Singletons.Prelude.Monoid
+import Data.Singletons.Prelude.Num
 import Data.Singletons.Prelude.Ord
 import Data.Singletons.Prelude.Show
 import Data.Singletons.Prelude.Traversable

--- a/src/Data/Singletons/TH/Options.hs
+++ b/src/Data/Singletons/TH/Options.hs
@@ -45,11 +45,7 @@ import Control.Monad.RWS (RWST)
 import Control.Monad.State (StateT)
 import Control.Monad.Trans.Class (MonadTrans(..))
 import Control.Monad.Writer (WriterT)
-import Data.Singletons.Names ( consName, listName, nilName
-                             , mk_name_tc, mkTupleDataName, mkTupleTypeName
-                             , sconsName, sListName, snilName
-                             , splitUnderscores
-                             )
+import Data.Singletons.Names (consName, listName, nilName, splitUnderscores)
 import Data.Singletons.Util
 import Language.Haskell.TH.Desugar
 import Language.Haskell.TH.Syntax hiding (Lift(..))
@@ -223,8 +219,7 @@ promoteTySym name sat
        -- treat unboxed tuples like tuples
     | Just degree <- tupleNameDegree_maybe name <|>
                      unboxedTupleNameDegree_maybe name
-    = mk_name_tc "Data.Singletons.Prelude.Instances" $
-                 "Tuple" ++ show degree ++ "Sym" ++ (show sat)
+    = mkName $ "Tuple" ++ show degree ++ "Sym" ++ show sat
 
     | otherwise
     = default_case name
@@ -244,18 +239,21 @@ promoteClassName = prefixName "P" "#"
 
 singDataConName :: Name -> Name
 singDataConName nm
-  | nm == nilName                                  = snilName
-  | nm == consName                                 = sconsName
-  | Just degree <- tupleNameDegree_maybe nm        = mkTupleDataName degree
-  | Just degree <- unboxedTupleNameDegree_maybe nm = mkTupleDataName degree
+  | nm == nilName                                  = mkName "SNil"
+  | nm == consName                                 = mkName "SCons"
+  | Just degree <- tupleNameDegree_maybe nm        = mkTupleName degree
+  | Just degree <- unboxedTupleNameDegree_maybe nm = mkTupleName degree
   | otherwise                                      = prefixConName "S" "%" nm
 
 singTyConName :: Name -> Name
 singTyConName name
-  | name == listName                                 = sListName
-  | Just degree <- tupleNameDegree_maybe name        = mkTupleTypeName degree
-  | Just degree <- unboxedTupleNameDegree_maybe name = mkTupleTypeName degree
+  | name == listName                                 = mkName "SList"
+  | Just degree <- tupleNameDegree_maybe name        = mkTupleName degree
+  | Just degree <- unboxedTupleNameDegree_maybe name = mkTupleName degree
   | otherwise                                        = prefixName "S" "%" name
+
+mkTupleName :: Int -> Name
+mkTupleName n = mkName $ "STuple" ++ show n
 
 singClassName :: Name -> Name
 singClassName = singTyConName

--- a/tests/SingletonsTestSuite.hs
+++ b/tests/SingletonsTestSuite.hs
@@ -135,6 +135,7 @@ tests =
     , afterSingletonsNat .
       compileAndDumpStdTest "T445"
     , compileAndDumpStdTest "T453"
+    , compileAndDumpStdTest "NegativeLiterals"
     ],
     testCompileAndDumpGroup "Promote"
     [ compileAndDumpStdTest "Constructors"

--- a/tests/compile-and-dump/Singletons/EnumDeriving.golden
+++ b/tests/compile-and-dump/Singletons/EnumDeriving.golden
@@ -29,13 +29,13 @@ Singletons/EnumDeriving.hs:(0,0)-(0,0): Splicing declarations
       Case_0123456789876543210 n 'False = Apply ErrorSym0 "toEnum: bad argument"
     type family Case_0123456789876543210 n t where
       Case_0123456789876543210 n 'True = BazSym0
-      Case_0123456789876543210 n 'False = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (Data.Singletons.Prelude.Num.FromInteger 2))
+      Case_0123456789876543210 n 'False = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (FromInteger 2))
     type family Case_0123456789876543210 n t where
       Case_0123456789876543210 n 'True = BarSym0
-      Case_0123456789876543210 n 'False = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (Data.Singletons.Prelude.Num.FromInteger 1))
+      Case_0123456789876543210 n 'False = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (FromInteger 1))
     type ToEnum_0123456789876543210 :: GHC.Types.Nat -> Foo
     type family ToEnum_0123456789876543210 a where
-      ToEnum_0123456789876543210 n = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (Data.Singletons.Prelude.Num.FromInteger 0))
+      ToEnum_0123456789876543210 n = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (FromInteger 0))
     type ToEnum_0123456789876543210Sym0 :: (~>) GHC.Types.Nat Foo
     data ToEnum_0123456789876543210Sym0 a0123456789876543210
       where
@@ -50,9 +50,9 @@ Singletons/EnumDeriving.hs:(0,0)-(0,0): Splicing declarations
       ToEnum_0123456789876543210Sym1 a0123456789876543210 = ToEnum_0123456789876543210 a0123456789876543210
     type FromEnum_0123456789876543210 :: Foo -> GHC.Types.Nat
     type family FromEnum_0123456789876543210 a where
-      FromEnum_0123456789876543210 Bar = Data.Singletons.Prelude.Num.FromInteger 0
-      FromEnum_0123456789876543210 Baz = Data.Singletons.Prelude.Num.FromInteger 1
-      FromEnum_0123456789876543210 Bum = Data.Singletons.Prelude.Num.FromInteger 2
+      FromEnum_0123456789876543210 Bar = FromInteger 0
+      FromEnum_0123456789876543210 Baz = FromInteger 1
+      FromEnum_0123456789876543210 Bum = FromInteger 2
     type FromEnum_0123456789876543210Sym0 :: (~>) Foo GHC.Types.Nat
     data FromEnum_0123456789876543210Sym0 a0123456789876543210
       where
@@ -106,35 +106,32 @@ Singletons/EnumDeriving.hs:(0,0)-(0,0): Splicing declarations
                                                                      -> GHC.Types.Type) t)
       sToEnum (sN :: Sing n)
         = (id
-             @(Sing (Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (Data.Singletons.Prelude.Num.FromInteger 0)))))
+             @(Sing (Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (FromInteger 0)))))
             (case
                  (applySing ((applySing ((singFun2 @(==@#@$)) (%==))) sN))
-                   (Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 0))
+                   (sFromInteger (sing :: Sing 0))
              of
                STrue -> SBar
                SFalse
                  -> (id
-                       @(Sing (Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (Data.Singletons.Prelude.Num.FromInteger 1)))))
+                       @(Sing (Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (FromInteger 1)))))
                       (case
                            (applySing ((applySing ((singFun2 @(==@#@$)) (%==))) sN))
-                             (Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 1))
+                             (sFromInteger (sing :: Sing 1))
                        of
                          STrue -> SBaz
                          SFalse
                            -> (id
-                                 @(Sing (Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (Data.Singletons.Prelude.Num.FromInteger 2)))))
+                                 @(Sing (Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (FromInteger 2)))))
                                 (case
                                      (applySing ((applySing ((singFun2 @(==@#@$)) (%==))) sN))
-                                       (Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 2))
+                                       (sFromInteger (sing :: Sing 2))
                                  of
                                    STrue -> SBum
                                    SFalse -> sError (sing :: Sing "toEnum: bad argument"))))
-      sFromEnum SBar
-        = Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 0)
-      sFromEnum SBaz
-        = Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 1)
-      sFromEnum SBum
-        = Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 2)
+      sFromEnum SBar = sFromInteger (sing :: Sing 0)
+      sFromEnum SBaz = sFromInteger (sing :: Sing 1)
+      sFromEnum SBum = sFromInteger (sing :: Sing 2)
     instance SingI Bar where
       sing = SBar
     instance SingI Baz where
@@ -153,10 +150,10 @@ Singletons/EnumDeriving.hs:0:0:: Splicing declarations
       Case_0123456789876543210 n 'False = Apply ErrorSym0 "toEnum: bad argument"
     type family Case_0123456789876543210 n t where
       Case_0123456789876543210 n 'True = Q1Sym0
-      Case_0123456789876543210 n 'False = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (Data.Singletons.Prelude.Num.FromInteger 1))
+      Case_0123456789876543210 n 'False = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (FromInteger 1))
     type ToEnum_0123456789876543210 :: GHC.Types.Nat -> Quux
     type family ToEnum_0123456789876543210 a where
-      ToEnum_0123456789876543210 n = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (Data.Singletons.Prelude.Num.FromInteger 0))
+      ToEnum_0123456789876543210 n = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (FromInteger 0))
     type ToEnum_0123456789876543210Sym0 :: (~>) GHC.Types.Nat Quux
     data ToEnum_0123456789876543210Sym0 a0123456789876543210
       where
@@ -171,8 +168,8 @@ Singletons/EnumDeriving.hs:0:0:: Splicing declarations
       ToEnum_0123456789876543210Sym1 a0123456789876543210 = ToEnum_0123456789876543210 a0123456789876543210
     type FromEnum_0123456789876543210 :: Quux -> GHC.Types.Nat
     type family FromEnum_0123456789876543210 a where
-      FromEnum_0123456789876543210 'Q1 = Data.Singletons.Prelude.Num.FromInteger 0
-      FromEnum_0123456789876543210 'Q2 = Data.Singletons.Prelude.Num.FromInteger 1
+      FromEnum_0123456789876543210 'Q1 = FromInteger 0
+      FromEnum_0123456789876543210 'Q2 = FromInteger 1
     type FromEnum_0123456789876543210Sym0 :: (~>) Quux GHC.Types.Nat
     data FromEnum_0123456789876543210Sym0 a0123456789876543210
       where
@@ -201,22 +198,20 @@ Singletons/EnumDeriving.hs:0:0:: Splicing declarations
                                                                      -> GHC.Types.Type) t)
       sToEnum (sN :: Sing n)
         = (id
-             @(Sing (Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (Data.Singletons.Prelude.Num.FromInteger 0)))))
+             @(Sing (Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (FromInteger 0)))))
             (case
                  (applySing ((applySing ((singFun2 @(==@#@$)) (%==))) sN))
-                   (Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 0))
+                   (sFromInteger (sing :: Sing 0))
              of
                STrue -> SQ1
                SFalse
                  -> (id
-                       @(Sing (Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (Data.Singletons.Prelude.Num.FromInteger 1)))))
+                       @(Sing (Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (FromInteger 1)))))
                       (case
                            (applySing ((applySing ((singFun2 @(==@#@$)) (%==))) sN))
-                             (Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 1))
+                             (sFromInteger (sing :: Sing 1))
                        of
                          STrue -> SQ2
                          SFalse -> sError (sing :: Sing "toEnum: bad argument")))
-      sFromEnum SQ1
-        = Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 0)
-      sFromEnum SQ2
-        = Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 1)
+      sFromEnum SQ1 = sFromInteger (sing :: Sing 0)
+      sFromEnum SQ2 = sFromInteger (sing :: Sing 1)

--- a/tests/compile-and-dump/Singletons/Maybe.golden
+++ b/tests/compile-and-dump/Singletons/Maybe.golden
@@ -55,7 +55,7 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
                                           -> Maybe a -> GHC.Types.Symbol -> GHC.Types.Symbol
     type family ShowsPrec_0123456789876543210 a a a where
       ShowsPrec_0123456789876543210 _ Nothing a_0123456789876543210 = Apply (Apply ShowStringSym0 "Nothing") a_0123456789876543210
-      ShowsPrec_0123456789876543210 p_0123456789876543210 (Just arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (Data.Singletons.Prelude.Num.FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Just ")) (Apply (Apply ShowsPrecSym0 (Data.Singletons.Prelude.Num.FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
+      ShowsPrec_0123456789876543210 p_0123456789876543210 (Just arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Just ")) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
     type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) (Maybe a) ((~>) GHC.Types.Symbol GHC.Types.Symbol))
     data ShowsPrec_0123456789876543210Sym0 a0123456789876543210
       where
@@ -147,14 +147,14 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
                  ((applySing ((singFun3 @ShowParenSym0) sShowParen))
                     ((applySing
                         ((applySing ((singFun2 @(>@#@$)) (%>))) sP_0123456789876543210))
-                       (Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 10)))))
+                       (sFromInteger (sing :: Sing 10)))))
                 ((applySing
                     ((applySing ((singFun3 @(.@#@$)) (%.)))
                        ((applySing ((singFun2 @ShowStringSym0) sShowString))
                           (sing :: Sing "Just "))))
                    ((applySing
                        ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
-                          (Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 11))))
+                          (sFromInteger (sing :: Sing 11))))
                       sArg_0123456789876543210))))
             sA_0123456789876543210
     instance SDecide a => SDecide (Maybe a) where

--- a/tests/compile-and-dump/Singletons/Nat.golden
+++ b/tests/compile-and-dump/Singletons/Nat.golden
@@ -109,7 +109,7 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
                                           -> Nat -> GHC.Types.Symbol -> GHC.Types.Symbol
     type family ShowsPrec_0123456789876543210 a a a where
       ShowsPrec_0123456789876543210 _ Zero a_0123456789876543210 = Apply (Apply ShowStringSym0 "Zero") a_0123456789876543210
-      ShowsPrec_0123456789876543210 p_0123456789876543210 (Succ arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (Data.Singletons.Prelude.Num.FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Succ ")) (Apply (Apply ShowsPrecSym0 (Data.Singletons.Prelude.Num.FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
+      ShowsPrec_0123456789876543210 p_0123456789876543210 (Succ arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Succ ")) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
     type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) Nat ((~>) GHC.Types.Symbol GHC.Types.Symbol))
     data ShowsPrec_0123456789876543210Sym0 a0123456789876543210
       where
@@ -246,14 +246,14 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
                  ((applySing ((singFun3 @ShowParenSym0) sShowParen))
                     ((applySing
                         ((applySing ((singFun2 @(>@#@$)) (%>))) sP_0123456789876543210))
-                       (Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 10)))))
+                       (sFromInteger (sing :: Sing 10)))))
                 ((applySing
                     ((applySing ((singFun3 @(.@#@$)) (%.)))
                        ((applySing ((singFun2 @ShowStringSym0) sShowString))
                           (sing :: Sing "Succ "))))
                    ((applySing
                        ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
-                          (Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 11))))
+                          (sFromInteger (sing :: Sing 11))))
                       sArg_0123456789876543210))))
             sA_0123456789876543210
     instance SOrd Nat => SOrd Nat where
@@ -269,7 +269,7 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
                  ((applySing ((singFun3 @FoldlSym0) sFoldl))
                     ((singFun2 @ThenCmpSym0) sThenCmp)))
                 SEQ))
-            Data.Singletons.Prelude.Instances.SNil
+            SNil
       sCompare
         (SSucc (sA_0123456789876543210 :: Sing a_0123456789876543210))
         (SSucc (sB_0123456789876543210 :: Sing b_0123456789876543210))
@@ -279,14 +279,12 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
                     ((singFun2 @ThenCmpSym0) sThenCmp)))
                 SEQ))
             ((applySing
-                ((applySing
-                    ((singFun2 @(:@#@$))
-                       Data.Singletons.Prelude.Instances.SCons))
+                ((applySing ((singFun2 @(:@#@$)) SCons))
                    ((applySing
                        ((applySing ((singFun2 @CompareSym0) sCompare))
                           sA_0123456789876543210))
                       sB_0123456789876543210)))
-               Data.Singletons.Prelude.Instances.SNil)
+               SNil)
       sCompare SZero (SSucc _) = SLT
       sCompare (SSucc _) SZero = SGT
     instance SDecide Nat => SDecide Nat where

--- a/tests/compile-and-dump/Singletons/NegativeLiterals.golden
+++ b/tests/compile-and-dump/Singletons/NegativeLiterals.golden
@@ -1,0 +1,15 @@
+Singletons/NegativeLiterals.hs:(0,0)-(0,0): Splicing declarations
+    singletons
+      [d| f :: Nat
+          f = -1 |]
+  ======>
+    f :: Nat
+    f = (-1)
+    type FSym0 :: Nat
+    type family FSym0 where
+      FSym0 = F
+    type F :: Nat
+    type family F where
+      F = Negate (FromInteger 1)
+    sF :: Sing (FSym0 :: Nat)
+    sF = sNegate (sFromInteger (sing :: Sing 1))

--- a/tests/compile-and-dump/Singletons/NegativeLiterals.hs
+++ b/tests/compile-and-dump/Singletons/NegativeLiterals.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE NegativeLiterals #-}
+module Singletons.NegativeLiterals where
+
+import Data.Singletons.TH
+import GHC.TypeNats (Nat)
+
+$(singletons [d|
+  f :: Nat
+  f = -1
+  |])

--- a/tests/compile-and-dump/Singletons/OverloadedStrings.golden
+++ b/tests/compile-and-dump/Singletons/OverloadedStrings.golden
@@ -25,7 +25,7 @@ Singletons/OverloadedStrings.hs:(0,0)-(0,0): Splicing declarations
       SymIdSym1 a0123456789876543210 = SymId a0123456789876543210
     type Foo :: Symbol
     type family Foo where
-      Foo = Apply SymIdSym0 (Data.Singletons.Prelude.IsString.FromString "foo")
+      Foo = Apply SymIdSym0 (FromString "foo")
     type SymId :: Symbol -> Symbol
     type family SymId a where
       SymId x = x
@@ -34,7 +34,7 @@ Singletons/OverloadedStrings.hs:(0,0)-(0,0): Splicing declarations
       forall (t :: Symbol). Sing t -> Sing (Apply SymIdSym0 t :: Symbol)
     sFoo
       = (applySing ((singFun1 @SymIdSym0) sSymId))
-          (Data.Singletons.Prelude.IsString.sFromString (sing :: Sing "foo"))
+          (sFromString (sing :: Sing "foo"))
     sSymId (sX :: Sing x) = sX
     instance SingI (SymIdSym0 :: (~>) Symbol Symbol) where
       sing = (singFun1 @SymIdSym0) sSymId

--- a/tests/compile-and-dump/Singletons/T166.golden
+++ b/tests/compile-and-dump/Singletons/T166.golden
@@ -45,7 +45,7 @@ Singletons/T166.hs:(0,0)-(0,0): Splicing declarations
     type family FooSym1 a0123456789876543210 where
       FooSym1 a0123456789876543210 = Foo a0123456789876543210
     type family Lambda_0123456789876543210 x s where
-      Lambda_0123456789876543210 x s = Apply (Apply (Apply FoosPrecSym0 (Data.Singletons.Prelude.Num.FromInteger 0)) x) s
+      Lambda_0123456789876543210 x s = Apply (Apply (Apply FoosPrecSym0 (FromInteger 0)) x) s
     data Lambda_0123456789876543210Sym0 x0123456789876543210
       where
         Lambda_0123456789876543210Sym0KindInference :: SameKind (Apply Lambda_0123456789876543210Sym0 arg) (Lambda_0123456789876543210Sym1 arg) =>
@@ -104,7 +104,7 @@ Singletons/T166.hs:(0,0)-(0,0): Splicing declarations
                       -> (applySing
                             ((applySing
                                 ((applySing ((singFun3 @FoosPrecSym0) sFoosPrec))
-                                   (Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 0))))
+                                   (sFromInteger (sing :: Sing 0))))
                                sX))
                            sS })
     instance SFoo a =>

--- a/tests/compile-and-dump/Singletons/T178.golden
+++ b/tests/compile-and-dump/Singletons/T178.golden
@@ -141,7 +141,7 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
     instance PShow Occ where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     sEmpty :: Sing (EmptySym0 :: [(Symbol, Occ)])
-    sEmpty = Data.Singletons.Prelude.Instances.SNil
+    sEmpty = SNil
     data SOcc :: Occ -> GHC.Types.Type
       where
         SStr :: SOcc (Str :: Occ)
@@ -185,21 +185,21 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
                  ((applySing ((singFun3 @FoldlSym0) sFoldl))
                     ((singFun2 @ThenCmpSym0) sThenCmp)))
                 SEQ))
-            Data.Singletons.Prelude.Instances.SNil
+            SNil
       sCompare SOpt SOpt
         = (applySing
              ((applySing
                  ((applySing ((singFun3 @FoldlSym0) sFoldl))
                     ((singFun2 @ThenCmpSym0) sThenCmp)))
                 SEQ))
-            Data.Singletons.Prelude.Instances.SNil
+            SNil
       sCompare SMany SMany
         = (applySing
              ((applySing
                  ((applySing ((singFun3 @FoldlSym0) sFoldl))
                     ((singFun2 @ThenCmpSym0) sThenCmp)))
                 SEQ))
-            Data.Singletons.Prelude.Instances.SNil
+            SNil
       sCompare SStr SOpt = SLT
       sCompare SStr SMany = SLT
       sCompare SOpt SStr = SGT

--- a/tests/compile-and-dump/Singletons/T190.golden
+++ b/tests/compile-and-dump/Singletons/T190.golden
@@ -67,7 +67,7 @@ Singletons/T190.hs:0:0:: Splicing declarations
       Case_0123456789876543210 n 'False = Apply ErrorSym0 "toEnum: bad argument"
     type ToEnum_0123456789876543210 :: GHC.Types.Nat -> T
     type family ToEnum_0123456789876543210 a where
-      ToEnum_0123456789876543210 n = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (Data.Singletons.Prelude.Num.FromInteger 0))
+      ToEnum_0123456789876543210 n = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (FromInteger 0))
     type ToEnum_0123456789876543210Sym0 :: (~>) GHC.Types.Nat T
     data ToEnum_0123456789876543210Sym0 a0123456789876543210
       where
@@ -82,7 +82,7 @@ Singletons/T190.hs:0:0:: Splicing declarations
       ToEnum_0123456789876543210Sym1 a0123456789876543210 = ToEnum_0123456789876543210 a0123456789876543210
     type FromEnum_0123456789876543210 :: T -> GHC.Types.Nat
     type family FromEnum_0123456789876543210 a where
-      FromEnum_0123456789876543210 T = Data.Singletons.Prelude.Num.FromInteger 0
+      FromEnum_0123456789876543210 T = FromInteger 0
     type FromEnum_0123456789876543210Sym0 :: (~>) T GHC.Types.Nat
     data FromEnum_0123456789876543210Sym0 a0123456789876543210
       where
@@ -179,7 +179,7 @@ Singletons/T190.hs:0:0:: Splicing declarations
                  ((applySing ((singFun3 @FoldlSym0) sFoldl))
                     ((singFun2 @ThenCmpSym0) sThenCmp)))
                 SEQ))
-            Data.Singletons.Prelude.Instances.SNil
+            SNil
     instance SEnum T where
       sToEnum ::
         forall (t :: GHC.Types.Nat).
@@ -193,15 +193,14 @@ Singletons/T190.hs:0:0:: Splicing declarations
                                                                      -> GHC.Types.Type) t)
       sToEnum (sN :: Sing n)
         = (id
-             @(Sing (Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (Data.Singletons.Prelude.Num.FromInteger 0)))))
+             @(Sing (Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (FromInteger 0)))))
             (case
                  (applySing ((applySing ((singFun2 @(==@#@$)) (%==))) sN))
-                   (Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 0))
+                   (sFromInteger (sing :: Sing 0))
              of
                STrue -> ST
                SFalse -> sError (sing :: Sing "toEnum: bad argument"))
-      sFromEnum ST
-        = Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 0)
+      sFromEnum ST = sFromInteger (sing :: Sing 0)
     instance SBounded T where
       sMinBound :: Sing (MinBoundSym0 :: T)
       sMaxBound :: Sing (MaxBoundSym0 :: T)

--- a/tests/compile-and-dump/Singletons/T271.golden
+++ b/tests/compile-and-dump/Singletons/T271.golden
@@ -206,14 +206,12 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
                     ((singFun2 @ThenCmpSym0) sThenCmp)))
                 SEQ))
             ((applySing
-                ((applySing
-                    ((singFun2 @(:@#@$))
-                       Data.Singletons.Prelude.Instances.SCons))
+                ((applySing ((singFun2 @(:@#@$)) SCons))
                    ((applySing
                        ((applySing ((singFun2 @CompareSym0) sCompare))
                           sA_0123456789876543210))
                       sB_0123456789876543210)))
-               Data.Singletons.Prelude.Instances.SNil)
+               SNil)
     instance SEq a => SEq (Identity a) where
       (%==) ::
         forall (t1 :: Identity a) (t2 :: Identity a).
@@ -243,14 +241,12 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
                     ((singFun2 @ThenCmpSym0) sThenCmp)))
                 SEQ))
             ((applySing
-                ((applySing
-                    ((singFun2 @(:@#@$))
-                       Data.Singletons.Prelude.Instances.SCons))
+                ((applySing ((singFun2 @(:@#@$)) SCons))
                    ((applySing
                        ((applySing ((singFun2 @CompareSym0) sCompare))
                           sA_0123456789876543210))
                       sB_0123456789876543210)))
-               Data.Singletons.Prelude.Instances.SNil)
+               SNil)
     instance SDecide a => SDecide (Constant a b) where
       (%~) (SConstant a) (SConstant b)
         = case ((%~) a) b of

--- a/tests/compile-and-dump/Singletons/T358.golden
+++ b/tests/compile-and-dump/Singletons/T358.golden
@@ -105,14 +105,14 @@ Singletons/T358.hs:(0,0)-(0,0): Splicing declarations
         forall b (t :: b). Sing t -> Sing (Apply Method2bSym0 t :: a)
     instance SC1 [] where
       sMethod1 :: forall a. Sing (Method1Sym0 :: [a])
-      sMethod1 = Data.Singletons.Prelude.Instances.SNil
+      sMethod1 = SNil
     instance SC2 [a] where
       sMethod2a ::
         forall b (t :: b). Sing t -> Sing (Apply Method2aSym0 t :: [a])
       sMethod2b ::
         forall b (t :: b). Sing t -> Sing (Apply Method2bSym0 t :: [a])
-      sMethod2a _ = Data.Singletons.Prelude.Instances.SNil
-      sMethod2b _ = Data.Singletons.Prelude.Instances.SNil
+      sMethod2a _ = SNil
+      sMethod2b _ = SNil
     instance SC2 a => SingI (Method2aSym0 :: (~>) b a) where
       sing = (singFun1 @Method2aSym0) sMethod2a
     instance SC2 a => SingI (Method2bSym0 :: (~>) b a) where

--- a/tests/compile-and-dump/Singletons/T371.golden
+++ b/tests/compile-and-dump/Singletons/T371.golden
@@ -45,7 +45,7 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
                                           -> X a -> GHC.Types.Symbol -> GHC.Types.Symbol
     type family ShowsPrec_0123456789876543210 a a a where
       ShowsPrec_0123456789876543210 _ X1 a_0123456789876543210 = Apply (Apply ShowStringSym0 "X1") a_0123456789876543210
-      ShowsPrec_0123456789876543210 p_0123456789876543210 (X2 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (Data.Singletons.Prelude.Num.FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "X2 ")) (Apply (Apply ShowsPrecSym0 (Data.Singletons.Prelude.Num.FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
+      ShowsPrec_0123456789876543210 p_0123456789876543210 (X2 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "X2 ")) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
     type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) (X a) ((~>) GHC.Types.Symbol GHC.Types.Symbol))
     data ShowsPrec_0123456789876543210Sym0 a0123456789876543210
       where
@@ -85,7 +85,7 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
                                           -> Y a -> GHC.Types.Symbol -> GHC.Types.Symbol
     type family ShowsPrec_0123456789876543210 a a a where
       ShowsPrec_0123456789876543210 _ Y1 a_0123456789876543210 = Apply (Apply ShowStringSym0 "Y1") a_0123456789876543210
-      ShowsPrec_0123456789876543210 p_0123456789876543210 (Y2 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (Data.Singletons.Prelude.Num.FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Y2 ")) (Apply (Apply ShowsPrecSym0 (Data.Singletons.Prelude.Num.FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
+      ShowsPrec_0123456789876543210 p_0123456789876543210 (Y2 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Y2 ")) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
     type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) (Y a) ((~>) GHC.Types.Symbol GHC.Types.Symbol))
     data ShowsPrec_0123456789876543210Sym0 a0123456789876543210
       where
@@ -174,14 +174,14 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
                  ((applySing ((singFun3 @ShowParenSym0) sShowParen))
                     ((applySing
                         ((applySing ((singFun2 @(>@#@$)) (%>))) sP_0123456789876543210))
-                       (Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 10)))))
+                       (sFromInteger (sing :: Sing 10)))))
                 ((applySing
                     ((applySing ((singFun3 @(.@#@$)) (%.)))
                        ((applySing ((singFun2 @ShowStringSym0) sShowString))
                           (sing :: Sing "X2 "))))
                    ((applySing
                        ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
-                          (Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 11))))
+                          (sFromInteger (sing :: Sing 11))))
                       sArg_0123456789876543210))))
             sA_0123456789876543210
     instance SShow (X a) => SShow (Y a) where
@@ -209,14 +209,14 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
                  ((applySing ((singFun3 @ShowParenSym0) sShowParen))
                     ((applySing
                         ((applySing ((singFun2 @(>@#@$)) (%>))) sP_0123456789876543210))
-                       (Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 10)))))
+                       (sFromInteger (sing :: Sing 10)))))
                 ((applySing
                     ((applySing ((singFun3 @(.@#@$)) (%.)))
                        ((applySing ((singFun2 @ShowStringSym0) sShowString))
                           (sing :: Sing "Y2 "))))
                    ((applySing
                        ((applySing ((singFun3 @ShowsPrecSym0) sShowsPrec))
-                          (Data.Singletons.Prelude.Num.sFromInteger (sing :: Sing 11))))
+                          (sFromInteger (sing :: Sing 11))))
                       sArg_0123456789876543210))))
             sA_0123456789876543210
     instance Data.Singletons.ShowSing.ShowSing (Y a) =>


### PR DESCRIPTION
For the reasons spelled out in the new `Note [Wired-in Names]` in
`D.S.Names`, we wish to generate all promoted and singled `Name`s
completely unqualified. This patch accomplishes that by deleting
wired-in `Name`s from `D.S.Names` and replacing them with proper
`promotedValueName`s and `singledValueName`s.

Doing this revealed that certain test cases in the test suite no
longer compiled, as they were generating `Name`s that were no longer
in scope due to the lack of wiring in. This is easily remedied by
re-exporting these names from `D.S.TH`, which we should have been
doing all along.

Fixes #452.