### PR TITLE
Generate redundant kind information for Haddock's benefit

### DIFF
--- a/singletons-base/src/Data/Singletons/Prelude/Const.hs
+++ b/singletons-base/src/Data/Singletons/Prelude/Const.hs
@@ -71,7 +71,7 @@ poly-kinded Sing instances (see #150), we simply write the singleton type by
 hand.
 -}
 type SConst :: Const a b -> Type
-data SConst c where
+data SConst :: Const a b -> Type where
   SConst :: Sing a -> SConst ('Const a)
 type instance Sing = SConst
 instance SingKind a => SingKind (Const a b) where

--- a/singletons-base/src/Data/Singletons/Prelude/Eq.hs
+++ b/singletons-base/src/Data/Singletons/Prelude/Eq.hs
@@ -113,7 +113,7 @@ $(singletonsOnly [d|
 -- /does/ reduce to 'True' for every @a@. The latter behavior is more desirable
 -- for @singletons@' purposes, so we use it instead of '(DTE.==)'.
 type DefaultEq :: k -> k -> Bool
-type family DefaultEq a b where
+type family DefaultEq (a :: k) (b :: k) :: Bool where
   DefaultEq a a = 'True
   DefaultEq a b = 'False
 $(genDefunSymbols [''DefaultEq])

--- a/singletons-base/src/Data/Singletons/Prelude/Proxy.hs
+++ b/singletons-base/src/Data/Singletons/Prelude/Proxy.hs
@@ -63,7 +63,7 @@ code in D.S.Prelude.Const. (See the comments above SConst in that module
 for more details on this choice.)
 -}
 type SProxy :: Proxy t -> Type
-data SProxy proxy where
+data SProxy :: Proxy t -> Type where
   SProxy :: forall t. SProxy ('Proxy @t)
 type instance Sing = SProxy
 instance SingKind (Proxy t) where

--- a/singletons-base/src/Data/Singletons/Prelude/Void.hs
+++ b/singletons-base/src/Data/Singletons/Prelude/Void.hs
@@ -29,13 +29,8 @@
 ----------------------------------------------------------------------------
 module Data.Singletons.Prelude.Void (
   -- * The 'Void' singleton
-  Sing,
-  -- | Just as 'Void' has no constructors, the 'Sing' instance above also has
-  -- no constructors.
-
-  SVoid,
-  -- | 'SVoid' is a kind-restricted synonym for 'Sing':
-  -- @type SVoid (a :: Void) = Sing a@
+  Sing, SVoid,
+  -- | Just as 'Void' has no constructors, 'SVoid' also has no constructors.
 
   -- * Singletons from @Data.Void@
   Absurd, sAbsurd,

--- a/singletons-base/src/Data/Singletons/TypeError.hs
+++ b/singletons-base/src/Data/Singletons/TypeError.hs
@@ -80,7 +80,7 @@ type PErrorMessage :: Type
 type PErrorMessage = ErrorMessage' Symbol
 
 type SErrorMessage :: PErrorMessage -> Type
-data SErrorMessage em where
+data SErrorMessage :: PErrorMessage -> Type where
   SText     :: Sing t             -> SErrorMessage ('Text t)
   SShowType :: Sing ty            -> SErrorMessage ('ShowType ty)
   (:%<>:)   :: Sing e1 -> Sing e2 -> SErrorMessage (e1 ':<>: e2)
@@ -137,7 +137,7 @@ typeError = error . showErrorMessage
 
 -- | Convert a 'PErrorMessage' to a 'TL.ErrorMessage' from "GHC.TypeLits".
 type ConvertPErrorMessage :: PErrorMessage -> TL.ErrorMessage
-type family ConvertPErrorMessage a where
+type family ConvertPErrorMessage (a :: PErrorMessage) :: TL.ErrorMessage where
   ConvertPErrorMessage ('Text t)      = 'TL.Text t
   ConvertPErrorMessage ('ShowType ty) = 'TL.ShowType ty
   ConvertPErrorMessage (e1 ':<>: e2)  = ConvertPErrorMessage e1 'TL.:<>: ConvertPErrorMessage e2
@@ -146,9 +146,9 @@ type family ConvertPErrorMessage a where
 -- | A drop-in replacement for 'TL.TypeError'. This also exists at the
 -- value-level as 'typeError'.
 type TypeError :: PErrorMessage -> a
-type family TypeError a where
+type family TypeError (x :: PErrorMessage) :: a where
   -- We cannot define this as a type synonym due to Trac #12048.
-  TypeError a = TL.TypeError (ConvertPErrorMessage a)
+  TypeError x = TL.TypeError (ConvertPErrorMessage x)
 
 -- | The singleton for 'typeError'.
 --

--- a/singletons-base/src/Data/Singletons/TypeLits/Internal.hs
+++ b/singletons-base/src/Data/Singletons/TypeLits/Internal.hs
@@ -61,7 +61,7 @@ import Data.Text ( Text )
 ----------------------------------------------------------------------
 
 type SNat :: Nat -> Type
-data SNat n = KnownNat n => SNat
+data SNat (n :: Nat) = KnownNat n => SNat
 type instance Sing = SNat
 
 instance KnownNat n => SingI n where
@@ -74,7 +74,7 @@ instance SingKind Nat where
                SomeNat (_ :: Proxy n) -> SomeSing (SNat :: Sing n)
 
 type SSymbol :: Symbol -> Type
-data SSymbol n = KnownSymbol n => SSym
+data SSymbol (n :: Symbol) = KnownSymbol n => SSym
 type instance Sing = SSymbol
 
 instance KnownSymbol n => SingI n where
@@ -179,7 +179,7 @@ withKnownSymbol SSym f = f
 -- | The promotion of 'error'. This version is more poly-kinded for
 -- easier use.
 type Error :: k0 -> k
-type family Error str where {}
+type family Error (str :: k0) :: k where {}
 $(genDefunSymbols [''Error])
 instance SingI (ErrorSym0 :: Symbol ~> a) where
   sing = singFun1 sError
@@ -191,7 +191,7 @@ sError sstr = error (T.unpack (fromSing sstr))
 -- | The promotion of 'errorWithoutStackTrace'. This version is more
 -- poly-kinded for easier use.
 type ErrorWithoutStackTrace :: k0 -> k
-type family ErrorWithoutStackTrace str where {}
+type family ErrorWithoutStackTrace (str :: k0) :: k where {}
 $(genDefunSymbols [''ErrorWithoutStackTrace])
 instance SingI (ErrorWithoutStackTraceSym0 :: Symbol ~> a) where
   sing = singFun1 sErrorWithoutStackTrace
@@ -202,7 +202,7 @@ sErrorWithoutStackTrace sstr = errorWithoutStackTrace (T.unpack (fromSing sstr))
 
 -- | The promotion of 'undefined'.
 type Undefined :: k
-type family Undefined where {}
+type family Undefined :: k where {}
 $(genDefunSymbols [''Undefined])
 
 -- | The singleton for 'undefined'.

--- a/singletons-base/src/Data/Singletons/TypeRepTYPE.hs
+++ b/singletons-base/src/Data/Singletons/TypeRepTYPE.hs
@@ -59,7 +59,7 @@ type instance Sing @(TYPE rep) = TypeRep
 -- | A variant of 'SomeTypeRep' whose underlying 'TypeRep' is restricted to
 -- kind @'TYPE' rep@ (for some 'RuntimeRep' @rep@).
 type SomeTypeRepTYPE :: RuntimeRep -> Type
-data SomeTypeRepTYPE r where
+data SomeTypeRepTYPE :: RuntimeRep -> Type where
   SomeTypeRepTYPE :: forall (rep :: RuntimeRep) (a :: TYPE rep). !(TypeRep a) -> SomeTypeRepTYPE rep
 
 instance Eq (SomeTypeRepTYPE rep) where

--- a/singletons-base/tests/compile-and-dump/GradingClient/Database.golden
+++ b/singletons-base/tests/compile-and-dump/GradingClient/Database.golden
@@ -8,10 +8,10 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       = Zero | Succ Nat
       deriving (Eq, Ord)
     type ZeroSym0 :: Nat
-    type family ZeroSym0 where
+    type family ZeroSym0 :: Nat where
       ZeroSym0 = Zero
     type SuccSym0 :: (~>) Nat Nat
-    data SuccSym0 a0123456789876543210
+    data SuccSym0 :: (~>) Nat Nat
       where
         SuccSym0KindInference :: SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
                                  SuccSym0 a0123456789876543210
@@ -19,16 +19,16 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings SuccSym0 where
       suppressUnusedWarnings = snd (((,) SuccSym0KindInference) ())
     type SuccSym1 :: Nat -> Nat
-    type family SuccSym1 a0123456789876543210 where
+    type family SuccSym1 (a0123456789876543210 :: Nat) :: Nat where
       SuccSym1 a0123456789876543210 = Succ a0123456789876543210
     type TFHelper_0123456789876543210 :: Nat -> Nat -> Bool
-    type family TFHelper_0123456789876543210 a a where
+    type family TFHelper_0123456789876543210 (a :: Nat) (a :: Nat) :: Bool where
       TFHelper_0123456789876543210 Zero Zero = TrueSym0
       TFHelper_0123456789876543210 Zero (Succ _) = FalseSym0
       TFHelper_0123456789876543210 (Succ _) Zero = FalseSym0
       TFHelper_0123456789876543210 (Succ a_0123456789876543210) (Succ b_0123456789876543210) = Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210
     type TFHelper_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Bool)
-    data TFHelper_0123456789876543210Sym0 a0123456789876543210
+    data TFHelper_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Bool)
       where
         TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
                                                          TFHelper_0123456789876543210Sym0 a0123456789876543210
@@ -37,7 +37,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym0KindInference) ())
     type TFHelper_0123456789876543210Sym1 :: Nat -> (~>) Nat Bool
-    data TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Nat) :: (~>) Nat Bool
       where
         TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                          TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -46,18 +46,18 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym1KindInference) ())
     type TFHelper_0123456789876543210Sym2 :: Nat -> Nat -> Bool
-    type family TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Bool where
       TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq Nat where
       type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
     type Compare_0123456789876543210 :: Nat -> Nat -> Ordering
-    type family Compare_0123456789876543210 a a where
+    type family Compare_0123456789876543210 (a :: Nat) (a :: Nat) :: Ordering where
       Compare_0123456789876543210 Zero Zero = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) NilSym0
       Compare_0123456789876543210 (Succ a_0123456789876543210) (Succ b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0)
       Compare_0123456789876543210 Zero (Succ _) = LTSym0
       Compare_0123456789876543210 (Succ _) Zero = GTSym0
     type Compare_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Ordering)
-    data Compare_0123456789876543210Sym0 a0123456789876543210
+    data Compare_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Ordering)
       where
         Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
                                                         Compare_0123456789876543210Sym0 a0123456789876543210
@@ -66,7 +66,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Compare_0123456789876543210Sym0KindInference) ())
     type Compare_0123456789876543210Sym1 :: Nat -> (~>) Nat Ordering
-    data Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Nat) :: (~>) Nat Ordering
       where
         Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                         Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -75,7 +75,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Compare_0123456789876543210Sym1KindInference) ())
     type Compare_0123456789876543210Sym2 :: Nat -> Nat -> Ordering
-    type family Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Compare_0123456789876543210Sym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Ordering where
       Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd Nat where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
@@ -268,16 +268,16 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     lookup name (Sch (Attr name' u : attrs))
       = if (name == name') then u else (lookup name) (Sch attrs)
     type BOOLSym0 :: U
-    type family BOOLSym0 where
+    type family BOOLSym0 :: U where
       BOOLSym0 = BOOL
     type STRINGSym0 :: U
-    type family STRINGSym0 where
+    type family STRINGSym0 :: U where
       STRINGSym0 = STRING
     type NATSym0 :: U
-    type family NATSym0 where
+    type family NATSym0 :: U where
       NATSym0 = NAT
     type VECSym0 :: (~>) U ((~>) Nat U)
-    data VECSym0 a0123456789876543210
+    data VECSym0 :: (~>) U ((~>) Nat U)
       where
         VECSym0KindInference :: SameKind (Apply VECSym0 arg) (VECSym1 arg) =>
                                 VECSym0 a0123456789876543210
@@ -285,7 +285,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings VECSym0 where
       suppressUnusedWarnings = snd (((,) VECSym0KindInference) ())
     type VECSym1 :: U -> (~>) Nat U
-    data VECSym1 a0123456789876543210 a0123456789876543210
+    data VECSym1 (a0123456789876543210 :: U) :: (~>) Nat U
       where
         VECSym1KindInference :: SameKind (Apply (VECSym1 a0123456789876543210) arg) (VECSym2 a0123456789876543210 arg) =>
                                 VECSym1 a0123456789876543210 a0123456789876543210
@@ -293,88 +293,88 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (VECSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) VECSym1KindInference) ())
     type VECSym2 :: U -> Nat -> U
-    type family VECSym2 a0123456789876543210 a0123456789876543210 where
+    type family VECSym2 (a0123456789876543210 :: U) (a0123456789876543210 :: Nat) :: U where
       VECSym2 a0123456789876543210 a0123456789876543210 = VEC a0123456789876543210 a0123456789876543210
     type CASym0 :: AChar
-    type family CASym0 where
+    type family CASym0 :: AChar where
       CASym0 = CA
     type CBSym0 :: AChar
-    type family CBSym0 where
+    type family CBSym0 :: AChar where
       CBSym0 = CB
     type CCSym0 :: AChar
-    type family CCSym0 where
+    type family CCSym0 :: AChar where
       CCSym0 = CC
     type CDSym0 :: AChar
-    type family CDSym0 where
+    type family CDSym0 :: AChar where
       CDSym0 = CD
     type CESym0 :: AChar
-    type family CESym0 where
+    type family CESym0 :: AChar where
       CESym0 = CE
     type CFSym0 :: AChar
-    type family CFSym0 where
+    type family CFSym0 :: AChar where
       CFSym0 = CF
     type CGSym0 :: AChar
-    type family CGSym0 where
+    type family CGSym0 :: AChar where
       CGSym0 = CG
     type CHSym0 :: AChar
-    type family CHSym0 where
+    type family CHSym0 :: AChar where
       CHSym0 = CH
     type CISym0 :: AChar
-    type family CISym0 where
+    type family CISym0 :: AChar where
       CISym0 = CI
     type CJSym0 :: AChar
-    type family CJSym0 where
+    type family CJSym0 :: AChar where
       CJSym0 = CJ
     type CKSym0 :: AChar
-    type family CKSym0 where
+    type family CKSym0 :: AChar where
       CKSym0 = CK
     type CLSym0 :: AChar
-    type family CLSym0 where
+    type family CLSym0 :: AChar where
       CLSym0 = CL
     type CMSym0 :: AChar
-    type family CMSym0 where
+    type family CMSym0 :: AChar where
       CMSym0 = CM
     type CNSym0 :: AChar
-    type family CNSym0 where
+    type family CNSym0 :: AChar where
       CNSym0 = CN
     type COSym0 :: AChar
-    type family COSym0 where
+    type family COSym0 :: AChar where
       COSym0 = CO
     type CPSym0 :: AChar
-    type family CPSym0 where
+    type family CPSym0 :: AChar where
       CPSym0 = CP
     type CQSym0 :: AChar
-    type family CQSym0 where
+    type family CQSym0 :: AChar where
       CQSym0 = CQ
     type CRSym0 :: AChar
-    type family CRSym0 where
+    type family CRSym0 :: AChar where
       CRSym0 = CR
     type CSSym0 :: AChar
-    type family CSSym0 where
+    type family CSSym0 :: AChar where
       CSSym0 = CS
     type CTSym0 :: AChar
-    type family CTSym0 where
+    type family CTSym0 :: AChar where
       CTSym0 = CT
     type CUSym0 :: AChar
-    type family CUSym0 where
+    type family CUSym0 :: AChar where
       CUSym0 = CU
     type CVSym0 :: AChar
-    type family CVSym0 where
+    type family CVSym0 :: AChar where
       CVSym0 = CV
     type CWSym0 :: AChar
-    type family CWSym0 where
+    type family CWSym0 :: AChar where
       CWSym0 = CW
     type CXSym0 :: AChar
-    type family CXSym0 where
+    type family CXSym0 :: AChar where
       CXSym0 = CX
     type CYSym0 :: AChar
-    type family CYSym0 where
+    type family CYSym0 :: AChar where
       CYSym0 = CY
     type CZSym0 :: AChar
-    type family CZSym0 where
+    type family CZSym0 :: AChar where
       CZSym0 = CZ
     type AttrSym0 :: (~>) [AChar] ((~>) U Attribute)
-    data AttrSym0 a0123456789876543210
+    data AttrSym0 :: (~>) [AChar] ((~>) U Attribute)
       where
         AttrSym0KindInference :: SameKind (Apply AttrSym0 arg) (AttrSym1 arg) =>
                                  AttrSym0 a0123456789876543210
@@ -382,7 +382,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings AttrSym0 where
       suppressUnusedWarnings = snd (((,) AttrSym0KindInference) ())
     type AttrSym1 :: [AChar] -> (~>) U Attribute
-    data AttrSym1 a0123456789876543210 a0123456789876543210
+    data AttrSym1 (a0123456789876543210 :: [AChar]) :: (~>) U Attribute
       where
         AttrSym1KindInference :: SameKind (Apply (AttrSym1 a0123456789876543210) arg) (AttrSym2 a0123456789876543210 arg) =>
                                  AttrSym1 a0123456789876543210 a0123456789876543210
@@ -390,10 +390,10 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (AttrSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) AttrSym1KindInference) ())
     type AttrSym2 :: [AChar] -> U -> Attribute
-    type family AttrSym2 a0123456789876543210 a0123456789876543210 where
+    type family AttrSym2 (a0123456789876543210 :: [AChar]) (a0123456789876543210 :: U) :: Attribute where
       AttrSym2 a0123456789876543210 a0123456789876543210 = Attr a0123456789876543210 a0123456789876543210
     type SchSym0 :: (~>) [Attribute] Schema
-    data SchSym0 a0123456789876543210
+    data SchSym0 :: (~>) [Attribute] Schema
       where
         SchSym0KindInference :: SameKind (Apply SchSym0 arg) (SchSym1 arg) =>
                                 SchSym0 a0123456789876543210
@@ -401,7 +401,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings SchSym0 where
       suppressUnusedWarnings = snd (((,) SchSym0KindInference) ())
     type SchSym1 :: [Attribute] -> Schema
-    type family SchSym1 a0123456789876543210 where
+    type family SchSym1 (a0123456789876543210 :: [Attribute]) :: Schema where
       SchSym1 a0123456789876543210 = Sch a0123456789876543210
     data Let0123456789876543210Scrutinee_0123456789876543210Sym0 name0123456789876543210
       where
@@ -455,7 +455,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       Case_0123456789876543210 name name' u attrs 'True = u
       Case_0123456789876543210 name name' u attrs 'False = Apply (Apply LookupSym0 name) (Apply SchSym0 attrs)
     type LookupSym0 :: (~>) [AChar] ((~>) Schema U)
-    data LookupSym0 a0123456789876543210
+    data LookupSym0 :: (~>) [AChar] ((~>) Schema U)
       where
         LookupSym0KindInference :: SameKind (Apply LookupSym0 arg) (LookupSym1 arg) =>
                                    LookupSym0 a0123456789876543210
@@ -463,7 +463,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings LookupSym0 where
       suppressUnusedWarnings = snd (((,) LookupSym0KindInference) ())
     type LookupSym1 :: [AChar] -> (~>) Schema U
-    data LookupSym1 a0123456789876543210 a0123456789876543210
+    data LookupSym1 (a0123456789876543210 :: [AChar]) :: (~>) Schema U
       where
         LookupSym1KindInference :: SameKind (Apply (LookupSym1 a0123456789876543210) arg) (LookupSym2 a0123456789876543210 arg) =>
                                    LookupSym1 a0123456789876543210 a0123456789876543210
@@ -471,10 +471,10 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (LookupSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) LookupSym1KindInference) ())
     type LookupSym2 :: [AChar] -> Schema -> U
-    type family LookupSym2 a0123456789876543210 a0123456789876543210 where
+    type family LookupSym2 (a0123456789876543210 :: [AChar]) (a0123456789876543210 :: Schema) :: U where
       LookupSym2 a0123456789876543210 a0123456789876543210 = Lookup a0123456789876543210 a0123456789876543210
     type OccursSym0 :: (~>) [AChar] ((~>) Schema Bool)
-    data OccursSym0 a0123456789876543210
+    data OccursSym0 :: (~>) [AChar] ((~>) Schema Bool)
       where
         OccursSym0KindInference :: SameKind (Apply OccursSym0 arg) (OccursSym1 arg) =>
                                    OccursSym0 a0123456789876543210
@@ -482,7 +482,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings OccursSym0 where
       suppressUnusedWarnings = snd (((,) OccursSym0KindInference) ())
     type OccursSym1 :: [AChar] -> (~>) Schema Bool
-    data OccursSym1 a0123456789876543210 a0123456789876543210
+    data OccursSym1 (a0123456789876543210 :: [AChar]) :: (~>) Schema Bool
       where
         OccursSym1KindInference :: SameKind (Apply (OccursSym1 a0123456789876543210) arg) (OccursSym2 a0123456789876543210 arg) =>
                                    OccursSym1 a0123456789876543210 a0123456789876543210
@@ -490,10 +490,10 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (OccursSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) OccursSym1KindInference) ())
     type OccursSym2 :: [AChar] -> Schema -> Bool
-    type family OccursSym2 a0123456789876543210 a0123456789876543210 where
+    type family OccursSym2 (a0123456789876543210 :: [AChar]) (a0123456789876543210 :: Schema) :: Bool where
       OccursSym2 a0123456789876543210 a0123456789876543210 = Occurs a0123456789876543210 a0123456789876543210
     type DisjointSym0 :: (~>) Schema ((~>) Schema Bool)
-    data DisjointSym0 a0123456789876543210
+    data DisjointSym0 :: (~>) Schema ((~>) Schema Bool)
       where
         DisjointSym0KindInference :: SameKind (Apply DisjointSym0 arg) (DisjointSym1 arg) =>
                                      DisjointSym0 a0123456789876543210
@@ -501,7 +501,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings DisjointSym0 where
       suppressUnusedWarnings = snd (((,) DisjointSym0KindInference) ())
     type DisjointSym1 :: Schema -> (~>) Schema Bool
-    data DisjointSym1 a0123456789876543210 a0123456789876543210
+    data DisjointSym1 (a0123456789876543210 :: Schema) :: (~>) Schema Bool
       where
         DisjointSym1KindInference :: SameKind (Apply (DisjointSym1 a0123456789876543210) arg) (DisjointSym2 a0123456789876543210 arg) =>
                                      DisjointSym1 a0123456789876543210 a0123456789876543210
@@ -509,10 +509,10 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (DisjointSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) DisjointSym1KindInference) ())
     type DisjointSym2 :: Schema -> Schema -> Bool
-    type family DisjointSym2 a0123456789876543210 a0123456789876543210 where
+    type family DisjointSym2 (a0123456789876543210 :: Schema) (a0123456789876543210 :: Schema) :: Bool where
       DisjointSym2 a0123456789876543210 a0123456789876543210 = Disjoint a0123456789876543210 a0123456789876543210
     type AttrNotInSym0 :: (~>) Attribute ((~>) Schema Bool)
-    data AttrNotInSym0 a0123456789876543210
+    data AttrNotInSym0 :: (~>) Attribute ((~>) Schema Bool)
       where
         AttrNotInSym0KindInference :: SameKind (Apply AttrNotInSym0 arg) (AttrNotInSym1 arg) =>
                                       AttrNotInSym0 a0123456789876543210
@@ -520,7 +520,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings AttrNotInSym0 where
       suppressUnusedWarnings = snd (((,) AttrNotInSym0KindInference) ())
     type AttrNotInSym1 :: Attribute -> (~>) Schema Bool
-    data AttrNotInSym1 a0123456789876543210 a0123456789876543210
+    data AttrNotInSym1 (a0123456789876543210 :: Attribute) :: (~>) Schema Bool
       where
         AttrNotInSym1KindInference :: SameKind (Apply (AttrNotInSym1 a0123456789876543210) arg) (AttrNotInSym2 a0123456789876543210 arg) =>
                                       AttrNotInSym1 a0123456789876543210 a0123456789876543210
@@ -528,10 +528,10 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (AttrNotInSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) AttrNotInSym1KindInference) ())
     type AttrNotInSym2 :: Attribute -> Schema -> Bool
-    type family AttrNotInSym2 a0123456789876543210 a0123456789876543210 where
+    type family AttrNotInSym2 (a0123456789876543210 :: Attribute) (a0123456789876543210 :: Schema) :: Bool where
       AttrNotInSym2 a0123456789876543210 a0123456789876543210 = AttrNotIn a0123456789876543210 a0123456789876543210
     type AppendSym0 :: (~>) Schema ((~>) Schema Schema)
-    data AppendSym0 a0123456789876543210
+    data AppendSym0 :: (~>) Schema ((~>) Schema Schema)
       where
         AppendSym0KindInference :: SameKind (Apply AppendSym0 arg) (AppendSym1 arg) =>
                                    AppendSym0 a0123456789876543210
@@ -539,7 +539,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings AppendSym0 where
       suppressUnusedWarnings = snd (((,) AppendSym0KindInference) ())
     type AppendSym1 :: Schema -> (~>) Schema Schema
-    data AppendSym1 a0123456789876543210 a0123456789876543210
+    data AppendSym1 (a0123456789876543210 :: Schema) :: (~>) Schema Schema
       where
         AppendSym1KindInference :: SameKind (Apply (AppendSym1 a0123456789876543210) arg) (AppendSym2 a0123456789876543210 arg) =>
                                    AppendSym1 a0123456789876543210 a0123456789876543210
@@ -547,29 +547,29 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (AppendSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) AppendSym1KindInference) ())
     type AppendSym2 :: Schema -> Schema -> Schema
-    type family AppendSym2 a0123456789876543210 a0123456789876543210 where
+    type family AppendSym2 (a0123456789876543210 :: Schema) (a0123456789876543210 :: Schema) :: Schema where
       AppendSym2 a0123456789876543210 a0123456789876543210 = Append a0123456789876543210 a0123456789876543210
     type Lookup :: [AChar] -> Schema -> U
-    type family Lookup a a where
+    type family Lookup (a :: [AChar]) (a :: Schema) :: U where
       Lookup _ (Sch '[]) = UndefinedSym0
       Lookup name (Sch ('(:) (Attr name' u) attrs)) = Case_0123456789876543210 name name' u attrs (Let0123456789876543210Scrutinee_0123456789876543210Sym4 name name' u attrs)
     type Occurs :: [AChar] -> Schema -> Bool
-    type family Occurs a a where
+    type family Occurs (a :: [AChar]) (a :: Schema) :: Bool where
       Occurs _ (Sch '[]) = FalseSym0
       Occurs name (Sch ('(:) (Attr name' _) attrs)) = Apply (Apply (||@#@$) (Apply (Apply (==@#@$) name) name')) (Apply (Apply OccursSym0 name) (Apply SchSym0 attrs))
     type Disjoint :: Schema -> Schema -> Bool
-    type family Disjoint a a where
+    type family Disjoint (a :: Schema) (a :: Schema) :: Bool where
       Disjoint (Sch '[]) _ = TrueSym0
       Disjoint (Sch ('(:) h t)) s = Apply (Apply (&&@#@$) (Apply (Apply AttrNotInSym0 h) s)) (Apply (Apply DisjointSym0 (Apply SchSym0 t)) s)
     type AttrNotIn :: Attribute -> Schema -> Bool
-    type family AttrNotIn a a where
+    type family AttrNotIn (a :: Attribute) (a :: Schema) :: Bool where
       AttrNotIn _ (Sch '[]) = TrueSym0
       AttrNotIn (Attr name u) (Sch ('(:) (Attr name' _) t)) = Apply (Apply (&&@#@$) (Apply (Apply (/=@#@$) name) name')) (Apply (Apply AttrNotInSym0 (Apply (Apply AttrSym0 name) u)) (Apply SchSym0 t))
     type Append :: Schema -> Schema -> Schema
-    type family Append a a where
+    type family Append (a :: Schema) (a :: Schema) :: Schema where
       Append (Sch s1) (Sch s2) = Apply SchSym0 (Apply (Apply (++@#@$) s1) s2)
     type TFHelper_0123456789876543210 :: U -> U -> Bool
-    type family TFHelper_0123456789876543210 a a where
+    type family TFHelper_0123456789876543210 (a :: U) (a :: U) :: Bool where
       TFHelper_0123456789876543210 BOOL BOOL = TrueSym0
       TFHelper_0123456789876543210 BOOL STRING = FalseSym0
       TFHelper_0123456789876543210 BOOL NAT = FalseSym0
@@ -587,7 +587,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       TFHelper_0123456789876543210 (VEC _ _) NAT = FalseSym0
       TFHelper_0123456789876543210 (VEC a_0123456789876543210 a_0123456789876543210) (VEC b_0123456789876543210 b_0123456789876543210) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)
     type TFHelper_0123456789876543210Sym0 :: (~>) U ((~>) U Bool)
-    data TFHelper_0123456789876543210Sym0 a0123456789876543210
+    data TFHelper_0123456789876543210Sym0 :: (~>) U ((~>) U Bool)
       where
         TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
                                                          TFHelper_0123456789876543210Sym0 a0123456789876543210
@@ -596,7 +596,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym0KindInference) ())
     type TFHelper_0123456789876543210Sym1 :: U -> (~>) U Bool
-    data TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: U) :: (~>) U Bool
       where
         TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                          TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -605,19 +605,19 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym1KindInference) ())
     type TFHelper_0123456789876543210Sym2 :: U -> U -> Bool
-    type family TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: U) (a0123456789876543210 :: U) :: Bool where
       TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq U where
       type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
     type ShowsPrec_0123456789876543210 :: GHC.Types.Nat
                                           -> U -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210 a a a where
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: U) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 _ BOOL a_0123456789876543210 = Apply (Apply ShowStringSym0 "BOOL") a_0123456789876543210
       ShowsPrec_0123456789876543210 _ STRING a_0123456789876543210 = Apply (Apply ShowStringSym0 "STRING") a_0123456789876543210
       ShowsPrec_0123456789876543210 _ NAT a_0123456789876543210 = Apply (Apply ShowStringSym0 "NAT") a_0123456789876543210
       ShowsPrec_0123456789876543210 p_0123456789876543210 (VEC arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "VEC ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
     type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) U ((~>) Symbol Symbol))
-    data ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) U ((~>) Symbol Symbol))
       where
         ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
                                                           ShowsPrec_0123456789876543210Sym0 a0123456789876543210
@@ -627,7 +627,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym0KindInference) ())
     type ShowsPrec_0123456789876543210Sym1 :: GHC.Types.Nat
                                               -> (~>) U ((~>) Symbol Symbol)
-    data ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: (~>) U ((~>) Symbol Symbol)
       where
         ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -637,7 +637,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym1KindInference) ())
     type ShowsPrec_0123456789876543210Sym2 :: GHC.Types.Nat
                                               -> U -> (~>) Symbol Symbol
-    data ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: U) :: (~>) Symbol Symbol
       where
         ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -647,13 +647,13 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym2KindInference) ())
     type ShowsPrec_0123456789876543210Sym3 :: GHC.Types.Nat
                                               -> U -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: U) (a0123456789876543210 :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow U where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type ShowsPrec_0123456789876543210 :: GHC.Types.Nat
                                           -> AChar -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210 a a a where
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: AChar) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 _ CA a_0123456789876543210 = Apply (Apply ShowStringSym0 "CA") a_0123456789876543210
       ShowsPrec_0123456789876543210 _ CB a_0123456789876543210 = Apply (Apply ShowStringSym0 "CB") a_0123456789876543210
       ShowsPrec_0123456789876543210 _ CC a_0123456789876543210 = Apply (Apply ShowStringSym0 "CC") a_0123456789876543210
@@ -681,7 +681,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       ShowsPrec_0123456789876543210 _ CY a_0123456789876543210 = Apply (Apply ShowStringSym0 "CY") a_0123456789876543210
       ShowsPrec_0123456789876543210 _ CZ a_0123456789876543210 = Apply (Apply ShowStringSym0 "CZ") a_0123456789876543210
     type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) AChar ((~>) Symbol Symbol))
-    data ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) AChar ((~>) Symbol Symbol))
       where
         ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
                                                           ShowsPrec_0123456789876543210Sym0 a0123456789876543210
@@ -691,7 +691,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym0KindInference) ())
     type ShowsPrec_0123456789876543210Sym1 :: GHC.Types.Nat
                                               -> (~>) AChar ((~>) Symbol Symbol)
-    data ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: (~>) AChar ((~>) Symbol Symbol)
       where
         ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -701,7 +701,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym1KindInference) ())
     type ShowsPrec_0123456789876543210Sym2 :: GHC.Types.Nat
                                               -> AChar -> (~>) Symbol Symbol
-    data ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: AChar) :: (~>) Symbol Symbol
       where
         ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -711,12 +711,12 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym2KindInference) ())
     type ShowsPrec_0123456789876543210Sym3 :: GHC.Types.Nat
                                               -> AChar -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: AChar) (a0123456789876543210 :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow AChar where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type TFHelper_0123456789876543210 :: AChar -> AChar -> Bool
-    type family TFHelper_0123456789876543210 a a where
+    type family TFHelper_0123456789876543210 (a :: AChar) (a :: AChar) :: Bool where
       TFHelper_0123456789876543210 CA CA = TrueSym0
       TFHelper_0123456789876543210 CA CB = FalseSym0
       TFHelper_0123456789876543210 CA CC = FalseSym0
@@ -1394,7 +1394,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       TFHelper_0123456789876543210 CZ CY = FalseSym0
       TFHelper_0123456789876543210 CZ CZ = TrueSym0
     type TFHelper_0123456789876543210Sym0 :: (~>) AChar ((~>) AChar Bool)
-    data TFHelper_0123456789876543210Sym0 a0123456789876543210
+    data TFHelper_0123456789876543210Sym0 :: (~>) AChar ((~>) AChar Bool)
       where
         TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
                                                          TFHelper_0123456789876543210Sym0 a0123456789876543210
@@ -1403,7 +1403,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym0KindInference) ())
     type TFHelper_0123456789876543210Sym1 :: AChar -> (~>) AChar Bool
-    data TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: AChar) :: (~>) AChar Bool
       where
         TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                          TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -1412,7 +1412,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym1KindInference) ())
     type TFHelper_0123456789876543210Sym2 :: AChar -> AChar -> Bool
-    type family TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: AChar) (a0123456789876543210 :: AChar) :: Bool where
       TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq AChar where
       type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a

--- a/singletons-base/tests/compile-and-dump/GradingClient/Main.golden
+++ b/singletons-base/tests/compile-and-dump/GradingClient/Main.golden
@@ -32,46 +32,46 @@ GradingClient/Main.hs:(0,0)-(0,0): Splicing declarations
     names :: Schema
     names = Sch [(Attr firstName) STRING, (Attr lastName) STRING]
     type NamesSym0 :: Schema
-    type family NamesSym0 where
+    type family NamesSym0 :: Schema where
       NamesSym0 = Names
     type GradingSchemaSym0 :: Schema
-    type family GradingSchemaSym0 where
+    type family GradingSchemaSym0 :: Schema where
       GradingSchemaSym0 = GradingSchema
     type MajorNameSym0 :: [AChar]
-    type family MajorNameSym0 where
+    type family MajorNameSym0 :: [AChar] where
       MajorNameSym0 = MajorName
     type GradeNameSym0 :: [AChar]
-    type family GradeNameSym0 where
+    type family GradeNameSym0 :: [AChar] where
       GradeNameSym0 = GradeName
     type YearNameSym0 :: [AChar]
-    type family YearNameSym0 where
+    type family YearNameSym0 :: [AChar] where
       YearNameSym0 = YearName
     type FirstNameSym0 :: [AChar]
-    type family FirstNameSym0 where
+    type family FirstNameSym0 :: [AChar] where
       FirstNameSym0 = FirstName
     type LastNameSym0 :: [AChar]
-    type family LastNameSym0 where
+    type family LastNameSym0 :: [AChar] where
       LastNameSym0 = LastName
     type Names :: Schema
-    type family Names where
+    type family Names :: Schema where
       Names = Apply SchSym0 (Apply (Apply (:@#@$) (Apply (Apply AttrSym0 FirstNameSym0) STRINGSym0)) (Apply (Apply (:@#@$) (Apply (Apply AttrSym0 LastNameSym0) STRINGSym0)) NilSym0))
     type GradingSchema :: Schema
-    type family GradingSchema where
+    type family GradingSchema :: Schema where
       GradingSchema = Apply SchSym0 (Apply (Apply (:@#@$) (Apply (Apply AttrSym0 LastNameSym0) STRINGSym0)) (Apply (Apply (:@#@$) (Apply (Apply AttrSym0 FirstNameSym0) STRINGSym0)) (Apply (Apply (:@#@$) (Apply (Apply AttrSym0 YearNameSym0) NATSym0)) (Apply (Apply (:@#@$) (Apply (Apply AttrSym0 GradeNameSym0) NATSym0)) (Apply (Apply (:@#@$) (Apply (Apply AttrSym0 MajorNameSym0) BOOLSym0)) NilSym0)))))
     type MajorName :: [AChar]
-    type family MajorName where
+    type family MajorName :: [AChar] where
       MajorName = Apply (Apply (:@#@$) CMSym0) (Apply (Apply (:@#@$) CASym0) (Apply (Apply (:@#@$) CJSym0) (Apply (Apply (:@#@$) COSym0) (Apply (Apply (:@#@$) CRSym0) NilSym0))))
     type GradeName :: [AChar]
-    type family GradeName where
+    type family GradeName :: [AChar] where
       GradeName = Apply (Apply (:@#@$) CGSym0) (Apply (Apply (:@#@$) CRSym0) (Apply (Apply (:@#@$) CASym0) (Apply (Apply (:@#@$) CDSym0) (Apply (Apply (:@#@$) CESym0) NilSym0))))
     type YearName :: [AChar]
-    type family YearName where
+    type family YearName :: [AChar] where
       YearName = Apply (Apply (:@#@$) CYSym0) (Apply (Apply (:@#@$) CESym0) (Apply (Apply (:@#@$) CASym0) (Apply (Apply (:@#@$) CRSym0) NilSym0)))
     type FirstName :: [AChar]
-    type family FirstName where
+    type family FirstName :: [AChar] where
       FirstName = Apply (Apply (:@#@$) CFSym0) (Apply (Apply (:@#@$) CISym0) (Apply (Apply (:@#@$) CRSym0) (Apply (Apply (:@#@$) CSSym0) (Apply (Apply (:@#@$) CTSym0) NilSym0))))
     type LastName :: [AChar]
-    type family LastName where
+    type family LastName :: [AChar] where
       LastName = Apply (Apply (:@#@$) CLSym0) (Apply (Apply (:@#@$) CASym0) (Apply (Apply (:@#@$) CSSym0) (Apply (Apply (:@#@$) CTSym0) NilSym0)))
     sNames :: Sing (NamesSym0 :: Schema)
     sGradingSchema :: Sing (GradingSchemaSym0 :: Schema)

--- a/singletons-base/tests/compile-and-dump/InsertionSort/InsertionSortImp.golden
+++ b/singletons-base/tests/compile-and-dump/InsertionSort/InsertionSortImp.golden
@@ -3,10 +3,10 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
   ======>
     data Nat = Zero | Succ Nat
     type ZeroSym0 :: Nat
-    type family ZeroSym0 where
+    type family ZeroSym0 :: Nat where
       ZeroSym0 = Zero
     type SuccSym0 :: (~>) Nat Nat
-    data SuccSym0 a0123456789876543210
+    data SuccSym0 :: (~>) Nat Nat
       where
         SuccSym0KindInference :: SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
                                  SuccSym0 a0123456789876543210
@@ -14,7 +14,7 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings SuccSym0 where
       suppressUnusedWarnings = snd (((,) SuccSym0KindInference) ())
     type SuccSym1 :: Nat -> Nat
-    type family SuccSym1 a0123456789876543210 where
+    type family SuccSym1 (a0123456789876543210 :: Nat) :: Nat where
       SuccSym1 a0123456789876543210 = Succ a0123456789876543210
     data SNat :: Nat -> Type
       where
@@ -101,7 +101,7 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
       Case_0123456789876543210 n h t 'True = Apply (Apply (:@#@$) n) (Apply (Apply (:@#@$) h) t)
       Case_0123456789876543210 n h t 'False = Apply (Apply (:@#@$) h) (Apply (Apply InsertSym0 n) t)
     type InsertionSortSym0 :: (~>) [Nat] [Nat]
-    data InsertionSortSym0 a0123456789876543210
+    data InsertionSortSym0 :: (~>) [Nat] [Nat]
       where
         InsertionSortSym0KindInference :: SameKind (Apply InsertionSortSym0 arg) (InsertionSortSym1 arg) =>
                                           InsertionSortSym0 a0123456789876543210
@@ -110,10 +110,10 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) InsertionSortSym0KindInference) ())
     type InsertionSortSym1 :: [Nat] -> [Nat]
-    type family InsertionSortSym1 a0123456789876543210 where
+    type family InsertionSortSym1 (a0123456789876543210 :: [Nat]) :: [Nat] where
       InsertionSortSym1 a0123456789876543210 = InsertionSort a0123456789876543210
     type InsertSym0 :: (~>) Nat ((~>) [Nat] [Nat])
-    data InsertSym0 a0123456789876543210
+    data InsertSym0 :: (~>) Nat ((~>) [Nat] [Nat])
       where
         InsertSym0KindInference :: SameKind (Apply InsertSym0 arg) (InsertSym1 arg) =>
                                    InsertSym0 a0123456789876543210
@@ -121,7 +121,7 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings InsertSym0 where
       suppressUnusedWarnings = snd (((,) InsertSym0KindInference) ())
     type InsertSym1 :: Nat -> (~>) [Nat] [Nat]
-    data InsertSym1 a0123456789876543210 a0123456789876543210
+    data InsertSym1 (a0123456789876543210 :: Nat) :: (~>) [Nat] [Nat]
       where
         InsertSym1KindInference :: SameKind (Apply (InsertSym1 a0123456789876543210) arg) (InsertSym2 a0123456789876543210 arg) =>
                                    InsertSym1 a0123456789876543210 a0123456789876543210
@@ -129,10 +129,10 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (InsertSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) InsertSym1KindInference) ())
     type InsertSym2 :: Nat -> [Nat] -> [Nat]
-    type family InsertSym2 a0123456789876543210 a0123456789876543210 where
+    type family InsertSym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: [Nat]) :: [Nat] where
       InsertSym2 a0123456789876543210 a0123456789876543210 = Insert a0123456789876543210 a0123456789876543210
     type LeqSym0 :: (~>) Nat ((~>) Nat Bool)
-    data LeqSym0 a0123456789876543210
+    data LeqSym0 :: (~>) Nat ((~>) Nat Bool)
       where
         LeqSym0KindInference :: SameKind (Apply LeqSym0 arg) (LeqSym1 arg) =>
                                 LeqSym0 a0123456789876543210
@@ -140,7 +140,7 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings LeqSym0 where
       suppressUnusedWarnings = snd (((,) LeqSym0KindInference) ())
     type LeqSym1 :: Nat -> (~>) Nat Bool
-    data LeqSym1 a0123456789876543210 a0123456789876543210
+    data LeqSym1 (a0123456789876543210 :: Nat) :: (~>) Nat Bool
       where
         LeqSym1KindInference :: SameKind (Apply (LeqSym1 a0123456789876543210) arg) (LeqSym2 a0123456789876543210 arg) =>
                                 LeqSym1 a0123456789876543210 a0123456789876543210
@@ -148,18 +148,18 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (LeqSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) LeqSym1KindInference) ())
     type LeqSym2 :: Nat -> Nat -> Bool
-    type family LeqSym2 a0123456789876543210 a0123456789876543210 where
+    type family LeqSym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Bool where
       LeqSym2 a0123456789876543210 a0123456789876543210 = Leq a0123456789876543210 a0123456789876543210
     type InsertionSort :: [Nat] -> [Nat]
-    type family InsertionSort a where
+    type family InsertionSort (a :: [Nat]) :: [Nat] where
       InsertionSort '[] = NilSym0
       InsertionSort ('(:) h t) = Apply (Apply InsertSym0 h) (Apply InsertionSortSym0 t)
     type Insert :: Nat -> [Nat] -> [Nat]
-    type family Insert a a where
+    type family Insert (a :: Nat) (a :: [Nat]) :: [Nat] where
       Insert n '[] = Apply (Apply (:@#@$) n) NilSym0
       Insert n ('(:) h t) = Case_0123456789876543210 n h t (Let0123456789876543210Scrutinee_0123456789876543210Sym3 n h t)
     type Leq :: Nat -> Nat -> Bool
-    type family Leq a a where
+    type family Leq (a :: Nat) (a :: Nat) :: Bool where
       Leq 'Zero _ = TrueSym0
       Leq ('Succ _) 'Zero = FalseSym0
       Leq ('Succ a) ('Succ b) = Apply (Apply LeqSym0 a) b

--- a/singletons-base/tests/compile-and-dump/Promote/Constructors.golden
+++ b/singletons-base/tests/compile-and-dump/Promote/Constructors.golden
@@ -6,10 +6,10 @@ Promote/Constructors.hs:(0,0)-(0,0): Splicing declarations
     data Foo = Foo | Foo :+ Foo
     data Bar = Bar Bar Bar Bar Bar Foo
     type FooSym0 :: Foo
-    type family FooSym0 where
+    type family FooSym0 :: Foo where
       FooSym0 = Foo
     type (:+@#@$) :: (~>) Foo ((~>) Foo Foo)
-    data (:+@#@$) a0123456789876543210
+    data (:+@#@$) :: (~>) Foo ((~>) Foo Foo)
       where
         (::+@#@$###) :: SameKind (Apply (:+@#@$) arg) ((:+@#@$$) arg) =>
                         (:+@#@$) a0123456789876543210
@@ -17,7 +17,7 @@ Promote/Constructors.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (:+@#@$) where
       suppressUnusedWarnings = snd (((,) (::+@#@$###)) ())
     type (:+@#@$$) :: Foo -> (~>) Foo Foo
-    data (:+@#@$$) a0123456789876543210 a0123456789876543210
+    data (:+@#@$$) (a0123456789876543210 :: Foo) :: (~>) Foo Foo
       where
         (::+@#@$$###) :: SameKind (Apply ((:+@#@$$) a0123456789876543210) arg) ((:+@#@$$$) a0123456789876543210 arg) =>
                          (:+@#@$$) a0123456789876543210 a0123456789876543210
@@ -25,10 +25,10 @@ Promote/Constructors.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ((:+@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) (::+@#@$$###)) ())
     type (:+@#@$$$) :: Foo -> Foo -> Foo
-    type family (:+@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family (:+@#@$$$) (a0123456789876543210 :: Foo) (a0123456789876543210 :: Foo) :: Foo where
       (:+@#@$$$) a0123456789876543210 a0123456789876543210 = (:+) a0123456789876543210 a0123456789876543210
     type BarSym0 :: (~>) Bar ((~>) Bar ((~>) Bar ((~>) Bar ((~>) Foo Bar))))
-    data BarSym0 a0123456789876543210
+    data BarSym0 :: (~>) Bar ((~>) Bar ((~>) Bar ((~>) Bar ((~>) Foo Bar))))
       where
         BarSym0KindInference :: SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
                                 BarSym0 a0123456789876543210
@@ -37,7 +37,7 @@ Promote/Constructors.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) BarSym0KindInference) ())
     type BarSym1 :: Bar
                     -> (~>) Bar ((~>) Bar ((~>) Bar ((~>) Foo Bar)))
-    data BarSym1 a0123456789876543210 a0123456789876543210
+    data BarSym1 (a0123456789876543210 :: Bar) :: (~>) Bar ((~>) Bar ((~>) Bar ((~>) Foo Bar)))
       where
         BarSym1KindInference :: SameKind (Apply (BarSym1 a0123456789876543210) arg) (BarSym2 a0123456789876543210 arg) =>
                                 BarSym1 a0123456789876543210 a0123456789876543210
@@ -45,7 +45,7 @@ Promote/Constructors.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (BarSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) BarSym1KindInference) ())
     type BarSym2 :: Bar -> Bar -> (~>) Bar ((~>) Bar ((~>) Foo Bar))
-    data BarSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data BarSym2 (a0123456789876543210 :: Bar) (a0123456789876543210 :: Bar) :: (~>) Bar ((~>) Bar ((~>) Foo Bar))
       where
         BarSym2KindInference :: SameKind (Apply (BarSym2 a0123456789876543210 a0123456789876543210) arg) (BarSym3 a0123456789876543210 a0123456789876543210 arg) =>
                                 BarSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -53,7 +53,7 @@ Promote/Constructors.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (BarSym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) BarSym2KindInference) ())
     type BarSym3 :: Bar -> Bar -> Bar -> (~>) Bar ((~>) Foo Bar)
-    data BarSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data BarSym3 (a0123456789876543210 :: Bar) (a0123456789876543210 :: Bar) (a0123456789876543210 :: Bar) :: (~>) Bar ((~>) Foo Bar)
       where
         BarSym3KindInference :: SameKind (Apply (BarSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) arg) (BarSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 arg) =>
                                 BarSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -61,7 +61,7 @@ Promote/Constructors.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (BarSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) BarSym3KindInference) ())
     type BarSym4 :: Bar -> Bar -> Bar -> Bar -> (~>) Foo Bar
-    data BarSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data BarSym4 (a0123456789876543210 :: Bar) (a0123456789876543210 :: Bar) (a0123456789876543210 :: Bar) (a0123456789876543210 :: Bar) :: (~>) Foo Bar
       where
         BarSym4KindInference :: SameKind (Apply (BarSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210) arg) (BarSym5 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 arg) =>
                                 BarSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -69,5 +69,5 @@ Promote/Constructors.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (BarSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) BarSym4KindInference) ())
     type BarSym5 :: Bar -> Bar -> Bar -> Bar -> Foo -> Bar
-    type family BarSym5 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family BarSym5 (a0123456789876543210 :: Bar) (a0123456789876543210 :: Bar) (a0123456789876543210 :: Bar) (a0123456789876543210 :: Bar) (a0123456789876543210 :: Foo) :: Bar where
       BarSym5 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 = Bar a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210

--- a/singletons-base/tests/compile-and-dump/Promote/GenDefunSymbols.golden
+++ b/singletons-base/tests/compile-and-dump/Promote/GenDefunSymbols.golden
@@ -3,7 +3,7 @@ Promote/GenDefunSymbols.hs:0:0:: Splicing declarations
   ======>
     type LiftMaybeSym0 :: forall (a :: Type) (b :: Type).
                           (~>) ((~>) a b) ((~>) (Maybe a) (Maybe b))
-    data LiftMaybeSym0 a0123456789876543210
+    data LiftMaybeSym0 :: (~>) ((~>) a b) ((~>) (Maybe a) (Maybe b))
       where
         LiftMaybeSym0KindInference :: Data.Singletons.SameKind (Apply LiftMaybeSym0 arg) (LiftMaybeSym1 arg) =>
                                       LiftMaybeSym0 a0123456789876543210
@@ -12,7 +12,7 @@ Promote/GenDefunSymbols.hs:0:0:: Splicing declarations
       suppressUnusedWarnings = snd (((,) LiftMaybeSym0KindInference) ())
     type LiftMaybeSym1 :: forall (a :: Type) (b :: Type).
                           (~>) a b -> (~>) (Maybe a) (Maybe b)
-    data LiftMaybeSym1 a0123456789876543210 a0123456789876543210
+    data LiftMaybeSym1 (a0123456789876543210 :: (~>) a b) :: (~>) (Maybe a) (Maybe b)
       where
         LiftMaybeSym1KindInference :: Data.Singletons.SameKind (Apply (LiftMaybeSym1 a0123456789876543210) arg) (LiftMaybeSym2 a0123456789876543210 arg) =>
                                       LiftMaybeSym1 a0123456789876543210 a0123456789876543210
@@ -21,13 +21,13 @@ Promote/GenDefunSymbols.hs:0:0:: Splicing declarations
       suppressUnusedWarnings = snd (((,) LiftMaybeSym1KindInference) ())
     type LiftMaybeSym2 :: forall (a :: Type) (b :: Type).
                           (~>) a b -> Maybe a -> Maybe b
-    type family LiftMaybeSym2 a0123456789876543210 a0123456789876543210 where
+    type family LiftMaybeSym2 (a0123456789876543210 :: (~>) a b) (a0123456789876543210 :: Maybe a) :: Maybe b where
       LiftMaybeSym2 a0123456789876543210 a0123456789876543210 = LiftMaybe a0123456789876543210 a0123456789876543210
     type ZeroSym0 :: NatT
-    type family ZeroSym0 where
+    type family ZeroSym0 :: NatT where
       ZeroSym0 = 'Zero
     type SuccSym0 :: (~>) NatT NatT
-    data SuccSym0 a0123456789876543210
+    data SuccSym0 :: (~>) NatT NatT
       where
         SuccSym0KindInference :: Data.Singletons.SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
                                  SuccSym0 a0123456789876543210
@@ -35,10 +35,10 @@ Promote/GenDefunSymbols.hs:0:0:: Splicing declarations
     instance SuppressUnusedWarnings SuccSym0 where
       suppressUnusedWarnings = snd (((,) SuccSym0KindInference) ())
     type SuccSym1 :: NatT -> NatT
-    type family SuccSym1 a0123456789876543210 where
+    type family SuccSym1 (a0123456789876543210 :: NatT) :: NatT where
       SuccSym1 a0123456789876543210 = 'Succ a0123456789876543210
     type (:+@#@$) :: (~>) Nat ((~>) Nat Nat)
-    data (:+@#@$) a0123456789876543210
+    data (:+@#@$) :: (~>) Nat ((~>) Nat Nat)
       where
         (::+@#@$###) :: Data.Singletons.SameKind (Apply (:+@#@$) arg) ((:+@#@$$) arg) =>
                         (:+@#@$) a0123456789876543210
@@ -46,7 +46,7 @@ Promote/GenDefunSymbols.hs:0:0:: Splicing declarations
     instance SuppressUnusedWarnings (:+@#@$) where
       suppressUnusedWarnings = snd (((,) (::+@#@$###)) ())
     type (:+@#@$$) :: Nat -> (~>) Nat Nat
-    data (:+@#@$$) a0123456789876543210 a0123456789876543210
+    data (:+@#@$$) (a0123456789876543210 :: Nat) :: (~>) Nat Nat
       where
         (::+@#@$$###) :: Data.Singletons.SameKind (Apply ((:+@#@$$) a0123456789876543210) arg) ((:+@#@$$$) a0123456789876543210 arg) =>
                          (:+@#@$$) a0123456789876543210 a0123456789876543210
@@ -54,5 +54,5 @@ Promote/GenDefunSymbols.hs:0:0:: Splicing declarations
     instance SuppressUnusedWarnings ((:+@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) (::+@#@$$###)) ())
     type (:+@#@$$$) :: Nat -> Nat -> Nat
-    type family (:+@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family (:+@#@$$$) (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Nat where
       (:+@#@$$$) a0123456789876543210 a0123456789876543210 = (:+) a0123456789876543210 a0123456789876543210

--- a/singletons-base/tests/compile-and-dump/Promote/Newtypes.golden
+++ b/singletons-base/tests/compile-and-dump/Promote/Newtypes.golden
@@ -10,7 +10,7 @@ Promote/Newtypes.hs:(0,0)-(0,0): Splicing declarations
       deriving Eq
     newtype Bar = Bar {unBar :: Nat}
     type FooSym0 :: (~>) Nat Foo
-    data FooSym0 a0123456789876543210
+    data FooSym0 :: (~>) Nat Foo
       where
         FooSym0KindInference :: SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
                                 FooSym0 a0123456789876543210
@@ -18,10 +18,10 @@ Promote/Newtypes.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings = snd (((,) FooSym0KindInference) ())
     type FooSym1 :: Nat -> Foo
-    type family FooSym1 a0123456789876543210 where
+    type family FooSym1 (a0123456789876543210 :: Nat) :: Foo where
       FooSym1 a0123456789876543210 = Foo a0123456789876543210
     type BarSym0 :: (~>) Nat Bar
-    data BarSym0 a0123456789876543210
+    data BarSym0 :: (~>) Nat Bar
       where
         BarSym0KindInference :: SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
                                 BarSym0 a0123456789876543210
@@ -29,10 +29,10 @@ Promote/Newtypes.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings BarSym0 where
       suppressUnusedWarnings = snd (((,) BarSym0KindInference) ())
     type BarSym1 :: Nat -> Bar
-    type family BarSym1 a0123456789876543210 where
+    type family BarSym1 (a0123456789876543210 :: Nat) :: Bar where
       BarSym1 a0123456789876543210 = Bar a0123456789876543210
     type UnBarSym0 :: (~>) Bar Nat
-    data UnBarSym0 a0123456789876543210
+    data UnBarSym0 :: (~>) Bar Nat
       where
         UnBarSym0KindInference :: SameKind (Apply UnBarSym0 arg) (UnBarSym1 arg) =>
                                   UnBarSym0 a0123456789876543210
@@ -40,16 +40,16 @@ Promote/Newtypes.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings UnBarSym0 where
       suppressUnusedWarnings = snd (((,) UnBarSym0KindInference) ())
     type UnBarSym1 :: Bar -> Nat
-    type family UnBarSym1 a0123456789876543210 where
+    type family UnBarSym1 (a0123456789876543210 :: Bar) :: Nat where
       UnBarSym1 a0123456789876543210 = UnBar a0123456789876543210
     type UnBar :: Bar -> Nat
-    type family UnBar a where
+    type family UnBar (a :: Bar) :: Nat where
       UnBar (Bar field) = field
     type TFHelper_0123456789876543210 :: Foo -> Foo -> Bool
-    type family TFHelper_0123456789876543210 a a where
+    type family TFHelper_0123456789876543210 (a :: Foo) (a :: Foo) :: Bool where
       TFHelper_0123456789876543210 (Foo a_0123456789876543210) (Foo b_0123456789876543210) = Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210
     type TFHelper_0123456789876543210Sym0 :: (~>) Foo ((~>) Foo Bool)
-    data TFHelper_0123456789876543210Sym0 a0123456789876543210
+    data TFHelper_0123456789876543210Sym0 :: (~>) Foo ((~>) Foo Bool)
       where
         TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
                                                          TFHelper_0123456789876543210Sym0 a0123456789876543210
@@ -58,7 +58,7 @@ Promote/Newtypes.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym0KindInference) ())
     type TFHelper_0123456789876543210Sym1 :: Foo -> (~>) Foo Bool
-    data TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Foo) :: (~>) Foo Bool
       where
         TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                          TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -67,7 +67,7 @@ Promote/Newtypes.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym1KindInference) ())
     type TFHelper_0123456789876543210Sym2 :: Foo -> Foo -> Bool
-    type family TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: Foo) (a0123456789876543210 :: Foo) :: Bool where
       TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq Foo where
       type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a

--- a/singletons-base/tests/compile-and-dump/Promote/Pragmas.golden
+++ b/singletons-base/tests/compile-and-dump/Promote/Pragmas.golden
@@ -8,8 +8,8 @@ Promote/Pragmas.hs:(0,0)-(0,0): Splicing declarations
     foo :: Bool
     foo = True
     type FooSym0 :: Bool
-    type family FooSym0 where
+    type family FooSym0 :: Bool where
       FooSym0 = Foo
     type Foo :: Bool
-    type family Foo where
+    type family Foo :: Bool where
       Foo = TrueSym0

--- a/singletons-base/tests/compile-and-dump/Promote/Prelude.golden
+++ b/singletons-base/tests/compile-and-dump/Promote/Prelude.golden
@@ -5,7 +5,7 @@ Promote/Prelude.hs:(0,0)-(0,0): Splicing declarations
           odd n = not . odd $ n - 1 |]
   ======>
     type OddSym0 :: (~>) Nat Bool
-    data OddSym0 a0123456789876543210
+    data OddSym0 :: (~>) Nat Bool
       where
         OddSym0KindInference :: SameKind (Apply OddSym0 arg) (OddSym1 arg) =>
                                 OddSym0 a0123456789876543210
@@ -13,9 +13,9 @@ Promote/Prelude.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings OddSym0 where
       suppressUnusedWarnings = snd (((,) OddSym0KindInference) ())
     type OddSym1 :: Nat -> Bool
-    type family OddSym1 a0123456789876543210 where
+    type family OddSym1 (a0123456789876543210 :: Nat) :: Bool where
       OddSym1 a0123456789876543210 = Odd a0123456789876543210
     type Odd :: Nat -> Bool
-    type family Odd a where
+    type family Odd (a :: Nat) :: Bool where
       Odd 0 = FalseSym0
       Odd n = Apply (Apply ($@#@$) (Apply (Apply (.@#@$) NotSym0) OddSym0)) (Apply (Apply (-@#@$) n) (FromInteger 1))

--- a/singletons-base/tests/compile-and-dump/Promote/T180.golden
+++ b/singletons-base/tests/compile-and-dump/Promote/T180.golden
@@ -9,7 +9,7 @@ Promote/T180.hs:(0,0)-(0,0): Splicing declarations
     z (X1 x) = x
     z (X2 x) = x
     type X1Sym0 :: (~>) Symbol X
-    data X1Sym0 a0123456789876543210
+    data X1Sym0 :: (~>) Symbol X
       where
         X1Sym0KindInference :: SameKind (Apply X1Sym0 arg) (X1Sym1 arg) =>
                                X1Sym0 a0123456789876543210
@@ -17,10 +17,10 @@ Promote/T180.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings X1Sym0 where
       suppressUnusedWarnings = snd (((,) X1Sym0KindInference) ())
     type X1Sym1 :: Symbol -> X
-    type family X1Sym1 a0123456789876543210 where
+    type family X1Sym1 (a0123456789876543210 :: Symbol) :: X where
       X1Sym1 a0123456789876543210 = X1 a0123456789876543210
     type X2Sym0 :: (~>) Symbol X
-    data X2Sym0 a0123456789876543210
+    data X2Sym0 :: (~>) Symbol X
       where
         X2Sym0KindInference :: SameKind (Apply X2Sym0 arg) (X2Sym1 arg) =>
                                X2Sym0 a0123456789876543210
@@ -28,7 +28,7 @@ Promote/T180.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings X2Sym0 where
       suppressUnusedWarnings = snd (((,) X2Sym0KindInference) ())
     type X2Sym1 :: Symbol -> X
-    type family X2Sym1 a0123456789876543210 where
+    type family X2Sym1 (a0123456789876543210 :: Symbol) :: X where
       X2Sym1 a0123456789876543210 = X2 a0123456789876543210
     data ZSym0 a0123456789876543210
       where
@@ -40,7 +40,7 @@ Promote/T180.hs:(0,0)-(0,0): Splicing declarations
     type family ZSym1 a0123456789876543210 where
       ZSym1 a0123456789876543210 = Z a0123456789876543210
     type YSym0 :: (~>) X Symbol
-    data YSym0 a0123456789876543210
+    data YSym0 :: (~>) X Symbol
       where
         YSym0KindInference :: SameKind (Apply YSym0 arg) (YSym1 arg) =>
                               YSym0 a0123456789876543210
@@ -48,12 +48,12 @@ Promote/T180.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings YSym0 where
       suppressUnusedWarnings = snd (((,) YSym0KindInference) ())
     type YSym1 :: X -> Symbol
-    type family YSym1 a0123456789876543210 where
+    type family YSym1 (a0123456789876543210 :: X) :: Symbol where
       YSym1 a0123456789876543210 = Y a0123456789876543210
     type family Z a where
       Z (X1 x) = x
       Z (X2 x) = x
     type Y :: X -> Symbol
-    type family Y a where
+    type family Y (a :: X) :: Symbol where
       Y (X1 field) = field
       Y (X2 field) = field

--- a/singletons-base/tests/compile-and-dump/Promote/T361.golden
+++ b/singletons-base/tests/compile-and-dump/Promote/T361.golden
@@ -2,7 +2,7 @@ Promote/T361.hs:0:0:: Splicing declarations
     genDefunSymbols [''Proxy]
   ======>
     type ProxySym0 :: forall k (t :: k). Proxy (t :: k)
-    type family ProxySym0 where
+    type family ProxySym0 :: Proxy (t :: k) where
       ProxySym0 = 'Proxy
 Promote/T361.hs:(0,0)-(0,0): Splicing declarations
     promote
@@ -12,7 +12,7 @@ Promote/T361.hs:(0,0)-(0,0): Splicing declarations
     f :: Proxy 1 -> Proxy 2
     f Proxy = Proxy
     type FSym0 :: (~>) (Proxy 1) (Proxy 2)
-    data FSym0 a0123456789876543210
+    data FSym0 :: (~>) (Proxy 1) (Proxy 2)
       where
         FSym0KindInference :: SameKind (Apply FSym0 arg) (FSym1 arg) =>
                               FSym0 a0123456789876543210
@@ -20,8 +20,8 @@ Promote/T361.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FSym0 where
       suppressUnusedWarnings = snd (((,) FSym0KindInference) ())
     type FSym1 :: Proxy 1 -> Proxy 2
-    type family FSym1 a0123456789876543210 where
+    type family FSym1 (a0123456789876543210 :: Proxy 1) :: Proxy 2 where
       FSym1 a0123456789876543210 = F a0123456789876543210
     type F :: Proxy 1 -> Proxy 2
-    type family F a where
+    type family F (a :: Proxy 1) :: Proxy 2 where
       F 'Proxy = ProxySym0

--- a/singletons-base/tests/compile-and-dump/Singletons/AsPattern.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/AsPattern.golden
@@ -35,7 +35,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
     foo p@[_] = p
     foo p@(_ : (_ : _)) = p
     type BazSym0 :: (~>) Nat ((~>) Nat ((~>) Nat Baz))
-    data BazSym0 a0123456789876543210
+    data BazSym0 :: (~>) Nat ((~>) Nat ((~>) Nat Baz))
       where
         BazSym0KindInference :: SameKind (Apply BazSym0 arg) (BazSym1 arg) =>
                                 BazSym0 a0123456789876543210
@@ -43,7 +43,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings BazSym0 where
       suppressUnusedWarnings = snd (((,) BazSym0KindInference) ())
     type BazSym1 :: Nat -> (~>) Nat ((~>) Nat Baz)
-    data BazSym1 a0123456789876543210 a0123456789876543210
+    data BazSym1 (a0123456789876543210 :: Nat) :: (~>) Nat ((~>) Nat Baz)
       where
         BazSym1KindInference :: SameKind (Apply (BazSym1 a0123456789876543210) arg) (BazSym2 a0123456789876543210 arg) =>
                                 BazSym1 a0123456789876543210 a0123456789876543210
@@ -51,7 +51,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (BazSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) BazSym1KindInference) ())
     type BazSym2 :: Nat -> Nat -> (~>) Nat Baz
-    data BazSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data BazSym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: (~>) Nat Baz
       where
         BazSym2KindInference :: SameKind (Apply (BazSym2 a0123456789876543210 a0123456789876543210) arg) (BazSym3 a0123456789876543210 a0123456789876543210 arg) =>
                                 BazSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -59,7 +59,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (BazSym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) BazSym2KindInference) ())
     type BazSym3 :: Nat -> Nat -> Nat -> Baz
-    type family BazSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family BazSym3 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Baz where
       BazSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = Baz a0123456789876543210 a0123456789876543210 a0123456789876543210
     type family Let0123456789876543210PSym0 where
       Let0123456789876543210PSym0 = Let0123456789876543210P
@@ -174,7 +174,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
     type family Let0123456789876543210P where
       Let0123456789876543210P = NothingSym0
     type FooSym0 :: (~>) [Nat] [Nat]
-    data FooSym0 a0123456789876543210
+    data FooSym0 :: (~>) [Nat] [Nat]
       where
         FooSym0KindInference :: SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
                                 FooSym0 a0123456789876543210
@@ -182,10 +182,10 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings = snd (((,) FooSym0KindInference) ())
     type FooSym1 :: [Nat] -> [Nat]
-    type family FooSym1 a0123456789876543210 where
+    type family FooSym1 (a0123456789876543210 :: [Nat]) :: [Nat] where
       FooSym1 a0123456789876543210 = Foo a0123456789876543210
     type TupSym0 :: (~>) (Nat, Nat) (Nat, Nat)
-    data TupSym0 a0123456789876543210
+    data TupSym0 :: (~>) (Nat, Nat) (Nat, Nat)
       where
         TupSym0KindInference :: SameKind (Apply TupSym0 arg) (TupSym1 arg) =>
                                 TupSym0 a0123456789876543210
@@ -193,10 +193,11 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings TupSym0 where
       suppressUnusedWarnings = snd (((,) TupSym0KindInference) ())
     type TupSym1 :: (Nat, Nat) -> (Nat, Nat)
-    type family TupSym1 a0123456789876543210 where
+    type family TupSym1 (a0123456789876543210 :: (Nat, Nat)) :: (Nat,
+                                                                 Nat) where
       TupSym1 a0123456789876543210 = Tup a0123456789876543210
     type Baz_Sym0 :: (~>) (Maybe Baz) (Maybe Baz)
-    data Baz_Sym0 a0123456789876543210
+    data Baz_Sym0 :: (~>) (Maybe Baz) (Maybe Baz)
       where
         Baz_Sym0KindInference :: SameKind (Apply Baz_Sym0 arg) (Baz_Sym1 arg) =>
                                  Baz_Sym0 a0123456789876543210
@@ -204,10 +205,10 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Baz_Sym0 where
       suppressUnusedWarnings = snd (((,) Baz_Sym0KindInference) ())
     type Baz_Sym1 :: Maybe Baz -> Maybe Baz
-    type family Baz_Sym1 a0123456789876543210 where
+    type family Baz_Sym1 (a0123456789876543210 :: Maybe Baz) :: Maybe Baz where
       Baz_Sym1 a0123456789876543210 = Baz_ a0123456789876543210
     type BarSym0 :: (~>) (Maybe Nat) (Maybe Nat)
-    data BarSym0 a0123456789876543210
+    data BarSym0 :: (~>) (Maybe Nat) (Maybe Nat)
       where
         BarSym0KindInference :: SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
                                 BarSym0 a0123456789876543210
@@ -215,10 +216,10 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings BarSym0 where
       suppressUnusedWarnings = snd (((,) BarSym0KindInference) ())
     type BarSym1 :: Maybe Nat -> Maybe Nat
-    type family BarSym1 a0123456789876543210 where
+    type family BarSym1 (a0123456789876543210 :: Maybe Nat) :: Maybe Nat where
       BarSym1 a0123456789876543210 = Bar a0123456789876543210
     type MaybePlusSym0 :: (~>) (Maybe Nat) (Maybe Nat)
-    data MaybePlusSym0 a0123456789876543210
+    data MaybePlusSym0 :: (~>) (Maybe Nat) (Maybe Nat)
       where
         MaybePlusSym0KindInference :: SameKind (Apply MaybePlusSym0 arg) (MaybePlusSym1 arg) =>
                                       MaybePlusSym0 a0123456789876543210
@@ -226,27 +227,27 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings MaybePlusSym0 where
       suppressUnusedWarnings = snd (((,) MaybePlusSym0KindInference) ())
     type MaybePlusSym1 :: Maybe Nat -> Maybe Nat
-    type family MaybePlusSym1 a0123456789876543210 where
+    type family MaybePlusSym1 (a0123456789876543210 :: Maybe Nat) :: Maybe Nat where
       MaybePlusSym1 a0123456789876543210 = MaybePlus a0123456789876543210
     type Foo :: [Nat] -> [Nat]
-    type family Foo a where
+    type family Foo (a :: [Nat]) :: [Nat] where
       Foo '[] = Let0123456789876543210PSym0
       Foo '[wild_0123456789876543210] = Let0123456789876543210PSym1 wild_0123456789876543210
       Foo ('(:) wild_0123456789876543210 ('(:) wild_0123456789876543210 wild_0123456789876543210)) = Let0123456789876543210PSym3 wild_0123456789876543210 wild_0123456789876543210 wild_0123456789876543210
     type Tup :: (Nat, Nat) -> (Nat, Nat)
-    type family Tup a where
+    type family Tup (a :: (Nat, Nat)) :: (Nat, Nat) where
       Tup '(wild_0123456789876543210,
             wild_0123456789876543210) = Let0123456789876543210PSym2 wild_0123456789876543210 wild_0123456789876543210
     type Baz_ :: Maybe Baz -> Maybe Baz
-    type family Baz_ a where
+    type family Baz_ (a :: Maybe Baz) :: Maybe Baz where
       Baz_ 'Nothing = Let0123456789876543210PSym0
       Baz_ ('Just (Baz wild_0123456789876543210 wild_0123456789876543210 wild_0123456789876543210)) = Let0123456789876543210PSym3 wild_0123456789876543210 wild_0123456789876543210 wild_0123456789876543210
     type Bar :: Maybe Nat -> Maybe Nat
-    type family Bar a where
+    type family Bar (a :: Maybe Nat) :: Maybe Nat where
       Bar ('Just wild_0123456789876543210) = Let0123456789876543210XSym1 wild_0123456789876543210
       Bar 'Nothing = NothingSym0
     type MaybePlus :: Maybe Nat -> Maybe Nat
-    type family MaybePlus a where
+    type family MaybePlus (a :: Maybe Nat) :: Maybe Nat where
       MaybePlus ('Just n) = Apply JustSym0 (Apply (Apply PlusSym0 (Apply SuccSym0 ZeroSym0)) n)
       MaybePlus 'Nothing = Let0123456789876543210PSym0
     sFoo ::

--- a/singletons-base/tests/compile-and-dump/Singletons/BoundedDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/BoundedDeriving.golden
@@ -32,25 +32,25 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
       = Pair Bool Bool
       deriving Bounded
     type Foo1Sym0 :: Foo1
-    type family Foo1Sym0 where
+    type family Foo1Sym0 :: Foo1 where
       Foo1Sym0 = Foo1
     type ASym0 :: Foo2
-    type family ASym0 where
+    type family ASym0 :: Foo2 where
       ASym0 = A
     type BSym0 :: Foo2
-    type family BSym0 where
+    type family BSym0 :: Foo2 where
       BSym0 = B
     type CSym0 :: Foo2
-    type family CSym0 where
+    type family CSym0 :: Foo2 where
       CSym0 = C
     type DSym0 :: Foo2
-    type family DSym0 where
+    type family DSym0 :: Foo2 where
       DSym0 = D
     type ESym0 :: Foo2
-    type family ESym0 where
+    type family ESym0 :: Foo2 where
       ESym0 = E
     type Foo3Sym0 :: forall a. (~>) a (Foo3 a)
-    data Foo3Sym0 a0123456789876543210
+    data Foo3Sym0 :: (~>) a (Foo3 a)
       where
         Foo3Sym0KindInference :: SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
                                  Foo3Sym0 a0123456789876543210
@@ -58,18 +58,18 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo3Sym0 where
       suppressUnusedWarnings = snd (((,) Foo3Sym0KindInference) ())
     type Foo3Sym1 :: forall a. a -> Foo3 a
-    type family Foo3Sym1 a0123456789876543210 where
+    type family Foo3Sym1 (a0123456789876543210 :: a) :: Foo3 a where
       Foo3Sym1 a0123456789876543210 = Foo3 a0123456789876543210
     type Foo41Sym0 :: forall (a :: Type) (b :: Type).
                       Foo4 (a :: Type) (b :: Type)
-    type family Foo41Sym0 where
+    type family Foo41Sym0 :: Foo4 (a :: Type) (b :: Type) where
       Foo41Sym0 = Foo41
     type Foo42Sym0 :: forall (a :: Type) (b :: Type).
                       Foo4 (a :: Type) (b :: Type)
-    type family Foo42Sym0 where
+    type family Foo42Sym0 :: Foo4 (a :: Type) (b :: Type) where
       Foo42Sym0 = Foo42
     type PairSym0 :: (~>) Bool ((~>) Bool Pair)
-    data PairSym0 a0123456789876543210
+    data PairSym0 :: (~>) Bool ((~>) Bool Pair)
       where
         PairSym0KindInference :: SameKind (Apply PairSym0 arg) (PairSym1 arg) =>
                                  PairSym0 a0123456789876543210
@@ -77,7 +77,7 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings PairSym0 where
       suppressUnusedWarnings = snd (((,) PairSym0KindInference) ())
     type PairSym1 :: Bool -> (~>) Bool Pair
-    data PairSym1 a0123456789876543210 a0123456789876543210
+    data PairSym1 (a0123456789876543210 :: Bool) :: (~>) Bool Pair
       where
         PairSym1KindInference :: SameKind (Apply (PairSym1 a0123456789876543210) arg) (PairSym2 a0123456789876543210 arg) =>
                                  PairSym1 a0123456789876543210 a0123456789876543210
@@ -85,79 +85,79 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (PairSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) PairSym1KindInference) ())
     type PairSym2 :: Bool -> Bool -> Pair
-    type family PairSym2 a0123456789876543210 a0123456789876543210 where
+    type family PairSym2 (a0123456789876543210 :: Bool) (a0123456789876543210 :: Bool) :: Pair where
       PairSym2 a0123456789876543210 a0123456789876543210 = Pair a0123456789876543210 a0123456789876543210
     type MinBound_0123456789876543210 :: Foo1
-    type family MinBound_0123456789876543210 where
+    type family MinBound_0123456789876543210 :: Foo1 where
       MinBound_0123456789876543210 = Foo1Sym0
     type MinBound_0123456789876543210Sym0 :: Foo1
-    type family MinBound_0123456789876543210Sym0 where
+    type family MinBound_0123456789876543210Sym0 :: Foo1 where
       MinBound_0123456789876543210Sym0 = MinBound_0123456789876543210
     type MaxBound_0123456789876543210 :: Foo1
-    type family MaxBound_0123456789876543210 where
+    type family MaxBound_0123456789876543210 :: Foo1 where
       MaxBound_0123456789876543210 = Foo1Sym0
     type MaxBound_0123456789876543210Sym0 :: Foo1
-    type family MaxBound_0123456789876543210Sym0 where
+    type family MaxBound_0123456789876543210Sym0 :: Foo1 where
       MaxBound_0123456789876543210Sym0 = MaxBound_0123456789876543210
     instance PBounded Foo1 where
       type MinBound = MinBound_0123456789876543210Sym0
       type MaxBound = MaxBound_0123456789876543210Sym0
     type MinBound_0123456789876543210 :: Foo2
-    type family MinBound_0123456789876543210 where
+    type family MinBound_0123456789876543210 :: Foo2 where
       MinBound_0123456789876543210 = ASym0
     type MinBound_0123456789876543210Sym0 :: Foo2
-    type family MinBound_0123456789876543210Sym0 where
+    type family MinBound_0123456789876543210Sym0 :: Foo2 where
       MinBound_0123456789876543210Sym0 = MinBound_0123456789876543210
     type MaxBound_0123456789876543210 :: Foo2
-    type family MaxBound_0123456789876543210 where
+    type family MaxBound_0123456789876543210 :: Foo2 where
       MaxBound_0123456789876543210 = ESym0
     type MaxBound_0123456789876543210Sym0 :: Foo2
-    type family MaxBound_0123456789876543210Sym0 where
+    type family MaxBound_0123456789876543210Sym0 :: Foo2 where
       MaxBound_0123456789876543210Sym0 = MaxBound_0123456789876543210
     instance PBounded Foo2 where
       type MinBound = MinBound_0123456789876543210Sym0
       type MaxBound = MaxBound_0123456789876543210Sym0
     type MinBound_0123456789876543210 :: Foo3 a
-    type family MinBound_0123456789876543210 where
+    type family MinBound_0123456789876543210 :: Foo3 a where
       MinBound_0123456789876543210 = Apply Foo3Sym0 MinBoundSym0
     type MinBound_0123456789876543210Sym0 :: Foo3 a
-    type family MinBound_0123456789876543210Sym0 where
+    type family MinBound_0123456789876543210Sym0 :: Foo3 a where
       MinBound_0123456789876543210Sym0 = MinBound_0123456789876543210
     type MaxBound_0123456789876543210 :: Foo3 a
-    type family MaxBound_0123456789876543210 where
+    type family MaxBound_0123456789876543210 :: Foo3 a where
       MaxBound_0123456789876543210 = Apply Foo3Sym0 MaxBoundSym0
     type MaxBound_0123456789876543210Sym0 :: Foo3 a
-    type family MaxBound_0123456789876543210Sym0 where
+    type family MaxBound_0123456789876543210Sym0 :: Foo3 a where
       MaxBound_0123456789876543210Sym0 = MaxBound_0123456789876543210
     instance PBounded (Foo3 a) where
       type MinBound = MinBound_0123456789876543210Sym0
       type MaxBound = MaxBound_0123456789876543210Sym0
     type MinBound_0123456789876543210 :: Foo4 a b
-    type family MinBound_0123456789876543210 where
+    type family MinBound_0123456789876543210 :: Foo4 a b where
       MinBound_0123456789876543210 = Foo41Sym0
     type MinBound_0123456789876543210Sym0 :: Foo4 a b
-    type family MinBound_0123456789876543210Sym0 where
+    type family MinBound_0123456789876543210Sym0 :: Foo4 a b where
       MinBound_0123456789876543210Sym0 = MinBound_0123456789876543210
     type MaxBound_0123456789876543210 :: Foo4 a b
-    type family MaxBound_0123456789876543210 where
+    type family MaxBound_0123456789876543210 :: Foo4 a b where
       MaxBound_0123456789876543210 = Foo42Sym0
     type MaxBound_0123456789876543210Sym0 :: Foo4 a b
-    type family MaxBound_0123456789876543210Sym0 where
+    type family MaxBound_0123456789876543210Sym0 :: Foo4 a b where
       MaxBound_0123456789876543210Sym0 = MaxBound_0123456789876543210
     instance PBounded (Foo4 a b) where
       type MinBound = MinBound_0123456789876543210Sym0
       type MaxBound = MaxBound_0123456789876543210Sym0
     type MinBound_0123456789876543210 :: Pair
-    type family MinBound_0123456789876543210 where
+    type family MinBound_0123456789876543210 :: Pair where
       MinBound_0123456789876543210 = Apply (Apply PairSym0 MinBoundSym0) MinBoundSym0
     type MinBound_0123456789876543210Sym0 :: Pair
-    type family MinBound_0123456789876543210Sym0 where
+    type family MinBound_0123456789876543210Sym0 :: Pair where
       MinBound_0123456789876543210Sym0 = MinBound_0123456789876543210
     type MaxBound_0123456789876543210 :: Pair
-    type family MaxBound_0123456789876543210 where
+    type family MaxBound_0123456789876543210 :: Pair where
       MaxBound_0123456789876543210 = Apply (Apply PairSym0 MaxBoundSym0) MaxBoundSym0
     type MaxBound_0123456789876543210Sym0 :: Pair
-    type family MaxBound_0123456789876543210Sym0 where
+    type family MaxBound_0123456789876543210Sym0 :: Pair where
       MaxBound_0123456789876543210Sym0 = MaxBound_0123456789876543210
     instance PBounded Pair where
       type MinBound = MinBound_0123456789876543210Sym0

--- a/singletons-base/tests/compile-and-dump/Singletons/BoxUnBox.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/BoxUnBox.golden
@@ -9,7 +9,7 @@ Singletons/BoxUnBox.hs:(0,0)-(0,0): Splicing declarations
     unBox :: Box a -> a
     unBox (FBox a) = a
     type FBoxSym0 :: forall a. (~>) a (Box a)
-    data FBoxSym0 a0123456789876543210
+    data FBoxSym0 :: (~>) a (Box a)
       where
         FBoxSym0KindInference :: SameKind (Apply FBoxSym0 arg) (FBoxSym1 arg) =>
                                  FBoxSym0 a0123456789876543210
@@ -17,10 +17,10 @@ Singletons/BoxUnBox.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FBoxSym0 where
       suppressUnusedWarnings = snd (((,) FBoxSym0KindInference) ())
     type FBoxSym1 :: forall a. a -> Box a
-    type family FBoxSym1 a0123456789876543210 where
+    type family FBoxSym1 (a0123456789876543210 :: a) :: Box a where
       FBoxSym1 a0123456789876543210 = FBox a0123456789876543210
     type UnBoxSym0 :: (~>) (Box a) a
-    data UnBoxSym0 a0123456789876543210
+    data UnBoxSym0 :: (~>) (Box a) a
       where
         UnBoxSym0KindInference :: SameKind (Apply UnBoxSym0 arg) (UnBoxSym1 arg) =>
                                   UnBoxSym0 a0123456789876543210
@@ -28,10 +28,10 @@ Singletons/BoxUnBox.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings UnBoxSym0 where
       suppressUnusedWarnings = snd (((,) UnBoxSym0KindInference) ())
     type UnBoxSym1 :: Box a -> a
-    type family UnBoxSym1 a0123456789876543210 where
+    type family UnBoxSym1 (a0123456789876543210 :: Box a) :: a where
       UnBoxSym1 a0123456789876543210 = UnBox a0123456789876543210
     type UnBox :: Box a -> a
-    type family UnBox a where
+    type family UnBox (a :: Box a) :: a where
       UnBox (FBox a) = a
     sUnBox ::
       forall a (t :: Box a). Sing t -> Sing (Apply UnBoxSym0 t :: a)

--- a/singletons-base/tests/compile-and-dump/Singletons/CaseExpressions.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/CaseExpressions.golden
@@ -140,7 +140,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
       Case_0123456789876543210 d x ('Just y) = y
       Case_0123456789876543210 d x 'Nothing = d
     type Foo5Sym0 :: (~>) a a
-    data Foo5Sym0 a0123456789876543210
+    data Foo5Sym0 :: (~>) a a
       where
         Foo5Sym0KindInference :: SameKind (Apply Foo5Sym0 arg) (Foo5Sym1 arg) =>
                                  Foo5Sym0 a0123456789876543210
@@ -148,10 +148,10 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo5Sym0 where
       suppressUnusedWarnings = snd (((,) Foo5Sym0KindInference) ())
     type Foo5Sym1 :: a -> a
-    type family Foo5Sym1 a0123456789876543210 where
+    type family Foo5Sym1 (a0123456789876543210 :: a) :: a where
       Foo5Sym1 a0123456789876543210 = Foo5 a0123456789876543210
     type Foo4Sym0 :: forall a. (~>) a a
-    data Foo4Sym0 a0123456789876543210
+    data Foo4Sym0 :: (~>) a a
       where
         Foo4Sym0KindInference :: SameKind (Apply Foo4Sym0 arg) (Foo4Sym1 arg) =>
                                  Foo4Sym0 a0123456789876543210
@@ -159,10 +159,10 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo4Sym0 where
       suppressUnusedWarnings = snd (((,) Foo4Sym0KindInference) ())
     type Foo4Sym1 :: forall a. a -> a
-    type family Foo4Sym1 a0123456789876543210 where
+    type family Foo4Sym1 (a0123456789876543210 :: a) :: a where
       Foo4Sym1 a0123456789876543210 = Foo4 a0123456789876543210
     type Foo3Sym0 :: (~>) a ((~>) b a)
-    data Foo3Sym0 a0123456789876543210
+    data Foo3Sym0 :: (~>) a ((~>) b a)
       where
         Foo3Sym0KindInference :: SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
                                  Foo3Sym0 a0123456789876543210
@@ -170,7 +170,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo3Sym0 where
       suppressUnusedWarnings = snd (((,) Foo3Sym0KindInference) ())
     type Foo3Sym1 :: a -> (~>) b a
-    data Foo3Sym1 a0123456789876543210 a0123456789876543210
+    data Foo3Sym1 (a0123456789876543210 :: a) :: (~>) b a
       where
         Foo3Sym1KindInference :: SameKind (Apply (Foo3Sym1 a0123456789876543210) arg) (Foo3Sym2 a0123456789876543210 arg) =>
                                  Foo3Sym1 a0123456789876543210 a0123456789876543210
@@ -178,10 +178,10 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (Foo3Sym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) Foo3Sym1KindInference) ())
     type Foo3Sym2 :: a -> b -> a
-    type family Foo3Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Foo3Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: a where
       Foo3Sym2 a0123456789876543210 a0123456789876543210 = Foo3 a0123456789876543210 a0123456789876543210
     type Foo2Sym0 :: (~>) a ((~>) (Maybe a) a)
-    data Foo2Sym0 a0123456789876543210
+    data Foo2Sym0 :: (~>) a ((~>) (Maybe a) a)
       where
         Foo2Sym0KindInference :: SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) =>
                                  Foo2Sym0 a0123456789876543210
@@ -189,7 +189,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo2Sym0 where
       suppressUnusedWarnings = snd (((,) Foo2Sym0KindInference) ())
     type Foo2Sym1 :: a -> (~>) (Maybe a) a
-    data Foo2Sym1 a0123456789876543210 a0123456789876543210
+    data Foo2Sym1 (a0123456789876543210 :: a) :: (~>) (Maybe a) a
       where
         Foo2Sym1KindInference :: SameKind (Apply (Foo2Sym1 a0123456789876543210) arg) (Foo2Sym2 a0123456789876543210 arg) =>
                                  Foo2Sym1 a0123456789876543210 a0123456789876543210
@@ -197,10 +197,10 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (Foo2Sym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) Foo2Sym1KindInference) ())
     type Foo2Sym2 :: a -> Maybe a -> a
-    type family Foo2Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Foo2Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: Maybe a) :: a where
       Foo2Sym2 a0123456789876543210 a0123456789876543210 = Foo2 a0123456789876543210 a0123456789876543210
     type Foo1Sym0 :: (~>) a ((~>) (Maybe a) a)
-    data Foo1Sym0 a0123456789876543210
+    data Foo1Sym0 :: (~>) a ((~>) (Maybe a) a)
       where
         Foo1Sym0KindInference :: SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
                                  Foo1Sym0 a0123456789876543210
@@ -208,7 +208,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo1Sym0 where
       suppressUnusedWarnings = snd (((,) Foo1Sym0KindInference) ())
     type Foo1Sym1 :: a -> (~>) (Maybe a) a
-    data Foo1Sym1 a0123456789876543210 a0123456789876543210
+    data Foo1Sym1 (a0123456789876543210 :: a) :: (~>) (Maybe a) a
       where
         Foo1Sym1KindInference :: SameKind (Apply (Foo1Sym1 a0123456789876543210) arg) (Foo1Sym2 a0123456789876543210 arg) =>
                                  Foo1Sym1 a0123456789876543210 a0123456789876543210
@@ -216,22 +216,22 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (Foo1Sym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) Foo1Sym1KindInference) ())
     type Foo1Sym2 :: a -> Maybe a -> a
-    type family Foo1Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Foo1Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: Maybe a) :: a where
       Foo1Sym2 a0123456789876543210 a0123456789876543210 = Foo1 a0123456789876543210 a0123456789876543210
     type Foo5 :: a -> a
-    type family Foo5 a where
+    type family Foo5 (a :: a) :: a where
       Foo5 x = Case_0123456789876543210 x x
     type Foo4 :: forall a. a -> a
-    type family Foo4 a where
+    type family Foo4 (a :: a) :: a where
       Foo4 x = Case_0123456789876543210 x x
     type Foo3 :: a -> b -> a
-    type family Foo3 a a where
+    type family Foo3 (a :: a) (a :: b) :: a where
       Foo3 a b = Case_0123456789876543210 a b (Let0123456789876543210Scrutinee_0123456789876543210Sym2 a b)
     type Foo2 :: a -> Maybe a -> a
-    type family Foo2 a a where
+    type family Foo2 (a :: a) (a :: Maybe a) :: a where
       Foo2 d _ = Case_0123456789876543210 d (Let0123456789876543210Scrutinee_0123456789876543210Sym1 d)
     type Foo1 :: a -> Maybe a -> a
-    type family Foo1 a a where
+    type family Foo1 (a :: a) (a :: Maybe a) :: a where
       Foo1 d x = Case_0123456789876543210 d x x
     sFoo5 :: forall a (t :: a). Sing t -> Sing (Apply Foo5Sym0 t :: a)
     sFoo4 :: forall a (t :: a). Sing t -> Sing (Apply Foo4Sym0 t :: a)

--- a/singletons-base/tests/compile-and-dump/Singletons/Classes.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Classes.golden
@@ -62,19 +62,19 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       (==) F G = False
       (==) G F = False
     type ASym0 :: Foo
-    type family ASym0 where
+    type family ASym0 :: Foo where
       ASym0 = A
     type BSym0 :: Foo
-    type family BSym0 where
+    type family BSym0 :: Foo where
       BSym0 = B
     type FSym0 :: Foo2
-    type family FSym0 where
+    type family FSym0 :: Foo2 where
       FSym0 = F
     type GSym0 :: Foo2
-    type family GSym0 where
+    type family GSym0 :: Foo2 where
       GSym0 = G
     type FooCompareSym0 :: (~>) Foo ((~>) Foo Ordering)
-    data FooCompareSym0 a0123456789876543210
+    data FooCompareSym0 :: (~>) Foo ((~>) Foo Ordering)
       where
         FooCompareSym0KindInference :: SameKind (Apply FooCompareSym0 arg) (FooCompareSym1 arg) =>
                                        FooCompareSym0 a0123456789876543210
@@ -82,7 +82,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FooCompareSym0 where
       suppressUnusedWarnings = snd (((,) FooCompareSym0KindInference) ())
     type FooCompareSym1 :: Foo -> (~>) Foo Ordering
-    data FooCompareSym1 a0123456789876543210 a0123456789876543210
+    data FooCompareSym1 (a0123456789876543210 :: Foo) :: (~>) Foo Ordering
       where
         FooCompareSym1KindInference :: SameKind (Apply (FooCompareSym1 a0123456789876543210) arg) (FooCompareSym2 a0123456789876543210 arg) =>
                                        FooCompareSym1 a0123456789876543210 a0123456789876543210
@@ -90,10 +90,10 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (FooCompareSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) FooCompareSym1KindInference) ())
     type FooCompareSym2 :: Foo -> Foo -> Ordering
-    type family FooCompareSym2 a0123456789876543210 a0123456789876543210 where
+    type family FooCompareSym2 (a0123456789876543210 :: Foo) (a0123456789876543210 :: Foo) :: Ordering where
       FooCompareSym2 a0123456789876543210 a0123456789876543210 = FooCompare a0123456789876543210 a0123456789876543210
     type ConstSym0 :: (~>) a ((~>) b a)
-    data ConstSym0 a0123456789876543210
+    data ConstSym0 :: (~>) a ((~>) b a)
       where
         ConstSym0KindInference :: SameKind (Apply ConstSym0 arg) (ConstSym1 arg) =>
                                   ConstSym0 a0123456789876543210
@@ -101,7 +101,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ConstSym0 where
       suppressUnusedWarnings = snd (((,) ConstSym0KindInference) ())
     type ConstSym1 :: a -> (~>) b a
-    data ConstSym1 a0123456789876543210 a0123456789876543210
+    data ConstSym1 (a0123456789876543210 :: a) :: (~>) b a
       where
         ConstSym1KindInference :: SameKind (Apply (ConstSym1 a0123456789876543210) arg) (ConstSym2 a0123456789876543210 arg) =>
                                   ConstSym1 a0123456789876543210 a0123456789876543210
@@ -109,19 +109,19 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (ConstSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) ConstSym1KindInference) ())
     type ConstSym2 :: a -> b -> a
-    type family ConstSym2 a0123456789876543210 a0123456789876543210 where
+    type family ConstSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: a where
       ConstSym2 a0123456789876543210 a0123456789876543210 = Const a0123456789876543210 a0123456789876543210
     type FooCompare :: Foo -> Foo -> Ordering
-    type family FooCompare a a where
+    type family FooCompare (a :: Foo) (a :: Foo) :: Ordering where
       FooCompare A A = EQSym0
       FooCompare A B = LTSym0
       FooCompare B B = GTSym0
       FooCompare B A = EQSym0
     type Const :: a -> b -> a
-    type family Const a a where
+    type family Const (a :: a) (a :: b) :: a where
       Const x _ = x
     type MycompareSym0 :: forall a. (~>) a ((~>) a Ordering)
-    data MycompareSym0 a0123456789876543210
+    data MycompareSym0 :: (~>) a ((~>) a Ordering)
       where
         MycompareSym0KindInference :: SameKind (Apply MycompareSym0 arg) (MycompareSym1 arg) =>
                                       MycompareSym0 a0123456789876543210
@@ -129,7 +129,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings MycompareSym0 where
       suppressUnusedWarnings = snd (((,) MycompareSym0KindInference) ())
     type MycompareSym1 :: forall a. a -> (~>) a Ordering
-    data MycompareSym1 a0123456789876543210 a0123456789876543210
+    data MycompareSym1 (a0123456789876543210 :: a) :: (~>) a Ordering
       where
         MycompareSym1KindInference :: SameKind (Apply (MycompareSym1 a0123456789876543210) arg) (MycompareSym2 a0123456789876543210 arg) =>
                                       MycompareSym1 a0123456789876543210 a0123456789876543210
@@ -137,10 +137,10 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (MycompareSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) MycompareSym1KindInference) ())
     type MycompareSym2 :: forall a. a -> a -> Ordering
-    type family MycompareSym2 a0123456789876543210 a0123456789876543210 where
+    type family MycompareSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Ordering where
       MycompareSym2 a0123456789876543210 a0123456789876543210 = Mycompare a0123456789876543210 a0123456789876543210
     type (<=>@#@$) :: forall a. (~>) a ((~>) a Ordering)
-    data (<=>@#@$) a0123456789876543210
+    data (<=>@#@$) :: (~>) a ((~>) a Ordering)
       where
         (:<=>@#@$###) :: SameKind (Apply (<=>@#@$) arg) ((<=>@#@$$) arg) =>
                          (<=>@#@$) a0123456789876543210
@@ -149,7 +149,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) (:<=>@#@$###)) ())
     infix 4 <=>@#@$
     type (<=>@#@$$) :: forall a. a -> (~>) a Ordering
-    data (<=>@#@$$) a0123456789876543210 a0123456789876543210
+    data (<=>@#@$$) (a0123456789876543210 :: a) :: (~>) a Ordering
       where
         (:<=>@#@$$###) :: SameKind (Apply ((<=>@#@$$) a0123456789876543210) arg) ((<=>@#@$$$) a0123456789876543210 arg) =>
                           (<=>@#@$$) a0123456789876543210 a0123456789876543210
@@ -158,14 +158,14 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) (:<=>@#@$$###)) ())
     infix 4 <=>@#@$$
     type (<=>@#@$$$) :: forall a. a -> a -> Ordering
-    type family (<=>@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family (<=>@#@$$$) (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Ordering where
       (<=>@#@$$$) a0123456789876543210 a0123456789876543210 = (<=>) a0123456789876543210 a0123456789876543210
     infix 4 <=>@#@$$$
     type TFHelper_0123456789876543210 :: a -> a -> Ordering
-    type family TFHelper_0123456789876543210 a a where
+    type family TFHelper_0123456789876543210 (a :: a) (a :: a) :: Ordering where
       TFHelper_0123456789876543210 a_0123456789876543210 a_0123456789876543210 = Apply (Apply MycompareSym0 a_0123456789876543210) a_0123456789876543210
     type TFHelper_0123456789876543210Sym0 :: (~>) a ((~>) a Ordering)
-    data TFHelper_0123456789876543210Sym0 a0123456789876543210
+    data TFHelper_0123456789876543210Sym0 :: (~>) a ((~>) a Ordering)
       where
         TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
                                                          TFHelper_0123456789876543210Sym0 a0123456789876543210
@@ -174,7 +174,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym0KindInference) ())
     type TFHelper_0123456789876543210Sym1 :: a -> (~>) a Ordering
-    data TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: a) :: (~>) a Ordering
       where
         TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                          TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -183,20 +183,20 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym1KindInference) ())
     type TFHelper_0123456789876543210Sym2 :: a -> a -> Ordering
-    type family TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Ordering where
       TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     class PMyOrd a where
       type Mycompare (arg :: a) (arg :: a) :: Ordering
       type (<=>) (arg :: a) (arg :: a) :: Ordering
       type (<=>) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
     type Mycompare_0123456789876543210 :: Nat -> Nat -> Ordering
-    type family Mycompare_0123456789876543210 a a where
+    type family Mycompare_0123456789876543210 (a :: Nat) (a :: Nat) :: Ordering where
       Mycompare_0123456789876543210 'Zero 'Zero = EQSym0
       Mycompare_0123456789876543210 'Zero ('Succ _) = LTSym0
       Mycompare_0123456789876543210 ('Succ _) 'Zero = GTSym0
       Mycompare_0123456789876543210 ('Succ n) ('Succ m) = Apply (Apply MycompareSym0 m) n
     type Mycompare_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Ordering)
-    data Mycompare_0123456789876543210Sym0 a0123456789876543210
+    data Mycompare_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Ordering)
       where
         Mycompare_0123456789876543210Sym0KindInference :: SameKind (Apply Mycompare_0123456789876543210Sym0 arg) (Mycompare_0123456789876543210Sym1 arg) =>
                                                           Mycompare_0123456789876543210Sym0 a0123456789876543210
@@ -205,7 +205,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Mycompare_0123456789876543210Sym0KindInference) ())
     type Mycompare_0123456789876543210Sym1 :: Nat -> (~>) Nat Ordering
-    data Mycompare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Mycompare_0123456789876543210Sym1 (a0123456789876543210 :: Nat) :: (~>) Nat Ordering
       where
         Mycompare_0123456789876543210Sym1KindInference :: SameKind (Apply (Mycompare_0123456789876543210Sym1 a0123456789876543210) arg) (Mycompare_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                           Mycompare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -214,15 +214,15 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Mycompare_0123456789876543210Sym1KindInference) ())
     type Mycompare_0123456789876543210Sym2 :: Nat -> Nat -> Ordering
-    type family Mycompare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Mycompare_0123456789876543210Sym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Ordering where
       Mycompare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PMyOrd Nat where
       type Mycompare a a = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
     type Mycompare_0123456789876543210 :: () -> () -> Ordering
-    type family Mycompare_0123456789876543210 a a where
+    type family Mycompare_0123456789876543210 (a :: ()) (a :: ()) :: Ordering where
       Mycompare_0123456789876543210 _ a_0123456789876543210 = Apply (Apply ConstSym0 EQSym0) a_0123456789876543210
     type Mycompare_0123456789876543210Sym0 :: (~>) () ((~>) () Ordering)
-    data Mycompare_0123456789876543210Sym0 a0123456789876543210
+    data Mycompare_0123456789876543210Sym0 :: (~>) () ((~>) () Ordering)
       where
         Mycompare_0123456789876543210Sym0KindInference :: SameKind (Apply Mycompare_0123456789876543210Sym0 arg) (Mycompare_0123456789876543210Sym1 arg) =>
                                                           Mycompare_0123456789876543210Sym0 a0123456789876543210
@@ -231,7 +231,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Mycompare_0123456789876543210Sym0KindInference) ())
     type Mycompare_0123456789876543210Sym1 :: () -> (~>) () Ordering
-    data Mycompare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Mycompare_0123456789876543210Sym1 (a0123456789876543210 :: ()) :: (~>) () Ordering
       where
         Mycompare_0123456789876543210Sym1KindInference :: SameKind (Apply (Mycompare_0123456789876543210Sym1 a0123456789876543210) arg) (Mycompare_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                           Mycompare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -240,15 +240,15 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Mycompare_0123456789876543210Sym1KindInference) ())
     type Mycompare_0123456789876543210Sym2 :: () -> () -> Ordering
-    type family Mycompare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Mycompare_0123456789876543210Sym2 (a0123456789876543210 :: ()) (a0123456789876543210 :: ()) :: Ordering where
       Mycompare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PMyOrd () where
       type Mycompare a a = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
     type Mycompare_0123456789876543210 :: Foo -> Foo -> Ordering
-    type family Mycompare_0123456789876543210 a a where
+    type family Mycompare_0123456789876543210 (a :: Foo) (a :: Foo) :: Ordering where
       Mycompare_0123456789876543210 a_0123456789876543210 a_0123456789876543210 = Apply (Apply FooCompareSym0 a_0123456789876543210) a_0123456789876543210
     type Mycompare_0123456789876543210Sym0 :: (~>) Foo ((~>) Foo Ordering)
-    data Mycompare_0123456789876543210Sym0 a0123456789876543210
+    data Mycompare_0123456789876543210Sym0 :: (~>) Foo ((~>) Foo Ordering)
       where
         Mycompare_0123456789876543210Sym0KindInference :: SameKind (Apply Mycompare_0123456789876543210Sym0 arg) (Mycompare_0123456789876543210Sym1 arg) =>
                                                           Mycompare_0123456789876543210Sym0 a0123456789876543210
@@ -257,7 +257,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Mycompare_0123456789876543210Sym0KindInference) ())
     type Mycompare_0123456789876543210Sym1 :: Foo -> (~>) Foo Ordering
-    data Mycompare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Mycompare_0123456789876543210Sym1 (a0123456789876543210 :: Foo) :: (~>) Foo Ordering
       where
         Mycompare_0123456789876543210Sym1KindInference :: SameKind (Apply (Mycompare_0123456789876543210Sym1 a0123456789876543210) arg) (Mycompare_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                           Mycompare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -266,18 +266,18 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Mycompare_0123456789876543210Sym1KindInference) ())
     type Mycompare_0123456789876543210Sym2 :: Foo -> Foo -> Ordering
-    type family Mycompare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Mycompare_0123456789876543210Sym2 (a0123456789876543210 :: Foo) (a0123456789876543210 :: Foo) :: Ordering where
       Mycompare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PMyOrd Foo where
       type Mycompare a a = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
     type TFHelper_0123456789876543210 :: Foo2 -> Foo2 -> Bool
-    type family TFHelper_0123456789876543210 a a where
+    type family TFHelper_0123456789876543210 (a :: Foo2) (a :: Foo2) :: Bool where
       TFHelper_0123456789876543210 F F = TrueSym0
       TFHelper_0123456789876543210 G G = TrueSym0
       TFHelper_0123456789876543210 F G = FalseSym0
       TFHelper_0123456789876543210 G F = FalseSym0
     type TFHelper_0123456789876543210Sym0 :: (~>) Foo2 ((~>) Foo2 Bool)
-    data TFHelper_0123456789876543210Sym0 a0123456789876543210
+    data TFHelper_0123456789876543210Sym0 :: (~>) Foo2 ((~>) Foo2 Bool)
       where
         TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
                                                          TFHelper_0123456789876543210Sym0 a0123456789876543210
@@ -286,7 +286,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym0KindInference) ())
     type TFHelper_0123456789876543210Sym1 :: Foo2 -> (~>) Foo2 Bool
-    data TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Foo2) :: (~>) Foo2 Bool
       where
         TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                          TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -295,7 +295,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym1KindInference) ())
     type TFHelper_0123456789876543210Sym2 :: Foo2 -> Foo2 -> Bool
-    type family TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: Foo2) (a0123456789876543210 :: Foo2) :: Bool where
       TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq Foo2 where
       type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
@@ -447,12 +447,12 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       compare F _ = LT
       compare _ _ = GT
     type Mycompare_0123456789876543210 :: Foo2 -> Foo2 -> Ordering
-    type family Mycompare_0123456789876543210 a a where
+    type family Mycompare_0123456789876543210 (a :: Foo2) (a :: Foo2) :: Ordering where
       Mycompare_0123456789876543210 'F 'F = EQSym0
       Mycompare_0123456789876543210 'F _ = LTSym0
       Mycompare_0123456789876543210 _ _ = GTSym0
     type Mycompare_0123456789876543210Sym0 :: (~>) Foo2 ((~>) Foo2 Ordering)
-    data Mycompare_0123456789876543210Sym0 a0123456789876543210
+    data Mycompare_0123456789876543210Sym0 :: (~>) Foo2 ((~>) Foo2 Ordering)
       where
         Mycompare_0123456789876543210Sym0KindInference :: SameKind (Apply Mycompare_0123456789876543210Sym0 arg) (Mycompare_0123456789876543210Sym1 arg) =>
                                                           Mycompare_0123456789876543210Sym0 a0123456789876543210
@@ -462,7 +462,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) Mycompare_0123456789876543210Sym0KindInference) ())
     type Mycompare_0123456789876543210Sym1 :: Foo2
                                               -> (~>) Foo2 Ordering
-    data Mycompare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Mycompare_0123456789876543210Sym1 (a0123456789876543210 :: Foo2) :: (~>) Foo2 Ordering
       where
         Mycompare_0123456789876543210Sym1KindInference :: SameKind (Apply (Mycompare_0123456789876543210Sym1 a0123456789876543210) arg) (Mycompare_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                           Mycompare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -471,17 +471,17 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Mycompare_0123456789876543210Sym1KindInference) ())
     type Mycompare_0123456789876543210Sym2 :: Foo2 -> Foo2 -> Ordering
-    type family Mycompare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Mycompare_0123456789876543210Sym2 (a0123456789876543210 :: Foo2) (a0123456789876543210 :: Foo2) :: Ordering where
       Mycompare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PMyOrd Foo2 where
       type Mycompare a a = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
     type Compare_0123456789876543210 :: Foo2 -> Foo2 -> Ordering
-    type family Compare_0123456789876543210 a a where
+    type family Compare_0123456789876543210 (a :: Foo2) (a :: Foo2) :: Ordering where
       Compare_0123456789876543210 'F 'F = EQSym0
       Compare_0123456789876543210 'F _ = LTSym0
       Compare_0123456789876543210 _ _ = GTSym0
     type Compare_0123456789876543210Sym0 :: (~>) Foo2 ((~>) Foo2 Ordering)
-    data Compare_0123456789876543210Sym0 a0123456789876543210
+    data Compare_0123456789876543210Sym0 :: (~>) Foo2 ((~>) Foo2 Ordering)
       where
         Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
                                                         Compare_0123456789876543210Sym0 a0123456789876543210
@@ -490,7 +490,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Compare_0123456789876543210Sym0KindInference) ())
     type Compare_0123456789876543210Sym1 :: Foo2 -> (~>) Foo2 Ordering
-    data Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Foo2) :: (~>) Foo2 Ordering
       where
         Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                         Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -499,7 +499,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Compare_0123456789876543210Sym1KindInference) ())
     type Compare_0123456789876543210Sym2 :: Foo2 -> Foo2 -> Ordering
-    type family Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Compare_0123456789876543210Sym2 (a0123456789876543210 :: Foo2) (a0123456789876543210 :: Foo2) :: Ordering where
       Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd Foo2 where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
@@ -520,10 +520,10 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       mycompare (Succ' _) Zero' = GT
       mycompare (Succ' n) (Succ' m) = (m `mycompare` n)
     type Zero'Sym0 :: Nat'
-    type family Zero'Sym0 where
+    type family Zero'Sym0 :: Nat' where
       Zero'Sym0 = Zero'
     type Succ'Sym0 :: (~>) Nat' Nat'
-    data Succ'Sym0 a0123456789876543210
+    data Succ'Sym0 :: (~>) Nat' Nat'
       where
         Succ'Sym0KindInference :: SameKind (Apply Succ'Sym0 arg) (Succ'Sym1 arg) =>
                                   Succ'Sym0 a0123456789876543210
@@ -531,16 +531,16 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Succ'Sym0 where
       suppressUnusedWarnings = snd (((,) Succ'Sym0KindInference) ())
     type Succ'Sym1 :: Nat' -> Nat'
-    type family Succ'Sym1 a0123456789876543210 where
+    type family Succ'Sym1 (a0123456789876543210 :: Nat') :: Nat' where
       Succ'Sym1 a0123456789876543210 = Succ' a0123456789876543210
     type Mycompare_0123456789876543210 :: Nat' -> Nat' -> Ordering
-    type family Mycompare_0123456789876543210 a a where
+    type family Mycompare_0123456789876543210 (a :: Nat') (a :: Nat') :: Ordering where
       Mycompare_0123456789876543210 Zero' Zero' = EQSym0
       Mycompare_0123456789876543210 Zero' (Succ' _) = LTSym0
       Mycompare_0123456789876543210 (Succ' _) Zero' = GTSym0
       Mycompare_0123456789876543210 (Succ' n) (Succ' m) = Apply (Apply MycompareSym0 m) n
     type Mycompare_0123456789876543210Sym0 :: (~>) Nat' ((~>) Nat' Ordering)
-    data Mycompare_0123456789876543210Sym0 a0123456789876543210
+    data Mycompare_0123456789876543210Sym0 :: (~>) Nat' ((~>) Nat' Ordering)
       where
         Mycompare_0123456789876543210Sym0KindInference :: SameKind (Apply Mycompare_0123456789876543210Sym0 arg) (Mycompare_0123456789876543210Sym1 arg) =>
                                                           Mycompare_0123456789876543210Sym0 a0123456789876543210
@@ -550,7 +550,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) Mycompare_0123456789876543210Sym0KindInference) ())
     type Mycompare_0123456789876543210Sym1 :: Nat'
                                               -> (~>) Nat' Ordering
-    data Mycompare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Mycompare_0123456789876543210Sym1 (a0123456789876543210 :: Nat') :: (~>) Nat' Ordering
       where
         Mycompare_0123456789876543210Sym1KindInference :: SameKind (Apply (Mycompare_0123456789876543210Sym1 a0123456789876543210) arg) (Mycompare_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                           Mycompare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -559,7 +559,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Mycompare_0123456789876543210Sym1KindInference) ())
     type Mycompare_0123456789876543210Sym2 :: Nat' -> Nat' -> Ordering
-    type family Mycompare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Mycompare_0123456789876543210Sym2 (a0123456789876543210 :: Nat') (a0123456789876543210 :: Nat') :: Ordering where
       Mycompare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PMyOrd Nat' where
       type Mycompare a a = Apply (Apply Mycompare_0123456789876543210Sym0 a) a

--- a/singletons-base/tests/compile-and-dump/Singletons/Classes2.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Classes2.golden
@@ -15,10 +15,10 @@ Singletons/Classes2.hs:(0,0)-(0,0): Splicing declarations
       mycompare (SuccFoo _) ZeroFoo = GT
       mycompare (SuccFoo n) (SuccFoo m) = (m `mycompare` n)
     type ZeroFooSym0 :: NatFoo
-    type family ZeroFooSym0 where
+    type family ZeroFooSym0 :: NatFoo where
       ZeroFooSym0 = ZeroFoo
     type SuccFooSym0 :: (~>) NatFoo NatFoo
-    data SuccFooSym0 a0123456789876543210
+    data SuccFooSym0 :: (~>) NatFoo NatFoo
       where
         SuccFooSym0KindInference :: SameKind (Apply SuccFooSym0 arg) (SuccFooSym1 arg) =>
                                     SuccFooSym0 a0123456789876543210
@@ -26,16 +26,16 @@ Singletons/Classes2.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings SuccFooSym0 where
       suppressUnusedWarnings = snd (((,) SuccFooSym0KindInference) ())
     type SuccFooSym1 :: NatFoo -> NatFoo
-    type family SuccFooSym1 a0123456789876543210 where
+    type family SuccFooSym1 (a0123456789876543210 :: NatFoo) :: NatFoo where
       SuccFooSym1 a0123456789876543210 = SuccFoo a0123456789876543210
     type Mycompare_0123456789876543210 :: NatFoo -> NatFoo -> Ordering
-    type family Mycompare_0123456789876543210 a a where
+    type family Mycompare_0123456789876543210 (a :: NatFoo) (a :: NatFoo) :: Ordering where
       Mycompare_0123456789876543210 ZeroFoo ZeroFoo = EQSym0
       Mycompare_0123456789876543210 ZeroFoo (SuccFoo _) = LTSym0
       Mycompare_0123456789876543210 (SuccFoo _) ZeroFoo = GTSym0
       Mycompare_0123456789876543210 (SuccFoo n) (SuccFoo m) = Apply (Apply MycompareSym0 m) n
     type Mycompare_0123456789876543210Sym0 :: (~>) NatFoo ((~>) NatFoo Ordering)
-    data Mycompare_0123456789876543210Sym0 a0123456789876543210
+    data Mycompare_0123456789876543210Sym0 :: (~>) NatFoo ((~>) NatFoo Ordering)
       where
         Mycompare_0123456789876543210Sym0KindInference :: SameKind (Apply Mycompare_0123456789876543210Sym0 arg) (Mycompare_0123456789876543210Sym1 arg) =>
                                                           Mycompare_0123456789876543210Sym0 a0123456789876543210
@@ -45,7 +45,7 @@ Singletons/Classes2.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) Mycompare_0123456789876543210Sym0KindInference) ())
     type Mycompare_0123456789876543210Sym1 :: NatFoo
                                               -> (~>) NatFoo Ordering
-    data Mycompare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Mycompare_0123456789876543210Sym1 (a0123456789876543210 :: NatFoo) :: (~>) NatFoo Ordering
       where
         Mycompare_0123456789876543210Sym1KindInference :: SameKind (Apply (Mycompare_0123456789876543210Sym1 a0123456789876543210) arg) (Mycompare_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                           Mycompare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -55,7 +55,7 @@ Singletons/Classes2.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) Mycompare_0123456789876543210Sym1KindInference) ())
     type Mycompare_0123456789876543210Sym2 :: NatFoo
                                               -> NatFoo -> Ordering
-    type family Mycompare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Mycompare_0123456789876543210Sym2 (a0123456789876543210 :: NatFoo) (a0123456789876543210 :: NatFoo) :: Ordering where
       Mycompare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PMyOrd NatFoo where
       type Mycompare a a = Apply (Apply Mycompare_0123456789876543210Sym0 a) a

--- a/singletons-base/tests/compile-and-dump/Singletons/Contains.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Contains.golden
@@ -8,7 +8,7 @@ Singletons/Contains.hs:(0,0)-(0,0): Splicing declarations
     contains _ [] = False
     contains elt (h : t) = ((elt == h) || (contains elt) t)
     type ContainsSym0 :: (~>) a ((~>) [a] Bool)
-    data ContainsSym0 a0123456789876543210
+    data ContainsSym0 :: (~>) a ((~>) [a] Bool)
       where
         ContainsSym0KindInference :: SameKind (Apply ContainsSym0 arg) (ContainsSym1 arg) =>
                                      ContainsSym0 a0123456789876543210
@@ -16,7 +16,7 @@ Singletons/Contains.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ContainsSym0 where
       suppressUnusedWarnings = snd (((,) ContainsSym0KindInference) ())
     type ContainsSym1 :: a -> (~>) [a] Bool
-    data ContainsSym1 a0123456789876543210 a0123456789876543210
+    data ContainsSym1 (a0123456789876543210 :: a) :: (~>) [a] Bool
       where
         ContainsSym1KindInference :: SameKind (Apply (ContainsSym1 a0123456789876543210) arg) (ContainsSym2 a0123456789876543210 arg) =>
                                      ContainsSym1 a0123456789876543210 a0123456789876543210
@@ -24,10 +24,10 @@ Singletons/Contains.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (ContainsSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) ContainsSym1KindInference) ())
     type ContainsSym2 :: a -> [a] -> Bool
-    type family ContainsSym2 a0123456789876543210 a0123456789876543210 where
+    type family ContainsSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: [a]) :: Bool where
       ContainsSym2 a0123456789876543210 a0123456789876543210 = Contains a0123456789876543210 a0123456789876543210
     type Contains :: a -> [a] -> Bool
-    type family Contains a a where
+    type family Contains (a :: a) (a :: [a]) :: Bool where
       Contains _ '[] = FalseSym0
       Contains elt ('(:) h t) = Apply (Apply (||@#@$) (Apply (Apply (==@#@$) elt) h)) (Apply (Apply ContainsSym0 elt) t)
     sContains ::

--- a/singletons-base/tests/compile-and-dump/Singletons/DataValues.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/DataValues.golden
@@ -17,7 +17,7 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
     tuple = (False, Just Zero, True)
     aList = [Zero, Succ Zero, Succ (Succ Zero)]
     type PairSym0 :: forall a b. (~>) a ((~>) b (Pair a b))
-    data PairSym0 a0123456789876543210
+    data PairSym0 :: (~>) a ((~>) b (Pair a b))
       where
         PairSym0KindInference :: SameKind (Apply PairSym0 arg) (PairSym1 arg) =>
                                  PairSym0 a0123456789876543210
@@ -25,7 +25,7 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings PairSym0 where
       suppressUnusedWarnings = snd (((,) PairSym0KindInference) ())
     type PairSym1 :: forall a b. a -> (~>) b (Pair a b)
-    data PairSym1 a0123456789876543210 a0123456789876543210
+    data PairSym1 (a0123456789876543210 :: a) :: (~>) b (Pair a b)
       where
         PairSym1KindInference :: SameKind (Apply (PairSym1 a0123456789876543210) arg) (PairSym2 a0123456789876543210 arg) =>
                                  PairSym1 a0123456789876543210 a0123456789876543210
@@ -33,7 +33,7 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (PairSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) PairSym1KindInference) ())
     type PairSym2 :: forall a b. a -> b -> Pair a b
-    type family PairSym2 a0123456789876543210 a0123456789876543210 where
+    type family PairSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: Pair a b where
       PairSym2 a0123456789876543210 a0123456789876543210 = Pair a0123456789876543210 a0123456789876543210
     type family AListSym0 where
       AListSym0 = AList
@@ -53,10 +53,10 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
       Pr = Apply (Apply PairSym0 (Apply SuccSym0 ZeroSym0)) (Apply (Apply (:@#@$) ZeroSym0) NilSym0)
     type ShowsPrec_0123456789876543210 :: GHC.Types.Nat
                                           -> Pair a b -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210 a a a where
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Pair a b) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 p_0123456789876543210 (Pair arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Pair ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
     type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) (Pair a b) ((~>) Symbol Symbol))
-    data ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) (Pair a b) ((~>) Symbol Symbol))
       where
         ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
                                                           ShowsPrec_0123456789876543210Sym0 a0123456789876543210
@@ -66,7 +66,7 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym0KindInference) ())
     type ShowsPrec_0123456789876543210Sym1 :: GHC.Types.Nat
                                               -> (~>) (Pair a b) ((~>) Symbol Symbol)
-    data ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: (~>) (Pair a b) ((~>) Symbol Symbol)
       where
         ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -76,7 +76,7 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym1KindInference) ())
     type ShowsPrec_0123456789876543210Sym2 :: GHC.Types.Nat
                                               -> Pair a b -> (~>) Symbol Symbol
-    data ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Pair a b) :: (~>) Symbol Symbol
       where
         ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -86,7 +86,7 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym2KindInference) ())
     type ShowsPrec_0123456789876543210Sym3 :: GHC.Types.Nat
                                               -> Pair a b -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Pair a b) (a0123456789876543210 :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow (Pair a b) where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a

--- a/singletons-base/tests/compile-and-dump/Singletons/EmptyShowDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/EmptyShowDeriving.golden
@@ -9,10 +9,10 @@ Singletons/EmptyShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     type family Case_0123456789876543210 v_0123456789876543210 a_0123456789876543210 t where
     type ShowsPrec_0123456789876543210 :: GHC.Types.Nat
                                           -> Foo -> GHC.Types.Symbol -> GHC.Types.Symbol
-    type family ShowsPrec_0123456789876543210 a a a where
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Foo) (a :: GHC.Types.Symbol) :: GHC.Types.Symbol where
       ShowsPrec_0123456789876543210 _ v_0123456789876543210 a_0123456789876543210 = Apply (Case_0123456789876543210 v_0123456789876543210 a_0123456789876543210 v_0123456789876543210) a_0123456789876543210
     type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) Foo ((~>) GHC.Types.Symbol GHC.Types.Symbol))
-    data ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) Foo ((~>) GHC.Types.Symbol GHC.Types.Symbol))
       where
         ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
                                                           ShowsPrec_0123456789876543210Sym0 a0123456789876543210
@@ -22,7 +22,7 @@ Singletons/EmptyShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym0KindInference) ())
     type ShowsPrec_0123456789876543210Sym1 :: GHC.Types.Nat
                                               -> (~>) Foo ((~>) GHC.Types.Symbol GHC.Types.Symbol)
-    data ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: (~>) Foo ((~>) GHC.Types.Symbol GHC.Types.Symbol)
       where
         ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -32,7 +32,7 @@ Singletons/EmptyShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym1KindInference) ())
     type ShowsPrec_0123456789876543210Sym2 :: GHC.Types.Nat
                                               -> Foo -> (~>) GHC.Types.Symbol GHC.Types.Symbol
-    data ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Foo) :: (~>) GHC.Types.Symbol GHC.Types.Symbol
       where
         ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -42,7 +42,7 @@ Singletons/EmptyShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym2KindInference) ())
     type ShowsPrec_0123456789876543210Sym3 :: GHC.Types.Nat
                                               -> Foo -> GHC.Types.Symbol -> GHC.Types.Symbol
-    type family ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Foo) (a0123456789876543210 :: GHC.Types.Symbol) :: GHC.Types.Symbol where
       ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow Foo where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a

--- a/singletons-base/tests/compile-and-dump/Singletons/EnumDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/EnumDeriving.golden
@@ -10,19 +10,19 @@ Singletons/EnumDeriving.hs:(0,0)-(0,0): Splicing declarations
       deriving Enum
     data Quux = Q1 | Q2
     type BarSym0 :: Foo
-    type family BarSym0 where
+    type family BarSym0 :: Foo where
       BarSym0 = Bar
     type BazSym0 :: Foo
-    type family BazSym0 where
+    type family BazSym0 :: Foo where
       BazSym0 = Baz
     type BumSym0 :: Foo
-    type family BumSym0 where
+    type family BumSym0 :: Foo where
       BumSym0 = Bum
     type Q1Sym0 :: Quux
-    type family Q1Sym0 where
+    type family Q1Sym0 :: Quux where
       Q1Sym0 = Q1
     type Q2Sym0 :: Quux
-    type family Q2Sym0 where
+    type family Q2Sym0 :: Quux where
       Q2Sym0 = Q2
     type family Case_0123456789876543210 n t where
       Case_0123456789876543210 n 'True = BumSym0
@@ -34,10 +34,10 @@ Singletons/EnumDeriving.hs:(0,0)-(0,0): Splicing declarations
       Case_0123456789876543210 n 'True = BarSym0
       Case_0123456789876543210 n 'False = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (FromInteger 1))
     type ToEnum_0123456789876543210 :: GHC.Types.Nat -> Foo
-    type family ToEnum_0123456789876543210 a where
+    type family ToEnum_0123456789876543210 (a :: GHC.Types.Nat) :: Foo where
       ToEnum_0123456789876543210 n = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (FromInteger 0))
     type ToEnum_0123456789876543210Sym0 :: (~>) GHC.Types.Nat Foo
-    data ToEnum_0123456789876543210Sym0 a0123456789876543210
+    data ToEnum_0123456789876543210Sym0 :: (~>) GHC.Types.Nat Foo
       where
         ToEnum_0123456789876543210Sym0KindInference :: SameKind (Apply ToEnum_0123456789876543210Sym0 arg) (ToEnum_0123456789876543210Sym1 arg) =>
                                                        ToEnum_0123456789876543210Sym0 a0123456789876543210
@@ -46,15 +46,15 @@ Singletons/EnumDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) ToEnum_0123456789876543210Sym0KindInference) ())
     type ToEnum_0123456789876543210Sym1 :: GHC.Types.Nat -> Foo
-    type family ToEnum_0123456789876543210Sym1 a0123456789876543210 where
+    type family ToEnum_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: Foo where
       ToEnum_0123456789876543210Sym1 a0123456789876543210 = ToEnum_0123456789876543210 a0123456789876543210
     type FromEnum_0123456789876543210 :: Foo -> GHC.Types.Nat
-    type family FromEnum_0123456789876543210 a where
+    type family FromEnum_0123456789876543210 (a :: Foo) :: GHC.Types.Nat where
       FromEnum_0123456789876543210 Bar = FromInteger 0
       FromEnum_0123456789876543210 Baz = FromInteger 1
       FromEnum_0123456789876543210 Bum = FromInteger 2
     type FromEnum_0123456789876543210Sym0 :: (~>) Foo GHC.Types.Nat
-    data FromEnum_0123456789876543210Sym0 a0123456789876543210
+    data FromEnum_0123456789876543210Sym0 :: (~>) Foo GHC.Types.Nat
       where
         FromEnum_0123456789876543210Sym0KindInference :: SameKind (Apply FromEnum_0123456789876543210Sym0 arg) (FromEnum_0123456789876543210Sym1 arg) =>
                                                          FromEnum_0123456789876543210Sym0 a0123456789876543210
@@ -63,7 +63,7 @@ Singletons/EnumDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) FromEnum_0123456789876543210Sym0KindInference) ())
     type FromEnum_0123456789876543210Sym1 :: Foo -> GHC.Types.Nat
-    type family FromEnum_0123456789876543210Sym1 a0123456789876543210 where
+    type family FromEnum_0123456789876543210Sym1 (a0123456789876543210 :: Foo) :: GHC.Types.Nat where
       FromEnum_0123456789876543210Sym1 a0123456789876543210 = FromEnum_0123456789876543210 a0123456789876543210
     instance PEnum Foo where
       type ToEnum a = Apply ToEnum_0123456789876543210Sym0 a
@@ -152,10 +152,10 @@ Singletons/EnumDeriving.hs:0:0:: Splicing declarations
       Case_0123456789876543210 n 'True = Q1Sym0
       Case_0123456789876543210 n 'False = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (FromInteger 1))
     type ToEnum_0123456789876543210 :: GHC.Types.Nat -> Quux
-    type family ToEnum_0123456789876543210 a where
+    type family ToEnum_0123456789876543210 (a :: GHC.Types.Nat) :: Quux where
       ToEnum_0123456789876543210 n = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (FromInteger 0))
     type ToEnum_0123456789876543210Sym0 :: (~>) GHC.Types.Nat Quux
-    data ToEnum_0123456789876543210Sym0 a0123456789876543210
+    data ToEnum_0123456789876543210Sym0 :: (~>) GHC.Types.Nat Quux
       where
         ToEnum_0123456789876543210Sym0KindInference :: SameKind (Apply ToEnum_0123456789876543210Sym0 arg) (ToEnum_0123456789876543210Sym1 arg) =>
                                                        ToEnum_0123456789876543210Sym0 a0123456789876543210
@@ -164,14 +164,14 @@ Singletons/EnumDeriving.hs:0:0:: Splicing declarations
       suppressUnusedWarnings
         = snd (((,) ToEnum_0123456789876543210Sym0KindInference) ())
     type ToEnum_0123456789876543210Sym1 :: GHC.Types.Nat -> Quux
-    type family ToEnum_0123456789876543210Sym1 a0123456789876543210 where
+    type family ToEnum_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: Quux where
       ToEnum_0123456789876543210Sym1 a0123456789876543210 = ToEnum_0123456789876543210 a0123456789876543210
     type FromEnum_0123456789876543210 :: Quux -> GHC.Types.Nat
-    type family FromEnum_0123456789876543210 a where
+    type family FromEnum_0123456789876543210 (a :: Quux) :: GHC.Types.Nat where
       FromEnum_0123456789876543210 'Q1 = FromInteger 0
       FromEnum_0123456789876543210 'Q2 = FromInteger 1
     type FromEnum_0123456789876543210Sym0 :: (~>) Quux GHC.Types.Nat
-    data FromEnum_0123456789876543210Sym0 a0123456789876543210
+    data FromEnum_0123456789876543210Sym0 :: (~>) Quux GHC.Types.Nat
       where
         FromEnum_0123456789876543210Sym0KindInference :: SameKind (Apply FromEnum_0123456789876543210Sym0 arg) (FromEnum_0123456789876543210Sym1 arg) =>
                                                          FromEnum_0123456789876543210Sym0 a0123456789876543210
@@ -180,7 +180,7 @@ Singletons/EnumDeriving.hs:0:0:: Splicing declarations
       suppressUnusedWarnings
         = snd (((,) FromEnum_0123456789876543210Sym0KindInference) ())
     type FromEnum_0123456789876543210Sym1 :: Quux -> GHC.Types.Nat
-    type family FromEnum_0123456789876543210Sym1 a0123456789876543210 where
+    type family FromEnum_0123456789876543210Sym1 (a0123456789876543210 :: Quux) :: GHC.Types.Nat where
       FromEnum_0123456789876543210Sym1 a0123456789876543210 = FromEnum_0123456789876543210 a0123456789876543210
     instance PEnum Quux where
       type ToEnum a = Apply ToEnum_0123456789876543210Sym0 a

--- a/singletons-base/tests/compile-and-dump/Singletons/EqInstances.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/EqInstances.golden
@@ -2,13 +2,13 @@ Singletons/EqInstances.hs:0:0:: Splicing declarations
     singEqInstances [''Foo, ''Empty]
   ======>
     type TFHelper_0123456789876543210 :: Foo -> Foo -> Bool
-    type family TFHelper_0123456789876543210 a a where
+    type family TFHelper_0123456789876543210 (a :: Foo) (a :: Foo) :: Bool where
       TFHelper_0123456789876543210 'FLeaf 'FLeaf = TrueSym0
       TFHelper_0123456789876543210 'FLeaf ('(:+:) _ _) = FalseSym0
       TFHelper_0123456789876543210 ('(:+:) _ _) 'FLeaf = FalseSym0
       TFHelper_0123456789876543210 ('(:+:) a_0123456789876543210 a_0123456789876543210) ('(:+:) b_0123456789876543210 b_0123456789876543210) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)
     type TFHelper_0123456789876543210Sym0 :: (~>) Foo ((~>) Foo Bool)
-    data TFHelper_0123456789876543210Sym0 a0123456789876543210
+    data TFHelper_0123456789876543210Sym0 :: (~>) Foo ((~>) Foo Bool)
       where
         TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
                                                          TFHelper_0123456789876543210Sym0 a0123456789876543210
@@ -17,7 +17,7 @@ Singletons/EqInstances.hs:0:0:: Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym0KindInference) ())
     type TFHelper_0123456789876543210Sym1 :: Foo -> (~>) Foo Bool
-    data TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Foo) :: (~>) Foo Bool
       where
         TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                          TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -26,7 +26,7 @@ Singletons/EqInstances.hs:0:0:: Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym1KindInference) ())
     type TFHelper_0123456789876543210Sym2 :: Foo -> Foo -> Bool
-    type family TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: Foo) (a0123456789876543210 :: Foo) :: Bool where
       TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq Foo where
       type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
@@ -54,10 +54,10 @@ Singletons/EqInstances.hs:0:0:: Splicing declarations
                 ((applySing ((singFun2 @(==@#@$)) (%==))) sA_0123456789876543210))
                sB_0123456789876543210)
     type TFHelper_0123456789876543210 :: Empty -> Empty -> Bool
-    type family TFHelper_0123456789876543210 a a where
+    type family TFHelper_0123456789876543210 (a :: Empty) (a :: Empty) :: Bool where
       TFHelper_0123456789876543210 _ _ = TrueSym0
     type TFHelper_0123456789876543210Sym0 :: (~>) Empty ((~>) Empty Bool)
-    data TFHelper_0123456789876543210Sym0 a0123456789876543210
+    data TFHelper_0123456789876543210Sym0 :: (~>) Empty ((~>) Empty Bool)
       where
         TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
                                                          TFHelper_0123456789876543210Sym0 a0123456789876543210
@@ -66,7 +66,7 @@ Singletons/EqInstances.hs:0:0:: Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym0KindInference) ())
     type TFHelper_0123456789876543210Sym1 :: Empty -> (~>) Empty Bool
-    data TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Empty) :: (~>) Empty Bool
       where
         TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                          TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -75,7 +75,7 @@ Singletons/EqInstances.hs:0:0:: Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym1KindInference) ())
     type TFHelper_0123456789876543210Sym2 :: Empty -> Empty -> Bool
-    type family TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: Empty) (a0123456789876543210 :: Empty) :: Bool where
       TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq Empty where
       type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a

--- a/singletons-base/tests/compile-and-dump/Singletons/Error.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Error.golden
@@ -8,7 +8,7 @@ Singletons/Error.hs:(0,0)-(0,0): Splicing declarations
     head (a : _) = a
     head [] = error "Data.Singletons.List.head: empty list"
     type HeadSym0 :: (~>) [a] a
-    data HeadSym0 a0123456789876543210
+    data HeadSym0 :: (~>) [a] a
       where
         HeadSym0KindInference :: SameKind (Apply HeadSym0 arg) (HeadSym1 arg) =>
                                  HeadSym0 a0123456789876543210
@@ -16,10 +16,10 @@ Singletons/Error.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings HeadSym0 where
       suppressUnusedWarnings = snd (((,) HeadSym0KindInference) ())
     type HeadSym1 :: [a] -> a
-    type family HeadSym1 a0123456789876543210 where
+    type family HeadSym1 (a0123456789876543210 :: [a]) :: a where
       HeadSym1 a0123456789876543210 = Head a0123456789876543210
     type Head :: [a] -> a
-    type family Head a where
+    type family Head (a :: [a]) :: a where
       Head ('(:) a _) = a
       Head '[] = Apply ErrorSym0 "Data.Singletons.List.head: empty list"
     sHead ::

--- a/singletons-base/tests/compile-and-dump/Singletons/Fixity.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Fixity.golden
@@ -17,7 +17,7 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
     (====) a _ = a
     infix 4 ====
     type (====@#@$) :: (~>) a ((~>) a a)
-    data (====@#@$) a0123456789876543210
+    data (====@#@$) :: (~>) a ((~>) a a)
       where
         (:====@#@$###) :: SameKind (Apply (====@#@$) arg) ((====@#@$$) arg) =>
                           (====@#@$) a0123456789876543210
@@ -26,7 +26,7 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) (:====@#@$###)) ())
     infix 4 ====@#@$
     type (====@#@$$) :: a -> (~>) a a
-    data (====@#@$$) a0123456789876543210 a0123456789876543210
+    data (====@#@$$) (a0123456789876543210 :: a) :: (~>) a a
       where
         (:====@#@$$###) :: SameKind (Apply ((====@#@$$) a0123456789876543210) arg) ((====@#@$$$) a0123456789876543210 arg) =>
                            (====@#@$$) a0123456789876543210 a0123456789876543210
@@ -35,14 +35,14 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) (:====@#@$$###)) ())
     infix 4 ====@#@$$
     type (====@#@$$$) :: a -> a -> a
-    type family (====@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family (====@#@$$$) (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: a where
       (====@#@$$$) a0123456789876543210 a0123456789876543210 = (====) a0123456789876543210 a0123456789876543210
     infix 4 ====@#@$$$
     type (====) :: a -> a -> a
-    type family (====) a a where
+    type family (====) (a :: a) (a :: a) :: a where
       (====) a _ = a
     type (<=>@#@$) :: forall a. (~>) a ((~>) a Ordering)
-    data (<=>@#@$) a0123456789876543210
+    data (<=>@#@$) :: (~>) a ((~>) a Ordering)
       where
         (:<=>@#@$###) :: SameKind (Apply (<=>@#@$) arg) ((<=>@#@$$) arg) =>
                          (<=>@#@$) a0123456789876543210
@@ -51,7 +51,7 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) (:<=>@#@$###)) ())
     infix 4 <=>@#@$
     type (<=>@#@$$) :: forall a. a -> (~>) a Ordering
-    data (<=>@#@$$) a0123456789876543210 a0123456789876543210
+    data (<=>@#@$$) (a0123456789876543210 :: a) :: (~>) a Ordering
       where
         (:<=>@#@$$###) :: SameKind (Apply ((<=>@#@$$) a0123456789876543210) arg) ((<=>@#@$$$) a0123456789876543210 arg) =>
                           (<=>@#@$$) a0123456789876543210 a0123456789876543210
@@ -60,7 +60,7 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) (:<=>@#@$$###)) ())
     infix 4 <=>@#@$$
     type (<=>@#@$$$) :: forall a. a -> a -> Ordering
-    type family (<=>@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family (<=>@#@$$$) (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Ordering where
       (<=>@#@$$$) a0123456789876543210 a0123456789876543210 = (<=>) a0123456789876543210 a0123456789876543210
     infix 4 <=>@#@$$$
     class PMyOrd a where

--- a/singletons-base/tests/compile-and-dump/Singletons/FunDeps.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/FunDeps.golden
@@ -24,7 +24,7 @@ Singletons/FunDeps.hs:(0,0)-(0,0): Splicing declarations
     type family T1 where
       T1 = Apply MethSym0 TrueSym0
     type MethSym0 :: forall a. (~>) a a
-    data MethSym0 a0123456789876543210
+    data MethSym0 :: (~>) a a
       where
         MethSym0KindInference :: SameKind (Apply MethSym0 arg) (MethSym1 arg) =>
                                  MethSym0 a0123456789876543210
@@ -32,10 +32,10 @@ Singletons/FunDeps.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings MethSym0 where
       suppressUnusedWarnings = snd (((,) MethSym0KindInference) ())
     type MethSym1 :: forall a. a -> a
-    type family MethSym1 a0123456789876543210 where
+    type family MethSym1 (a0123456789876543210 :: a) :: a where
       MethSym1 a0123456789876543210 = Meth a0123456789876543210
     type L2rSym0 :: forall a b. (~>) a b
-    data L2rSym0 a0123456789876543210
+    data L2rSym0 :: (~>) a b
       where
         L2rSym0KindInference :: SameKind (Apply L2rSym0 arg) (L2rSym1 arg) =>
                                 L2rSym0 a0123456789876543210
@@ -43,16 +43,16 @@ Singletons/FunDeps.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings L2rSym0 where
       suppressUnusedWarnings = snd (((,) L2rSym0KindInference) ())
     type L2rSym1 :: forall a b. a -> b
-    type family L2rSym1 a0123456789876543210 where
+    type family L2rSym1 (a0123456789876543210 :: a) :: b where
       L2rSym1 a0123456789876543210 = L2r a0123456789876543210
     class PFD a b | a -> b where
       type Meth (arg :: a) :: a
       type L2r (arg :: a) :: b
     type Meth_0123456789876543210 :: Bool -> Bool
-    type family Meth_0123456789876543210 a where
+    type family Meth_0123456789876543210 (a :: Bool) :: Bool where
       Meth_0123456789876543210 a_0123456789876543210 = Apply NotSym0 a_0123456789876543210
     type Meth_0123456789876543210Sym0 :: (~>) Bool Bool
-    data Meth_0123456789876543210Sym0 a0123456789876543210
+    data Meth_0123456789876543210Sym0 :: (~>) Bool Bool
       where
         Meth_0123456789876543210Sym0KindInference :: SameKind (Apply Meth_0123456789876543210Sym0 arg) (Meth_0123456789876543210Sym1 arg) =>
                                                      Meth_0123456789876543210Sym0 a0123456789876543210
@@ -61,14 +61,14 @@ Singletons/FunDeps.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Meth_0123456789876543210Sym0KindInference) ())
     type Meth_0123456789876543210Sym1 :: Bool -> Bool
-    type family Meth_0123456789876543210Sym1 a0123456789876543210 where
+    type family Meth_0123456789876543210Sym1 (a0123456789876543210 :: Bool) :: Bool where
       Meth_0123456789876543210Sym1 a0123456789876543210 = Meth_0123456789876543210 a0123456789876543210
     type L2r_0123456789876543210 :: Bool -> Nat
-    type family L2r_0123456789876543210 a where
+    type family L2r_0123456789876543210 (a :: Bool) :: Nat where
       L2r_0123456789876543210 'False = FromInteger 0
       L2r_0123456789876543210 'True = FromInteger 1
     type L2r_0123456789876543210Sym0 :: (~>) Bool Nat
-    data L2r_0123456789876543210Sym0 a0123456789876543210
+    data L2r_0123456789876543210Sym0 :: (~>) Bool Nat
       where
         L2r_0123456789876543210Sym0KindInference :: SameKind (Apply L2r_0123456789876543210Sym0 arg) (L2r_0123456789876543210Sym1 arg) =>
                                                     L2r_0123456789876543210Sym0 a0123456789876543210
@@ -77,7 +77,7 @@ Singletons/FunDeps.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) L2r_0123456789876543210Sym0KindInference) ())
     type L2r_0123456789876543210Sym1 :: Bool -> Nat
-    type family L2r_0123456789876543210Sym1 a0123456789876543210 where
+    type family L2r_0123456789876543210Sym1 (a0123456789876543210 :: Bool) :: Nat where
       L2r_0123456789876543210Sym1 a0123456789876543210 = L2r_0123456789876543210 a0123456789876543210
     instance PFD Bool Nat where
       type Meth a = Apply Meth_0123456789876543210Sym0 a

--- a/singletons-base/tests/compile-and-dump/Singletons/FunctorLikeDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/FunctorLikeDeriving.golden
@@ -11,7 +11,7 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
     data Empty (a :: Type) deriving (Functor, Foldable, Traversable)
     type MkT1Sym0 :: forall x a.
                      (~>) x ((~>) a ((~>) (Maybe a) ((~>) (Maybe (Maybe a)) (T x a))))
-    data MkT1Sym0 a0123456789876543210
+    data MkT1Sym0 :: (~>) x ((~>) a ((~>) (Maybe a) ((~>) (Maybe (Maybe a)) (T x a))))
       where
         MkT1Sym0KindInference :: SameKind (Apply MkT1Sym0 arg) (MkT1Sym1 arg) =>
                                  MkT1Sym0 a0123456789876543210
@@ -20,7 +20,7 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) MkT1Sym0KindInference) ())
     type MkT1Sym1 :: forall x a.
                      x -> (~>) a ((~>) (Maybe a) ((~>) (Maybe (Maybe a)) (T x a)))
-    data MkT1Sym1 a0123456789876543210 a0123456789876543210
+    data MkT1Sym1 (a0123456789876543210 :: x) :: (~>) a ((~>) (Maybe a) ((~>) (Maybe (Maybe a)) (T x a)))
       where
         MkT1Sym1KindInference :: SameKind (Apply (MkT1Sym1 a0123456789876543210) arg) (MkT1Sym2 a0123456789876543210 arg) =>
                                  MkT1Sym1 a0123456789876543210 a0123456789876543210
@@ -29,7 +29,7 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) MkT1Sym1KindInference) ())
     type MkT1Sym2 :: forall x a.
                      x -> a -> (~>) (Maybe a) ((~>) (Maybe (Maybe a)) (T x a))
-    data MkT1Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data MkT1Sym2 (a0123456789876543210 :: x) (a0123456789876543210 :: a) :: (~>) (Maybe a) ((~>) (Maybe (Maybe a)) (T x a))
       where
         MkT1Sym2KindInference :: SameKind (Apply (MkT1Sym2 a0123456789876543210 a0123456789876543210) arg) (MkT1Sym3 a0123456789876543210 a0123456789876543210 arg) =>
                                  MkT1Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -38,7 +38,7 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) MkT1Sym2KindInference) ())
     type MkT1Sym3 :: forall x a.
                      x -> a -> Maybe a -> (~>) (Maybe (Maybe a)) (T x a)
-    data MkT1Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data MkT1Sym3 (a0123456789876543210 :: x) (a0123456789876543210 :: a) (a0123456789876543210 :: Maybe a) :: (~>) (Maybe (Maybe a)) (T x a)
       where
         MkT1Sym3KindInference :: SameKind (Apply (MkT1Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) arg) (MkT1Sym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 arg) =>
                                  MkT1Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -47,10 +47,10 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) MkT1Sym3KindInference) ())
     type MkT1Sym4 :: forall x a.
                      x -> a -> Maybe a -> Maybe (Maybe a) -> T x a
-    type family MkT1Sym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family MkT1Sym4 (a0123456789876543210 :: x) (a0123456789876543210 :: a) (a0123456789876543210 :: Maybe a) (a0123456789876543210 :: Maybe (Maybe a)) :: T x a where
       MkT1Sym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 = MkT1 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     type MkT2Sym0 :: forall x a. (~>) (Maybe x) (T x a)
-    data MkT2Sym0 a0123456789876543210
+    data MkT2Sym0 :: (~>) (Maybe x) (T x a)
       where
         MkT2Sym0KindInference :: SameKind (Apply MkT2Sym0 arg) (MkT2Sym1 arg) =>
                                  MkT2Sym0 a0123456789876543210
@@ -58,7 +58,7 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings MkT2Sym0 where
       suppressUnusedWarnings = snd (((,) MkT2Sym0KindInference) ())
     type MkT2Sym1 :: forall x a. Maybe x -> T x a
-    type family MkT2Sym1 a0123456789876543210 where
+    type family MkT2Sym1 (a0123456789876543210 :: Maybe x) :: T x a where
       MkT2Sym1 a0123456789876543210 = MkT2 a0123456789876543210
     type family Lambda_0123456789876543210 _f_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 n_0123456789876543210 where
       Lambda_0123456789876543210 _f_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 n_0123456789876543210 = n_0123456789876543210
@@ -141,11 +141,11 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
     type family Lambda_0123456789876543210Sym3 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 n_01234567898765432100123456789876543210 where
       Lambda_0123456789876543210Sym3 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 n_01234567898765432100123456789876543210 = Lambda_0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 n_01234567898765432100123456789876543210
     type Fmap_0123456789876543210 :: (~>) a b -> T x a -> T x b
-    type family Fmap_0123456789876543210 a a where
+    type family Fmap_0123456789876543210 (a :: (~>) a b) (a :: T x a) :: T x b where
       Fmap_0123456789876543210 _f_0123456789876543210 (MkT1 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210) = Apply (Apply (Apply (Apply MkT1Sym0 (Apply (Apply (Apply (Apply (Apply (Apply Lambda_0123456789876543210Sym0 _f_0123456789876543210) a_0123456789876543210) a_0123456789876543210) a_0123456789876543210) a_0123456789876543210) a_0123456789876543210)) (Apply _f_0123456789876543210 a_0123456789876543210)) (Apply (Apply FmapSym0 _f_0123456789876543210) a_0123456789876543210)) (Apply (Apply FmapSym0 (Apply FmapSym0 _f_0123456789876543210)) a_0123456789876543210)
       Fmap_0123456789876543210 _f_0123456789876543210 (MkT2 a_0123456789876543210) = Apply MkT2Sym0 (Apply (Apply (Apply Lambda_0123456789876543210Sym0 _f_0123456789876543210) a_0123456789876543210) a_0123456789876543210)
     type Fmap_0123456789876543210Sym0 :: (~>) ((~>) a b) ((~>) (T x a) (T x b))
-    data Fmap_0123456789876543210Sym0 a0123456789876543210
+    data Fmap_0123456789876543210Sym0 :: (~>) ((~>) a b) ((~>) (T x a) (T x b))
       where
         Fmap_0123456789876543210Sym0KindInference :: SameKind (Apply Fmap_0123456789876543210Sym0 arg) (Fmap_0123456789876543210Sym1 arg) =>
                                                      Fmap_0123456789876543210Sym0 a0123456789876543210
@@ -155,7 +155,7 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) Fmap_0123456789876543210Sym0KindInference) ())
     type Fmap_0123456789876543210Sym1 :: (~>) a b
                                          -> (~>) (T x a) (T x b)
-    data Fmap_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Fmap_0123456789876543210Sym1 (a0123456789876543210 :: (~>) a b) :: (~>) (T x a) (T x b)
       where
         Fmap_0123456789876543210Sym1KindInference :: SameKind (Apply (Fmap_0123456789876543210Sym1 a0123456789876543210) arg) (Fmap_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                      Fmap_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -164,7 +164,7 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Fmap_0123456789876543210Sym1KindInference) ())
     type Fmap_0123456789876543210Sym2 :: (~>) a b -> T x a -> T x b
-    type family Fmap_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Fmap_0123456789876543210Sym2 (a0123456789876543210 :: (~>) a b) (a0123456789876543210 :: T x a) :: T x b where
       Fmap_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Fmap_0123456789876543210 a0123456789876543210 a0123456789876543210
     type family Lambda_0123456789876543210 _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 n_0123456789876543210 where
       Lambda_0123456789876543210 _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 n_0123456789876543210 = n_0123456789876543210
@@ -299,11 +299,11 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
     type family Lambda_0123456789876543210Sym3 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 n_01234567898765432100123456789876543210 where
       Lambda_0123456789876543210Sym3 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 n_01234567898765432100123456789876543210 = Lambda_0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 n_01234567898765432100123456789876543210
     type TFHelper_0123456789876543210 :: a -> T x b -> T x a
-    type family TFHelper_0123456789876543210 a a where
+    type family TFHelper_0123456789876543210 (a :: a) (a :: T x b) :: T x a where
       TFHelper_0123456789876543210 _z_0123456789876543210 (MkT1 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210) = Apply (Apply (Apply (Apply MkT1Sym0 (Apply (Apply (Apply (Apply (Apply (Apply Lambda_0123456789876543210Sym0 _z_0123456789876543210) a_0123456789876543210) a_0123456789876543210) a_0123456789876543210) a_0123456789876543210) a_0123456789876543210)) (Apply (Apply (Apply (Apply (Apply (Apply Lambda_0123456789876543210Sym0 _z_0123456789876543210) a_0123456789876543210) a_0123456789876543210) a_0123456789876543210) a_0123456789876543210) a_0123456789876543210)) (Apply (Apply (<$@#@$) _z_0123456789876543210) a_0123456789876543210)) (Apply (Apply FmapSym0 (Apply (<$@#@$) _z_0123456789876543210)) a_0123456789876543210)
       TFHelper_0123456789876543210 _z_0123456789876543210 (MkT2 a_0123456789876543210) = Apply MkT2Sym0 (Apply (Apply (Apply Lambda_0123456789876543210Sym0 _z_0123456789876543210) a_0123456789876543210) a_0123456789876543210)
     type TFHelper_0123456789876543210Sym0 :: (~>) a ((~>) (T x b) (T x a))
-    data TFHelper_0123456789876543210Sym0 a0123456789876543210
+    data TFHelper_0123456789876543210Sym0 :: (~>) a ((~>) (T x b) (T x a))
       where
         TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
                                                          TFHelper_0123456789876543210Sym0 a0123456789876543210
@@ -312,7 +312,7 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym0KindInference) ())
     type TFHelper_0123456789876543210Sym1 :: a -> (~>) (T x b) (T x a)
-    data TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: a) :: (~>) (T x b) (T x a)
       where
         TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                          TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -321,7 +321,7 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym1KindInference) ())
     type TFHelper_0123456789876543210Sym2 :: a -> T x b -> T x a
-    type family TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: T x b) :: T x a where
       TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PFunctor (T x) where
       type Fmap a a = Apply (Apply Fmap_0123456789876543210Sym0 a) a
@@ -407,11 +407,11 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
     type family Lambda_0123456789876543210Sym3 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 n_01234567898765432100123456789876543210 where
       Lambda_0123456789876543210Sym3 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 n_01234567898765432100123456789876543210 = Lambda_0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 n_01234567898765432100123456789876543210
     type FoldMap_0123456789876543210 :: (~>) a m -> T x a -> m
-    type family FoldMap_0123456789876543210 a a where
+    type family FoldMap_0123456789876543210 (a :: (~>) a m) (a :: T x a) :: m where
       FoldMap_0123456789876543210 _f_0123456789876543210 (MkT1 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210) = Apply (Apply MappendSym0 (Apply (Apply (Apply (Apply (Apply (Apply Lambda_0123456789876543210Sym0 _f_0123456789876543210) a_0123456789876543210) a_0123456789876543210) a_0123456789876543210) a_0123456789876543210) a_0123456789876543210)) (Apply (Apply MappendSym0 (Apply _f_0123456789876543210 a_0123456789876543210)) (Apply (Apply MappendSym0 (Apply (Apply FoldMapSym0 _f_0123456789876543210) a_0123456789876543210)) (Apply (Apply FoldMapSym0 (Apply FoldMapSym0 _f_0123456789876543210)) a_0123456789876543210)))
       FoldMap_0123456789876543210 _f_0123456789876543210 (MkT2 a_0123456789876543210) = Apply (Apply (Apply Lambda_0123456789876543210Sym0 _f_0123456789876543210) a_0123456789876543210) a_0123456789876543210
     type FoldMap_0123456789876543210Sym0 :: (~>) ((~>) a m) ((~>) (T x a) m)
-    data FoldMap_0123456789876543210Sym0 a0123456789876543210
+    data FoldMap_0123456789876543210Sym0 :: (~>) ((~>) a m) ((~>) (T x a) m)
       where
         FoldMap_0123456789876543210Sym0KindInference :: SameKind (Apply FoldMap_0123456789876543210Sym0 arg) (FoldMap_0123456789876543210Sym1 arg) =>
                                                         FoldMap_0123456789876543210Sym0 a0123456789876543210
@@ -420,7 +420,7 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) FoldMap_0123456789876543210Sym0KindInference) ())
     type FoldMap_0123456789876543210Sym1 :: (~>) a m -> (~>) (T x a) m
-    data FoldMap_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data FoldMap_0123456789876543210Sym1 (a0123456789876543210 :: (~>) a m) :: (~>) (T x a) m
       where
         FoldMap_0123456789876543210Sym1KindInference :: SameKind (Apply (FoldMap_0123456789876543210Sym1 a0123456789876543210) arg) (FoldMap_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                         FoldMap_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -429,7 +429,7 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) FoldMap_0123456789876543210Sym1KindInference) ())
     type FoldMap_0123456789876543210Sym2 :: (~>) a m -> T x a -> m
-    type family FoldMap_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family FoldMap_0123456789876543210Sym2 (a0123456789876543210 :: (~>) a m) (a0123456789876543210 :: T x a) :: m where
       FoldMap_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = FoldMap_0123456789876543210 a0123456789876543210 a0123456789876543210
     type family Lambda_0123456789876543210 _f_0123456789876543210 _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 n1_0123456789876543210 n2_0123456789876543210 where
       Lambda_0123456789876543210 _f_0123456789876543210 _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 n1_0123456789876543210 n2_0123456789876543210 = n2_0123456789876543210
@@ -765,11 +765,11 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
       Lambda_0123456789876543210Sym5 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 n1_01234567898765432100123456789876543210 n2_01234567898765432100123456789876543210 = Lambda_0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 n1_01234567898765432100123456789876543210 n2_01234567898765432100123456789876543210
     type Foldr_0123456789876543210 :: (~>) a ((~>) b b)
                                       -> b -> T x a -> b
-    type family Foldr_0123456789876543210 a a a where
+    type family Foldr_0123456789876543210 (a :: (~>) a ((~>) b b)) (a :: b) (a :: T x a) :: b where
       Foldr_0123456789876543210 _f_0123456789876543210 _z_0123456789876543210 (MkT1 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210) = Apply (Apply (Apply (Apply (Apply (Apply (Apply (Apply Lambda_0123456789876543210Sym0 _f_0123456789876543210) _z_0123456789876543210) a_0123456789876543210) a_0123456789876543210) a_0123456789876543210) a_0123456789876543210) a_0123456789876543210) (Apply (Apply _f_0123456789876543210 a_0123456789876543210) (Apply (Apply (Apply (Apply (Apply (Apply (Apply (Apply Lambda_0123456789876543210Sym0 _f_0123456789876543210) _z_0123456789876543210) a_0123456789876543210) a_0123456789876543210) a_0123456789876543210) a_0123456789876543210) a_0123456789876543210) (Apply (Apply (Apply (Apply (Apply (Apply (Apply (Apply Lambda_0123456789876543210Sym0 _f_0123456789876543210) _z_0123456789876543210) a_0123456789876543210) a_0123456789876543210) a_0123456789876543210) a_0123456789876543210) a_0123456789876543210) _z_0123456789876543210)))
       Foldr_0123456789876543210 _f_0123456789876543210 _z_0123456789876543210 (MkT2 a_0123456789876543210) = Apply (Apply (Apply (Apply (Apply Lambda_0123456789876543210Sym0 _f_0123456789876543210) _z_0123456789876543210) a_0123456789876543210) a_0123456789876543210) _z_0123456789876543210
     type Foldr_0123456789876543210Sym0 :: (~>) ((~>) a ((~>) b b)) ((~>) b ((~>) (T x a) b))
-    data Foldr_0123456789876543210Sym0 a0123456789876543210
+    data Foldr_0123456789876543210Sym0 :: (~>) ((~>) a ((~>) b b)) ((~>) b ((~>) (T x a) b))
       where
         Foldr_0123456789876543210Sym0KindInference :: SameKind (Apply Foldr_0123456789876543210Sym0 arg) (Foldr_0123456789876543210Sym1 arg) =>
                                                       Foldr_0123456789876543210Sym0 a0123456789876543210
@@ -779,7 +779,7 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) Foldr_0123456789876543210Sym0KindInference) ())
     type Foldr_0123456789876543210Sym1 :: (~>) a ((~>) b b)
                                           -> (~>) b ((~>) (T x a) b)
-    data Foldr_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Foldr_0123456789876543210Sym1 (a0123456789876543210 :: (~>) a ((~>) b b)) :: (~>) b ((~>) (T x a) b)
       where
         Foldr_0123456789876543210Sym1KindInference :: SameKind (Apply (Foldr_0123456789876543210Sym1 a0123456789876543210) arg) (Foldr_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                       Foldr_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -789,7 +789,7 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) Foldr_0123456789876543210Sym1KindInference) ())
     type Foldr_0123456789876543210Sym2 :: (~>) a ((~>) b b)
                                           -> b -> (~>) (T x a) b
-    data Foldr_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data Foldr_0123456789876543210Sym2 (a0123456789876543210 :: (~>) a ((~>) b b)) (a0123456789876543210 :: b) :: (~>) (T x a) b
       where
         Foldr_0123456789876543210Sym2KindInference :: SameKind (Apply (Foldr_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (Foldr_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
                                                       Foldr_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -799,18 +799,18 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) Foldr_0123456789876543210Sym2KindInference) ())
     type Foldr_0123456789876543210Sym3 :: (~>) a ((~>) b b)
                                           -> b -> T x a -> b
-    type family Foldr_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family Foldr_0123456789876543210Sym3 (a0123456789876543210 :: (~>) a ((~>) b b)) (a0123456789876543210 :: b) (a0123456789876543210 :: T x a) :: b where
       Foldr_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = Foldr_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PFoldable (T x) where
       type FoldMap a a = Apply (Apply FoldMap_0123456789876543210Sym0 a) a
       type Foldr a a a = Apply (Apply (Apply Foldr_0123456789876543210Sym0 a) a) a
     type Traverse_0123456789876543210 :: (~>) a (f b)
                                          -> T x a -> f (T x b)
-    type family Traverse_0123456789876543210 a a where
+    type family Traverse_0123456789876543210 (a :: (~>) a (f b)) (a :: T x a) :: f (T x b) where
       Traverse_0123456789876543210 _f_0123456789876543210 (MkT1 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210) = Apply (Apply (<*>@#@$) (Apply (Apply (<*>@#@$) (Apply (Apply (Apply LiftA2Sym0 MkT1Sym0) (Apply PureSym0 a_0123456789876543210)) (Apply _f_0123456789876543210 a_0123456789876543210))) (Apply (Apply TraverseSym0 _f_0123456789876543210) a_0123456789876543210))) (Apply (Apply TraverseSym0 (Apply TraverseSym0 _f_0123456789876543210)) a_0123456789876543210)
       Traverse_0123456789876543210 _f_0123456789876543210 (MkT2 a_0123456789876543210) = Apply (Apply FmapSym0 MkT2Sym0) (Apply PureSym0 a_0123456789876543210)
     type Traverse_0123456789876543210Sym0 :: (~>) ((~>) a (f b)) ((~>) (T x a) (f (T x b)))
-    data Traverse_0123456789876543210Sym0 a0123456789876543210
+    data Traverse_0123456789876543210Sym0 :: (~>) ((~>) a (f b)) ((~>) (T x a) (f (T x b)))
       where
         Traverse_0123456789876543210Sym0KindInference :: SameKind (Apply Traverse_0123456789876543210Sym0 arg) (Traverse_0123456789876543210Sym1 arg) =>
                                                          Traverse_0123456789876543210Sym0 a0123456789876543210
@@ -820,7 +820,7 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) Traverse_0123456789876543210Sym0KindInference) ())
     type Traverse_0123456789876543210Sym1 :: (~>) a (f b)
                                              -> (~>) (T x a) (f (T x b))
-    data Traverse_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Traverse_0123456789876543210Sym1 (a0123456789876543210 :: (~>) a (f b)) :: (~>) (T x a) (f (T x b))
       where
         Traverse_0123456789876543210Sym1KindInference :: SameKind (Apply (Traverse_0123456789876543210Sym1 a0123456789876543210) arg) (Traverse_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                          Traverse_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -830,16 +830,16 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) Traverse_0123456789876543210Sym1KindInference) ())
     type Traverse_0123456789876543210Sym2 :: (~>) a (f b)
                                              -> T x a -> f (T x b)
-    type family Traverse_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Traverse_0123456789876543210Sym2 (a0123456789876543210 :: (~>) a (f b)) (a0123456789876543210 :: T x a) :: f (T x b) where
       Traverse_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Traverse_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PTraversable (T x) where
       type Traverse a a = Apply (Apply Traverse_0123456789876543210Sym0 a) a
     type family Case_0123456789876543210 v_0123456789876543210 t where
     type Fmap_0123456789876543210 :: (~>) a b -> Empty a -> Empty b
-    type family Fmap_0123456789876543210 a a where
+    type family Fmap_0123456789876543210 (a :: (~>) a b) (a :: Empty a) :: Empty b where
       Fmap_0123456789876543210 _ v_0123456789876543210 = Case_0123456789876543210 v_0123456789876543210 v_0123456789876543210
     type Fmap_0123456789876543210Sym0 :: (~>) ((~>) a b) ((~>) (Empty a) (Empty b))
-    data Fmap_0123456789876543210Sym0 a0123456789876543210
+    data Fmap_0123456789876543210Sym0 :: (~>) ((~>) a b) ((~>) (Empty a) (Empty b))
       where
         Fmap_0123456789876543210Sym0KindInference :: SameKind (Apply Fmap_0123456789876543210Sym0 arg) (Fmap_0123456789876543210Sym1 arg) =>
                                                      Fmap_0123456789876543210Sym0 a0123456789876543210
@@ -849,7 +849,7 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) Fmap_0123456789876543210Sym0KindInference) ())
     type Fmap_0123456789876543210Sym1 :: (~>) a b
                                          -> (~>) (Empty a) (Empty b)
-    data Fmap_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Fmap_0123456789876543210Sym1 (a0123456789876543210 :: (~>) a b) :: (~>) (Empty a) (Empty b)
       where
         Fmap_0123456789876543210Sym1KindInference :: SameKind (Apply (Fmap_0123456789876543210Sym1 a0123456789876543210) arg) (Fmap_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                      Fmap_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -858,14 +858,14 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Fmap_0123456789876543210Sym1KindInference) ())
     type Fmap_0123456789876543210Sym2 :: (~>) a b -> Empty a -> Empty b
-    type family Fmap_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Fmap_0123456789876543210Sym2 (a0123456789876543210 :: (~>) a b) (a0123456789876543210 :: Empty a) :: Empty b where
       Fmap_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Fmap_0123456789876543210 a0123456789876543210 a0123456789876543210
     type family Case_0123456789876543210 v_0123456789876543210 t where
     type TFHelper_0123456789876543210 :: a -> Empty b -> Empty a
-    type family TFHelper_0123456789876543210 a a where
+    type family TFHelper_0123456789876543210 (a :: a) (a :: Empty b) :: Empty a where
       TFHelper_0123456789876543210 _ v_0123456789876543210 = Case_0123456789876543210 v_0123456789876543210 v_0123456789876543210
     type TFHelper_0123456789876543210Sym0 :: (~>) a ((~>) (Empty b) (Empty a))
-    data TFHelper_0123456789876543210Sym0 a0123456789876543210
+    data TFHelper_0123456789876543210Sym0 :: (~>) a ((~>) (Empty b) (Empty a))
       where
         TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
                                                          TFHelper_0123456789876543210Sym0 a0123456789876543210
@@ -875,7 +875,7 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) TFHelper_0123456789876543210Sym0KindInference) ())
     type TFHelper_0123456789876543210Sym1 :: a
                                              -> (~>) (Empty b) (Empty a)
-    data TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: a) :: (~>) (Empty b) (Empty a)
       where
         TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                          TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -884,16 +884,16 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym1KindInference) ())
     type TFHelper_0123456789876543210Sym2 :: a -> Empty b -> Empty a
-    type family TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: Empty b) :: Empty a where
       TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PFunctor Empty where
       type Fmap a a = Apply (Apply Fmap_0123456789876543210Sym0 a) a
       type (<$) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
     type FoldMap_0123456789876543210 :: (~>) a m -> Empty a -> m
-    type family FoldMap_0123456789876543210 a a where
+    type family FoldMap_0123456789876543210 (a :: (~>) a m) (a :: Empty a) :: m where
       FoldMap_0123456789876543210 _ _ = MemptySym0
     type FoldMap_0123456789876543210Sym0 :: (~>) ((~>) a m) ((~>) (Empty a) m)
-    data FoldMap_0123456789876543210Sym0 a0123456789876543210
+    data FoldMap_0123456789876543210Sym0 :: (~>) ((~>) a m) ((~>) (Empty a) m)
       where
         FoldMap_0123456789876543210Sym0KindInference :: SameKind (Apply FoldMap_0123456789876543210Sym0 arg) (FoldMap_0123456789876543210Sym1 arg) =>
                                                         FoldMap_0123456789876543210Sym0 a0123456789876543210
@@ -903,7 +903,7 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) FoldMap_0123456789876543210Sym0KindInference) ())
     type FoldMap_0123456789876543210Sym1 :: (~>) a m
                                             -> (~>) (Empty a) m
-    data FoldMap_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data FoldMap_0123456789876543210Sym1 (a0123456789876543210 :: (~>) a m) :: (~>) (Empty a) m
       where
         FoldMap_0123456789876543210Sym1KindInference :: SameKind (Apply (FoldMap_0123456789876543210Sym1 a0123456789876543210) arg) (FoldMap_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                         FoldMap_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -912,17 +912,17 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) FoldMap_0123456789876543210Sym1KindInference) ())
     type FoldMap_0123456789876543210Sym2 :: (~>) a m -> Empty a -> m
-    type family FoldMap_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family FoldMap_0123456789876543210Sym2 (a0123456789876543210 :: (~>) a m) (a0123456789876543210 :: Empty a) :: m where
       FoldMap_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = FoldMap_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PFoldable Empty where
       type FoldMap a a = Apply (Apply FoldMap_0123456789876543210Sym0 a) a
     type family Case_0123456789876543210 v_0123456789876543210 t where
     type Traverse_0123456789876543210 :: (~>) a (f b)
                                          -> Empty a -> f (Empty b)
-    type family Traverse_0123456789876543210 a a where
+    type family Traverse_0123456789876543210 (a :: (~>) a (f b)) (a :: Empty a) :: f (Empty b) where
       Traverse_0123456789876543210 _ v_0123456789876543210 = Apply PureSym0 (Case_0123456789876543210 v_0123456789876543210 v_0123456789876543210)
     type Traverse_0123456789876543210Sym0 :: (~>) ((~>) a (f b)) ((~>) (Empty a) (f (Empty b)))
-    data Traverse_0123456789876543210Sym0 a0123456789876543210
+    data Traverse_0123456789876543210Sym0 :: (~>) ((~>) a (f b)) ((~>) (Empty a) (f (Empty b)))
       where
         Traverse_0123456789876543210Sym0KindInference :: SameKind (Apply Traverse_0123456789876543210Sym0 arg) (Traverse_0123456789876543210Sym1 arg) =>
                                                          Traverse_0123456789876543210Sym0 a0123456789876543210
@@ -932,7 +932,7 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) Traverse_0123456789876543210Sym0KindInference) ())
     type Traverse_0123456789876543210Sym1 :: (~>) a (f b)
                                              -> (~>) (Empty a) (f (Empty b))
-    data Traverse_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Traverse_0123456789876543210Sym1 (a0123456789876543210 :: (~>) a (f b)) :: (~>) (Empty a) (f (Empty b))
       where
         Traverse_0123456789876543210Sym1KindInference :: SameKind (Apply (Traverse_0123456789876543210Sym1 a0123456789876543210) arg) (Traverse_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                          Traverse_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -942,7 +942,7 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) Traverse_0123456789876543210Sym1KindInference) ())
     type Traverse_0123456789876543210Sym2 :: (~>) a (f b)
                                              -> Empty a -> f (Empty b)
-    type family Traverse_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Traverse_0123456789876543210Sym2 (a0123456789876543210 :: (~>) a (f b)) (a0123456789876543210 :: Empty a) :: f (Empty b) where
       Traverse_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Traverse_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PTraversable Empty where
       type Traverse a a = Apply (Apply Traverse_0123456789876543210Sym0 a) a

--- a/singletons-base/tests/compile-and-dump/Singletons/HigherOrder.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/HigherOrder.golden
@@ -41,7 +41,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     etad :: [Nat] -> [Bool] -> [Nat]
     etad = zipWith (\ n b -> if b then Succ (Succ n) else n)
     type LeftSym0 :: forall a b. (~>) a (Either a b)
-    data LeftSym0 a0123456789876543210
+    data LeftSym0 :: (~>) a (Either a b)
       where
         LeftSym0KindInference :: SameKind (Apply LeftSym0 arg) (LeftSym1 arg) =>
                                  LeftSym0 a0123456789876543210
@@ -49,10 +49,10 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings LeftSym0 where
       suppressUnusedWarnings = snd (((,) LeftSym0KindInference) ())
     type LeftSym1 :: forall a b. a -> Either a b
-    type family LeftSym1 a0123456789876543210 where
+    type family LeftSym1 (a0123456789876543210 :: a) :: Either a b where
       LeftSym1 a0123456789876543210 = Left a0123456789876543210
     type RightSym0 :: forall a b. (~>) b (Either a b)
-    data RightSym0 a0123456789876543210
+    data RightSym0 :: (~>) b (Either a b)
       where
         RightSym0KindInference :: SameKind (Apply RightSym0 arg) (RightSym1 arg) =>
                                   RightSym0 a0123456789876543210
@@ -60,7 +60,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings RightSym0 where
       suppressUnusedWarnings = snd (((,) RightSym0KindInference) ())
     type RightSym1 :: forall a b. b -> Either a b
-    type family RightSym1 a0123456789876543210 where
+    type family RightSym1 (a0123456789876543210 :: b) :: Either a b where
       RightSym1 a0123456789876543210 = Right a0123456789876543210
     type family Case_0123456789876543210 n b a_0123456789876543210 a_0123456789876543210 t where
       Case_0123456789876543210 n b a_0123456789876543210 a_0123456789876543210 'True = Apply SuccSym0 (Apply SuccSym0 n)
@@ -141,7 +141,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     type family Lambda_0123456789876543210Sym4 ns0123456789876543210 bs0123456789876543210 n0123456789876543210 b0123456789876543210 where
       Lambda_0123456789876543210Sym4 ns0123456789876543210 bs0123456789876543210 n0123456789876543210 b0123456789876543210 = Lambda_0123456789876543210 ns0123456789876543210 bs0123456789876543210 n0123456789876543210 b0123456789876543210
     type EtadSym0 :: (~>) [Nat] ((~>) [Bool] [Nat])
-    data EtadSym0 a0123456789876543210
+    data EtadSym0 :: (~>) [Nat] ((~>) [Bool] [Nat])
       where
         EtadSym0KindInference :: SameKind (Apply EtadSym0 arg) (EtadSym1 arg) =>
                                  EtadSym0 a0123456789876543210
@@ -149,7 +149,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings EtadSym0 where
       suppressUnusedWarnings = snd (((,) EtadSym0KindInference) ())
     type EtadSym1 :: [Nat] -> (~>) [Bool] [Nat]
-    data EtadSym1 a0123456789876543210 a0123456789876543210
+    data EtadSym1 (a0123456789876543210 :: [Nat]) :: (~>) [Bool] [Nat]
       where
         EtadSym1KindInference :: SameKind (Apply (EtadSym1 a0123456789876543210) arg) (EtadSym2 a0123456789876543210 arg) =>
                                  EtadSym1 a0123456789876543210 a0123456789876543210
@@ -157,10 +157,10 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (EtadSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) EtadSym1KindInference) ())
     type EtadSym2 :: [Nat] -> [Bool] -> [Nat]
-    type family EtadSym2 a0123456789876543210 a0123456789876543210 where
+    type family EtadSym2 (a0123456789876543210 :: [Nat]) (a0123456789876543210 :: [Bool]) :: [Nat] where
       EtadSym2 a0123456789876543210 a0123456789876543210 = Etad a0123456789876543210 a0123456789876543210
     type SplungeSym0 :: (~>) [Nat] ((~>) [Bool] [Nat])
-    data SplungeSym0 a0123456789876543210
+    data SplungeSym0 :: (~>) [Nat] ((~>) [Bool] [Nat])
       where
         SplungeSym0KindInference :: SameKind (Apply SplungeSym0 arg) (SplungeSym1 arg) =>
                                     SplungeSym0 a0123456789876543210
@@ -168,7 +168,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings SplungeSym0 where
       suppressUnusedWarnings = snd (((,) SplungeSym0KindInference) ())
     type SplungeSym1 :: [Nat] -> (~>) [Bool] [Nat]
-    data SplungeSym1 a0123456789876543210 a0123456789876543210
+    data SplungeSym1 (a0123456789876543210 :: [Nat]) :: (~>) [Bool] [Nat]
       where
         SplungeSym1KindInference :: SameKind (Apply (SplungeSym1 a0123456789876543210) arg) (SplungeSym2 a0123456789876543210 arg) =>
                                     SplungeSym1 a0123456789876543210 a0123456789876543210
@@ -176,10 +176,10 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (SplungeSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) SplungeSym1KindInference) ())
     type SplungeSym2 :: [Nat] -> [Bool] -> [Nat]
-    type family SplungeSym2 a0123456789876543210 a0123456789876543210 where
+    type family SplungeSym2 (a0123456789876543210 :: [Nat]) (a0123456789876543210 :: [Bool]) :: [Nat] where
       SplungeSym2 a0123456789876543210 a0123456789876543210 = Splunge a0123456789876543210 a0123456789876543210
     type FooSym0 :: (~>) ((~>) ((~>) a b) ((~>) a b)) ((~>) ((~>) a b) ((~>) a b))
-    data FooSym0 a0123456789876543210
+    data FooSym0 :: (~>) ((~>) ((~>) a b) ((~>) a b)) ((~>) ((~>) a b) ((~>) a b))
       where
         FooSym0KindInference :: SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
                                 FooSym0 a0123456789876543210
@@ -188,7 +188,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) FooSym0KindInference) ())
     type FooSym1 :: (~>) ((~>) a b) ((~>) a b)
                     -> (~>) ((~>) a b) ((~>) a b)
-    data FooSym1 a0123456789876543210 a0123456789876543210
+    data FooSym1 (a0123456789876543210 :: (~>) ((~>) a b) ((~>) a b)) :: (~>) ((~>) a b) ((~>) a b)
       where
         FooSym1KindInference :: SameKind (Apply (FooSym1 a0123456789876543210) arg) (FooSym2 a0123456789876543210 arg) =>
                                 FooSym1 a0123456789876543210 a0123456789876543210
@@ -196,7 +196,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (FooSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) FooSym1KindInference) ())
     type FooSym2 :: (~>) ((~>) a b) ((~>) a b) -> (~>) a b -> (~>) a b
-    data FooSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data FooSym2 (a0123456789876543210 :: (~>) ((~>) a b) ((~>) a b)) (a0123456789876543210 :: (~>) a b) :: (~>) a b
       where
         FooSym2KindInference :: SameKind (Apply (FooSym2 a0123456789876543210 a0123456789876543210) arg) (FooSym3 a0123456789876543210 a0123456789876543210 arg) =>
                                 FooSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -204,10 +204,10 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (FooSym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) FooSym2KindInference) ())
     type FooSym3 :: (~>) ((~>) a b) ((~>) a b) -> (~>) a b -> a -> b
-    type family FooSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family FooSym3 (a0123456789876543210 :: (~>) ((~>) a b) ((~>) a b)) (a0123456789876543210 :: (~>) a b) (a0123456789876543210 :: a) :: b where
       FooSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = Foo a0123456789876543210 a0123456789876543210 a0123456789876543210
     type ZipWithSym0 :: (~>) ((~>) a ((~>) b c)) ((~>) [a] ((~>) [b] [c]))
-    data ZipWithSym0 a0123456789876543210
+    data ZipWithSym0 :: (~>) ((~>) a ((~>) b c)) ((~>) [a] ((~>) [b] [c]))
       where
         ZipWithSym0KindInference :: SameKind (Apply ZipWithSym0 arg) (ZipWithSym1 arg) =>
                                     ZipWithSym0 a0123456789876543210
@@ -215,7 +215,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ZipWithSym0 where
       suppressUnusedWarnings = snd (((,) ZipWithSym0KindInference) ())
     type ZipWithSym1 :: (~>) a ((~>) b c) -> (~>) [a] ((~>) [b] [c])
-    data ZipWithSym1 a0123456789876543210 a0123456789876543210
+    data ZipWithSym1 (a0123456789876543210 :: (~>) a ((~>) b c)) :: (~>) [a] ((~>) [b] [c])
       where
         ZipWithSym1KindInference :: SameKind (Apply (ZipWithSym1 a0123456789876543210) arg) (ZipWithSym2 a0123456789876543210 arg) =>
                                     ZipWithSym1 a0123456789876543210 a0123456789876543210
@@ -223,7 +223,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (ZipWithSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) ZipWithSym1KindInference) ())
     type ZipWithSym2 :: (~>) a ((~>) b c) -> [a] -> (~>) [b] [c]
-    data ZipWithSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data ZipWithSym2 (a0123456789876543210 :: (~>) a ((~>) b c)) (a0123456789876543210 :: [a]) :: (~>) [b] [c]
       where
         ZipWithSym2KindInference :: SameKind (Apply (ZipWithSym2 a0123456789876543210 a0123456789876543210) arg) (ZipWithSym3 a0123456789876543210 a0123456789876543210 arg) =>
                                     ZipWithSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -231,10 +231,10 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (ZipWithSym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) ZipWithSym2KindInference) ())
     type ZipWithSym3 :: (~>) a ((~>) b c) -> [a] -> [b] -> [c]
-    type family ZipWithSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family ZipWithSym3 (a0123456789876543210 :: (~>) a ((~>) b c)) (a0123456789876543210 :: [a]) (a0123456789876543210 :: [b]) :: [c] where
       ZipWithSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ZipWith a0123456789876543210 a0123456789876543210 a0123456789876543210
     type LiftMaybeSym0 :: (~>) ((~>) a b) ((~>) (Maybe a) (Maybe b))
-    data LiftMaybeSym0 a0123456789876543210
+    data LiftMaybeSym0 :: (~>) ((~>) a b) ((~>) (Maybe a) (Maybe b))
       where
         LiftMaybeSym0KindInference :: SameKind (Apply LiftMaybeSym0 arg) (LiftMaybeSym1 arg) =>
                                       LiftMaybeSym0 a0123456789876543210
@@ -242,7 +242,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings LiftMaybeSym0 where
       suppressUnusedWarnings = snd (((,) LiftMaybeSym0KindInference) ())
     type LiftMaybeSym1 :: (~>) a b -> (~>) (Maybe a) (Maybe b)
-    data LiftMaybeSym1 a0123456789876543210 a0123456789876543210
+    data LiftMaybeSym1 (a0123456789876543210 :: (~>) a b) :: (~>) (Maybe a) (Maybe b)
       where
         LiftMaybeSym1KindInference :: SameKind (Apply (LiftMaybeSym1 a0123456789876543210) arg) (LiftMaybeSym2 a0123456789876543210 arg) =>
                                       LiftMaybeSym1 a0123456789876543210 a0123456789876543210
@@ -250,10 +250,10 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (LiftMaybeSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) LiftMaybeSym1KindInference) ())
     type LiftMaybeSym2 :: (~>) a b -> Maybe a -> Maybe b
-    type family LiftMaybeSym2 a0123456789876543210 a0123456789876543210 where
+    type family LiftMaybeSym2 (a0123456789876543210 :: (~>) a b) (a0123456789876543210 :: Maybe a) :: Maybe b where
       LiftMaybeSym2 a0123456789876543210 a0123456789876543210 = LiftMaybe a0123456789876543210 a0123456789876543210
     type MapSym0 :: (~>) ((~>) a b) ((~>) [a] [b])
-    data MapSym0 a0123456789876543210
+    data MapSym0 :: (~>) ((~>) a b) ((~>) [a] [b])
       where
         MapSym0KindInference :: SameKind (Apply MapSym0 arg) (MapSym1 arg) =>
                                 MapSym0 a0123456789876543210
@@ -261,7 +261,7 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings MapSym0 where
       suppressUnusedWarnings = snd (((,) MapSym0KindInference) ())
     type MapSym1 :: (~>) a b -> (~>) [a] [b]
-    data MapSym1 a0123456789876543210 a0123456789876543210
+    data MapSym1 (a0123456789876543210 :: (~>) a b) :: (~>) [a] [b]
       where
         MapSym1KindInference :: SameKind (Apply (MapSym1 a0123456789876543210) arg) (MapSym2 a0123456789876543210 arg) =>
                                 MapSym1 a0123456789876543210 a0123456789876543210
@@ -269,29 +269,29 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (MapSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) MapSym1KindInference) ())
     type MapSym2 :: (~>) a b -> [a] -> [b]
-    type family MapSym2 a0123456789876543210 a0123456789876543210 where
+    type family MapSym2 (a0123456789876543210 :: (~>) a b) (a0123456789876543210 :: [a]) :: [b] where
       MapSym2 a0123456789876543210 a0123456789876543210 = Map a0123456789876543210 a0123456789876543210
     type Etad :: [Nat] -> [Bool] -> [Nat]
-    type family Etad a a where
+    type family Etad (a :: [Nat]) (a :: [Bool]) :: [Nat] where
       Etad a_0123456789876543210 a_0123456789876543210 = Apply (Apply (Apply ZipWithSym0 (Apply (Apply Lambda_0123456789876543210Sym0 a_0123456789876543210) a_0123456789876543210)) a_0123456789876543210) a_0123456789876543210
     type Splunge :: [Nat] -> [Bool] -> [Nat]
-    type family Splunge a a where
+    type family Splunge (a :: [Nat]) (a :: [Bool]) :: [Nat] where
       Splunge ns bs = Apply (Apply (Apply ZipWithSym0 (Apply (Apply Lambda_0123456789876543210Sym0 ns) bs)) ns) bs
     type Foo :: (~>) ((~>) a b) ((~>) a b) -> (~>) a b -> a -> b
-    type family Foo a a a where
+    type family Foo (a :: (~>) ((~>) a b) ((~>) a b)) (a :: (~>) a b) (a :: a) :: b where
       Foo f g a = Apply (Apply f g) a
     type ZipWith :: (~>) a ((~>) b c) -> [a] -> [b] -> [c]
-    type family ZipWith a a a where
+    type family ZipWith (a :: (~>) a ((~>) b c)) (a :: [a]) (a :: [b]) :: [c] where
       ZipWith f ('(:) x xs) ('(:) y ys) = Apply (Apply (:@#@$) (Apply (Apply f x) y)) (Apply (Apply (Apply ZipWithSym0 f) xs) ys)
       ZipWith _ '[] '[] = NilSym0
       ZipWith _ ('(:) _ _) '[] = NilSym0
       ZipWith _ '[] ('(:) _ _) = NilSym0
     type LiftMaybe :: (~>) a b -> Maybe a -> Maybe b
-    type family LiftMaybe a a where
+    type family LiftMaybe (a :: (~>) a b) (a :: Maybe a) :: Maybe b where
       LiftMaybe f ('Just x) = Apply JustSym0 (Apply f x)
       LiftMaybe _ 'Nothing = NothingSym0
     type Map :: (~>) a b -> [a] -> [b]
-    type family Map a a where
+    type family Map (a :: (~>) a b) (a :: [a]) :: [b] where
       Map _ '[] = NilSym0
       Map f ('(:) h t) = Apply (Apply (:@#@$) (Apply f h)) (Apply (Apply MapSym0 f) t)
     sEtad ::

--- a/singletons-base/tests/compile-and-dump/Singletons/LambdaCase.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/LambdaCase.golden
@@ -114,7 +114,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
     type family Lambda_0123456789876543210Sym3 d0123456789876543210 x0123456789876543210 x_01234567898765432100123456789876543210 where
       Lambda_0123456789876543210Sym3 d0123456789876543210 x0123456789876543210 x_01234567898765432100123456789876543210 = Lambda_0123456789876543210 d0123456789876543210 x0123456789876543210 x_01234567898765432100123456789876543210
     type Foo3Sym0 :: (~>) a ((~>) b a)
-    data Foo3Sym0 a0123456789876543210
+    data Foo3Sym0 :: (~>) a ((~>) b a)
       where
         Foo3Sym0KindInference :: SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
                                  Foo3Sym0 a0123456789876543210
@@ -122,7 +122,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo3Sym0 where
       suppressUnusedWarnings = snd (((,) Foo3Sym0KindInference) ())
     type Foo3Sym1 :: a -> (~>) b a
-    data Foo3Sym1 a0123456789876543210 a0123456789876543210
+    data Foo3Sym1 (a0123456789876543210 :: a) :: (~>) b a
       where
         Foo3Sym1KindInference :: SameKind (Apply (Foo3Sym1 a0123456789876543210) arg) (Foo3Sym2 a0123456789876543210 arg) =>
                                  Foo3Sym1 a0123456789876543210 a0123456789876543210
@@ -130,10 +130,10 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (Foo3Sym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) Foo3Sym1KindInference) ())
     type Foo3Sym2 :: a -> b -> a
-    type family Foo3Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Foo3Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: a where
       Foo3Sym2 a0123456789876543210 a0123456789876543210 = Foo3 a0123456789876543210 a0123456789876543210
     type Foo2Sym0 :: (~>) a ((~>) (Maybe a) a)
-    data Foo2Sym0 a0123456789876543210
+    data Foo2Sym0 :: (~>) a ((~>) (Maybe a) a)
       where
         Foo2Sym0KindInference :: SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) =>
                                  Foo2Sym0 a0123456789876543210
@@ -141,7 +141,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo2Sym0 where
       suppressUnusedWarnings = snd (((,) Foo2Sym0KindInference) ())
     type Foo2Sym1 :: a -> (~>) (Maybe a) a
-    data Foo2Sym1 a0123456789876543210 a0123456789876543210
+    data Foo2Sym1 (a0123456789876543210 :: a) :: (~>) (Maybe a) a
       where
         Foo2Sym1KindInference :: SameKind (Apply (Foo2Sym1 a0123456789876543210) arg) (Foo2Sym2 a0123456789876543210 arg) =>
                                  Foo2Sym1 a0123456789876543210 a0123456789876543210
@@ -149,10 +149,10 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (Foo2Sym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) Foo2Sym1KindInference) ())
     type Foo2Sym2 :: a -> Maybe a -> a
-    type family Foo2Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Foo2Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: Maybe a) :: a where
       Foo2Sym2 a0123456789876543210 a0123456789876543210 = Foo2 a0123456789876543210 a0123456789876543210
     type Foo1Sym0 :: (~>) a ((~>) (Maybe a) a)
-    data Foo1Sym0 a0123456789876543210
+    data Foo1Sym0 :: (~>) a ((~>) (Maybe a) a)
       where
         Foo1Sym0KindInference :: SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
                                  Foo1Sym0 a0123456789876543210
@@ -160,7 +160,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo1Sym0 where
       suppressUnusedWarnings = snd (((,) Foo1Sym0KindInference) ())
     type Foo1Sym1 :: a -> (~>) (Maybe a) a
-    data Foo1Sym1 a0123456789876543210 a0123456789876543210
+    data Foo1Sym1 (a0123456789876543210 :: a) :: (~>) (Maybe a) a
       where
         Foo1Sym1KindInference :: SameKind (Apply (Foo1Sym1 a0123456789876543210) arg) (Foo1Sym2 a0123456789876543210 arg) =>
                                  Foo1Sym1 a0123456789876543210 a0123456789876543210
@@ -168,16 +168,16 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (Foo1Sym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) Foo1Sym1KindInference) ())
     type Foo1Sym2 :: a -> Maybe a -> a
-    type family Foo1Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Foo1Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: Maybe a) :: a where
       Foo1Sym2 a0123456789876543210 a0123456789876543210 = Foo1 a0123456789876543210 a0123456789876543210
     type Foo3 :: a -> b -> a
-    type family Foo3 a a where
+    type family Foo3 (a :: a) (a :: b) :: a where
       Foo3 a b = Apply (Apply (Apply Lambda_0123456789876543210Sym0 a) b) (Apply (Apply Tuple2Sym0 a) b)
     type Foo2 :: a -> Maybe a -> a
-    type family Foo2 a a where
+    type family Foo2 (a :: a) (a :: Maybe a) :: a where
       Foo2 d _ = Apply (Apply Lambda_0123456789876543210Sym0 d) (Apply JustSym0 d)
     type Foo1 :: a -> Maybe a -> a
-    type family Foo1 a a where
+    type family Foo1 (a :: a) (a :: Maybe a) :: a where
       Foo1 d x = Apply (Apply (Apply Lambda_0123456789876543210Sym0 d) x) x
     sFoo3 ::
       forall a b (t :: a) (t :: b).

--- a/singletons-base/tests/compile-and-dump/Singletons/Lambdas.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Lambdas.golden
@@ -41,7 +41,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     foo8 :: Foo a b -> a
     foo8 x = (\ (Foo a _) -> a) x
     type FooSym0 :: forall a b. (~>) a ((~>) b (Foo a b))
-    data FooSym0 a0123456789876543210
+    data FooSym0 :: (~>) a ((~>) b (Foo a b))
       where
         FooSym0KindInference :: SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
                                 FooSym0 a0123456789876543210
@@ -49,7 +49,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings = snd (((,) FooSym0KindInference) ())
     type FooSym1 :: forall a b. a -> (~>) b (Foo a b)
-    data FooSym1 a0123456789876543210 a0123456789876543210
+    data FooSym1 (a0123456789876543210 :: a) :: (~>) b (Foo a b)
       where
         FooSym1KindInference :: SameKind (Apply (FooSym1 a0123456789876543210) arg) (FooSym2 a0123456789876543210 arg) =>
                                 FooSym1 a0123456789876543210 a0123456789876543210
@@ -57,7 +57,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (FooSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) FooSym1KindInference) ())
     type FooSym2 :: forall a b. a -> b -> Foo a b
-    type family FooSym2 a0123456789876543210 a0123456789876543210 where
+    type family FooSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: Foo a b where
       FooSym2 a0123456789876543210 a0123456789876543210 = Foo a0123456789876543210 a0123456789876543210
     type family Case_0123456789876543210 arg_0123456789876543210 x t where
       Case_0123456789876543210 arg_0123456789876543210 x (Foo a _) = a
@@ -369,7 +369,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     type family Lambda_0123456789876543210Sym4 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 x0123456789876543210 y0123456789876543210 where
       Lambda_0123456789876543210Sym4 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 x0123456789876543210 y0123456789876543210 = Lambda_0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 x0123456789876543210 y0123456789876543210
     type Foo8Sym0 :: (~>) (Foo a b) a
-    data Foo8Sym0 a0123456789876543210
+    data Foo8Sym0 :: (~>) (Foo a b) a
       where
         Foo8Sym0KindInference :: SameKind (Apply Foo8Sym0 arg) (Foo8Sym1 arg) =>
                                  Foo8Sym0 a0123456789876543210
@@ -377,10 +377,10 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo8Sym0 where
       suppressUnusedWarnings = snd (((,) Foo8Sym0KindInference) ())
     type Foo8Sym1 :: Foo a b -> a
-    type family Foo8Sym1 a0123456789876543210 where
+    type family Foo8Sym1 (a0123456789876543210 :: Foo a b) :: a where
       Foo8Sym1 a0123456789876543210 = Foo8 a0123456789876543210
     type Foo7Sym0 :: (~>) a ((~>) b b)
-    data Foo7Sym0 a0123456789876543210
+    data Foo7Sym0 :: (~>) a ((~>) b b)
       where
         Foo7Sym0KindInference :: SameKind (Apply Foo7Sym0 arg) (Foo7Sym1 arg) =>
                                  Foo7Sym0 a0123456789876543210
@@ -388,7 +388,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo7Sym0 where
       suppressUnusedWarnings = snd (((,) Foo7Sym0KindInference) ())
     type Foo7Sym1 :: a -> (~>) b b
-    data Foo7Sym1 a0123456789876543210 a0123456789876543210
+    data Foo7Sym1 (a0123456789876543210 :: a) :: (~>) b b
       where
         Foo7Sym1KindInference :: SameKind (Apply (Foo7Sym1 a0123456789876543210) arg) (Foo7Sym2 a0123456789876543210 arg) =>
                                  Foo7Sym1 a0123456789876543210 a0123456789876543210
@@ -396,10 +396,10 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (Foo7Sym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) Foo7Sym1KindInference) ())
     type Foo7Sym2 :: a -> b -> b
-    type family Foo7Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Foo7Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: b where
       Foo7Sym2 a0123456789876543210 a0123456789876543210 = Foo7 a0123456789876543210 a0123456789876543210
     type Foo6Sym0 :: (~>) a ((~>) b a)
-    data Foo6Sym0 a0123456789876543210
+    data Foo6Sym0 :: (~>) a ((~>) b a)
       where
         Foo6Sym0KindInference :: SameKind (Apply Foo6Sym0 arg) (Foo6Sym1 arg) =>
                                  Foo6Sym0 a0123456789876543210
@@ -407,7 +407,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo6Sym0 where
       suppressUnusedWarnings = snd (((,) Foo6Sym0KindInference) ())
     type Foo6Sym1 :: a -> (~>) b a
-    data Foo6Sym1 a0123456789876543210 a0123456789876543210
+    data Foo6Sym1 (a0123456789876543210 :: a) :: (~>) b a
       where
         Foo6Sym1KindInference :: SameKind (Apply (Foo6Sym1 a0123456789876543210) arg) (Foo6Sym2 a0123456789876543210 arg) =>
                                  Foo6Sym1 a0123456789876543210 a0123456789876543210
@@ -415,10 +415,10 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (Foo6Sym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) Foo6Sym1KindInference) ())
     type Foo6Sym2 :: a -> b -> a
-    type family Foo6Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Foo6Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: a where
       Foo6Sym2 a0123456789876543210 a0123456789876543210 = Foo6 a0123456789876543210 a0123456789876543210
     type Foo5Sym0 :: (~>) a ((~>) b b)
-    data Foo5Sym0 a0123456789876543210
+    data Foo5Sym0 :: (~>) a ((~>) b b)
       where
         Foo5Sym0KindInference :: SameKind (Apply Foo5Sym0 arg) (Foo5Sym1 arg) =>
                                  Foo5Sym0 a0123456789876543210
@@ -426,7 +426,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo5Sym0 where
       suppressUnusedWarnings = snd (((,) Foo5Sym0KindInference) ())
     type Foo5Sym1 :: a -> (~>) b b
-    data Foo5Sym1 a0123456789876543210 a0123456789876543210
+    data Foo5Sym1 (a0123456789876543210 :: a) :: (~>) b b
       where
         Foo5Sym1KindInference :: SameKind (Apply (Foo5Sym1 a0123456789876543210) arg) (Foo5Sym2 a0123456789876543210 arg) =>
                                  Foo5Sym1 a0123456789876543210 a0123456789876543210
@@ -434,10 +434,10 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (Foo5Sym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) Foo5Sym1KindInference) ())
     type Foo5Sym2 :: a -> b -> b
-    type family Foo5Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Foo5Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: b where
       Foo5Sym2 a0123456789876543210 a0123456789876543210 = Foo5 a0123456789876543210 a0123456789876543210
     type Foo4Sym0 :: (~>) a ((~>) b ((~>) c a))
-    data Foo4Sym0 a0123456789876543210
+    data Foo4Sym0 :: (~>) a ((~>) b ((~>) c a))
       where
         Foo4Sym0KindInference :: SameKind (Apply Foo4Sym0 arg) (Foo4Sym1 arg) =>
                                  Foo4Sym0 a0123456789876543210
@@ -445,7 +445,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo4Sym0 where
       suppressUnusedWarnings = snd (((,) Foo4Sym0KindInference) ())
     type Foo4Sym1 :: a -> (~>) b ((~>) c a)
-    data Foo4Sym1 a0123456789876543210 a0123456789876543210
+    data Foo4Sym1 (a0123456789876543210 :: a) :: (~>) b ((~>) c a)
       where
         Foo4Sym1KindInference :: SameKind (Apply (Foo4Sym1 a0123456789876543210) arg) (Foo4Sym2 a0123456789876543210 arg) =>
                                  Foo4Sym1 a0123456789876543210 a0123456789876543210
@@ -453,7 +453,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (Foo4Sym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) Foo4Sym1KindInference) ())
     type Foo4Sym2 :: a -> b -> (~>) c a
-    data Foo4Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data Foo4Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: (~>) c a
       where
         Foo4Sym2KindInference :: SameKind (Apply (Foo4Sym2 a0123456789876543210 a0123456789876543210) arg) (Foo4Sym3 a0123456789876543210 a0123456789876543210 arg) =>
                                  Foo4Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -461,10 +461,10 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (Foo4Sym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) Foo4Sym2KindInference) ())
     type Foo4Sym3 :: a -> b -> c -> a
-    type family Foo4Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family Foo4Sym3 (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: c) :: a where
       Foo4Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = Foo4 a0123456789876543210 a0123456789876543210 a0123456789876543210
     type Foo3Sym0 :: (~>) a a
-    data Foo3Sym0 a0123456789876543210
+    data Foo3Sym0 :: (~>) a a
       where
         Foo3Sym0KindInference :: SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
                                  Foo3Sym0 a0123456789876543210
@@ -472,10 +472,10 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo3Sym0 where
       suppressUnusedWarnings = snd (((,) Foo3Sym0KindInference) ())
     type Foo3Sym1 :: a -> a
-    type family Foo3Sym1 a0123456789876543210 where
+    type family Foo3Sym1 (a0123456789876543210 :: a) :: a where
       Foo3Sym1 a0123456789876543210 = Foo3 a0123456789876543210
     type Foo2Sym0 :: (~>) a ((~>) b a)
-    data Foo2Sym0 a0123456789876543210
+    data Foo2Sym0 :: (~>) a ((~>) b a)
       where
         Foo2Sym0KindInference :: SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) =>
                                  Foo2Sym0 a0123456789876543210
@@ -483,7 +483,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo2Sym0 where
       suppressUnusedWarnings = snd (((,) Foo2Sym0KindInference) ())
     type Foo2Sym1 :: a -> (~>) b a
-    data Foo2Sym1 a0123456789876543210 a0123456789876543210
+    data Foo2Sym1 (a0123456789876543210 :: a) :: (~>) b a
       where
         Foo2Sym1KindInference :: SameKind (Apply (Foo2Sym1 a0123456789876543210) arg) (Foo2Sym2 a0123456789876543210 arg) =>
                                  Foo2Sym1 a0123456789876543210 a0123456789876543210
@@ -491,10 +491,10 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (Foo2Sym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) Foo2Sym1KindInference) ())
     type Foo2Sym2 :: a -> b -> a
-    type family Foo2Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Foo2Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: a where
       Foo2Sym2 a0123456789876543210 a0123456789876543210 = Foo2 a0123456789876543210 a0123456789876543210
     type Foo1Sym0 :: (~>) a ((~>) b a)
-    data Foo1Sym0 a0123456789876543210
+    data Foo1Sym0 :: (~>) a ((~>) b a)
       where
         Foo1Sym0KindInference :: SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
                                  Foo1Sym0 a0123456789876543210
@@ -502,7 +502,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo1Sym0 where
       suppressUnusedWarnings = snd (((,) Foo1Sym0KindInference) ())
     type Foo1Sym1 :: a -> (~>) b a
-    data Foo1Sym1 a0123456789876543210 a0123456789876543210
+    data Foo1Sym1 (a0123456789876543210 :: a) :: (~>) b a
       where
         Foo1Sym1KindInference :: SameKind (Apply (Foo1Sym1 a0123456789876543210) arg) (Foo1Sym2 a0123456789876543210 arg) =>
                                  Foo1Sym1 a0123456789876543210 a0123456789876543210
@@ -510,10 +510,10 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (Foo1Sym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) Foo1Sym1KindInference) ())
     type Foo1Sym2 :: a -> b -> a
-    type family Foo1Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Foo1Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: a where
       Foo1Sym2 a0123456789876543210 a0123456789876543210 = Foo1 a0123456789876543210 a0123456789876543210
     type Foo0Sym0 :: (~>) a ((~>) b a)
-    data Foo0Sym0 a0123456789876543210
+    data Foo0Sym0 :: (~>) a ((~>) b a)
       where
         Foo0Sym0KindInference :: SameKind (Apply Foo0Sym0 arg) (Foo0Sym1 arg) =>
                                  Foo0Sym0 a0123456789876543210
@@ -521,7 +521,7 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo0Sym0 where
       suppressUnusedWarnings = snd (((,) Foo0Sym0KindInference) ())
     type Foo0Sym1 :: a -> (~>) b a
-    data Foo0Sym1 a0123456789876543210 a0123456789876543210
+    data Foo0Sym1 (a0123456789876543210 :: a) :: (~>) b a
       where
         Foo0Sym1KindInference :: SameKind (Apply (Foo0Sym1 a0123456789876543210) arg) (Foo0Sym2 a0123456789876543210 arg) =>
                                  Foo0Sym1 a0123456789876543210 a0123456789876543210
@@ -529,34 +529,34 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (Foo0Sym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) Foo0Sym1KindInference) ())
     type Foo0Sym2 :: a -> b -> a
-    type family Foo0Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Foo0Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: a where
       Foo0Sym2 a0123456789876543210 a0123456789876543210 = Foo0 a0123456789876543210 a0123456789876543210
     type Foo8 :: Foo a b -> a
-    type family Foo8 a where
+    type family Foo8 (a :: Foo a b) :: a where
       Foo8 x = Apply (Apply Lambda_0123456789876543210Sym0 x) x
     type Foo7 :: a -> b -> b
-    type family Foo7 a a where
+    type family Foo7 (a :: a) (a :: b) :: b where
       Foo7 x y = Apply (Apply (Apply Lambda_0123456789876543210Sym0 x) y) (Apply (Apply Tuple2Sym0 x) y)
     type Foo6 :: a -> b -> a
-    type family Foo6 a a where
+    type family Foo6 (a :: a) (a :: b) :: a where
       Foo6 a b = Apply (Apply (Apply (Apply Lambda_0123456789876543210Sym0 a) b) a) b
     type Foo5 :: a -> b -> b
-    type family Foo5 a a where
+    type family Foo5 (a :: a) (a :: b) :: b where
       Foo5 x y = Apply (Apply (Apply Lambda_0123456789876543210Sym0 x) y) y
     type Foo4 :: a -> b -> c -> a
-    type family Foo4 a a a where
+    type family Foo4 (a :: a) (a :: b) (a :: c) :: a where
       Foo4 x y z = Apply (Apply (Apply (Apply (Apply Lambda_0123456789876543210Sym0 x) y) z) y) z
     type Foo3 :: a -> a
-    type family Foo3 a where
+    type family Foo3 (a :: a) :: a where
       Foo3 x = Apply (Apply Lambda_0123456789876543210Sym0 x) x
     type Foo2 :: a -> b -> a
-    type family Foo2 a a where
+    type family Foo2 (a :: a) (a :: b) :: a where
       Foo2 x y = Apply (Apply (Apply Lambda_0123456789876543210Sym0 x) y) y
     type Foo1 :: a -> b -> a
-    type family Foo1 a a where
+    type family Foo1 (a :: a) (a :: b) :: a where
       Foo1 x a_0123456789876543210 = Apply (Apply (Apply Lambda_0123456789876543210Sym0 x) a_0123456789876543210) a_0123456789876543210
     type Foo0 :: a -> b -> a
-    type family Foo0 a a where
+    type family Foo0 (a :: a) (a :: b) :: a where
       Foo0 a_0123456789876543210 a_0123456789876543210 = Apply (Apply (Apply (Apply Lambda_0123456789876543210Sym0 a_0123456789876543210) a_0123456789876543210) a_0123456789876543210) a_0123456789876543210
     sFoo8 ::
       forall a b (t :: Foo a b). Sing t -> Sing (Apply Foo8Sym0 t :: a)

--- a/singletons-base/tests/compile-and-dump/Singletons/LambdasComprehensive.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/LambdasComprehensive.golden
@@ -25,16 +25,16 @@ Singletons/LambdasComprehensive.hs:(0,0)-(0,0): Splicing declarations
     type family Lambda_0123456789876543210Sym1 x0123456789876543210 where
       Lambda_0123456789876543210Sym1 x0123456789876543210 = Lambda_0123456789876543210 x0123456789876543210
     type BarSym0 :: [Nat]
-    type family BarSym0 where
+    type family BarSym0 :: [Nat] where
       BarSym0 = Bar
     type FooSym0 :: [Nat]
-    type family FooSym0 where
+    type family FooSym0 :: [Nat] where
       FooSym0 = Foo
     type Bar :: [Nat]
-    type family Bar where
+    type family Bar :: [Nat] where
       Bar = Apply (Apply MapSym0 (Apply (Apply Either_Sym0 PredSym0) SuccSym0)) (Apply (Apply (:@#@$) (Apply LeftSym0 ZeroSym0)) (Apply (Apply (:@#@$) (Apply RightSym0 (Apply SuccSym0 ZeroSym0))) NilSym0))
     type Foo :: [Nat]
-    type family Foo where
+    type family Foo :: [Nat] where
       Foo = Apply (Apply MapSym0 Lambda_0123456789876543210Sym0) (Apply (Apply (:@#@$) (Apply LeftSym0 ZeroSym0)) (Apply (Apply (:@#@$) (Apply RightSym0 (Apply SuccSym0 ZeroSym0))) NilSym0))
     sBar :: Sing (BarSym0 :: [Nat])
     sFoo :: Sing (FooSym0 :: [Nat])

--- a/singletons-base/tests/compile-and-dump/Singletons/LetStatements.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/LetStatements.golden
@@ -561,7 +561,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type family Let0123456789876543210Y x :: Nat where
       Let0123456789876543210Y x = Apply SuccSym0 ZeroSym0
     type Foo14Sym0 :: (~>) Nat (Nat, Nat)
-    data Foo14Sym0 a0123456789876543210
+    data Foo14Sym0 :: (~>) Nat (Nat, Nat)
       where
         Foo14Sym0KindInference :: SameKind (Apply Foo14Sym0 arg) (Foo14Sym1 arg) =>
                                   Foo14Sym0 a0123456789876543210
@@ -569,10 +569,11 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo14Sym0 where
       suppressUnusedWarnings = snd (((,) Foo14Sym0KindInference) ())
     type Foo14Sym1 :: Nat -> (Nat, Nat)
-    type family Foo14Sym1 a0123456789876543210 where
+    type family Foo14Sym1 (a0123456789876543210 :: Nat) :: (Nat,
+                                                            Nat) where
       Foo14Sym1 a0123456789876543210 = Foo14 a0123456789876543210
     type Foo13_Sym0 :: (~>) a a
-    data Foo13_Sym0 a0123456789876543210
+    data Foo13_Sym0 :: (~>) a a
       where
         Foo13_Sym0KindInference :: SameKind (Apply Foo13_Sym0 arg) (Foo13_Sym1 arg) =>
                                    Foo13_Sym0 a0123456789876543210
@@ -580,10 +581,10 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo13_Sym0 where
       suppressUnusedWarnings = snd (((,) Foo13_Sym0KindInference) ())
     type Foo13_Sym1 :: a -> a
-    type family Foo13_Sym1 a0123456789876543210 where
+    type family Foo13_Sym1 (a0123456789876543210 :: a) :: a where
       Foo13_Sym1 a0123456789876543210 = Foo13_ a0123456789876543210
     type Foo13Sym0 :: forall a. (~>) a a
-    data Foo13Sym0 a0123456789876543210
+    data Foo13Sym0 :: (~>) a a
       where
         Foo13Sym0KindInference :: SameKind (Apply Foo13Sym0 arg) (Foo13Sym1 arg) =>
                                   Foo13Sym0 a0123456789876543210
@@ -591,10 +592,10 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo13Sym0 where
       suppressUnusedWarnings = snd (((,) Foo13Sym0KindInference) ())
     type Foo13Sym1 :: forall a. a -> a
-    type family Foo13Sym1 a0123456789876543210 where
+    type family Foo13Sym1 (a0123456789876543210 :: a) :: a where
       Foo13Sym1 a0123456789876543210 = Foo13 a0123456789876543210
     type Foo12Sym0 :: (~>) Nat Nat
-    data Foo12Sym0 a0123456789876543210
+    data Foo12Sym0 :: (~>) Nat Nat
       where
         Foo12Sym0KindInference :: SameKind (Apply Foo12Sym0 arg) (Foo12Sym1 arg) =>
                                   Foo12Sym0 a0123456789876543210
@@ -602,10 +603,10 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo12Sym0 where
       suppressUnusedWarnings = snd (((,) Foo12Sym0KindInference) ())
     type Foo12Sym1 :: Nat -> Nat
-    type family Foo12Sym1 a0123456789876543210 where
+    type family Foo12Sym1 (a0123456789876543210 :: Nat) :: Nat where
       Foo12Sym1 a0123456789876543210 = Foo12 a0123456789876543210
     type Foo11Sym0 :: (~>) Nat Nat
-    data Foo11Sym0 a0123456789876543210
+    data Foo11Sym0 :: (~>) Nat Nat
       where
         Foo11Sym0KindInference :: SameKind (Apply Foo11Sym0 arg) (Foo11Sym1 arg) =>
                                   Foo11Sym0 a0123456789876543210
@@ -613,10 +614,10 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo11Sym0 where
       suppressUnusedWarnings = snd (((,) Foo11Sym0KindInference) ())
     type Foo11Sym1 :: Nat -> Nat
-    type family Foo11Sym1 a0123456789876543210 where
+    type family Foo11Sym1 (a0123456789876543210 :: Nat) :: Nat where
       Foo11Sym1 a0123456789876543210 = Foo11 a0123456789876543210
     type Foo10Sym0 :: (~>) Nat Nat
-    data Foo10Sym0 a0123456789876543210
+    data Foo10Sym0 :: (~>) Nat Nat
       where
         Foo10Sym0KindInference :: SameKind (Apply Foo10Sym0 arg) (Foo10Sym1 arg) =>
                                   Foo10Sym0 a0123456789876543210
@@ -624,10 +625,10 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo10Sym0 where
       suppressUnusedWarnings = snd (((,) Foo10Sym0KindInference) ())
     type Foo10Sym1 :: Nat -> Nat
-    type family Foo10Sym1 a0123456789876543210 where
+    type family Foo10Sym1 (a0123456789876543210 :: Nat) :: Nat where
       Foo10Sym1 a0123456789876543210 = Foo10 a0123456789876543210
     type Foo9Sym0 :: (~>) Nat Nat
-    data Foo9Sym0 a0123456789876543210
+    data Foo9Sym0 :: (~>) Nat Nat
       where
         Foo9Sym0KindInference :: SameKind (Apply Foo9Sym0 arg) (Foo9Sym1 arg) =>
                                  Foo9Sym0 a0123456789876543210
@@ -635,10 +636,10 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo9Sym0 where
       suppressUnusedWarnings = snd (((,) Foo9Sym0KindInference) ())
     type Foo9Sym1 :: Nat -> Nat
-    type family Foo9Sym1 a0123456789876543210 where
+    type family Foo9Sym1 (a0123456789876543210 :: Nat) :: Nat where
       Foo9Sym1 a0123456789876543210 = Foo9 a0123456789876543210
     type Foo8Sym0 :: (~>) Nat Nat
-    data Foo8Sym0 a0123456789876543210
+    data Foo8Sym0 :: (~>) Nat Nat
       where
         Foo8Sym0KindInference :: SameKind (Apply Foo8Sym0 arg) (Foo8Sym1 arg) =>
                                  Foo8Sym0 a0123456789876543210
@@ -646,10 +647,10 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo8Sym0 where
       suppressUnusedWarnings = snd (((,) Foo8Sym0KindInference) ())
     type Foo8Sym1 :: Nat -> Nat
-    type family Foo8Sym1 a0123456789876543210 where
+    type family Foo8Sym1 (a0123456789876543210 :: Nat) :: Nat where
       Foo8Sym1 a0123456789876543210 = Foo8 a0123456789876543210
     type Foo7Sym0 :: (~>) Nat Nat
-    data Foo7Sym0 a0123456789876543210
+    data Foo7Sym0 :: (~>) Nat Nat
       where
         Foo7Sym0KindInference :: SameKind (Apply Foo7Sym0 arg) (Foo7Sym1 arg) =>
                                  Foo7Sym0 a0123456789876543210
@@ -657,10 +658,10 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo7Sym0 where
       suppressUnusedWarnings = snd (((,) Foo7Sym0KindInference) ())
     type Foo7Sym1 :: Nat -> Nat
-    type family Foo7Sym1 a0123456789876543210 where
+    type family Foo7Sym1 (a0123456789876543210 :: Nat) :: Nat where
       Foo7Sym1 a0123456789876543210 = Foo7 a0123456789876543210
     type Foo6Sym0 :: (~>) Nat Nat
-    data Foo6Sym0 a0123456789876543210
+    data Foo6Sym0 :: (~>) Nat Nat
       where
         Foo6Sym0KindInference :: SameKind (Apply Foo6Sym0 arg) (Foo6Sym1 arg) =>
                                  Foo6Sym0 a0123456789876543210
@@ -668,10 +669,10 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo6Sym0 where
       suppressUnusedWarnings = snd (((,) Foo6Sym0KindInference) ())
     type Foo6Sym1 :: Nat -> Nat
-    type family Foo6Sym1 a0123456789876543210 where
+    type family Foo6Sym1 (a0123456789876543210 :: Nat) :: Nat where
       Foo6Sym1 a0123456789876543210 = Foo6 a0123456789876543210
     type Foo5Sym0 :: (~>) Nat Nat
-    data Foo5Sym0 a0123456789876543210
+    data Foo5Sym0 :: (~>) Nat Nat
       where
         Foo5Sym0KindInference :: SameKind (Apply Foo5Sym0 arg) (Foo5Sym1 arg) =>
                                  Foo5Sym0 a0123456789876543210
@@ -679,10 +680,10 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo5Sym0 where
       suppressUnusedWarnings = snd (((,) Foo5Sym0KindInference) ())
     type Foo5Sym1 :: Nat -> Nat
-    type family Foo5Sym1 a0123456789876543210 where
+    type family Foo5Sym1 (a0123456789876543210 :: Nat) :: Nat where
       Foo5Sym1 a0123456789876543210 = Foo5 a0123456789876543210
     type Foo4Sym0 :: (~>) Nat Nat
-    data Foo4Sym0 a0123456789876543210
+    data Foo4Sym0 :: (~>) Nat Nat
       where
         Foo4Sym0KindInference :: SameKind (Apply Foo4Sym0 arg) (Foo4Sym1 arg) =>
                                  Foo4Sym0 a0123456789876543210
@@ -690,10 +691,10 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo4Sym0 where
       suppressUnusedWarnings = snd (((,) Foo4Sym0KindInference) ())
     type Foo4Sym1 :: Nat -> Nat
-    type family Foo4Sym1 a0123456789876543210 where
+    type family Foo4Sym1 (a0123456789876543210 :: Nat) :: Nat where
       Foo4Sym1 a0123456789876543210 = Foo4 a0123456789876543210
     type Foo3Sym0 :: (~>) Nat Nat
-    data Foo3Sym0 a0123456789876543210
+    data Foo3Sym0 :: (~>) Nat Nat
       where
         Foo3Sym0KindInference :: SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
                                  Foo3Sym0 a0123456789876543210
@@ -701,13 +702,13 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo3Sym0 where
       suppressUnusedWarnings = snd (((,) Foo3Sym0KindInference) ())
     type Foo3Sym1 :: Nat -> Nat
-    type family Foo3Sym1 a0123456789876543210 where
+    type family Foo3Sym1 (a0123456789876543210 :: Nat) :: Nat where
       Foo3Sym1 a0123456789876543210 = Foo3 a0123456789876543210
     type Foo2Sym0 :: Nat
-    type family Foo2Sym0 where
+    type family Foo2Sym0 :: Nat where
       Foo2Sym0 = Foo2
     type Foo1Sym0 :: (~>) Nat Nat
-    data Foo1Sym0 a0123456789876543210
+    data Foo1Sym0 :: (~>) Nat Nat
       where
         Foo1Sym0KindInference :: SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
                                  Foo1Sym0 a0123456789876543210
@@ -715,52 +716,52 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo1Sym0 where
       suppressUnusedWarnings = snd (((,) Foo1Sym0KindInference) ())
     type Foo1Sym1 :: Nat -> Nat
-    type family Foo1Sym1 a0123456789876543210 where
+    type family Foo1Sym1 (a0123456789876543210 :: Nat) :: Nat where
       Foo1Sym1 a0123456789876543210 = Foo1 a0123456789876543210
     type Foo14 :: Nat -> (Nat, Nat)
-    type family Foo14 a where
+    type family Foo14 (a :: Nat) :: (Nat, Nat) where
       Foo14 x = Apply (Apply Tuple2Sym0 (Let0123456789876543210ZSym1 x)) (Let0123456789876543210YSym1 x)
     type Foo13_ :: a -> a
-    type family Foo13_ a where
+    type family Foo13_ (a :: a) :: a where
       Foo13_ y = y
     type Foo13 :: forall a. a -> a
-    type family Foo13 a where
+    type family Foo13 (a :: a) :: a where
       Foo13 x = Apply Foo13_Sym0 (Let0123456789876543210BarSym1 x)
     type Foo12 :: Nat -> Nat
-    type family Foo12 a where
+    type family Foo12 (a :: Nat) :: Nat where
       Foo12 x = Apply (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x) x) (Apply SuccSym0 (Apply SuccSym0 ZeroSym0))
     type Foo11 :: Nat -> Nat
-    type family Foo11 a where
+    type family Foo11 (a :: Nat) :: Nat where
       Foo11 x = Apply (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x) (Apply SuccSym0 ZeroSym0)) (Let0123456789876543210ZSym1 x)
     type Foo10 :: Nat -> Nat
-    type family Foo10 a where
+    type family Foo10 (a :: Nat) :: Nat where
       Foo10 x = Apply (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x) (Apply SuccSym0 ZeroSym0)) x
     type Foo9 :: Nat -> Nat
-    type family Foo9 a where
+    type family Foo9 (a :: Nat) :: Nat where
       Foo9 x = Apply (Let0123456789876543210ZSym1 x) x
     type Foo8 :: Nat -> Nat
-    type family Foo8 a where
+    type family Foo8 (a :: Nat) :: Nat where
       Foo8 x = Let0123456789876543210ZSym1 x
     type Foo7 :: Nat -> Nat
-    type family Foo7 a where
+    type family Foo7 (a :: Nat) :: Nat where
       Foo7 x = Let0123456789876543210XSym1 x
     type Foo6 :: Nat -> Nat
-    type family Foo6 a where
+    type family Foo6 (a :: Nat) :: Nat where
       Foo6 x = Let0123456789876543210ZSym1 x
     type Foo5 :: Nat -> Nat
-    type family Foo5 a where
+    type family Foo5 (a :: Nat) :: Nat where
       Foo5 x = Apply (Let0123456789876543210FSym1 x) x
     type Foo4 :: Nat -> Nat
-    type family Foo4 a where
+    type family Foo4 (a :: Nat) :: Nat where
       Foo4 x = Apply (Let0123456789876543210FSym1 x) x
     type Foo3 :: Nat -> Nat
-    type family Foo3 a where
+    type family Foo3 (a :: Nat) :: Nat where
       Foo3 x = Let0123456789876543210YSym1 x
     type Foo2 :: Nat
-    type family Foo2 where
+    type family Foo2 :: Nat where
       Foo2 = Let0123456789876543210ZSym0
     type Foo1 :: Nat -> Nat
-    type family Foo1 a where
+    type family Foo1 (a :: Nat) :: Nat where
       Foo1 x = Let0123456789876543210YSym1 x
     sFoo14 ::
       forall (t :: Nat). Sing t -> Sing (Apply Foo14Sym0 t :: (Nat, Nat))

--- a/singletons-base/tests/compile-and-dump/Singletons/Maybe.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Maybe.golden
@@ -8,10 +8,10 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
       = Nothing | Just a
       deriving (Eq, Show)
     type NothingSym0 :: forall a. Maybe a
-    type family NothingSym0 where
+    type family NothingSym0 :: Maybe a where
       NothingSym0 = Nothing
     type JustSym0 :: forall a. (~>) a (Maybe a)
-    data JustSym0 a0123456789876543210
+    data JustSym0 :: (~>) a (Maybe a)
       where
         JustSym0KindInference :: SameKind (Apply JustSym0 arg) (JustSym1 arg) =>
                                  JustSym0 a0123456789876543210
@@ -19,16 +19,16 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings JustSym0 where
       suppressUnusedWarnings = snd (((,) JustSym0KindInference) ())
     type JustSym1 :: forall a. a -> Maybe a
-    type family JustSym1 a0123456789876543210 where
+    type family JustSym1 (a0123456789876543210 :: a) :: Maybe a where
       JustSym1 a0123456789876543210 = Just a0123456789876543210
     type TFHelper_0123456789876543210 :: Maybe a -> Maybe a -> Bool
-    type family TFHelper_0123456789876543210 a a where
+    type family TFHelper_0123456789876543210 (a :: Maybe a) (a :: Maybe a) :: Bool where
       TFHelper_0123456789876543210 Nothing Nothing = TrueSym0
       TFHelper_0123456789876543210 Nothing (Just _) = FalseSym0
       TFHelper_0123456789876543210 (Just _) Nothing = FalseSym0
       TFHelper_0123456789876543210 (Just a_0123456789876543210) (Just b_0123456789876543210) = Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210
     type TFHelper_0123456789876543210Sym0 :: (~>) (Maybe a) ((~>) (Maybe a) Bool)
-    data TFHelper_0123456789876543210Sym0 a0123456789876543210
+    data TFHelper_0123456789876543210Sym0 :: (~>) (Maybe a) ((~>) (Maybe a) Bool)
       where
         TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
                                                          TFHelper_0123456789876543210Sym0 a0123456789876543210
@@ -38,7 +38,7 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) TFHelper_0123456789876543210Sym0KindInference) ())
     type TFHelper_0123456789876543210Sym1 :: Maybe a
                                              -> (~>) (Maybe a) Bool
-    data TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Maybe a) :: (~>) (Maybe a) Bool
       where
         TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                          TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -47,17 +47,17 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym1KindInference) ())
     type TFHelper_0123456789876543210Sym2 :: Maybe a -> Maybe a -> Bool
-    type family TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: Maybe a) (a0123456789876543210 :: Maybe a) :: Bool where
       TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq (Maybe a) where
       type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
     type ShowsPrec_0123456789876543210 :: GHC.Types.Nat
                                           -> Maybe a -> GHC.Types.Symbol -> GHC.Types.Symbol
-    type family ShowsPrec_0123456789876543210 a a a where
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Maybe a) (a :: GHC.Types.Symbol) :: GHC.Types.Symbol where
       ShowsPrec_0123456789876543210 _ Nothing a_0123456789876543210 = Apply (Apply ShowStringSym0 "Nothing") a_0123456789876543210
       ShowsPrec_0123456789876543210 p_0123456789876543210 (Just arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Just ")) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
     type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) (Maybe a) ((~>) GHC.Types.Symbol GHC.Types.Symbol))
-    data ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) (Maybe a) ((~>) GHC.Types.Symbol GHC.Types.Symbol))
       where
         ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
                                                           ShowsPrec_0123456789876543210Sym0 a0123456789876543210
@@ -67,7 +67,7 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym0KindInference) ())
     type ShowsPrec_0123456789876543210Sym1 :: GHC.Types.Nat
                                               -> (~>) (Maybe a) ((~>) GHC.Types.Symbol GHC.Types.Symbol)
-    data ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: (~>) (Maybe a) ((~>) GHC.Types.Symbol GHC.Types.Symbol)
       where
         ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -77,7 +77,7 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym1KindInference) ())
     type ShowsPrec_0123456789876543210Sym2 :: GHC.Types.Nat
                                               -> Maybe a -> (~>) GHC.Types.Symbol GHC.Types.Symbol
-    data ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Maybe a) :: (~>) GHC.Types.Symbol GHC.Types.Symbol
       where
         ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -87,7 +87,7 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym2KindInference) ())
     type ShowsPrec_0123456789876543210Sym3 :: GHC.Types.Nat
                                               -> Maybe a -> GHC.Types.Symbol -> GHC.Types.Symbol
-    type family ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Maybe a) (a0123456789876543210 :: GHC.Types.Symbol) :: GHC.Types.Symbol where
       ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow (Maybe a) where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a

--- a/singletons-base/tests/compile-and-dump/Singletons/Nat.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Nat.golden
@@ -25,10 +25,10 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
     pred Zero = Zero
     pred (Succ n) = n
     type ZeroSym0 :: Nat
-    type family ZeroSym0 where
+    type family ZeroSym0 :: Nat where
       ZeroSym0 = Zero
     type SuccSym0 :: (~>) Nat Nat
-    data SuccSym0 a0123456789876543210
+    data SuccSym0 :: (~>) Nat Nat
       where
         SuccSym0KindInference :: SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
                                  SuccSym0 a0123456789876543210
@@ -36,10 +36,10 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings SuccSym0 where
       suppressUnusedWarnings = snd (((,) SuccSym0KindInference) ())
     type SuccSym1 :: Nat -> Nat
-    type family SuccSym1 a0123456789876543210 where
+    type family SuccSym1 (a0123456789876543210 :: Nat) :: Nat where
       SuccSym1 a0123456789876543210 = Succ a0123456789876543210
     type PredSym0 :: (~>) Nat Nat
-    data PredSym0 a0123456789876543210
+    data PredSym0 :: (~>) Nat Nat
       where
         PredSym0KindInference :: SameKind (Apply PredSym0 arg) (PredSym1 arg) =>
                                  PredSym0 a0123456789876543210
@@ -47,10 +47,10 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings PredSym0 where
       suppressUnusedWarnings = snd (((,) PredSym0KindInference) ())
     type PredSym1 :: Nat -> Nat
-    type family PredSym1 a0123456789876543210 where
+    type family PredSym1 (a0123456789876543210 :: Nat) :: Nat where
       PredSym1 a0123456789876543210 = Pred a0123456789876543210
     type PlusSym0 :: (~>) Nat ((~>) Nat Nat)
-    data PlusSym0 a0123456789876543210
+    data PlusSym0 :: (~>) Nat ((~>) Nat Nat)
       where
         PlusSym0KindInference :: SameKind (Apply PlusSym0 arg) (PlusSym1 arg) =>
                                  PlusSym0 a0123456789876543210
@@ -58,7 +58,7 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings PlusSym0 where
       suppressUnusedWarnings = snd (((,) PlusSym0KindInference) ())
     type PlusSym1 :: Nat -> (~>) Nat Nat
-    data PlusSym1 a0123456789876543210 a0123456789876543210
+    data PlusSym1 (a0123456789876543210 :: Nat) :: (~>) Nat Nat
       where
         PlusSym1KindInference :: SameKind (Apply (PlusSym1 a0123456789876543210) arg) (PlusSym2 a0123456789876543210 arg) =>
                                  PlusSym1 a0123456789876543210 a0123456789876543210
@@ -66,24 +66,24 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (PlusSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) PlusSym1KindInference) ())
     type PlusSym2 :: Nat -> Nat -> Nat
-    type family PlusSym2 a0123456789876543210 a0123456789876543210 where
+    type family PlusSym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Nat where
       PlusSym2 a0123456789876543210 a0123456789876543210 = Plus a0123456789876543210 a0123456789876543210
     type Pred :: Nat -> Nat
-    type family Pred a where
+    type family Pred (a :: Nat) :: Nat where
       Pred Zero = ZeroSym0
       Pred (Succ n) = n
     type Plus :: Nat -> Nat -> Nat
-    type family Plus a a where
+    type family Plus (a :: Nat) (a :: Nat) :: Nat where
       Plus Zero m = m
       Plus (Succ n) m = Apply SuccSym0 (Apply (Apply PlusSym0 n) m)
     type TFHelper_0123456789876543210 :: Nat -> Nat -> Bool
-    type family TFHelper_0123456789876543210 a a where
+    type family TFHelper_0123456789876543210 (a :: Nat) (a :: Nat) :: Bool where
       TFHelper_0123456789876543210 Zero Zero = TrueSym0
       TFHelper_0123456789876543210 Zero (Succ _) = FalseSym0
       TFHelper_0123456789876543210 (Succ _) Zero = FalseSym0
       TFHelper_0123456789876543210 (Succ a_0123456789876543210) (Succ b_0123456789876543210) = Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210
     type TFHelper_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Bool)
-    data TFHelper_0123456789876543210Sym0 a0123456789876543210
+    data TFHelper_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Bool)
       where
         TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
                                                          TFHelper_0123456789876543210Sym0 a0123456789876543210
@@ -92,7 +92,7 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym0KindInference) ())
     type TFHelper_0123456789876543210Sym1 :: Nat -> (~>) Nat Bool
-    data TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Nat) :: (~>) Nat Bool
       where
         TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                          TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -101,17 +101,17 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym1KindInference) ())
     type TFHelper_0123456789876543210Sym2 :: Nat -> Nat -> Bool
-    type family TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Bool where
       TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq Nat where
       type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
     type ShowsPrec_0123456789876543210 :: GHC.Types.Nat
                                           -> Nat -> GHC.Types.Symbol -> GHC.Types.Symbol
-    type family ShowsPrec_0123456789876543210 a a a where
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Nat) (a :: GHC.Types.Symbol) :: GHC.Types.Symbol where
       ShowsPrec_0123456789876543210 _ Zero a_0123456789876543210 = Apply (Apply ShowStringSym0 "Zero") a_0123456789876543210
       ShowsPrec_0123456789876543210 p_0123456789876543210 (Succ arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Succ ")) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
     type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) Nat ((~>) GHC.Types.Symbol GHC.Types.Symbol))
-    data ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) Nat ((~>) GHC.Types.Symbol GHC.Types.Symbol))
       where
         ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
                                                           ShowsPrec_0123456789876543210Sym0 a0123456789876543210
@@ -121,7 +121,7 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym0KindInference) ())
     type ShowsPrec_0123456789876543210Sym1 :: GHC.Types.Nat
                                               -> (~>) Nat ((~>) GHC.Types.Symbol GHC.Types.Symbol)
-    data ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: (~>) Nat ((~>) GHC.Types.Symbol GHC.Types.Symbol)
       where
         ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -131,7 +131,7 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym1KindInference) ())
     type ShowsPrec_0123456789876543210Sym2 :: GHC.Types.Nat
                                               -> Nat -> (~>) GHC.Types.Symbol GHC.Types.Symbol
-    data ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Nat) :: (~>) GHC.Types.Symbol GHC.Types.Symbol
       where
         ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -141,18 +141,18 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym2KindInference) ())
     type ShowsPrec_0123456789876543210Sym3 :: GHC.Types.Nat
                                               -> Nat -> GHC.Types.Symbol -> GHC.Types.Symbol
-    type family ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Nat) (a0123456789876543210 :: GHC.Types.Symbol) :: GHC.Types.Symbol where
       ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow Nat where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type Compare_0123456789876543210 :: Nat -> Nat -> Ordering
-    type family Compare_0123456789876543210 a a where
+    type family Compare_0123456789876543210 (a :: Nat) (a :: Nat) :: Ordering where
       Compare_0123456789876543210 Zero Zero = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) NilSym0
       Compare_0123456789876543210 (Succ a_0123456789876543210) (Succ b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0)
       Compare_0123456789876543210 Zero (Succ _) = LTSym0
       Compare_0123456789876543210 (Succ _) Zero = GTSym0
     type Compare_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Ordering)
-    data Compare_0123456789876543210Sym0 a0123456789876543210
+    data Compare_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Ordering)
       where
         Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
                                                         Compare_0123456789876543210Sym0 a0123456789876543210
@@ -161,7 +161,7 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Compare_0123456789876543210Sym0KindInference) ())
     type Compare_0123456789876543210Sym1 :: Nat -> (~>) Nat Ordering
-    data Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Nat) :: (~>) Nat Ordering
       where
         Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                         Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -170,7 +170,7 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Compare_0123456789876543210Sym1KindInference) ())
     type Compare_0123456789876543210Sym2 :: Nat -> Nat -> Ordering
-    type family Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Compare_0123456789876543210Sym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Ordering where
       Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd Nat where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a

--- a/singletons-base/tests/compile-and-dump/Singletons/NegativeLiterals.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/NegativeLiterals.golden
@@ -6,10 +6,10 @@ Singletons/NegativeLiterals.hs:(0,0)-(0,0): Splicing declarations
     f :: Nat
     f = (-1)
     type FSym0 :: Nat
-    type family FSym0 where
+    type family FSym0 :: Nat where
       FSym0 = F
     type F :: Nat
-    type family F where
+    type family F :: Nat where
       F = Negate (FromInteger 1)
     sF :: Sing (FSym0 :: Nat)
     sF = sNegate (sFromInteger (sing :: Sing 1))

--- a/singletons-base/tests/compile-and-dump/Singletons/Operators.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Operators.golden
@@ -23,10 +23,10 @@ Singletons/Operators.hs:(0,0)-(0,0): Splicing declarations
     (+) Zero m = m
     (+) (Succ n) m = Succ (n + m)
     type FLeafSym0 :: Foo
-    type family FLeafSym0 where
+    type family FLeafSym0 :: Foo where
       FLeafSym0 = FLeaf
     type (:+:@#@$) :: (~>) Foo ((~>) Foo Foo)
-    data (:+:@#@$) a0123456789876543210
+    data (:+:@#@$) :: (~>) Foo ((~>) Foo Foo)
       where
         (::+:@#@$###) :: SameKind (Apply (:+:@#@$) arg) ((:+:@#@$$) arg) =>
                          (:+:@#@$) a0123456789876543210
@@ -34,7 +34,7 @@ Singletons/Operators.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (:+:@#@$) where
       suppressUnusedWarnings = snd (((,) (::+:@#@$###)) ())
     type (:+:@#@$$) :: Foo -> (~>) Foo Foo
-    data (:+:@#@$$) a0123456789876543210 a0123456789876543210
+    data (:+:@#@$$) (a0123456789876543210 :: Foo) :: (~>) Foo Foo
       where
         (::+:@#@$$###) :: SameKind (Apply ((:+:@#@$$) a0123456789876543210) arg) ((:+:@#@$$$) a0123456789876543210 arg) =>
                           (:+:@#@$$) a0123456789876543210 a0123456789876543210
@@ -42,10 +42,10 @@ Singletons/Operators.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ((:+:@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) (::+:@#@$$###)) ())
     type (:+:@#@$$$) :: Foo -> Foo -> Foo
-    type family (:+:@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family (:+:@#@$$$) (a0123456789876543210 :: Foo) (a0123456789876543210 :: Foo) :: Foo where
       (:+:@#@$$$) a0123456789876543210 a0123456789876543210 = (:+:) a0123456789876543210 a0123456789876543210
     type (+@#@$) :: (~>) Nat ((~>) Nat Nat)
-    data (+@#@$) a0123456789876543210
+    data (+@#@$) :: (~>) Nat ((~>) Nat Nat)
       where
         (:+@#@$###) :: SameKind (Apply (+@#@$) arg) ((+@#@$$) arg) =>
                        (+@#@$) a0123456789876543210
@@ -53,7 +53,7 @@ Singletons/Operators.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (+@#@$) where
       suppressUnusedWarnings = snd (((,) (:+@#@$###)) ())
     type (+@#@$$) :: Nat -> (~>) Nat Nat
-    data (+@#@$$) a0123456789876543210 a0123456789876543210
+    data (+@#@$$) (a0123456789876543210 :: Nat) :: (~>) Nat Nat
       where
         (:+@#@$$###) :: SameKind (Apply ((+@#@$$) a0123456789876543210) arg) ((+@#@$$$) a0123456789876543210 arg) =>
                         (+@#@$$) a0123456789876543210 a0123456789876543210
@@ -61,10 +61,10 @@ Singletons/Operators.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ((+@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) (:+@#@$$###)) ())
     type (+@#@$$$) :: Nat -> Nat -> Nat
-    type family (+@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family (+@#@$$$) (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Nat where
       (+@#@$$$) a0123456789876543210 a0123456789876543210 = (+) a0123456789876543210 a0123456789876543210
     type ChildSym0 :: (~>) Foo Foo
-    data ChildSym0 a0123456789876543210
+    data ChildSym0 :: (~>) Foo Foo
       where
         ChildSym0KindInference :: SameKind (Apply ChildSym0 arg) (ChildSym1 arg) =>
                                   ChildSym0 a0123456789876543210
@@ -72,14 +72,14 @@ Singletons/Operators.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ChildSym0 where
       suppressUnusedWarnings = snd (((,) ChildSym0KindInference) ())
     type ChildSym1 :: Foo -> Foo
-    type family ChildSym1 a0123456789876543210 where
+    type family ChildSym1 (a0123456789876543210 :: Foo) :: Foo where
       ChildSym1 a0123456789876543210 = Child a0123456789876543210
     type (+) :: Nat -> Nat -> Nat
-    type family (+) a a where
+    type family (+) (a :: Nat) (a :: Nat) :: Nat where
       (+) 'Zero m = m
       (+) ('Succ n) m = Apply SuccSym0 (Apply (Apply (+@#@$) n) m)
     type Child :: Foo -> Foo
-    type family Child a where
+    type family Child (a :: Foo) :: Foo where
       Child FLeaf = FLeafSym0
       Child ((:+:) a _) = a
     (%+) ::

--- a/singletons-base/tests/compile-and-dump/Singletons/OrdDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/OrdDeriving.golden
@@ -24,10 +24,10 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         F a b c d
       deriving (Eq, Ord)
     type ZeroSym0 :: Nat
-    type family ZeroSym0 where
+    type family ZeroSym0 :: Nat where
       ZeroSym0 = Zero
     type SuccSym0 :: (~>) Nat Nat
-    data SuccSym0 a0123456789876543210
+    data SuccSym0 :: (~>) Nat Nat
       where
         SuccSym0KindInference :: SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
                                  SuccSym0 a0123456789876543210
@@ -35,11 +35,11 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings SuccSym0 where
       suppressUnusedWarnings = snd (((,) SuccSym0KindInference) ())
     type SuccSym1 :: Nat -> Nat
-    type family SuccSym1 a0123456789876543210 where
+    type family SuccSym1 (a0123456789876543210 :: Nat) :: Nat where
       SuccSym1 a0123456789876543210 = Succ a0123456789876543210
     type ASym0 :: forall a b c d.
                   (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))
-    data ASym0 a0123456789876543210
+    data ASym0 :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))
       where
         ASym0KindInference :: SameKind (Apply ASym0 arg) (ASym1 arg) =>
                               ASym0 a0123456789876543210
@@ -48,7 +48,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) ASym0KindInference) ())
     type ASym1 :: forall a b c d.
                   a -> (~>) b ((~>) c ((~>) d (Foo a b c d)))
-    data ASym1 a0123456789876543210 a0123456789876543210
+    data ASym1 (a0123456789876543210 :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))
       where
         ASym1KindInference :: SameKind (Apply (ASym1 a0123456789876543210) arg) (ASym2 a0123456789876543210 arg) =>
                               ASym1 a0123456789876543210 a0123456789876543210
@@ -57,7 +57,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) ASym1KindInference) ())
     type ASym2 :: forall a b c d.
                   a -> b -> (~>) c ((~>) d (Foo a b c d))
-    data ASym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data ASym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: (~>) c ((~>) d (Foo a b c d))
       where
         ASym2KindInference :: SameKind (Apply (ASym2 a0123456789876543210 a0123456789876543210) arg) (ASym3 a0123456789876543210 a0123456789876543210 arg) =>
                               ASym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -65,7 +65,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (ASym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) ASym2KindInference) ())
     type ASym3 :: forall a b c d. a -> b -> c -> (~>) d (Foo a b c d)
-    data ASym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data ASym3 (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: c) :: (~>) d (Foo a b c d)
       where
         ASym3KindInference :: SameKind (Apply (ASym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) arg) (ASym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 arg) =>
                               ASym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -73,11 +73,11 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (ASym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) ASym3KindInference) ())
     type ASym4 :: forall a b c d. a -> b -> c -> d -> Foo a b c d
-    type family ASym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family ASym4 (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: c) (a0123456789876543210 :: d) :: Foo a b c d where
       ASym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 = A a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     type BSym0 :: forall a b c d.
                   (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))
-    data BSym0 a0123456789876543210
+    data BSym0 :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))
       where
         BSym0KindInference :: SameKind (Apply BSym0 arg) (BSym1 arg) =>
                               BSym0 a0123456789876543210
@@ -86,7 +86,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) BSym0KindInference) ())
     type BSym1 :: forall a b c d.
                   a -> (~>) b ((~>) c ((~>) d (Foo a b c d)))
-    data BSym1 a0123456789876543210 a0123456789876543210
+    data BSym1 (a0123456789876543210 :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))
       where
         BSym1KindInference :: SameKind (Apply (BSym1 a0123456789876543210) arg) (BSym2 a0123456789876543210 arg) =>
                               BSym1 a0123456789876543210 a0123456789876543210
@@ -95,7 +95,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) BSym1KindInference) ())
     type BSym2 :: forall a b c d.
                   a -> b -> (~>) c ((~>) d (Foo a b c d))
-    data BSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data BSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: (~>) c ((~>) d (Foo a b c d))
       where
         BSym2KindInference :: SameKind (Apply (BSym2 a0123456789876543210 a0123456789876543210) arg) (BSym3 a0123456789876543210 a0123456789876543210 arg) =>
                               BSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -103,7 +103,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (BSym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) BSym2KindInference) ())
     type BSym3 :: forall a b c d. a -> b -> c -> (~>) d (Foo a b c d)
-    data BSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data BSym3 (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: c) :: (~>) d (Foo a b c d)
       where
         BSym3KindInference :: SameKind (Apply (BSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) arg) (BSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 arg) =>
                               BSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -111,11 +111,11 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (BSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) BSym3KindInference) ())
     type BSym4 :: forall a b c d. a -> b -> c -> d -> Foo a b c d
-    type family BSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family BSym4 (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: c) (a0123456789876543210 :: d) :: Foo a b c d where
       BSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 = B a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     type CSym0 :: forall a b c d.
                   (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))
-    data CSym0 a0123456789876543210
+    data CSym0 :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))
       where
         CSym0KindInference :: SameKind (Apply CSym0 arg) (CSym1 arg) =>
                               CSym0 a0123456789876543210
@@ -124,7 +124,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) CSym0KindInference) ())
     type CSym1 :: forall a b c d.
                   a -> (~>) b ((~>) c ((~>) d (Foo a b c d)))
-    data CSym1 a0123456789876543210 a0123456789876543210
+    data CSym1 (a0123456789876543210 :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))
       where
         CSym1KindInference :: SameKind (Apply (CSym1 a0123456789876543210) arg) (CSym2 a0123456789876543210 arg) =>
                               CSym1 a0123456789876543210 a0123456789876543210
@@ -133,7 +133,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) CSym1KindInference) ())
     type CSym2 :: forall a b c d.
                   a -> b -> (~>) c ((~>) d (Foo a b c d))
-    data CSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data CSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: (~>) c ((~>) d (Foo a b c d))
       where
         CSym2KindInference :: SameKind (Apply (CSym2 a0123456789876543210 a0123456789876543210) arg) (CSym3 a0123456789876543210 a0123456789876543210 arg) =>
                               CSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -141,7 +141,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (CSym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) CSym2KindInference) ())
     type CSym3 :: forall a b c d. a -> b -> c -> (~>) d (Foo a b c d)
-    data CSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data CSym3 (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: c) :: (~>) d (Foo a b c d)
       where
         CSym3KindInference :: SameKind (Apply (CSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) arg) (CSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 arg) =>
                               CSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -149,11 +149,11 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (CSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) CSym3KindInference) ())
     type CSym4 :: forall a b c d. a -> b -> c -> d -> Foo a b c d
-    type family CSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family CSym4 (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: c) (a0123456789876543210 :: d) :: Foo a b c d where
       CSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 = C a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     type DSym0 :: forall a b c d.
                   (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))
-    data DSym0 a0123456789876543210
+    data DSym0 :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))
       where
         DSym0KindInference :: SameKind (Apply DSym0 arg) (DSym1 arg) =>
                               DSym0 a0123456789876543210
@@ -162,7 +162,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) DSym0KindInference) ())
     type DSym1 :: forall a b c d.
                   a -> (~>) b ((~>) c ((~>) d (Foo a b c d)))
-    data DSym1 a0123456789876543210 a0123456789876543210
+    data DSym1 (a0123456789876543210 :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))
       where
         DSym1KindInference :: SameKind (Apply (DSym1 a0123456789876543210) arg) (DSym2 a0123456789876543210 arg) =>
                               DSym1 a0123456789876543210 a0123456789876543210
@@ -171,7 +171,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) DSym1KindInference) ())
     type DSym2 :: forall a b c d.
                   a -> b -> (~>) c ((~>) d (Foo a b c d))
-    data DSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data DSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: (~>) c ((~>) d (Foo a b c d))
       where
         DSym2KindInference :: SameKind (Apply (DSym2 a0123456789876543210 a0123456789876543210) arg) (DSym3 a0123456789876543210 a0123456789876543210 arg) =>
                               DSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -179,7 +179,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (DSym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) DSym2KindInference) ())
     type DSym3 :: forall a b c d. a -> b -> c -> (~>) d (Foo a b c d)
-    data DSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data DSym3 (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: c) :: (~>) d (Foo a b c d)
       where
         DSym3KindInference :: SameKind (Apply (DSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) arg) (DSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 arg) =>
                               DSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -187,11 +187,11 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (DSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) DSym3KindInference) ())
     type DSym4 :: forall a b c d. a -> b -> c -> d -> Foo a b c d
-    type family DSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family DSym4 (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: c) (a0123456789876543210 :: d) :: Foo a b c d where
       DSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 = D a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     type ESym0 :: forall a b c d.
                   (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))
-    data ESym0 a0123456789876543210
+    data ESym0 :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))
       where
         ESym0KindInference :: SameKind (Apply ESym0 arg) (ESym1 arg) =>
                               ESym0 a0123456789876543210
@@ -200,7 +200,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) ESym0KindInference) ())
     type ESym1 :: forall a b c d.
                   a -> (~>) b ((~>) c ((~>) d (Foo a b c d)))
-    data ESym1 a0123456789876543210 a0123456789876543210
+    data ESym1 (a0123456789876543210 :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))
       where
         ESym1KindInference :: SameKind (Apply (ESym1 a0123456789876543210) arg) (ESym2 a0123456789876543210 arg) =>
                               ESym1 a0123456789876543210 a0123456789876543210
@@ -209,7 +209,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) ESym1KindInference) ())
     type ESym2 :: forall a b c d.
                   a -> b -> (~>) c ((~>) d (Foo a b c d))
-    data ESym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data ESym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: (~>) c ((~>) d (Foo a b c d))
       where
         ESym2KindInference :: SameKind (Apply (ESym2 a0123456789876543210 a0123456789876543210) arg) (ESym3 a0123456789876543210 a0123456789876543210 arg) =>
                               ESym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -217,7 +217,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (ESym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) ESym2KindInference) ())
     type ESym3 :: forall a b c d. a -> b -> c -> (~>) d (Foo a b c d)
-    data ESym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data ESym3 (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: c) :: (~>) d (Foo a b c d)
       where
         ESym3KindInference :: SameKind (Apply (ESym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) arg) (ESym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 arg) =>
                               ESym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -225,11 +225,11 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (ESym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) ESym3KindInference) ())
     type ESym4 :: forall a b c d. a -> b -> c -> d -> Foo a b c d
-    type family ESym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family ESym4 (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: c) (a0123456789876543210 :: d) :: Foo a b c d where
       ESym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 = E a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     type FSym0 :: forall a b c d.
                   (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))
-    data FSym0 a0123456789876543210
+    data FSym0 :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))
       where
         FSym0KindInference :: SameKind (Apply FSym0 arg) (FSym1 arg) =>
                               FSym0 a0123456789876543210
@@ -238,7 +238,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) FSym0KindInference) ())
     type FSym1 :: forall a b c d.
                   a -> (~>) b ((~>) c ((~>) d (Foo a b c d)))
-    data FSym1 a0123456789876543210 a0123456789876543210
+    data FSym1 (a0123456789876543210 :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))
       where
         FSym1KindInference :: SameKind (Apply (FSym1 a0123456789876543210) arg) (FSym2 a0123456789876543210 arg) =>
                               FSym1 a0123456789876543210 a0123456789876543210
@@ -247,7 +247,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) FSym1KindInference) ())
     type FSym2 :: forall a b c d.
                   a -> b -> (~>) c ((~>) d (Foo a b c d))
-    data FSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data FSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: (~>) c ((~>) d (Foo a b c d))
       where
         FSym2KindInference :: SameKind (Apply (FSym2 a0123456789876543210 a0123456789876543210) arg) (FSym3 a0123456789876543210 a0123456789876543210 arg) =>
                               FSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -255,7 +255,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (FSym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) FSym2KindInference) ())
     type FSym3 :: forall a b c d. a -> b -> c -> (~>) d (Foo a b c d)
-    data FSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data FSym3 (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: c) :: (~>) d (Foo a b c d)
       where
         FSym3KindInference :: SameKind (Apply (FSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) arg) (FSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 arg) =>
                               FSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -263,16 +263,16 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (FSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) FSym3KindInference) ())
     type FSym4 :: forall a b c d. a -> b -> c -> d -> Foo a b c d
-    type family FSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family FSym4 (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: c) (a0123456789876543210 :: d) :: Foo a b c d where
       FSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 = F a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     type TFHelper_0123456789876543210 :: Nat -> Nat -> Bool
-    type family TFHelper_0123456789876543210 a a where
+    type family TFHelper_0123456789876543210 (a :: Nat) (a :: Nat) :: Bool where
       TFHelper_0123456789876543210 Zero Zero = TrueSym0
       TFHelper_0123456789876543210 Zero (Succ _) = FalseSym0
       TFHelper_0123456789876543210 (Succ _) Zero = FalseSym0
       TFHelper_0123456789876543210 (Succ a_0123456789876543210) (Succ b_0123456789876543210) = Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210
     type TFHelper_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Bool)
-    data TFHelper_0123456789876543210Sym0 a0123456789876543210
+    data TFHelper_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Bool)
       where
         TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
                                                          TFHelper_0123456789876543210Sym0 a0123456789876543210
@@ -281,7 +281,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym0KindInference) ())
     type TFHelper_0123456789876543210Sym1 :: Nat -> (~>) Nat Bool
-    data TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Nat) :: (~>) Nat Bool
       where
         TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                          TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -290,18 +290,18 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym1KindInference) ())
     type TFHelper_0123456789876543210Sym2 :: Nat -> Nat -> Bool
-    type family TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Bool where
       TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq Nat where
       type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
     type Compare_0123456789876543210 :: Nat -> Nat -> Ordering
-    type family Compare_0123456789876543210 a a where
+    type family Compare_0123456789876543210 (a :: Nat) (a :: Nat) :: Ordering where
       Compare_0123456789876543210 Zero Zero = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) NilSym0
       Compare_0123456789876543210 (Succ a_0123456789876543210) (Succ b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0)
       Compare_0123456789876543210 Zero (Succ _) = LTSym0
       Compare_0123456789876543210 (Succ _) Zero = GTSym0
     type Compare_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Ordering)
-    data Compare_0123456789876543210Sym0 a0123456789876543210
+    data Compare_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Ordering)
       where
         Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
                                                         Compare_0123456789876543210Sym0 a0123456789876543210
@@ -310,7 +310,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Compare_0123456789876543210Sym0KindInference) ())
     type Compare_0123456789876543210Sym1 :: Nat -> (~>) Nat Ordering
-    data Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Nat) :: (~>) Nat Ordering
       where
         Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                         Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -319,13 +319,13 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Compare_0123456789876543210Sym1KindInference) ())
     type Compare_0123456789876543210Sym2 :: Nat -> Nat -> Ordering
-    type family Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Compare_0123456789876543210Sym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Ordering where
       Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd Nat where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type TFHelper_0123456789876543210 :: Foo a b c d
                                          -> Foo a b c d -> Bool
-    type family TFHelper_0123456789876543210 a a where
+    type family TFHelper_0123456789876543210 (a :: Foo a b c d) (a :: Foo a b c d) :: Bool where
       TFHelper_0123456789876543210 (A a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210) (A b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 b_0123456789876543210) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)))
       TFHelper_0123456789876543210 (A _ _ _ _) (B _ _ _ _) = FalseSym0
       TFHelper_0123456789876543210 (A _ _ _ _) (C _ _ _ _) = FalseSym0
@@ -363,7 +363,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       TFHelper_0123456789876543210 (F _ _ _ _) (E _ _ _ _) = FalseSym0
       TFHelper_0123456789876543210 (F a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210) (F b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 b_0123456789876543210) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)))
     type TFHelper_0123456789876543210Sym0 :: (~>) (Foo a b c d) ((~>) (Foo a b c d) Bool)
-    data TFHelper_0123456789876543210Sym0 a0123456789876543210
+    data TFHelper_0123456789876543210Sym0 :: (~>) (Foo a b c d) ((~>) (Foo a b c d) Bool)
       where
         TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
                                                          TFHelper_0123456789876543210Sym0 a0123456789876543210
@@ -373,7 +373,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) TFHelper_0123456789876543210Sym0KindInference) ())
     type TFHelper_0123456789876543210Sym1 :: Foo a b c d
                                              -> (~>) (Foo a b c d) Bool
-    data TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Foo a b c d) :: (~>) (Foo a b c d) Bool
       where
         TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                          TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -383,13 +383,13 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) TFHelper_0123456789876543210Sym1KindInference) ())
     type TFHelper_0123456789876543210Sym2 :: Foo a b c d
                                              -> Foo a b c d -> Bool
-    type family TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: Foo a b c d) (a0123456789876543210 :: Foo a b c d) :: Bool where
       TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq (Foo a b c d) where
       type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
     type Compare_0123456789876543210 :: Foo a b c d
                                         -> Foo a b c d -> Ordering
-    type family Compare_0123456789876543210 a a where
+    type family Compare_0123456789876543210 (a :: Foo a b c d) (a :: Foo a b c d) :: Ordering where
       Compare_0123456789876543210 (A a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210) (A b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0))))
       Compare_0123456789876543210 (B a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210) (B b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0))))
       Compare_0123456789876543210 (C a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210) (C b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0))))
@@ -427,7 +427,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       Compare_0123456789876543210 (F _ _ _ _) (D _ _ _ _) = GTSym0
       Compare_0123456789876543210 (F _ _ _ _) (E _ _ _ _) = GTSym0
     type Compare_0123456789876543210Sym0 :: (~>) (Foo a b c d) ((~>) (Foo a b c d) Ordering)
-    data Compare_0123456789876543210Sym0 a0123456789876543210
+    data Compare_0123456789876543210Sym0 :: (~>) (Foo a b c d) ((~>) (Foo a b c d) Ordering)
       where
         Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
                                                         Compare_0123456789876543210Sym0 a0123456789876543210
@@ -437,7 +437,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) Compare_0123456789876543210Sym0KindInference) ())
     type Compare_0123456789876543210Sym1 :: Foo a b c d
                                             -> (~>) (Foo a b c d) Ordering
-    data Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Foo a b c d) :: (~>) (Foo a b c d) Ordering
       where
         Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                         Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -447,7 +447,7 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) Compare_0123456789876543210Sym1KindInference) ())
     type Compare_0123456789876543210Sym2 :: Foo a b c d
                                             -> Foo a b c d -> Ordering
-    type family Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Compare_0123456789876543210Sym2 (a0123456789876543210 :: Foo a b c d) (a0123456789876543210 :: Foo a b c d) :: Ordering where
       Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd (Foo a b c d) where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a

--- a/singletons-base/tests/compile-and-dump/Singletons/OverloadedStrings.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/OverloadedStrings.golden
@@ -10,10 +10,10 @@ Singletons/OverloadedStrings.hs:(0,0)-(0,0): Splicing declarations
     foo :: Symbol
     foo = symId "foo"
     type FooSym0 :: Symbol
-    type family FooSym0 where
+    type family FooSym0 :: Symbol where
       FooSym0 = Foo
     type SymIdSym0 :: (~>) Symbol Symbol
-    data SymIdSym0 a0123456789876543210
+    data SymIdSym0 :: (~>) Symbol Symbol
       where
         SymIdSym0KindInference :: SameKind (Apply SymIdSym0 arg) (SymIdSym1 arg) =>
                                   SymIdSym0 a0123456789876543210
@@ -21,13 +21,13 @@ Singletons/OverloadedStrings.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings SymIdSym0 where
       suppressUnusedWarnings = snd (((,) SymIdSym0KindInference) ())
     type SymIdSym1 :: Symbol -> Symbol
-    type family SymIdSym1 a0123456789876543210 where
+    type family SymIdSym1 (a0123456789876543210 :: Symbol) :: Symbol where
       SymIdSym1 a0123456789876543210 = SymId a0123456789876543210
     type Foo :: Symbol
-    type family Foo where
+    type family Foo :: Symbol where
       Foo = Apply SymIdSym0 (FromString "foo")
     type SymId :: Symbol -> Symbol
-    type family SymId a where
+    type family SymId (a :: Symbol) :: Symbol where
       SymId x = x
     sFoo :: Sing (FooSym0 :: Symbol)
     sSymId ::

--- a/singletons-base/tests/compile-and-dump/Singletons/PatternMatching.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/PatternMatching.golden
@@ -17,7 +17,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     tuple = (False, Just Zero, True)
     aList = [Zero, Succ Zero, Succ (Succ Zero)]
     type PairSym0 :: forall a b. (~>) a ((~>) b (Pair a b))
-    data PairSym0 a0123456789876543210
+    data PairSym0 :: (~>) a ((~>) b (Pair a b))
       where
         PairSym0KindInference :: SameKind (Apply PairSym0 arg) (PairSym1 arg) =>
                                  PairSym0 a0123456789876543210
@@ -25,7 +25,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings PairSym0 where
       suppressUnusedWarnings = snd (((,) PairSym0KindInference) ())
     type PairSym1 :: forall a b. a -> (~>) b (Pair a b)
-    data PairSym1 a0123456789876543210 a0123456789876543210
+    data PairSym1 (a0123456789876543210 :: a) :: (~>) b (Pair a b)
       where
         PairSym1KindInference :: SameKind (Apply (PairSym1 a0123456789876543210) arg) (PairSym2 a0123456789876543210 arg) =>
                                  PairSym1 a0123456789876543210 a0123456789876543210
@@ -33,7 +33,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (PairSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) PairSym1KindInference) ())
     type PairSym2 :: forall a b. a -> b -> Pair a b
-    type family PairSym2 a0123456789876543210 a0123456789876543210 where
+    type family PairSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: Pair a b where
       PairSym2 a0123456789876543210 a0123456789876543210 = Pair a0123456789876543210 a0123456789876543210
     type family AListSym0 where
       AListSym0 = AList
@@ -53,10 +53,10 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
       Pr = Apply (Apply PairSym0 (Apply SuccSym0 ZeroSym0)) (Apply (Apply (:@#@$) ZeroSym0) NilSym0)
     type ShowsPrec_0123456789876543210 :: GHC.Types.Nat
                                           -> Pair a b -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210 a a a where
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Pair a b) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 p_0123456789876543210 (Pair arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Pair ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
     type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) (Pair a b) ((~>) Symbol Symbol))
-    data ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) (Pair a b) ((~>) Symbol Symbol))
       where
         ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
                                                           ShowsPrec_0123456789876543210Sym0 a0123456789876543210
@@ -66,7 +66,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym0KindInference) ())
     type ShowsPrec_0123456789876543210Sym1 :: GHC.Types.Nat
                                               -> (~>) (Pair a b) ((~>) Symbol Symbol)
-    data ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: (~>) (Pair a b) ((~>) Symbol Symbol)
       where
         ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -76,7 +76,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym1KindInference) ())
     type ShowsPrec_0123456789876543210Sym2 :: GHC.Types.Nat
                                               -> Pair a b -> (~>) Symbol Symbol
-    data ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Pair a b) :: (~>) Symbol Symbol
       where
         ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -86,7 +86,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym2KindInference) ())
     type ShowsPrec_0123456789876543210Sym3 :: GHC.Types.Nat
                                               -> Pair a b -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Pair a b) (a0123456789876543210 :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow (Pair a b) where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
@@ -351,7 +351,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     type family Case_0123456789876543210 t where
       Case_0123456789876543210 ('Pair y_0123456789876543210 _) = y_0123456789876543210
     type SillySym0 :: (~>) a ()
-    data SillySym0 a0123456789876543210
+    data SillySym0 :: (~>) a ()
       where
         SillySym0KindInference :: SameKind (Apply SillySym0 arg) (SillySym1 arg) =>
                                   SillySym0 a0123456789876543210
@@ -359,10 +359,10 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings SillySym0 where
       suppressUnusedWarnings = snd (((,) SillySym0KindInference) ())
     type SillySym1 :: a -> ()
-    type family SillySym1 a0123456789876543210 where
+    type family SillySym1 (a0123456789876543210 :: a) :: () where
       SillySym1 a0123456789876543210 = Silly a0123456789876543210
     type Foo2Sym0 :: (~>) (a, b) a
-    data Foo2Sym0 a0123456789876543210
+    data Foo2Sym0 :: (~>) (a, b) a
       where
         Foo2Sym0KindInference :: SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) =>
                                  Foo2Sym0 a0123456789876543210
@@ -370,10 +370,10 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo2Sym0 where
       suppressUnusedWarnings = snd (((,) Foo2Sym0KindInference) ())
     type Foo2Sym1 :: (a, b) -> a
-    type family Foo2Sym1 a0123456789876543210 where
+    type family Foo2Sym1 (a0123456789876543210 :: (a, b)) :: a where
       Foo2Sym1 a0123456789876543210 = Foo2 a0123456789876543210
     type Foo1Sym0 :: (~>) (a, b) a
-    data Foo1Sym0 a0123456789876543210
+    data Foo1Sym0 :: (~>) (a, b) a
       where
         Foo1Sym0KindInference :: SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
                                  Foo1Sym0 a0123456789876543210
@@ -381,12 +381,12 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo1Sym0 where
       suppressUnusedWarnings = snd (((,) Foo1Sym0KindInference) ())
     type Foo1Sym1 :: (a, b) -> a
-    type family Foo1Sym1 a0123456789876543210 where
+    type family Foo1Sym1 (a0123456789876543210 :: (a, b)) :: a where
       Foo1Sym1 a0123456789876543210 = Foo1 a0123456789876543210
     type family BlimySym0 where
       BlimySym0 = Blimy
     type LszSym0 :: Nat
-    type family LszSym0 where
+    type family LszSym0 :: Nat where
       LszSym0 = Lsz
     type family X_0123456789876543210Sym0 where
       X_0123456789876543210Sym0 = X_0123456789876543210
@@ -399,7 +399,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     type family X_0123456789876543210Sym0 where
       X_0123456789876543210Sym0 = X_0123456789876543210
     type FlsSym0 :: Bool
-    type family FlsSym0 where
+    type family FlsSym0 :: Bool where
       FlsSym0 = Fls
     type family ZzSym0 where
       ZzSym0 = Zz
@@ -414,20 +414,20 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     type family X_0123456789876543210Sym0 where
       X_0123456789876543210Sym0 = X_0123456789876543210
     type Silly :: a -> ()
-    type family Silly a where
+    type family Silly (a :: a) :: () where
       Silly x = Case_0123456789876543210 x x
     type Foo2 :: (a, b) -> a
-    type family Foo2 a where
+    type family Foo2 (a :: (a, b)) :: a where
       Foo2 '(x,
              y) = Case_0123456789876543210 x y (Let0123456789876543210TSym2 x y)
     type Foo1 :: (a, b) -> a
-    type family Foo1 a where
+    type family Foo1 (a :: (a, b)) :: a where
       Foo1 '(x,
              y) = Apply (Apply (Apply Lambda_0123456789876543210Sym0 x) y) y
     type family Blimy where
       Blimy = Case_0123456789876543210 X_0123456789876543210Sym0
     type Lsz :: Nat
-    type family Lsz where
+    type family Lsz :: Nat where
       Lsz = Case_0123456789876543210 X_0123456789876543210Sym0
     type family X_0123456789876543210 where
       X_0123456789876543210 = AListSym0
@@ -440,7 +440,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     type family X_0123456789876543210 where
       X_0123456789876543210 = TupleSym0
     type Fls :: Bool
-    type family Fls where
+    type family Fls :: Bool where
       Fls = Case_0123456789876543210 X_0123456789876543210Sym0
     type family Zz where
       Zz = Case_0123456789876543210 X_0123456789876543210Sym0

--- a/singletons-base/tests/compile-and-dump/Singletons/PolyKinds.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/PolyKinds.golden
@@ -6,7 +6,7 @@ Singletons/PolyKinds.hs:(0,0)-(0,0): Splicing declarations
     class Cls (a :: k) where
       fff :: Proxy (a :: k) -> ()
     type FffSym0 :: forall k (a :: k). (~>) (Proxy (a :: k)) ()
-    data FffSym0 a0123456789876543210
+    data FffSym0 :: (~>) (Proxy (a :: k)) ()
       where
         FffSym0KindInference :: SameKind (Apply FffSym0 arg) (FffSym1 arg) =>
                                 FffSym0 a0123456789876543210
@@ -14,7 +14,7 @@ Singletons/PolyKinds.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FffSym0 where
       suppressUnusedWarnings = snd (((,) FffSym0KindInference) ())
     type FffSym1 :: forall k (a :: k). Proxy (a :: k) -> ()
-    type family FffSym1 a0123456789876543210 where
+    type family FffSym1 (a0123456789876543210 :: Proxy (a :: k)) :: () where
       FffSym1 a0123456789876543210 = Fff a0123456789876543210
     class PCls (a :: k) where
       type Fff (arg :: Proxy (a :: k)) :: ()

--- a/singletons-base/tests/compile-and-dump/Singletons/PolyKindsApp.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/PolyKindsApp.golden
@@ -7,7 +7,7 @@ Singletons/PolyKindsApp.hs:(0,0)-(0,0): Splicing declarations
       fff :: (a :: k -> Type) (b :: k)
     type FffSym0 :: forall k (a :: k -> Type) (b :: k).
                     (a :: k -> Type) (b :: k)
-    type family FffSym0 where
+    type family FffSym0 :: (a :: k -> Type) (b :: k) where
       FffSym0 = Fff
     class PCls (a :: k -> Type) where
       type Fff :: (a :: k -> Type) (b :: k)

--- a/singletons-base/tests/compile-and-dump/Singletons/Records.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Records.golden
@@ -4,7 +4,7 @@ Singletons/Records.hs:(0,0)-(0,0): Splicing declarations
   ======>
     data Record a = MkRecord {field1 :: a, field2 :: Bool}
     type MkRecordSym0 :: forall a. (~>) a ((~>) Bool (Record a))
-    data MkRecordSym0 a0123456789876543210
+    data MkRecordSym0 :: (~>) a ((~>) Bool (Record a))
       where
         MkRecordSym0KindInference :: SameKind (Apply MkRecordSym0 arg) (MkRecordSym1 arg) =>
                                      MkRecordSym0 a0123456789876543210
@@ -12,7 +12,7 @@ Singletons/Records.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings MkRecordSym0 where
       suppressUnusedWarnings = snd (((,) MkRecordSym0KindInference) ())
     type MkRecordSym1 :: forall a. a -> (~>) Bool (Record a)
-    data MkRecordSym1 a0123456789876543210 a0123456789876543210
+    data MkRecordSym1 (a0123456789876543210 :: a) :: (~>) Bool (Record a)
       where
         MkRecordSym1KindInference :: SameKind (Apply (MkRecordSym1 a0123456789876543210) arg) (MkRecordSym2 a0123456789876543210 arg) =>
                                      MkRecordSym1 a0123456789876543210 a0123456789876543210
@@ -20,10 +20,10 @@ Singletons/Records.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (MkRecordSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) MkRecordSym1KindInference) ())
     type MkRecordSym2 :: forall a. a -> Bool -> Record a
-    type family MkRecordSym2 a0123456789876543210 a0123456789876543210 where
+    type family MkRecordSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: Bool) :: Record a where
       MkRecordSym2 a0123456789876543210 a0123456789876543210 = MkRecord a0123456789876543210 a0123456789876543210
     type Field2Sym0 :: forall a. (~>) (Record a) Bool
-    data Field2Sym0 a0123456789876543210
+    data Field2Sym0 :: (~>) (Record a) Bool
       where
         Field2Sym0KindInference :: SameKind (Apply Field2Sym0 arg) (Field2Sym1 arg) =>
                                    Field2Sym0 a0123456789876543210
@@ -31,10 +31,10 @@ Singletons/Records.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Field2Sym0 where
       suppressUnusedWarnings = snd (((,) Field2Sym0KindInference) ())
     type Field2Sym1 :: forall a. Record a -> Bool
-    type family Field2Sym1 a0123456789876543210 where
+    type family Field2Sym1 (a0123456789876543210 :: Record a) :: Bool where
       Field2Sym1 a0123456789876543210 = Field2 a0123456789876543210
     type Field1Sym0 :: forall a. (~>) (Record a) a
-    data Field1Sym0 a0123456789876543210
+    data Field1Sym0 :: (~>) (Record a) a
       where
         Field1Sym0KindInference :: SameKind (Apply Field1Sym0 arg) (Field1Sym1 arg) =>
                                    Field1Sym0 a0123456789876543210
@@ -42,13 +42,13 @@ Singletons/Records.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Field1Sym0 where
       suppressUnusedWarnings = snd (((,) Field1Sym0KindInference) ())
     type Field1Sym1 :: forall a. Record a -> a
-    type family Field1Sym1 a0123456789876543210 where
+    type family Field1Sym1 (a0123456789876543210 :: Record a) :: a where
       Field1Sym1 a0123456789876543210 = Field1 a0123456789876543210
     type Field2 :: forall a. Record a -> Bool
-    type family Field2 a where
+    type family Field2 (a :: Record a) :: Bool where
       Field2 (MkRecord _ field) = field
     type Field1 :: forall a. Record a -> a
-    type family Field1 a where
+    type family Field1 (a :: Record a) :: a where
       Field1 (MkRecord field _) = field
     sField2 ::
       forall a (t :: Record a).

--- a/singletons-base/tests/compile-and-dump/Singletons/ReturnFunc.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/ReturnFunc.golden
@@ -14,7 +14,7 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
     idFoo :: c -> a -> a
     idFoo _ = id
     type IdFooSym0 :: (~>) c ((~>) a a)
-    data IdFooSym0 a0123456789876543210
+    data IdFooSym0 :: (~>) c ((~>) a a)
       where
         IdFooSym0KindInference :: SameKind (Apply IdFooSym0 arg) (IdFooSym1 arg) =>
                                   IdFooSym0 a0123456789876543210
@@ -22,7 +22,7 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings IdFooSym0 where
       suppressUnusedWarnings = snd (((,) IdFooSym0KindInference) ())
     type IdFooSym1 :: c -> (~>) a a
-    data IdFooSym1 a0123456789876543210 a0123456789876543210
+    data IdFooSym1 (a0123456789876543210 :: c) :: (~>) a a
       where
         IdFooSym1KindInference :: SameKind (Apply (IdFooSym1 a0123456789876543210) arg) (IdFooSym2 a0123456789876543210 arg) =>
                                   IdFooSym1 a0123456789876543210 a0123456789876543210
@@ -30,10 +30,10 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (IdFooSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) IdFooSym1KindInference) ())
     type IdFooSym2 :: c -> a -> a
-    type family IdFooSym2 a0123456789876543210 a0123456789876543210 where
+    type family IdFooSym2 (a0123456789876543210 :: c) (a0123456789876543210 :: a) :: a where
       IdFooSym2 a0123456789876543210 a0123456789876543210 = IdFoo a0123456789876543210 a0123456789876543210
     type IdSym0 :: (~>) a a
-    data IdSym0 a0123456789876543210
+    data IdSym0 :: (~>) a a
       where
         IdSym0KindInference :: SameKind (Apply IdSym0 arg) (IdSym1 arg) =>
                                IdSym0 a0123456789876543210
@@ -41,10 +41,10 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings IdSym0 where
       suppressUnusedWarnings = snd (((,) IdSym0KindInference) ())
     type IdSym1 :: a -> a
-    type family IdSym1 a0123456789876543210 where
+    type family IdSym1 (a0123456789876543210 :: a) :: a where
       IdSym1 a0123456789876543210 = Id a0123456789876543210
     type ReturnFuncSym0 :: (~>) Nat ((~>) Nat Nat)
-    data ReturnFuncSym0 a0123456789876543210
+    data ReturnFuncSym0 :: (~>) Nat ((~>) Nat Nat)
       where
         ReturnFuncSym0KindInference :: SameKind (Apply ReturnFuncSym0 arg) (ReturnFuncSym1 arg) =>
                                        ReturnFuncSym0 a0123456789876543210
@@ -52,7 +52,7 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ReturnFuncSym0 where
       suppressUnusedWarnings = snd (((,) ReturnFuncSym0KindInference) ())
     type ReturnFuncSym1 :: Nat -> (~>) Nat Nat
-    data ReturnFuncSym1 a0123456789876543210 a0123456789876543210
+    data ReturnFuncSym1 (a0123456789876543210 :: Nat) :: (~>) Nat Nat
       where
         ReturnFuncSym1KindInference :: SameKind (Apply (ReturnFuncSym1 a0123456789876543210) arg) (ReturnFuncSym2 a0123456789876543210 arg) =>
                                        ReturnFuncSym1 a0123456789876543210 a0123456789876543210
@@ -60,16 +60,16 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (ReturnFuncSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) ReturnFuncSym1KindInference) ())
     type ReturnFuncSym2 :: Nat -> Nat -> Nat
-    type family ReturnFuncSym2 a0123456789876543210 a0123456789876543210 where
+    type family ReturnFuncSym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Nat where
       ReturnFuncSym2 a0123456789876543210 a0123456789876543210 = ReturnFunc a0123456789876543210 a0123456789876543210
     type IdFoo :: c -> a -> a
-    type family IdFoo a a where
+    type family IdFoo (a :: c) (a :: a) :: a where
       IdFoo _ a_0123456789876543210 = Apply IdSym0 a_0123456789876543210
     type Id :: a -> a
-    type family Id a where
+    type family Id (a :: a) :: a where
       Id x = x
     type ReturnFunc :: Nat -> Nat -> Nat
-    type family ReturnFunc a a where
+    type family ReturnFunc (a :: Nat) (a :: Nat) :: Nat where
       ReturnFunc _ a_0123456789876543210 = Apply SuccSym0 a_0123456789876543210
     sIdFoo ::
       forall c a (t :: c) (t :: a).

--- a/singletons-base/tests/compile-and-dump/Singletons/Sections.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Sections.golden
@@ -32,16 +32,16 @@ Singletons/Sections.hs:(0,0)-(0,0): Splicing declarations
     type family Lambda_0123456789876543210Sym1 lhs_01234567898765432100123456789876543210 where
       Lambda_0123456789876543210Sym1 lhs_01234567898765432100123456789876543210 = Lambda_0123456789876543210 lhs_01234567898765432100123456789876543210
     type Foo3Sym0 :: [Nat]
-    type family Foo3Sym0 where
+    type family Foo3Sym0 :: [Nat] where
       Foo3Sym0 = Foo3
     type Foo2Sym0 :: [Nat]
-    type family Foo2Sym0 where
+    type family Foo2Sym0 :: [Nat] where
       Foo2Sym0 = Foo2
     type Foo1Sym0 :: [Nat]
-    type family Foo1Sym0 where
+    type family Foo1Sym0 :: [Nat] where
       Foo1Sym0 = Foo1
     type (+@#@$) :: (~>) Nat ((~>) Nat Nat)
-    data (+@#@$) a0123456789876543210
+    data (+@#@$) :: (~>) Nat ((~>) Nat Nat)
       where
         (:+@#@$###) :: SameKind (Apply (+@#@$) arg) ((+@#@$$) arg) =>
                        (+@#@$) a0123456789876543210
@@ -49,7 +49,7 @@ Singletons/Sections.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (+@#@$) where
       suppressUnusedWarnings = snd (((,) (:+@#@$###)) ())
     type (+@#@$$) :: Nat -> (~>) Nat Nat
-    data (+@#@$$) a0123456789876543210 a0123456789876543210
+    data (+@#@$$) (a0123456789876543210 :: Nat) :: (~>) Nat Nat
       where
         (:+@#@$$###) :: SameKind (Apply ((+@#@$$) a0123456789876543210) arg) ((+@#@$$$) a0123456789876543210 arg) =>
                         (+@#@$$) a0123456789876543210 a0123456789876543210
@@ -57,19 +57,19 @@ Singletons/Sections.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ((+@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) (:+@#@$$###)) ())
     type (+@#@$$$) :: Nat -> Nat -> Nat
-    type family (+@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family (+@#@$$$) (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Nat where
       (+@#@$$$) a0123456789876543210 a0123456789876543210 = (+) a0123456789876543210 a0123456789876543210
     type Foo3 :: [Nat]
-    type family Foo3 where
+    type family Foo3 :: [Nat] where
       Foo3 = Apply (Apply (Apply ZipWithSym0 (+@#@$)) (Apply (Apply (:@#@$) (Apply SuccSym0 ZeroSym0)) (Apply (Apply (:@#@$) (Apply SuccSym0 ZeroSym0)) NilSym0))) (Apply (Apply (:@#@$) ZeroSym0) (Apply (Apply (:@#@$) (Apply SuccSym0 ZeroSym0)) NilSym0))
     type Foo2 :: [Nat]
-    type family Foo2 where
+    type family Foo2 :: [Nat] where
       Foo2 = Apply (Apply MapSym0 Lambda_0123456789876543210Sym0) (Apply (Apply (:@#@$) ZeroSym0) (Apply (Apply (:@#@$) (Apply SuccSym0 ZeroSym0)) NilSym0))
     type Foo1 :: [Nat]
-    type family Foo1 where
+    type family Foo1 :: [Nat] where
       Foo1 = Apply (Apply MapSym0 (Apply (+@#@$) (Apply SuccSym0 ZeroSym0))) (Apply (Apply (:@#@$) ZeroSym0) (Apply (Apply (:@#@$) (Apply SuccSym0 ZeroSym0)) NilSym0))
     type (+) :: Nat -> Nat -> Nat
-    type family (+) a a where
+    type family (+) (a :: Nat) (a :: Nat) :: Nat where
       (+) 'Zero m = m
       (+) ('Succ n) m = Apply SuccSym0 (Apply (Apply (+@#@$) n) m)
     sFoo3 :: Sing (Foo3Sym0 :: [Nat])

--- a/singletons-base/tests/compile-and-dump/Singletons/ShowDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/ShowDeriving.golden
@@ -25,10 +25,10 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
       = MkFoo3 {getFoo3a :: Bool, *** :: Bool}
       deriving Show
     type MkFoo1Sym0 :: Foo1
-    type family MkFoo1Sym0 where
+    type family MkFoo1Sym0 :: Foo1 where
       MkFoo1Sym0 = MkFoo1
     type MkFoo2aSym0 :: forall a. (~>) a ((~>) a (Foo2 a))
-    data MkFoo2aSym0 a0123456789876543210
+    data MkFoo2aSym0 :: (~>) a ((~>) a (Foo2 a))
       where
         MkFoo2aSym0KindInference :: SameKind (Apply MkFoo2aSym0 arg) (MkFoo2aSym1 arg) =>
                                     MkFoo2aSym0 a0123456789876543210
@@ -36,7 +36,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings MkFoo2aSym0 where
       suppressUnusedWarnings = snd (((,) MkFoo2aSym0KindInference) ())
     type MkFoo2aSym1 :: forall a. a -> (~>) a (Foo2 a)
-    data MkFoo2aSym1 a0123456789876543210 a0123456789876543210
+    data MkFoo2aSym1 (a0123456789876543210 :: a) :: (~>) a (Foo2 a)
       where
         MkFoo2aSym1KindInference :: SameKind (Apply (MkFoo2aSym1 a0123456789876543210) arg) (MkFoo2aSym2 a0123456789876543210 arg) =>
                                     MkFoo2aSym1 a0123456789876543210 a0123456789876543210
@@ -44,10 +44,10 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (MkFoo2aSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) MkFoo2aSym1KindInference) ())
     type MkFoo2aSym2 :: forall a. a -> a -> Foo2 a
-    type family MkFoo2aSym2 a0123456789876543210 a0123456789876543210 where
+    type family MkFoo2aSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Foo2 a where
       MkFoo2aSym2 a0123456789876543210 a0123456789876543210 = MkFoo2a a0123456789876543210 a0123456789876543210
     type MkFoo2bSym0 :: forall a. (~>) a ((~>) a (Foo2 a))
-    data MkFoo2bSym0 a0123456789876543210
+    data MkFoo2bSym0 :: (~>) a ((~>) a (Foo2 a))
       where
         MkFoo2bSym0KindInference :: SameKind (Apply MkFoo2bSym0 arg) (MkFoo2bSym1 arg) =>
                                     MkFoo2bSym0 a0123456789876543210
@@ -56,7 +56,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) MkFoo2bSym0KindInference) ())
     infixl 5 `MkFoo2bSym0`
     type MkFoo2bSym1 :: forall a. a -> (~>) a (Foo2 a)
-    data MkFoo2bSym1 a0123456789876543210 a0123456789876543210
+    data MkFoo2bSym1 (a0123456789876543210 :: a) :: (~>) a (Foo2 a)
       where
         MkFoo2bSym1KindInference :: SameKind (Apply (MkFoo2bSym1 a0123456789876543210) arg) (MkFoo2bSym2 a0123456789876543210 arg) =>
                                     MkFoo2bSym1 a0123456789876543210 a0123456789876543210
@@ -65,11 +65,11 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) MkFoo2bSym1KindInference) ())
     infixl 5 `MkFoo2bSym1`
     type MkFoo2bSym2 :: forall a. a -> a -> Foo2 a
-    type family MkFoo2bSym2 a0123456789876543210 a0123456789876543210 where
+    type family MkFoo2bSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Foo2 a where
       MkFoo2bSym2 a0123456789876543210 a0123456789876543210 = MkFoo2b a0123456789876543210 a0123456789876543210
     infixl 5 `MkFoo2bSym2`
     type (:*:@#@$) :: forall a. (~>) a ((~>) a (Foo2 a))
-    data (:*:@#@$) a0123456789876543210
+    data (:*:@#@$) :: (~>) a ((~>) a (Foo2 a))
       where
         (::*:@#@$###) :: SameKind (Apply (:*:@#@$) arg) ((:*:@#@$$) arg) =>
                          (:*:@#@$) a0123456789876543210
@@ -78,7 +78,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) (::*:@#@$###)) ())
     infixl 5 :*:@#@$
     type (:*:@#@$$) :: forall a. a -> (~>) a (Foo2 a)
-    data (:*:@#@$$) a0123456789876543210 a0123456789876543210
+    data (:*:@#@$$) (a0123456789876543210 :: a) :: (~>) a (Foo2 a)
       where
         (::*:@#@$$###) :: SameKind (Apply ((:*:@#@$$) a0123456789876543210) arg) ((:*:@#@$$$) a0123456789876543210 arg) =>
                           (:*:@#@$$) a0123456789876543210 a0123456789876543210
@@ -87,11 +87,11 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) (::*:@#@$$###)) ())
     infixl 5 :*:@#@$$
     type (:*:@#@$$$) :: forall a. a -> a -> Foo2 a
-    type family (:*:@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family (:*:@#@$$$) (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Foo2 a where
       (:*:@#@$$$) a0123456789876543210 a0123456789876543210 = (:*:) a0123456789876543210 a0123456789876543210
     infixl 5 :*:@#@$$$
     type (:&:@#@$) :: forall a. (~>) a ((~>) a (Foo2 a))
-    data (:&:@#@$) a0123456789876543210
+    data (:&:@#@$) :: (~>) a ((~>) a (Foo2 a))
       where
         (::&:@#@$###) :: SameKind (Apply (:&:@#@$) arg) ((:&:@#@$$) arg) =>
                          (:&:@#@$) a0123456789876543210
@@ -100,7 +100,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) (::&:@#@$###)) ())
     infixl 5 :&:@#@$
     type (:&:@#@$$) :: forall a. a -> (~>) a (Foo2 a)
-    data (:&:@#@$$) a0123456789876543210 a0123456789876543210
+    data (:&:@#@$$) (a0123456789876543210 :: a) :: (~>) a (Foo2 a)
       where
         (::&:@#@$$###) :: SameKind (Apply ((:&:@#@$$) a0123456789876543210) arg) ((:&:@#@$$$) a0123456789876543210 arg) =>
                           (:&:@#@$$) a0123456789876543210 a0123456789876543210
@@ -109,11 +109,11 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) (::&:@#@$$###)) ())
     infixl 5 :&:@#@$$
     type (:&:@#@$$$) :: forall a. a -> a -> Foo2 a
-    type family (:&:@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family (:&:@#@$$$) (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Foo2 a where
       (:&:@#@$$$) a0123456789876543210 a0123456789876543210 = (:&:) a0123456789876543210 a0123456789876543210
     infixl 5 :&:@#@$$$
     type MkFoo3Sym0 :: (~>) Bool ((~>) Bool Foo3)
-    data MkFoo3Sym0 a0123456789876543210
+    data MkFoo3Sym0 :: (~>) Bool ((~>) Bool Foo3)
       where
         MkFoo3Sym0KindInference :: SameKind (Apply MkFoo3Sym0 arg) (MkFoo3Sym1 arg) =>
                                    MkFoo3Sym0 a0123456789876543210
@@ -121,7 +121,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings MkFoo3Sym0 where
       suppressUnusedWarnings = snd (((,) MkFoo3Sym0KindInference) ())
     type MkFoo3Sym1 :: Bool -> (~>) Bool Foo3
-    data MkFoo3Sym1 a0123456789876543210 a0123456789876543210
+    data MkFoo3Sym1 (a0123456789876543210 :: Bool) :: (~>) Bool Foo3
       where
         MkFoo3Sym1KindInference :: SameKind (Apply (MkFoo3Sym1 a0123456789876543210) arg) (MkFoo3Sym2 a0123456789876543210 arg) =>
                                    MkFoo3Sym1 a0123456789876543210 a0123456789876543210
@@ -129,10 +129,10 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (MkFoo3Sym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) MkFoo3Sym1KindInference) ())
     type MkFoo3Sym2 :: Bool -> Bool -> Foo3
-    type family MkFoo3Sym2 a0123456789876543210 a0123456789876543210 where
+    type family MkFoo3Sym2 (a0123456789876543210 :: Bool) (a0123456789876543210 :: Bool) :: Foo3 where
       MkFoo3Sym2 a0123456789876543210 a0123456789876543210 = MkFoo3 a0123456789876543210 a0123456789876543210
     type (***@#@$) :: (~>) Foo3 Bool
-    data (***@#@$) a0123456789876543210
+    data (***@#@$) :: (~>) Foo3 Bool
       where
         (:***@#@$###) :: SameKind (Apply (***@#@$) arg) ((***@#@$$) arg) =>
                          (***@#@$) a0123456789876543210
@@ -140,10 +140,10 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (***@#@$) where
       suppressUnusedWarnings = snd (((,) (:***@#@$###)) ())
     type (***@#@$$) :: Foo3 -> Bool
-    type family (***@#@$$) a0123456789876543210 where
+    type family (***@#@$$) (a0123456789876543210 :: Foo3) :: Bool where
       (***@#@$$) a0123456789876543210 = (***) a0123456789876543210
     type GetFoo3aSym0 :: (~>) Foo3 Bool
-    data GetFoo3aSym0 a0123456789876543210
+    data GetFoo3aSym0 :: (~>) Foo3 Bool
       where
         GetFoo3aSym0KindInference :: SameKind (Apply GetFoo3aSym0 arg) (GetFoo3aSym1 arg) =>
                                      GetFoo3aSym0 a0123456789876543210
@@ -151,20 +151,20 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings GetFoo3aSym0 where
       suppressUnusedWarnings = snd (((,) GetFoo3aSym0KindInference) ())
     type GetFoo3aSym1 :: Foo3 -> Bool
-    type family GetFoo3aSym1 a0123456789876543210 where
+    type family GetFoo3aSym1 (a0123456789876543210 :: Foo3) :: Bool where
       GetFoo3aSym1 a0123456789876543210 = GetFoo3a a0123456789876543210
     type (***) :: Foo3 -> Bool
-    type family (***) a where
+    type family (***) (a :: Foo3) :: Bool where
       (***) (MkFoo3 _ field) = field
     type GetFoo3a :: Foo3 -> Bool
-    type family GetFoo3a a where
+    type family GetFoo3a (a :: Foo3) :: Bool where
       GetFoo3a (MkFoo3 field _) = field
     type ShowsPrec_0123456789876543210 :: GHC.Types.Nat
                                           -> Foo1 -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210 a a a where
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Foo1) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 _ MkFoo1 a_0123456789876543210 = Apply (Apply ShowStringSym0 "MkFoo1") a_0123456789876543210
     type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) Foo1 ((~>) Symbol Symbol))
-    data ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) Foo1 ((~>) Symbol Symbol))
       where
         ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
                                                           ShowsPrec_0123456789876543210Sym0 a0123456789876543210
@@ -174,7 +174,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym0KindInference) ())
     type ShowsPrec_0123456789876543210Sym1 :: GHC.Types.Nat
                                               -> (~>) Foo1 ((~>) Symbol Symbol)
-    data ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: (~>) Foo1 ((~>) Symbol Symbol)
       where
         ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -184,7 +184,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym1KindInference) ())
     type ShowsPrec_0123456789876543210Sym2 :: GHC.Types.Nat
                                               -> Foo1 -> (~>) Symbol Symbol
-    data ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Foo1) :: (~>) Symbol Symbol
       where
         ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -194,19 +194,19 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym2KindInference) ())
     type ShowsPrec_0123456789876543210Sym3 :: GHC.Types.Nat
                                               -> Foo1 -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Foo1) (a0123456789876543210 :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow Foo1 where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type ShowsPrec_0123456789876543210 :: GHC.Types.Nat
                                           -> Foo2 a -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210 a a a where
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Foo2 a) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 p_0123456789876543210 (MkFoo2a arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "MkFoo2a ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
       ShowsPrec_0123456789876543210 p_0123456789876543210 (MkFoo2b argL_0123456789876543210 argR_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 5))) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 6)) argL_0123456789876543210)) (Apply (Apply (.@#@$) (Apply ShowStringSym0 " `MkFoo2b` ")) (Apply (Apply ShowsPrecSym0 (FromInteger 6)) argR_0123456789876543210)))) a_0123456789876543210
       ShowsPrec_0123456789876543210 p_0123456789876543210 ((:*:) arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "(:*:) ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
       ShowsPrec_0123456789876543210 p_0123456789876543210 ((:&:) argL_0123456789876543210 argR_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 5))) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 6)) argL_0123456789876543210)) (Apply (Apply (.@#@$) (Apply ShowStringSym0 " :&: ")) (Apply (Apply ShowsPrecSym0 (FromInteger 6)) argR_0123456789876543210)))) a_0123456789876543210
     type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) (Foo2 a) ((~>) Symbol Symbol))
-    data ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) (Foo2 a) ((~>) Symbol Symbol))
       where
         ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
                                                           ShowsPrec_0123456789876543210Sym0 a0123456789876543210
@@ -216,7 +216,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym0KindInference) ())
     type ShowsPrec_0123456789876543210Sym1 :: GHC.Types.Nat
                                               -> (~>) (Foo2 a) ((~>) Symbol Symbol)
-    data ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: (~>) (Foo2 a) ((~>) Symbol Symbol)
       where
         ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -226,7 +226,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym1KindInference) ())
     type ShowsPrec_0123456789876543210Sym2 :: GHC.Types.Nat
                                               -> Foo2 a -> (~>) Symbol Symbol
-    data ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Foo2 a) :: (~>) Symbol Symbol
       where
         ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -236,16 +236,16 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym2KindInference) ())
     type ShowsPrec_0123456789876543210Sym3 :: GHC.Types.Nat
                                               -> Foo2 a -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Foo2 a) (a0123456789876543210 :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow (Foo2 a) where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type ShowsPrec_0123456789876543210 :: GHC.Types.Nat
                                           -> Foo3 -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210 a a a where
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Foo3) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 p_0123456789876543210 (MkFoo3 arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "MkFoo3 ")) (Apply (Apply (.@#@$) (Apply ShowCharSym0 "{")) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "getFoo3a = ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 0)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowCommaSpaceSym0) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "(***) = ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 0)) arg_0123456789876543210)) (Apply ShowCharSym0 "}"))))))))) a_0123456789876543210
     type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) Foo3 ((~>) Symbol Symbol))
-    data ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) Foo3 ((~>) Symbol Symbol))
       where
         ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
                                                           ShowsPrec_0123456789876543210Sym0 a0123456789876543210
@@ -255,7 +255,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym0KindInference) ())
     type ShowsPrec_0123456789876543210Sym1 :: GHC.Types.Nat
                                               -> (~>) Foo3 ((~>) Symbol Symbol)
-    data ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: (~>) Foo3 ((~>) Symbol Symbol)
       where
         ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -265,7 +265,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym1KindInference) ())
     type ShowsPrec_0123456789876543210Sym2 :: GHC.Types.Nat
                                               -> Foo3 -> (~>) Symbol Symbol
-    data ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Foo3) :: (~>) Symbol Symbol
       where
         ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -275,7 +275,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym2KindInference) ())
     type ShowsPrec_0123456789876543210Sym3 :: GHC.Types.Nat
                                               -> Foo3 -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Foo3) (a0123456789876543210 :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow Foo3 where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a

--- a/singletons-base/tests/compile-and-dump/Singletons/StandaloneDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/StandaloneDeriving.golden
@@ -26,7 +26,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
     deriving instance Bounded S
     deriving instance Enum S
     type (:*:@#@$) :: forall a b. (~>) a ((~>) b (T a b))
-    data (:*:@#@$) a0123456789876543210
+    data (:*:@#@$) :: (~>) a ((~>) b (T a b))
       where
         (::*:@#@$###) :: SameKind (Apply (:*:@#@$) arg) ((:*:@#@$$) arg) =>
                          (:*:@#@$) a0123456789876543210
@@ -35,7 +35,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) (::*:@#@$###)) ())
     infixl 6 :*:@#@$
     type (:*:@#@$$) :: forall a b. a -> (~>) b (T a b)
-    data (:*:@#@$$) a0123456789876543210 a0123456789876543210
+    data (:*:@#@$$) (a0123456789876543210 :: a) :: (~>) b (T a b)
       where
         (::*:@#@$$###) :: SameKind (Apply ((:*:@#@$$) a0123456789876543210) arg) ((:*:@#@$$$) a0123456789876543210 arg) =>
                           (:*:@#@$$) a0123456789876543210 a0123456789876543210
@@ -44,20 +44,20 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) (::*:@#@$$###)) ())
     infixl 6 :*:@#@$$
     type (:*:@#@$$$) :: forall a b. a -> b -> T a b
-    type family (:*:@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family (:*:@#@$$$) (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: T a b where
       (:*:@#@$$$) a0123456789876543210 a0123456789876543210 = (:*:) a0123456789876543210 a0123456789876543210
     infixl 6 :*:@#@$$$
     type S1Sym0 :: S
-    type family S1Sym0 where
+    type family S1Sym0 :: S where
       S1Sym0 = S1
     type S2Sym0 :: S
-    type family S2Sym0 where
+    type family S2Sym0 :: S where
       S2Sym0 = S2
     type TFHelper_0123456789876543210 :: T a () -> T a () -> Bool
-    type family TFHelper_0123456789876543210 a a where
+    type family TFHelper_0123456789876543210 (a :: T a ()) (a :: T a ()) :: Bool where
       TFHelper_0123456789876543210 ((:*:) a_0123456789876543210 a_0123456789876543210) ((:*:) b_0123456789876543210 b_0123456789876543210) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)
     type TFHelper_0123456789876543210Sym0 :: (~>) (T a ()) ((~>) (T a ()) Bool)
-    data TFHelper_0123456789876543210Sym0 a0123456789876543210
+    data TFHelper_0123456789876543210Sym0 :: (~>) (T a ()) ((~>) (T a ()) Bool)
       where
         TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
                                                          TFHelper_0123456789876543210Sym0 a0123456789876543210
@@ -67,7 +67,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) TFHelper_0123456789876543210Sym0KindInference) ())
     type TFHelper_0123456789876543210Sym1 :: T a ()
                                              -> (~>) (T a ()) Bool
-    data TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: T a ()) :: (~>) (T a ()) Bool
       where
         TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                          TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -76,15 +76,15 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym1KindInference) ())
     type TFHelper_0123456789876543210Sym2 :: T a () -> T a () -> Bool
-    type family TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: T a ()) (a0123456789876543210 :: T a ()) :: Bool where
       TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq (T a ()) where
       type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
     type Compare_0123456789876543210 :: T a () -> T a () -> Ordering
-    type family Compare_0123456789876543210 a a where
+    type family Compare_0123456789876543210 (a :: T a ()) (a :: T a ()) :: Ordering where
       Compare_0123456789876543210 ((:*:) a_0123456789876543210 a_0123456789876543210) ((:*:) b_0123456789876543210 b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0))
     type Compare_0123456789876543210Sym0 :: (~>) (T a ()) ((~>) (T a ()) Ordering)
-    data Compare_0123456789876543210Sym0 a0123456789876543210
+    data Compare_0123456789876543210Sym0 :: (~>) (T a ()) ((~>) (T a ()) Ordering)
       where
         Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
                                                         Compare_0123456789876543210Sym0 a0123456789876543210
@@ -94,7 +94,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) Compare_0123456789876543210Sym0KindInference) ())
     type Compare_0123456789876543210Sym1 :: T a ()
                                             -> (~>) (T a ()) Ordering
-    data Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: T a ()) :: (~>) (T a ()) Ordering
       where
         Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                         Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -104,16 +104,16 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) Compare_0123456789876543210Sym1KindInference) ())
     type Compare_0123456789876543210Sym2 :: T a ()
                                             -> T a () -> Ordering
-    type family Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Compare_0123456789876543210Sym2 (a0123456789876543210 :: T a ()) (a0123456789876543210 :: T a ()) :: Ordering where
       Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd (T a ()) where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type ShowsPrec_0123456789876543210 :: GHC.Types.Nat
                                           -> T a () -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210 a a a where
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: T a ()) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 p_0123456789876543210 ((:*:) argL_0123456789876543210 argR_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 6))) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 7)) argL_0123456789876543210)) (Apply (Apply (.@#@$) (Apply ShowStringSym0 " :*: ")) (Apply (Apply ShowsPrecSym0 (FromInteger 7)) argR_0123456789876543210)))) a_0123456789876543210
     type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) (T a ()) ((~>) Symbol Symbol))
-    data ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) (T a ()) ((~>) Symbol Symbol))
       where
         ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
                                                           ShowsPrec_0123456789876543210Sym0 a0123456789876543210
@@ -123,7 +123,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym0KindInference) ())
     type ShowsPrec_0123456789876543210Sym1 :: GHC.Types.Nat
                                               -> (~>) (T a ()) ((~>) Symbol Symbol)
-    data ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: (~>) (T a ()) ((~>) Symbol Symbol)
       where
         ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -133,7 +133,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym1KindInference) ())
     type ShowsPrec_0123456789876543210Sym2 :: GHC.Types.Nat
                                               -> T a () -> (~>) Symbol Symbol
-    data ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: T a ()) :: (~>) Symbol Symbol
       where
         ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -143,18 +143,18 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym2KindInference) ())
     type ShowsPrec_0123456789876543210Sym3 :: GHC.Types.Nat
                                               -> T a () -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: T a ()) (a0123456789876543210 :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow (T a ()) where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type TFHelper_0123456789876543210 :: S -> S -> Bool
-    type family TFHelper_0123456789876543210 a a where
+    type family TFHelper_0123456789876543210 (a :: S) (a :: S) :: Bool where
       TFHelper_0123456789876543210 S1 S1 = TrueSym0
       TFHelper_0123456789876543210 S1 S2 = FalseSym0
       TFHelper_0123456789876543210 S2 S1 = FalseSym0
       TFHelper_0123456789876543210 S2 S2 = TrueSym0
     type TFHelper_0123456789876543210Sym0 :: (~>) S ((~>) S Bool)
-    data TFHelper_0123456789876543210Sym0 a0123456789876543210
+    data TFHelper_0123456789876543210Sym0 :: (~>) S ((~>) S Bool)
       where
         TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
                                                          TFHelper_0123456789876543210Sym0 a0123456789876543210
@@ -163,7 +163,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym0KindInference) ())
     type TFHelper_0123456789876543210Sym1 :: S -> (~>) S Bool
-    data TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: S) :: (~>) S Bool
       where
         TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                          TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -172,18 +172,18 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym1KindInference) ())
     type TFHelper_0123456789876543210Sym2 :: S -> S -> Bool
-    type family TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: S) (a0123456789876543210 :: S) :: Bool where
       TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq S where
       type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
     type Compare_0123456789876543210 :: S -> S -> Ordering
-    type family Compare_0123456789876543210 a a where
+    type family Compare_0123456789876543210 (a :: S) (a :: S) :: Ordering where
       Compare_0123456789876543210 S1 S1 = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) NilSym0
       Compare_0123456789876543210 S2 S2 = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) NilSym0
       Compare_0123456789876543210 S1 S2 = LTSym0
       Compare_0123456789876543210 S2 S1 = GTSym0
     type Compare_0123456789876543210Sym0 :: (~>) S ((~>) S Ordering)
-    data Compare_0123456789876543210Sym0 a0123456789876543210
+    data Compare_0123456789876543210Sym0 :: (~>) S ((~>) S Ordering)
       where
         Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
                                                         Compare_0123456789876543210Sym0 a0123456789876543210
@@ -192,7 +192,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Compare_0123456789876543210Sym0KindInference) ())
     type Compare_0123456789876543210Sym1 :: S -> (~>) S Ordering
-    data Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: S) :: (~>) S Ordering
       where
         Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                         Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -201,17 +201,17 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Compare_0123456789876543210Sym1KindInference) ())
     type Compare_0123456789876543210Sym2 :: S -> S -> Ordering
-    type family Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Compare_0123456789876543210Sym2 (a0123456789876543210 :: S) (a0123456789876543210 :: S) :: Ordering where
       Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd S where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type ShowsPrec_0123456789876543210 :: GHC.Types.Nat
                                           -> S -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210 a a a where
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: S) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 _ S1 a_0123456789876543210 = Apply (Apply ShowStringSym0 "S1") a_0123456789876543210
       ShowsPrec_0123456789876543210 _ S2 a_0123456789876543210 = Apply (Apply ShowStringSym0 "S2") a_0123456789876543210
     type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) S ((~>) Symbol Symbol))
-    data ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) S ((~>) Symbol Symbol))
       where
         ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
                                                           ShowsPrec_0123456789876543210Sym0 a0123456789876543210
@@ -221,7 +221,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym0KindInference) ())
     type ShowsPrec_0123456789876543210Sym1 :: GHC.Types.Nat
                                               -> (~>) S ((~>) Symbol Symbol)
-    data ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: (~>) S ((~>) Symbol Symbol)
       where
         ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -231,7 +231,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym1KindInference) ())
     type ShowsPrec_0123456789876543210Sym2 :: GHC.Types.Nat
                                               -> S -> (~>) Symbol Symbol
-    data ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: S) :: (~>) Symbol Symbol
       where
         ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -241,21 +241,21 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym2KindInference) ())
     type ShowsPrec_0123456789876543210Sym3 :: GHC.Types.Nat
                                               -> S -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: S) (a0123456789876543210 :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow S where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type MinBound_0123456789876543210 :: S
-    type family MinBound_0123456789876543210 where
+    type family MinBound_0123456789876543210 :: S where
       MinBound_0123456789876543210 = S1Sym0
     type MinBound_0123456789876543210Sym0 :: S
-    type family MinBound_0123456789876543210Sym0 where
+    type family MinBound_0123456789876543210Sym0 :: S where
       MinBound_0123456789876543210Sym0 = MinBound_0123456789876543210
     type MaxBound_0123456789876543210 :: S
-    type family MaxBound_0123456789876543210 where
+    type family MaxBound_0123456789876543210 :: S where
       MaxBound_0123456789876543210 = S2Sym0
     type MaxBound_0123456789876543210Sym0 :: S
-    type family MaxBound_0123456789876543210Sym0 where
+    type family MaxBound_0123456789876543210Sym0 :: S where
       MaxBound_0123456789876543210Sym0 = MaxBound_0123456789876543210
     instance PBounded S where
       type MinBound = MinBound_0123456789876543210Sym0
@@ -267,10 +267,10 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
       Case_0123456789876543210 n 'True = S1Sym0
       Case_0123456789876543210 n 'False = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (FromInteger 1))
     type ToEnum_0123456789876543210 :: GHC.Types.Nat -> S
-    type family ToEnum_0123456789876543210 a where
+    type family ToEnum_0123456789876543210 (a :: GHC.Types.Nat) :: S where
       ToEnum_0123456789876543210 n = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (FromInteger 0))
     type ToEnum_0123456789876543210Sym0 :: (~>) GHC.Types.Nat S
-    data ToEnum_0123456789876543210Sym0 a0123456789876543210
+    data ToEnum_0123456789876543210Sym0 :: (~>) GHC.Types.Nat S
       where
         ToEnum_0123456789876543210Sym0KindInference :: SameKind (Apply ToEnum_0123456789876543210Sym0 arg) (ToEnum_0123456789876543210Sym1 arg) =>
                                                        ToEnum_0123456789876543210Sym0 a0123456789876543210
@@ -279,14 +279,14 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) ToEnum_0123456789876543210Sym0KindInference) ())
     type ToEnum_0123456789876543210Sym1 :: GHC.Types.Nat -> S
-    type family ToEnum_0123456789876543210Sym1 a0123456789876543210 where
+    type family ToEnum_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: S where
       ToEnum_0123456789876543210Sym1 a0123456789876543210 = ToEnum_0123456789876543210 a0123456789876543210
     type FromEnum_0123456789876543210 :: S -> GHC.Types.Nat
-    type family FromEnum_0123456789876543210 a where
+    type family FromEnum_0123456789876543210 (a :: S) :: GHC.Types.Nat where
       FromEnum_0123456789876543210 S1 = FromInteger 0
       FromEnum_0123456789876543210 S2 = FromInteger 1
     type FromEnum_0123456789876543210Sym0 :: (~>) S GHC.Types.Nat
-    data FromEnum_0123456789876543210Sym0 a0123456789876543210
+    data FromEnum_0123456789876543210Sym0 :: (~>) S GHC.Types.Nat
       where
         FromEnum_0123456789876543210Sym0KindInference :: SameKind (Apply FromEnum_0123456789876543210Sym0 arg) (FromEnum_0123456789876543210Sym1 arg) =>
                                                          FromEnum_0123456789876543210Sym0 a0123456789876543210
@@ -295,7 +295,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) FromEnum_0123456789876543210Sym0KindInference) ())
     type FromEnum_0123456789876543210Sym1 :: S -> GHC.Types.Nat
-    type family FromEnum_0123456789876543210Sym1 a0123456789876543210 where
+    type family FromEnum_0123456789876543210Sym1 (a0123456789876543210 :: S) :: GHC.Types.Nat where
       FromEnum_0123456789876543210Sym1 a0123456789876543210 = FromEnum_0123456789876543210 a0123456789876543210
     instance PEnum S where
       type ToEnum a = Apply ToEnum_0123456789876543210Sym0 a

--- a/singletons-base/tests/compile-and-dump/Singletons/Star.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Star.golden
@@ -10,16 +10,16 @@ Singletons/Star.hs:0:0:: Splicing declarations
         Singletons.Star.Vec :: Rep -> Nat -> Rep
       deriving (Eq, Ord, Read, Show)
     type NatSym0 :: Type
-    type family NatSym0 where
+    type family NatSym0 :: Type where
       NatSym0 = Nat
     type IntSym0 :: Type
-    type family IntSym0 where
+    type family IntSym0 :: Type where
       IntSym0 = Int
     type StringSym0 :: Type
-    type family StringSym0 where
+    type family StringSym0 :: Type where
       StringSym0 = String
     type MaybeSym0 :: (~>) Type Type
-    data MaybeSym0 a0123456789876543210
+    data MaybeSym0 :: (~>) Type Type
       where
         MaybeSym0KindInference :: SameKind (Apply MaybeSym0 arg) (MaybeSym1 arg) =>
                                   MaybeSym0 a0123456789876543210
@@ -27,10 +27,10 @@ Singletons/Star.hs:0:0:: Splicing declarations
     instance SuppressUnusedWarnings MaybeSym0 where
       suppressUnusedWarnings = snd (((,) MaybeSym0KindInference) ())
     type MaybeSym1 :: Type -> Type
-    type family MaybeSym1 a0123456789876543210 where
+    type family MaybeSym1 (a0123456789876543210 :: Type) :: Type where
       MaybeSym1 a0123456789876543210 = Maybe a0123456789876543210
     type VecSym0 :: (~>) Type ((~>) Nat Type)
-    data VecSym0 a0123456789876543210
+    data VecSym0 :: (~>) Type ((~>) Nat Type)
       where
         VecSym0KindInference :: SameKind (Apply VecSym0 arg) (VecSym1 arg) =>
                                 VecSym0 a0123456789876543210
@@ -38,7 +38,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
     instance SuppressUnusedWarnings VecSym0 where
       suppressUnusedWarnings = snd (((,) VecSym0KindInference) ())
     type VecSym1 :: Type -> (~>) Nat Type
-    data VecSym1 a0123456789876543210 a0123456789876543210
+    data VecSym1 (a0123456789876543210 :: Type) :: (~>) Nat Type
       where
         VecSym1KindInference :: SameKind (Apply (VecSym1 a0123456789876543210) arg) (VecSym2 a0123456789876543210 arg) =>
                                 VecSym1 a0123456789876543210 a0123456789876543210
@@ -46,10 +46,10 @@ Singletons/Star.hs:0:0:: Splicing declarations
     instance SuppressUnusedWarnings (VecSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) VecSym1KindInference) ())
     type VecSym2 :: Type -> Nat -> Type
-    type family VecSym2 a0123456789876543210 a0123456789876543210 where
+    type family VecSym2 (a0123456789876543210 :: Type) (a0123456789876543210 :: Nat) :: Type where
       VecSym2 a0123456789876543210 a0123456789876543210 = Vec a0123456789876543210 a0123456789876543210
     type TFHelper_0123456789876543210 :: Type -> Type -> Bool
-    type family TFHelper_0123456789876543210 a a where
+    type family TFHelper_0123456789876543210 (a :: Type) (a :: Type) :: Bool where
       TFHelper_0123456789876543210 Nat Nat = TrueSym0
       TFHelper_0123456789876543210 Nat Int = FalseSym0
       TFHelper_0123456789876543210 Nat String = FalseSym0
@@ -76,7 +76,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
       TFHelper_0123456789876543210 (Vec _ _) (Maybe _) = FalseSym0
       TFHelper_0123456789876543210 (Vec a_0123456789876543210 a_0123456789876543210) (Vec b_0123456789876543210 b_0123456789876543210) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)
     type TFHelper_0123456789876543210Sym0 :: (~>) Type ((~>) Type Bool)
-    data TFHelper_0123456789876543210Sym0 a0123456789876543210
+    data TFHelper_0123456789876543210Sym0 :: (~>) Type ((~>) Type Bool)
       where
         TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
                                                          TFHelper_0123456789876543210Sym0 a0123456789876543210
@@ -85,7 +85,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym0KindInference) ())
     type TFHelper_0123456789876543210Sym1 :: Type -> (~>) Type Bool
-    data TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Type) :: (~>) Type Bool
       where
         TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                          TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -94,12 +94,12 @@ Singletons/Star.hs:0:0:: Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym1KindInference) ())
     type TFHelper_0123456789876543210Sym2 :: Type -> Type -> Bool
-    type family TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: Type) (a0123456789876543210 :: Type) :: Bool where
       TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq Type where
       type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
     type Compare_0123456789876543210 :: Type -> Type -> Ordering
-    type family Compare_0123456789876543210 a a where
+    type family Compare_0123456789876543210 (a :: Type) (a :: Type) :: Ordering where
       Compare_0123456789876543210 Nat Nat = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) NilSym0
       Compare_0123456789876543210 Int Int = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) NilSym0
       Compare_0123456789876543210 String String = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) NilSym0
@@ -126,7 +126,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
       Compare_0123456789876543210 (Vec _ _) String = GTSym0
       Compare_0123456789876543210 (Vec _ _) (Maybe _) = GTSym0
     type Compare_0123456789876543210Sym0 :: (~>) Type ((~>) Type Ordering)
-    data Compare_0123456789876543210Sym0 a0123456789876543210
+    data Compare_0123456789876543210Sym0 :: (~>) Type ((~>) Type Ordering)
       where
         Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
                                                         Compare_0123456789876543210Sym0 a0123456789876543210
@@ -135,7 +135,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Compare_0123456789876543210Sym0KindInference) ())
     type Compare_0123456789876543210Sym1 :: Type -> (~>) Type Ordering
-    data Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Type) :: (~>) Type Ordering
       where
         Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                         Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -144,20 +144,20 @@ Singletons/Star.hs:0:0:: Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Compare_0123456789876543210Sym1KindInference) ())
     type Compare_0123456789876543210Sym2 :: Type -> Type -> Ordering
-    type family Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Compare_0123456789876543210Sym2 (a0123456789876543210 :: Type) (a0123456789876543210 :: Type) :: Ordering where
       Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd Type where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type ShowsPrec_0123456789876543210 :: GHC.Types.Nat
                                           -> Type -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210 a a a where
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Type) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 _ Nat a_0123456789876543210 = Apply (Apply ShowStringSym0 "Nat") a_0123456789876543210
       ShowsPrec_0123456789876543210 _ Int a_0123456789876543210 = Apply (Apply ShowStringSym0 "Int") a_0123456789876543210
       ShowsPrec_0123456789876543210 _ String a_0123456789876543210 = Apply (Apply ShowStringSym0 "String") a_0123456789876543210
       ShowsPrec_0123456789876543210 p_0123456789876543210 (Maybe arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Maybe ")) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
       ShowsPrec_0123456789876543210 p_0123456789876543210 (Vec arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Vec ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
     type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) Type ((~>) Symbol Symbol))
-    data ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) Type ((~>) Symbol Symbol))
       where
         ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
                                                           ShowsPrec_0123456789876543210Sym0 a0123456789876543210
@@ -167,7 +167,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym0KindInference) ())
     type ShowsPrec_0123456789876543210Sym1 :: GHC.Types.Nat
                                               -> (~>) Type ((~>) Symbol Symbol)
-    data ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: (~>) Type ((~>) Symbol Symbol)
       where
         ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -177,7 +177,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym1KindInference) ())
     type ShowsPrec_0123456789876543210Sym2 :: GHC.Types.Nat
                                               -> Type -> (~>) Symbol Symbol
-    data ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Type) :: (~>) Symbol Symbol
       where
         ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -187,7 +187,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym2KindInference) ())
     type ShowsPrec_0123456789876543210Sym3 :: GHC.Types.Nat
                                               -> Type -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Type) (a0123456789876543210 :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow Type where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a

--- a/singletons-base/tests/compile-and-dump/Singletons/T124.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T124.golden
@@ -8,7 +8,7 @@ Singletons/T124.hs:(0,0)-(0,0): Splicing declarations
     foo True = ()
     foo False = ()
     type FooSym0 :: (~>) Bool ()
-    data FooSym0 a0123456789876543210
+    data FooSym0 :: (~>) Bool ()
       where
         FooSym0KindInference :: SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
                                 FooSym0 a0123456789876543210
@@ -16,10 +16,10 @@ Singletons/T124.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings = snd (((,) FooSym0KindInference) ())
     type FooSym1 :: Bool -> ()
-    type family FooSym1 a0123456789876543210 where
+    type family FooSym1 (a0123456789876543210 :: Bool) :: () where
       FooSym1 a0123456789876543210 = Foo a0123456789876543210
     type Foo :: Bool -> ()
-    type family Foo a where
+    type family Foo (a :: Bool) :: () where
       Foo 'True = Tuple0Sym0
       Foo 'False = Tuple0Sym0
     sFoo :: forall (t :: Bool). Sing t -> Sing (Apply FooSym0 t :: ())

--- a/singletons-base/tests/compile-and-dump/Singletons/T136.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T136.golden
@@ -30,12 +30,12 @@ Singletons/T136.hs:(0,0)-(0,0): Splicing declarations
       fromEnum (False : as) = (2 * fromEnum as)
       fromEnum (True : as) = (1 + (2 * fromEnum as))
     type Succ_0123456789876543210 :: [Bool] -> [Bool]
-    type family Succ_0123456789876543210 a where
+    type family Succ_0123456789876543210 (a :: [Bool]) :: [Bool] where
       Succ_0123456789876543210 '[] = Apply (Apply (:@#@$) TrueSym0) NilSym0
       Succ_0123456789876543210 ('(:) 'False as) = Apply (Apply (:@#@$) TrueSym0) as
       Succ_0123456789876543210 ('(:) 'True as) = Apply (Apply (:@#@$) FalseSym0) (Apply SuccSym0 as)
     type Succ_0123456789876543210Sym0 :: (~>) [Bool] [Bool]
-    data Succ_0123456789876543210Sym0 a0123456789876543210
+    data Succ_0123456789876543210Sym0 :: (~>) [Bool] [Bool]
       where
         Succ_0123456789876543210Sym0KindInference :: SameKind (Apply Succ_0123456789876543210Sym0 arg) (Succ_0123456789876543210Sym1 arg) =>
                                                      Succ_0123456789876543210Sym0 a0123456789876543210
@@ -44,15 +44,15 @@ Singletons/T136.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Succ_0123456789876543210Sym0KindInference) ())
     type Succ_0123456789876543210Sym1 :: [Bool] -> [Bool]
-    type family Succ_0123456789876543210Sym1 a0123456789876543210 where
+    type family Succ_0123456789876543210Sym1 (a0123456789876543210 :: [Bool]) :: [Bool] where
       Succ_0123456789876543210Sym1 a0123456789876543210 = Succ_0123456789876543210 a0123456789876543210
     type Pred_0123456789876543210 :: [Bool] -> [Bool]
-    type family Pred_0123456789876543210 a where
+    type family Pred_0123456789876543210 (a :: [Bool]) :: [Bool] where
       Pred_0123456789876543210 '[] = Apply ErrorSym0 "pred 0"
       Pred_0123456789876543210 ('(:) 'False as) = Apply (Apply (:@#@$) TrueSym0) (Apply PredSym0 as)
       Pred_0123456789876543210 ('(:) 'True as) = Apply (Apply (:@#@$) FalseSym0) as
     type Pred_0123456789876543210Sym0 :: (~>) [Bool] [Bool]
-    data Pred_0123456789876543210Sym0 a0123456789876543210
+    data Pred_0123456789876543210Sym0 :: (~>) [Bool] [Bool]
       where
         Pred_0123456789876543210Sym0KindInference :: SameKind (Apply Pred_0123456789876543210Sym0 arg) (Pred_0123456789876543210Sym1 arg) =>
                                                      Pred_0123456789876543210Sym0 a0123456789876543210
@@ -61,7 +61,7 @@ Singletons/T136.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Pred_0123456789876543210Sym0KindInference) ())
     type Pred_0123456789876543210Sym1 :: [Bool] -> [Bool]
-    type family Pred_0123456789876543210Sym1 a0123456789876543210 where
+    type family Pred_0123456789876543210Sym1 (a0123456789876543210 :: [Bool]) :: [Bool] where
       Pred_0123456789876543210Sym1 a0123456789876543210 = Pred_0123456789876543210 a0123456789876543210
     type family Case_0123456789876543210 i arg_0123456789876543210 t where
       Case_0123456789876543210 i arg_0123456789876543210 'True = NilSym0
@@ -72,10 +72,10 @@ Singletons/T136.hs:(0,0)-(0,0): Splicing declarations
     type family Case_0123456789876543210 arg_0123456789876543210 t where
       Case_0123456789876543210 arg_0123456789876543210 i = Case_0123456789876543210 i arg_0123456789876543210 (Apply (Apply (<@#@$) i) (FromInteger 0))
     type ToEnum_0123456789876543210 :: GHC.Types.Nat -> [Bool]
-    type family ToEnum_0123456789876543210 a where
+    type family ToEnum_0123456789876543210 (a :: GHC.Types.Nat) :: [Bool] where
       ToEnum_0123456789876543210 arg_0123456789876543210 = Case_0123456789876543210 arg_0123456789876543210 arg_0123456789876543210
     type ToEnum_0123456789876543210Sym0 :: (~>) GHC.Types.Nat [Bool]
-    data ToEnum_0123456789876543210Sym0 a0123456789876543210
+    data ToEnum_0123456789876543210Sym0 :: (~>) GHC.Types.Nat [Bool]
       where
         ToEnum_0123456789876543210Sym0KindInference :: SameKind (Apply ToEnum_0123456789876543210Sym0 arg) (ToEnum_0123456789876543210Sym1 arg) =>
                                                        ToEnum_0123456789876543210Sym0 a0123456789876543210
@@ -84,15 +84,15 @@ Singletons/T136.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) ToEnum_0123456789876543210Sym0KindInference) ())
     type ToEnum_0123456789876543210Sym1 :: GHC.Types.Nat -> [Bool]
-    type family ToEnum_0123456789876543210Sym1 a0123456789876543210 where
+    type family ToEnum_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: [Bool] where
       ToEnum_0123456789876543210Sym1 a0123456789876543210 = ToEnum_0123456789876543210 a0123456789876543210
     type FromEnum_0123456789876543210 :: [Bool] -> GHC.Types.Nat
-    type family FromEnum_0123456789876543210 a where
+    type family FromEnum_0123456789876543210 (a :: [Bool]) :: GHC.Types.Nat where
       FromEnum_0123456789876543210 '[] = FromInteger 0
       FromEnum_0123456789876543210 ('(:) 'False as) = Apply (Apply (*@#@$) (FromInteger 2)) (Apply FromEnumSym0 as)
       FromEnum_0123456789876543210 ('(:) 'True as) = Apply (Apply (+@#@$) (FromInteger 1)) (Apply (Apply (*@#@$) (FromInteger 2)) (Apply FromEnumSym0 as))
     type FromEnum_0123456789876543210Sym0 :: (~>) [Bool] GHC.Types.Nat
-    data FromEnum_0123456789876543210Sym0 a0123456789876543210
+    data FromEnum_0123456789876543210Sym0 :: (~>) [Bool] GHC.Types.Nat
       where
         FromEnum_0123456789876543210Sym0KindInference :: SameKind (Apply FromEnum_0123456789876543210Sym0 arg) (FromEnum_0123456789876543210Sym1 arg) =>
                                                          FromEnum_0123456789876543210Sym0 a0123456789876543210
@@ -101,7 +101,7 @@ Singletons/T136.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) FromEnum_0123456789876543210Sym0KindInference) ())
     type FromEnum_0123456789876543210Sym1 :: [Bool] -> GHC.Types.Nat
-    type family FromEnum_0123456789876543210Sym1 a0123456789876543210 where
+    type family FromEnum_0123456789876543210Sym1 (a0123456789876543210 :: [Bool]) :: GHC.Types.Nat where
       FromEnum_0123456789876543210Sym1 a0123456789876543210 = FromEnum_0123456789876543210 a0123456789876543210
     instance PEnum [Bool] where
       type Succ a = Apply Succ_0123456789876543210Sym0 a

--- a/singletons-base/tests/compile-and-dump/Singletons/T136b.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T136b.golden
@@ -6,7 +6,7 @@ Singletons/T136b.hs:(0,0)-(0,0): Splicing declarations
     class C a where
       meth :: a -> a
     type MethSym0 :: forall a. (~>) a a
-    data MethSym0 a0123456789876543210
+    data MethSym0 :: (~>) a a
       where
         MethSym0KindInference :: SameKind (Apply MethSym0 arg) (MethSym1 arg) =>
                                  MethSym0 a0123456789876543210
@@ -14,7 +14,7 @@ Singletons/T136b.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings MethSym0 where
       suppressUnusedWarnings = snd (((,) MethSym0KindInference) ())
     type MethSym1 :: forall a. a -> a
-    type family MethSym1 a0123456789876543210 where
+    type family MethSym1 (a0123456789876543210 :: a) :: a where
       MethSym1 a0123456789876543210 = Meth a0123456789876543210
     class PC a where
       type Meth (arg :: a) :: a
@@ -30,10 +30,10 @@ Singletons/T136b.hs:(0,0)-(0,0): Splicing declarations
     instance C Bool where
       meth = not
     type Meth_0123456789876543210 :: Bool -> Bool
-    type family Meth_0123456789876543210 a where
+    type family Meth_0123456789876543210 (a :: Bool) :: Bool where
       Meth_0123456789876543210 a_0123456789876543210 = Apply NotSym0 a_0123456789876543210
     type Meth_0123456789876543210Sym0 :: (~>) Bool Bool
-    data Meth_0123456789876543210Sym0 a0123456789876543210
+    data Meth_0123456789876543210Sym0 :: (~>) Bool Bool
       where
         Meth_0123456789876543210Sym0KindInference :: SameKind (Apply Meth_0123456789876543210Sym0 arg) (Meth_0123456789876543210Sym1 arg) =>
                                                      Meth_0123456789876543210Sym0 a0123456789876543210
@@ -42,7 +42,7 @@ Singletons/T136b.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Meth_0123456789876543210Sym0KindInference) ())
     type Meth_0123456789876543210Sym1 :: Bool -> Bool
-    type family Meth_0123456789876543210Sym1 a0123456789876543210 where
+    type family Meth_0123456789876543210Sym1 (a0123456789876543210 :: Bool) :: Bool where
       Meth_0123456789876543210Sym1 a0123456789876543210 = Meth_0123456789876543210 a0123456789876543210
     instance PC Bool where
       type Meth a = Apply Meth_0123456789876543210Sym0 a

--- a/singletons-base/tests/compile-and-dump/Singletons/T145.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T145.golden
@@ -6,7 +6,7 @@ Singletons/T145.hs:(0,0)-(0,0): Splicing declarations
     class Column (f :: Type -> Type) where
       col :: f a -> a -> Bool
     type ColSym0 :: forall f a. (~>) (f a) ((~>) a Bool)
-    data ColSym0 a0123456789876543210
+    data ColSym0 :: (~>) (f a) ((~>) a Bool)
       where
         ColSym0KindInference :: SameKind (Apply ColSym0 arg) (ColSym1 arg) =>
                                 ColSym0 a0123456789876543210
@@ -14,7 +14,7 @@ Singletons/T145.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ColSym0 where
       suppressUnusedWarnings = snd (((,) ColSym0KindInference) ())
     type ColSym1 :: forall f a. f a -> (~>) a Bool
-    data ColSym1 a0123456789876543210 a0123456789876543210
+    data ColSym1 (a0123456789876543210 :: f a) :: (~>) a Bool
       where
         ColSym1KindInference :: SameKind (Apply (ColSym1 a0123456789876543210) arg) (ColSym2 a0123456789876543210 arg) =>
                                 ColSym1 a0123456789876543210 a0123456789876543210
@@ -22,7 +22,7 @@ Singletons/T145.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (ColSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) ColSym1KindInference) ())
     type ColSym2 :: forall f a. f a -> a -> Bool
-    type family ColSym2 a0123456789876543210 a0123456789876543210 where
+    type family ColSym2 (a0123456789876543210 :: f a) (a0123456789876543210 :: a) :: Bool where
       ColSym2 a0123456789876543210 a0123456789876543210 = Col a0123456789876543210 a0123456789876543210
     class PColumn (f :: Type -> Type) where
       type Col (arg :: f a) (arg :: a) :: Bool

--- a/singletons-base/tests/compile-and-dump/Singletons/T150.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T150.golden
@@ -71,10 +71,10 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
         HCons :: x -> (HList xs) -> HList ('(:) x xs)
     data Obj :: Type where Obj :: a -> Obj
     type FZSym0 :: Fin ('Succ n)
-    type family FZSym0 where
+    type family FZSym0 :: Fin ('Succ n) where
       FZSym0 = FZ
     type FSSym0 :: (~>) (Fin n) (Fin ('Succ n))
-    data FSSym0 a0123456789876543210
+    data FSSym0 :: (~>) (Fin n) (Fin ('Succ n))
       where
         FSSym0KindInference :: SameKind (Apply FSSym0 arg) (FSSym1 arg) =>
                                FSSym0 a0123456789876543210
@@ -82,19 +82,19 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FSSym0 where
       suppressUnusedWarnings = snd (((,) FSSym0KindInference) ())
     type FSSym1 :: Fin n -> Fin ('Succ n)
-    type family FSSym1 a0123456789876543210 where
+    type family FSSym1 (a0123456789876543210 :: Fin n) :: Fin ('Succ n) where
       FSSym1 a0123456789876543210 = FS a0123456789876543210
     type MkFoo1Sym0 :: Foo Bool
-    type family MkFoo1Sym0 where
+    type family MkFoo1Sym0 :: Foo Bool where
       MkFoo1Sym0 = MkFoo1
     type MkFoo2Sym0 :: Foo Ordering
-    type family MkFoo2Sym0 where
+    type family MkFoo2Sym0 :: Foo Ordering where
       MkFoo2Sym0 = MkFoo2
     type VNilSym0 :: Vec 'Zero a
-    type family VNilSym0 where
+    type family VNilSym0 :: Vec 'Zero a where
       VNilSym0 = VNil
     type VConsSym0 :: (~>) a ((~>) (Vec n a) (Vec ('Succ n) a))
-    data VConsSym0 a0123456789876543210
+    data VConsSym0 :: (~>) a ((~>) (Vec n a) (Vec ('Succ n) a))
       where
         VConsSym0KindInference :: SameKind (Apply VConsSym0 arg) (VConsSym1 arg) =>
                                   VConsSym0 a0123456789876543210
@@ -102,7 +102,7 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings VConsSym0 where
       suppressUnusedWarnings = snd (((,) VConsSym0KindInference) ())
     type VConsSym1 :: a -> (~>) (Vec n a) (Vec ('Succ n) a)
-    data VConsSym1 a0123456789876543210 a0123456789876543210
+    data VConsSym1 (a0123456789876543210 :: a) :: (~>) (Vec n a) (Vec ('Succ n) a)
       where
         VConsSym1KindInference :: SameKind (Apply (VConsSym1 a0123456789876543210) arg) (VConsSym2 a0123456789876543210 arg) =>
                                   VConsSym1 a0123456789876543210 a0123456789876543210
@@ -110,16 +110,16 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (VConsSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) VConsSym1KindInference) ())
     type VConsSym2 :: a -> Vec n a -> Vec ('Succ n) a
-    type family VConsSym2 a0123456789876543210 a0123456789876543210 where
+    type family VConsSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: Vec n a) :: Vec ('Succ n) a where
       VConsSym2 a0123456789876543210 a0123456789876543210 = VCons a0123456789876543210 a0123456789876543210
     type ReflexiveSym0 :: Equal a a
-    type family ReflexiveSym0 where
+    type family ReflexiveSym0 :: Equal a a where
       ReflexiveSym0 = Reflexive
     type HNilSym0 :: HList '[]
-    type family HNilSym0 where
+    type family HNilSym0 :: HList '[] where
       HNilSym0 = HNil
     type HConsSym0 :: (~>) x ((~>) (HList xs) (HList ('(:) x xs)))
-    data HConsSym0 a0123456789876543210
+    data HConsSym0 :: (~>) x ((~>) (HList xs) (HList ('(:) x xs)))
       where
         HConsSym0KindInference :: SameKind (Apply HConsSym0 arg) (HConsSym1 arg) =>
                                   HConsSym0 a0123456789876543210
@@ -127,7 +127,7 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings HConsSym0 where
       suppressUnusedWarnings = snd (((,) HConsSym0KindInference) ())
     type HConsSym1 :: x -> (~>) (HList xs) (HList ('(:) x xs))
-    data HConsSym1 a0123456789876543210 a0123456789876543210
+    data HConsSym1 (a0123456789876543210 :: x) :: (~>) (HList xs) (HList ('(:) x xs))
       where
         HConsSym1KindInference :: SameKind (Apply (HConsSym1 a0123456789876543210) arg) (HConsSym2 a0123456789876543210 arg) =>
                                   HConsSym1 a0123456789876543210 a0123456789876543210
@@ -135,10 +135,10 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (HConsSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) HConsSym1KindInference) ())
     type HConsSym2 :: x -> HList xs -> HList ('(:) x xs)
-    type family HConsSym2 a0123456789876543210 a0123456789876543210 where
+    type family HConsSym2 (a0123456789876543210 :: x) (a0123456789876543210 :: HList xs) :: HList ('(:) x xs) where
       HConsSym2 a0123456789876543210 a0123456789876543210 = HCons a0123456789876543210 a0123456789876543210
     type ObjSym0 :: (~>) a Obj
-    data ObjSym0 a0123456789876543210
+    data ObjSym0 :: (~>) a Obj
       where
         ObjSym0KindInference :: SameKind (Apply ObjSym0 arg) (ObjSym1 arg) =>
                                 ObjSym0 a0123456789876543210
@@ -146,11 +146,11 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ObjSym0 where
       suppressUnusedWarnings = snd (((,) ObjSym0KindInference) ())
     type ObjSym1 :: a -> Obj
-    type family ObjSym1 a0123456789876543210 where
+    type family ObjSym1 (a0123456789876543210 :: a) :: Obj where
       ObjSym1 a0123456789876543210 = Obj a0123456789876543210
     type family Case_0123456789876543210 n t where
     type TransitivitySym0 :: (~>) (Equal a b) ((~>) (Equal b c) (Equal a c))
-    data TransitivitySym0 a0123456789876543210
+    data TransitivitySym0 :: (~>) (Equal a b) ((~>) (Equal b c) (Equal a c))
       where
         TransitivitySym0KindInference :: SameKind (Apply TransitivitySym0 arg) (TransitivitySym1 arg) =>
                                          TransitivitySym0 a0123456789876543210
@@ -159,7 +159,7 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TransitivitySym0KindInference) ())
     type TransitivitySym1 :: Equal a b -> (~>) (Equal b c) (Equal a c)
-    data TransitivitySym1 a0123456789876543210 a0123456789876543210
+    data TransitivitySym1 (a0123456789876543210 :: Equal a b) :: (~>) (Equal b c) (Equal a c)
       where
         TransitivitySym1KindInference :: SameKind (Apply (TransitivitySym1 a0123456789876543210) arg) (TransitivitySym2 a0123456789876543210 arg) =>
                                          TransitivitySym1 a0123456789876543210 a0123456789876543210
@@ -168,10 +168,10 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TransitivitySym1KindInference) ())
     type TransitivitySym2 :: Equal a b -> Equal b c -> Equal a c
-    type family TransitivitySym2 a0123456789876543210 a0123456789876543210 where
+    type family TransitivitySym2 (a0123456789876543210 :: Equal a b) (a0123456789876543210 :: Equal b c) :: Equal a c where
       TransitivitySym2 a0123456789876543210 a0123456789876543210 = Transitivity a0123456789876543210 a0123456789876543210
     type SymmetrySym0 :: (~>) (Equal a b) (Equal b a)
-    data SymmetrySym0 a0123456789876543210
+    data SymmetrySym0 :: (~>) (Equal a b) (Equal b a)
       where
         SymmetrySym0KindInference :: SameKind (Apply SymmetrySym0 arg) (SymmetrySym1 arg) =>
                                      SymmetrySym0 a0123456789876543210
@@ -179,10 +179,10 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings SymmetrySym0 where
       suppressUnusedWarnings = snd (((,) SymmetrySym0KindInference) ())
     type SymmetrySym1 :: Equal a b -> Equal b a
-    type family SymmetrySym1 a0123456789876543210 where
+    type family SymmetrySym1 (a0123456789876543210 :: Equal a b) :: Equal b a where
       SymmetrySym1 a0123456789876543210 = Symmetry a0123456789876543210
     type MapVecSym0 :: (~>) ((~>) a b) ((~>) (Vec n a) (Vec n b))
-    data MapVecSym0 a0123456789876543210
+    data MapVecSym0 :: (~>) ((~>) a b) ((~>) (Vec n a) (Vec n b))
       where
         MapVecSym0KindInference :: SameKind (Apply MapVecSym0 arg) (MapVecSym1 arg) =>
                                    MapVecSym0 a0123456789876543210
@@ -190,7 +190,7 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings MapVecSym0 where
       suppressUnusedWarnings = snd (((,) MapVecSym0KindInference) ())
     type MapVecSym1 :: (~>) a b -> (~>) (Vec n a) (Vec n b)
-    data MapVecSym1 a0123456789876543210 a0123456789876543210
+    data MapVecSym1 (a0123456789876543210 :: (~>) a b) :: (~>) (Vec n a) (Vec n b)
       where
         MapVecSym1KindInference :: SameKind (Apply (MapVecSym1 a0123456789876543210) arg) (MapVecSym2 a0123456789876543210 arg) =>
                                    MapVecSym1 a0123456789876543210 a0123456789876543210
@@ -198,10 +198,10 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (MapVecSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) MapVecSym1KindInference) ())
     type MapVecSym2 :: (~>) a b -> Vec n a -> Vec n b
-    type family MapVecSym2 a0123456789876543210 a0123456789876543210 where
+    type family MapVecSym2 (a0123456789876543210 :: (~>) a b) (a0123456789876543210 :: Vec n a) :: Vec n b where
       MapVecSym2 a0123456789876543210 a0123456789876543210 = MapVec a0123456789876543210 a0123456789876543210
     type (!@#@$) :: (~>) (Vec n a) ((~>) (Fin n) a)
-    data (!@#@$) a0123456789876543210
+    data (!@#@$) :: (~>) (Vec n a) ((~>) (Fin n) a)
       where
         (:!@#@$###) :: SameKind (Apply (!@#@$) arg) ((!@#@$$) arg) =>
                        (!@#@$) a0123456789876543210
@@ -209,7 +209,7 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (!@#@$) where
       suppressUnusedWarnings = snd (((,) (:!@#@$###)) ())
     type (!@#@$$) :: Vec n a -> (~>) (Fin n) a
-    data (!@#@$$) a0123456789876543210 a0123456789876543210
+    data (!@#@$$) (a0123456789876543210 :: Vec n a) :: (~>) (Fin n) a
       where
         (:!@#@$$###) :: SameKind (Apply ((!@#@$$) a0123456789876543210) arg) ((!@#@$$$) a0123456789876543210 arg) =>
                         (!@#@$$) a0123456789876543210 a0123456789876543210
@@ -217,10 +217,10 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ((!@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) (:!@#@$$###)) ())
     type (!@#@$$$) :: Vec n a -> Fin n -> a
-    type family (!@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family (!@#@$$$) (a0123456789876543210 :: Vec n a) (a0123456789876543210 :: Fin n) :: a where
       (!@#@$$$) a0123456789876543210 a0123456789876543210 = (!) a0123456789876543210 a0123456789876543210
     type TailVecSym0 :: (~>) (Vec ('Succ n) a) (Vec n a)
-    data TailVecSym0 a0123456789876543210
+    data TailVecSym0 :: (~>) (Vec ('Succ n) a) (Vec n a)
       where
         TailVecSym0KindInference :: SameKind (Apply TailVecSym0 arg) (TailVecSym1 arg) =>
                                     TailVecSym0 a0123456789876543210
@@ -228,10 +228,10 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings TailVecSym0 where
       suppressUnusedWarnings = snd (((,) TailVecSym0KindInference) ())
     type TailVecSym1 :: Vec ('Succ n) a -> Vec n a
-    type family TailVecSym1 a0123456789876543210 where
+    type family TailVecSym1 (a0123456789876543210 :: Vec ('Succ n) a) :: Vec n a where
       TailVecSym1 a0123456789876543210 = TailVec a0123456789876543210
     type HeadVecSym0 :: (~>) (Vec ('Succ n) a) a
-    data HeadVecSym0 a0123456789876543210
+    data HeadVecSym0 :: (~>) (Vec ('Succ n) a) a
       where
         HeadVecSym0KindInference :: SameKind (Apply HeadVecSym0 arg) (HeadVecSym1 arg) =>
                                     HeadVecSym0 a0123456789876543210
@@ -239,28 +239,28 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings HeadVecSym0 where
       suppressUnusedWarnings = snd (((,) HeadVecSym0KindInference) ())
     type HeadVecSym1 :: Vec ('Succ n) a -> a
-    type family HeadVecSym1 a0123456789876543210 where
+    type family HeadVecSym1 (a0123456789876543210 :: Vec ('Succ n) a) :: a where
       HeadVecSym1 a0123456789876543210 = HeadVec a0123456789876543210
     type Transitivity :: Equal a b -> Equal b c -> Equal a c
-    type family Transitivity a a where
+    type family Transitivity (a :: Equal a b) (a :: Equal b c) :: Equal a c where
       Transitivity Reflexive Reflexive = ReflexiveSym0
     type Symmetry :: Equal a b -> Equal b a
-    type family Symmetry a where
+    type family Symmetry (a :: Equal a b) :: Equal b a where
       Symmetry Reflexive = ReflexiveSym0
     type MapVec :: (~>) a b -> Vec n a -> Vec n b
-    type family MapVec a a where
+    type family MapVec (a :: (~>) a b) (a :: Vec n a) :: Vec n b where
       MapVec _ VNil = VNilSym0
       MapVec f (VCons x xs) = Apply (Apply VConsSym0 (Apply f x)) (Apply (Apply MapVecSym0 f) xs)
     type (!) :: Vec n a -> Fin n -> a
-    type family (!) a a where
+    type family (!) (a :: Vec n a) (a :: Fin n) :: a where
       (!) (VCons x _) FZ = x
       (!) (VCons _ xs) (FS n) = Apply (Apply (!@#@$) xs) n
       (!) VNil n = Case_0123456789876543210 n n
     type TailVec :: Vec ('Succ n) a -> Vec n a
-    type family TailVec a where
+    type family TailVec (a :: Vec ('Succ n) a) :: Vec n a where
       TailVec (VCons _ xs) = xs
     type HeadVec :: Vec ('Succ n) a -> a
-    type family HeadVec a where
+    type family HeadVec (a :: Vec ('Succ n) a) :: a where
       HeadVec (VCons x _) = x
     sTransitivity ::
       forall a b c (t :: Equal a b) (t :: Equal b c).

--- a/singletons-base/tests/compile-and-dump/Singletons/T159.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T159.golden
@@ -2,25 +2,25 @@ Singletons/T159.hs:0:0:: Splicing declarations
     genSingletons [''T0, ''T1]
   ======>
     type ASym0 :: T0
-    type family ASym0 where
+    type family ASym0 :: T0 where
       ASym0 = 'A
     type BSym0 :: T0
-    type family BSym0 where
+    type family BSym0 :: T0 where
       BSym0 = 'B
     type CSym0 :: T0
-    type family CSym0 where
+    type family CSym0 :: T0 where
       CSym0 = 'C
     type DSym0 :: T0
-    type family DSym0 where
+    type family DSym0 :: T0 where
       DSym0 = 'D
     type ESym0 :: T0
-    type family ESym0 where
+    type family ESym0 :: T0 where
       ESym0 = 'E
     type FSym0 :: T0
-    type family FSym0 where
+    type family FSym0 :: T0 where
       FSym0 = 'F
     type ST0 :: T0 -> GHC.Types.Type
-    data ST0 z
+    data ST0 :: T0 -> GHC.Types.Type
       where
         SA :: ST0 ('A :: T0)
         SB :: ST0 ('B :: T0)
@@ -56,10 +56,10 @@ Singletons/T159.hs:0:0:: Splicing declarations
     instance SingI 'F where
       sing = SF
     type N1Sym0 :: T1
-    type family N1Sym0 where
+    type family N1Sym0 :: T1 where
       N1Sym0 = 'N1
     type C1Sym0 :: (~>) T0 ((~>) T1 T1)
-    data C1Sym0 a0123456789876543210
+    data C1Sym0 :: (~>) T0 ((~>) T1 T1)
       where
         C1Sym0KindInference :: SameKind (Apply C1Sym0 arg) (C1Sym1 arg) =>
                                C1Sym0 a0123456789876543210
@@ -68,7 +68,7 @@ Singletons/T159.hs:0:0:: Splicing declarations
       suppressUnusedWarnings = snd (((,) C1Sym0KindInference) ())
     infixr 5 `C1Sym0`
     type C1Sym1 :: T0 -> (~>) T1 T1
-    data C1Sym1 a0123456789876543210 a0123456789876543210
+    data C1Sym1 (a0123456789876543210 :: T0) :: (~>) T1 T1
       where
         C1Sym1KindInference :: SameKind (Apply (C1Sym1 a0123456789876543210) arg) (C1Sym2 a0123456789876543210 arg) =>
                                C1Sym1 a0123456789876543210 a0123456789876543210
@@ -77,11 +77,11 @@ Singletons/T159.hs:0:0:: Splicing declarations
       suppressUnusedWarnings = snd (((,) C1Sym1KindInference) ())
     infixr 5 `C1Sym1`
     type C1Sym2 :: T0 -> T1 -> T1
-    type family C1Sym2 a0123456789876543210 a0123456789876543210 where
+    type family C1Sym2 (a0123456789876543210 :: T0) (a0123456789876543210 :: T1) :: T1 where
       C1Sym2 a0123456789876543210 a0123456789876543210 = 'C1 a0123456789876543210 a0123456789876543210
     infixr 5 `C1Sym2`
     type (:&&@#@$) :: (~>) T0 ((~>) T1 T1)
-    data (:&&@#@$) a0123456789876543210
+    data (:&&@#@$) :: (~>) T0 ((~>) T1 T1)
       where
         (::&&@#@$###) :: SameKind (Apply (:&&@#@$) arg) ((:&&@#@$$) arg) =>
                          (:&&@#@$) a0123456789876543210
@@ -90,7 +90,7 @@ Singletons/T159.hs:0:0:: Splicing declarations
       suppressUnusedWarnings = snd (((,) (::&&@#@$###)) ())
     infixr 5 :&&@#@$
     type (:&&@#@$$) :: T0 -> (~>) T1 T1
-    data (:&&@#@$$) a0123456789876543210 a0123456789876543210
+    data (:&&@#@$$) (a0123456789876543210 :: T0) :: (~>) T1 T1
       where
         (::&&@#@$$###) :: SameKind (Apply ((:&&@#@$$) a0123456789876543210) arg) ((:&&@#@$$$) a0123456789876543210 arg) =>
                           (:&&@#@$$) a0123456789876543210 a0123456789876543210
@@ -99,11 +99,11 @@ Singletons/T159.hs:0:0:: Splicing declarations
       suppressUnusedWarnings = snd (((,) (::&&@#@$$###)) ())
     infixr 5 :&&@#@$$
     type (:&&@#@$$$) :: T0 -> T1 -> T1
-    type family (:&&@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family (:&&@#@$$$) (a0123456789876543210 :: T0) (a0123456789876543210 :: T1) :: T1 where
       (:&&@#@$$$) a0123456789876543210 a0123456789876543210 = '(:&&) a0123456789876543210 a0123456789876543210
     infixr 5 :&&@#@$$$
     type ST1 :: T1 -> GHC.Types.Type
-    data ST1 z
+    data ST1 :: T1 -> GHC.Types.Type
       where
         SN1 :: ST1 ('N1 :: T1)
         SC1 :: forall (n :: T0) (n :: T1).
@@ -157,10 +157,10 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
     infixr 5 `C2`
     infixr 5 :||
     type N2Sym0 :: T2
-    type family N2Sym0 where
+    type family N2Sym0 :: T2 where
       N2Sym0 = N2
     type C2Sym0 :: (~>) T0 ((~>) T2 T2)
-    data C2Sym0 a0123456789876543210
+    data C2Sym0 :: (~>) T0 ((~>) T2 T2)
       where
         C2Sym0KindInference :: SameKind (Apply C2Sym0 arg) (C2Sym1 arg) =>
                                C2Sym0 a0123456789876543210
@@ -169,7 +169,7 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) C2Sym0KindInference) ())
     infixr 5 `C2Sym0`
     type C2Sym1 :: T0 -> (~>) T2 T2
-    data C2Sym1 a0123456789876543210 a0123456789876543210
+    data C2Sym1 (a0123456789876543210 :: T0) :: (~>) T2 T2
       where
         C2Sym1KindInference :: SameKind (Apply (C2Sym1 a0123456789876543210) arg) (C2Sym2 a0123456789876543210 arg) =>
                                C2Sym1 a0123456789876543210 a0123456789876543210
@@ -178,11 +178,11 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) C2Sym1KindInference) ())
     infixr 5 `C2Sym1`
     type C2Sym2 :: T0 -> T2 -> T2
-    type family C2Sym2 a0123456789876543210 a0123456789876543210 where
+    type family C2Sym2 (a0123456789876543210 :: T0) (a0123456789876543210 :: T2) :: T2 where
       C2Sym2 a0123456789876543210 a0123456789876543210 = C2 a0123456789876543210 a0123456789876543210
     infixr 5 `C2Sym2`
     type (:||@#@$) :: (~>) T0 ((~>) T2 T2)
-    data (:||@#@$) a0123456789876543210
+    data (:||@#@$) :: (~>) T0 ((~>) T2 T2)
       where
         (::||@#@$###) :: SameKind (Apply (:||@#@$) arg) ((:||@#@$$) arg) =>
                          (:||@#@$) a0123456789876543210
@@ -191,7 +191,7 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) (::||@#@$###)) ())
     infixr 5 :||@#@$
     type (:||@#@$$) :: T0 -> (~>) T2 T2
-    data (:||@#@$$) a0123456789876543210 a0123456789876543210
+    data (:||@#@$$) (a0123456789876543210 :: T0) :: (~>) T2 T2
       where
         (::||@#@$$###) :: SameKind (Apply ((:||@#@$$) a0123456789876543210) arg) ((:||@#@$$$) a0123456789876543210 arg) =>
                           (:||@#@$$) a0123456789876543210 a0123456789876543210
@@ -200,7 +200,7 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) (::||@#@$$###)) ())
     infixr 5 :||@#@$$
     type (:||@#@$$$) :: T0 -> T2 -> T2
-    type family (:||@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family (:||@#@$$$) (a0123456789876543210 :: T0) (a0123456789876543210 :: T2) :: T2 where
       (:||@#@$$$) a0123456789876543210 a0123456789876543210 = (:||) a0123456789876543210 a0123456789876543210
     infixr 5 :||@#@$$$
     infixr 5 :%||

--- a/singletons-base/tests/compile-and-dump/Singletons/T160.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T160.golden
@@ -24,7 +24,7 @@ Singletons/T160.hs:(0,0)-(0,0): Splicing declarations
       Case_0123456789876543210 x 'True = FromInteger 1
       Case_0123456789876543210 x 'False = Apply (Apply ($@#@$) TypeErrorSym0) (Apply ShowTypeSym0 x)
     type FooSym0 :: (~>) a a
-    data FooSym0 a0123456789876543210
+    data FooSym0 :: (~>) a a
       where
         FooSym0KindInference :: SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
                                 FooSym0 a0123456789876543210
@@ -32,10 +32,10 @@ Singletons/T160.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings = snd (((,) FooSym0KindInference) ())
     type FooSym1 :: a -> a
-    type family FooSym1 a0123456789876543210 where
+    type family FooSym1 (a0123456789876543210 :: a) :: a where
       FooSym1 a0123456789876543210 = Foo a0123456789876543210
     type Foo :: a -> a
-    type family Foo a where
+    type family Foo (a :: a) :: a where
       Foo x = Case_0123456789876543210 x (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x)
     sFoo ::
       forall a (t :: a).

--- a/singletons-base/tests/compile-and-dump/Singletons/T163.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T163.golden
@@ -3,7 +3,7 @@ Singletons/T163.hs:0:0:: Splicing declarations
   ======>
     data (+) a b = L a | R b
     type LSym0 :: forall a b. (~>) a ((+) a b)
-    data LSym0 a0123456789876543210
+    data LSym0 :: (~>) a ((+) a b)
       where
         LSym0KindInference :: SameKind (Apply LSym0 arg) (LSym1 arg) =>
                               LSym0 a0123456789876543210
@@ -11,10 +11,10 @@ Singletons/T163.hs:0:0:: Splicing declarations
     instance SuppressUnusedWarnings LSym0 where
       suppressUnusedWarnings = snd (((,) LSym0KindInference) ())
     type LSym1 :: forall a b. a -> (+) a b
-    type family LSym1 a0123456789876543210 where
+    type family LSym1 (a0123456789876543210 :: a) :: (+) a b where
       LSym1 a0123456789876543210 = L a0123456789876543210
     type RSym0 :: forall a b. (~>) b ((+) a b)
-    data RSym0 a0123456789876543210
+    data RSym0 :: (~>) b ((+) a b)
       where
         RSym0KindInference :: SameKind (Apply RSym0 arg) (RSym1 arg) =>
                               RSym0 a0123456789876543210
@@ -22,7 +22,7 @@ Singletons/T163.hs:0:0:: Splicing declarations
     instance SuppressUnusedWarnings RSym0 where
       suppressUnusedWarnings = snd (((,) RSym0KindInference) ())
     type RSym1 :: forall a b. b -> (+) a b
-    type family RSym1 a0123456789876543210 where
+    type family RSym1 (a0123456789876543210 :: b) :: (+) a b where
       RSym1 a0123456789876543210 = R a0123456789876543210
     data (%+) :: forall a b. (+) a b -> GHC.Types.Type
       where

--- a/singletons-base/tests/compile-and-dump/Singletons/T166.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T166.golden
@@ -7,7 +7,7 @@ Singletons/T166.hs:(0,0)-(0,0): Splicing declarations
   ======>
     type FoosPrecSym0 :: forall a.
                          (~>) Nat ((~>) a ((~>) [Bool] [Bool]))
-    data FoosPrecSym0 a0123456789876543210
+    data FoosPrecSym0 :: (~>) Nat ((~>) a ((~>) [Bool] [Bool]))
       where
         FoosPrecSym0KindInference :: SameKind (Apply FoosPrecSym0 arg) (FoosPrecSym1 arg) =>
                                      FoosPrecSym0 a0123456789876543210
@@ -15,7 +15,7 @@ Singletons/T166.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FoosPrecSym0 where
       suppressUnusedWarnings = snd (((,) FoosPrecSym0KindInference) ())
     type FoosPrecSym1 :: forall a. Nat -> (~>) a ((~>) [Bool] [Bool])
-    data FoosPrecSym1 a0123456789876543210 a0123456789876543210
+    data FoosPrecSym1 (a0123456789876543210 :: Nat) :: (~>) a ((~>) [Bool] [Bool])
       where
         FoosPrecSym1KindInference :: SameKind (Apply (FoosPrecSym1 a0123456789876543210) arg) (FoosPrecSym2 a0123456789876543210 arg) =>
                                      FoosPrecSym1 a0123456789876543210 a0123456789876543210
@@ -23,7 +23,7 @@ Singletons/T166.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (FoosPrecSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) FoosPrecSym1KindInference) ())
     type FoosPrecSym2 :: forall a. Nat -> a -> (~>) [Bool] [Bool]
-    data FoosPrecSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data FoosPrecSym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: a) :: (~>) [Bool] [Bool]
       where
         FoosPrecSym2KindInference :: SameKind (Apply (FoosPrecSym2 a0123456789876543210 a0123456789876543210) arg) (FoosPrecSym3 a0123456789876543210 a0123456789876543210 arg) =>
                                      FoosPrecSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -31,10 +31,10 @@ Singletons/T166.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (FoosPrecSym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) FoosPrecSym2KindInference) ())
     type FoosPrecSym3 :: forall a. Nat -> a -> [Bool] -> [Bool]
-    type family FoosPrecSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family FoosPrecSym3 (a0123456789876543210 :: Nat) (a0123456789876543210 :: a) (a0123456789876543210 :: [Bool]) :: [Bool] where
       FoosPrecSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = FoosPrec a0123456789876543210 a0123456789876543210 a0123456789876543210
     type FooSym0 :: forall a. (~>) a [Bool]
-    data FooSym0 a0123456789876543210
+    data FooSym0 :: (~>) a [Bool]
       where
         FooSym0KindInference :: SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
                                 FooSym0 a0123456789876543210
@@ -42,7 +42,7 @@ Singletons/T166.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings = snd (((,) FooSym0KindInference) ())
     type FooSym1 :: forall a. a -> [Bool]
-    type family FooSym1 a0123456789876543210 where
+    type family FooSym1 (a0123456789876543210 :: a) :: [Bool] where
       FooSym1 a0123456789876543210 = Foo a0123456789876543210
     type family Lambda_0123456789876543210 x s where
       Lambda_0123456789876543210 x s = Apply (Apply (Apply FoosPrecSym0 (FromInteger 0)) x) s
@@ -65,10 +65,10 @@ Singletons/T166.hs:(0,0)-(0,0): Splicing declarations
     type family Lambda_0123456789876543210Sym2 x0123456789876543210 s0123456789876543210 where
       Lambda_0123456789876543210Sym2 x0123456789876543210 s0123456789876543210 = Lambda_0123456789876543210 x0123456789876543210 s0123456789876543210
     type Foo_0123456789876543210 :: a -> [Bool]
-    type family Foo_0123456789876543210 a where
+    type family Foo_0123456789876543210 (a :: a) :: [Bool] where
       Foo_0123456789876543210 x = Apply Lambda_0123456789876543210Sym0 x
     type Foo_0123456789876543210Sym0 :: (~>) a [Bool]
-    data Foo_0123456789876543210Sym0 a0123456789876543210
+    data Foo_0123456789876543210Sym0 :: (~>) a [Bool]
       where
         Foo_0123456789876543210Sym0KindInference :: SameKind (Apply Foo_0123456789876543210Sym0 arg) (Foo_0123456789876543210Sym1 arg) =>
                                                     Foo_0123456789876543210Sym0 a0123456789876543210
@@ -77,7 +77,7 @@ Singletons/T166.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Foo_0123456789876543210Sym0KindInference) ())
     type Foo_0123456789876543210Sym1 :: a -> [Bool]
-    type family Foo_0123456789876543210Sym1 a0123456789876543210 where
+    type family Foo_0123456789876543210Sym1 (a0123456789876543210 :: a) :: [Bool] where
       Foo_0123456789876543210Sym1 a0123456789876543210 = Foo_0123456789876543210 a0123456789876543210
     class PFoo a where
       type FoosPrec (arg :: Nat) (arg :: a) (arg :: [Bool]) :: [Bool]

--- a/singletons-base/tests/compile-and-dump/Singletons/T167.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T167.golden
@@ -10,7 +10,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
   ======>
     type FoosPrecSym0 :: forall a.
                          (~>) Nat ((~>) a ((~>) [Bool] [Bool]))
-    data FoosPrecSym0 a0123456789876543210
+    data FoosPrecSym0 :: (~>) Nat ((~>) a ((~>) [Bool] [Bool]))
       where
         FoosPrecSym0KindInference :: SameKind (Apply FoosPrecSym0 arg) (FoosPrecSym1 arg) =>
                                      FoosPrecSym0 a0123456789876543210
@@ -18,7 +18,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FoosPrecSym0 where
       suppressUnusedWarnings = snd (((,) FoosPrecSym0KindInference) ())
     type FoosPrecSym1 :: forall a. Nat -> (~>) a ((~>) [Bool] [Bool])
-    data FoosPrecSym1 a0123456789876543210 a0123456789876543210
+    data FoosPrecSym1 (a0123456789876543210 :: Nat) :: (~>) a ((~>) [Bool] [Bool])
       where
         FoosPrecSym1KindInference :: SameKind (Apply (FoosPrecSym1 a0123456789876543210) arg) (FoosPrecSym2 a0123456789876543210 arg) =>
                                      FoosPrecSym1 a0123456789876543210 a0123456789876543210
@@ -26,7 +26,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (FoosPrecSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) FoosPrecSym1KindInference) ())
     type FoosPrecSym2 :: forall a. Nat -> a -> (~>) [Bool] [Bool]
-    data FoosPrecSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data FoosPrecSym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: a) :: (~>) [Bool] [Bool]
       where
         FoosPrecSym2KindInference :: SameKind (Apply (FoosPrecSym2 a0123456789876543210 a0123456789876543210) arg) (FoosPrecSym3 a0123456789876543210 a0123456789876543210 arg) =>
                                      FoosPrecSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -34,10 +34,10 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (FoosPrecSym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) FoosPrecSym2KindInference) ())
     type FoosPrecSym3 :: forall a. Nat -> a -> [Bool] -> [Bool]
-    type family FoosPrecSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family FoosPrecSym3 (a0123456789876543210 :: Nat) (a0123456789876543210 :: a) (a0123456789876543210 :: [Bool]) :: [Bool] where
       FoosPrecSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = FoosPrec a0123456789876543210 a0123456789876543210 a0123456789876543210
     type FooListSym0 :: forall a. (~>) a ((~>) [Bool] [Bool])
-    data FooListSym0 a0123456789876543210
+    data FooListSym0 :: (~>) a ((~>) [Bool] [Bool])
       where
         FooListSym0KindInference :: SameKind (Apply FooListSym0 arg) (FooListSym1 arg) =>
                                     FooListSym0 a0123456789876543210
@@ -45,7 +45,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FooListSym0 where
       suppressUnusedWarnings = snd (((,) FooListSym0KindInference) ())
     type FooListSym1 :: forall a. a -> (~>) [Bool] [Bool]
-    data FooListSym1 a0123456789876543210 a0123456789876543210
+    data FooListSym1 (a0123456789876543210 :: a) :: (~>) [Bool] [Bool]
       where
         FooListSym1KindInference :: SameKind (Apply (FooListSym1 a0123456789876543210) arg) (FooListSym2 a0123456789876543210 arg) =>
                                     FooListSym1 a0123456789876543210 a0123456789876543210
@@ -53,13 +53,13 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (FooListSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) FooListSym1KindInference) ())
     type FooListSym2 :: forall a. a -> [Bool] -> [Bool]
-    type family FooListSym2 a0123456789876543210 a0123456789876543210 where
+    type family FooListSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: [Bool]) :: [Bool] where
       FooListSym2 a0123456789876543210 a0123456789876543210 = FooList a0123456789876543210 a0123456789876543210
     type FooList_0123456789876543210 :: a -> [Bool] -> [Bool]
-    type family FooList_0123456789876543210 a a where
+    type family FooList_0123456789876543210 (a :: a) (a :: [Bool]) :: [Bool] where
       FooList_0123456789876543210 a_0123456789876543210 a_0123456789876543210 = Apply (Apply UndefinedSym0 a_0123456789876543210) a_0123456789876543210
     type FooList_0123456789876543210Sym0 :: (~>) a ((~>) [Bool] [Bool])
-    data FooList_0123456789876543210Sym0 a0123456789876543210
+    data FooList_0123456789876543210Sym0 :: (~>) a ((~>) [Bool] [Bool])
       where
         FooList_0123456789876543210Sym0KindInference :: SameKind (Apply FooList_0123456789876543210Sym0 arg) (FooList_0123456789876543210Sym1 arg) =>
                                                         FooList_0123456789876543210Sym0 a0123456789876543210
@@ -68,7 +68,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) FooList_0123456789876543210Sym0KindInference) ())
     type FooList_0123456789876543210Sym1 :: a -> (~>) [Bool] [Bool]
-    data FooList_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data FooList_0123456789876543210Sym1 (a0123456789876543210 :: a) :: (~>) [Bool] [Bool]
       where
         FooList_0123456789876543210Sym1KindInference :: SameKind (Apply (FooList_0123456789876543210Sym1 a0123456789876543210) arg) (FooList_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                         FooList_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -77,17 +77,17 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) FooList_0123456789876543210Sym1KindInference) ())
     type FooList_0123456789876543210Sym2 :: a -> [Bool] -> [Bool]
-    type family FooList_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family FooList_0123456789876543210Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: [Bool]) :: [Bool] where
       FooList_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = FooList_0123456789876543210 a0123456789876543210 a0123456789876543210
     class PFoo a where
       type FoosPrec (arg :: Nat) (arg :: a) (arg :: [Bool]) :: [Bool]
       type FooList (arg :: a) (arg :: [Bool]) :: [Bool]
       type FooList a a = Apply (Apply FooList_0123456789876543210Sym0 a) a
     type FoosPrec_0123456789876543210 :: Nat -> [a] -> [Bool] -> [Bool]
-    type family FoosPrec_0123456789876543210 a a a where
+    type family FoosPrec_0123456789876543210 (a :: Nat) (a :: [a]) (a :: [Bool]) :: [Bool] where
       FoosPrec_0123456789876543210 _ a_0123456789876543210 a_0123456789876543210 = Apply (Apply FooListSym0 a_0123456789876543210) a_0123456789876543210
     type FoosPrec_0123456789876543210Sym0 :: (~>) Nat ((~>) [a] ((~>) [Bool] [Bool]))
-    data FoosPrec_0123456789876543210Sym0 a0123456789876543210
+    data FoosPrec_0123456789876543210Sym0 :: (~>) Nat ((~>) [a] ((~>) [Bool] [Bool]))
       where
         FoosPrec_0123456789876543210Sym0KindInference :: SameKind (Apply FoosPrec_0123456789876543210Sym0 arg) (FoosPrec_0123456789876543210Sym1 arg) =>
                                                          FoosPrec_0123456789876543210Sym0 a0123456789876543210
@@ -97,7 +97,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) FoosPrec_0123456789876543210Sym0KindInference) ())
     type FoosPrec_0123456789876543210Sym1 :: Nat
                                              -> (~>) [a] ((~>) [Bool] [Bool])
-    data FoosPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data FoosPrec_0123456789876543210Sym1 (a0123456789876543210 :: Nat) :: (~>) [a] ((~>) [Bool] [Bool])
       where
         FoosPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (FoosPrec_0123456789876543210Sym1 a0123456789876543210) arg) (FoosPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                          FoosPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -107,7 +107,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) FoosPrec_0123456789876543210Sym1KindInference) ())
     type FoosPrec_0123456789876543210Sym2 :: Nat
                                              -> [a] -> (~>) [Bool] [Bool]
-    data FoosPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data FoosPrec_0123456789876543210Sym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: [a]) :: (~>) [Bool] [Bool]
       where
         FoosPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (FoosPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (FoosPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
                                                          FoosPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -117,7 +117,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) FoosPrec_0123456789876543210Sym2KindInference) ())
     type FoosPrec_0123456789876543210Sym3 :: Nat
                                              -> [a] -> [Bool] -> [Bool]
-    type family FoosPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family FoosPrec_0123456789876543210Sym3 (a0123456789876543210 :: Nat) (a0123456789876543210 :: [a]) (a0123456789876543210 :: [Bool]) :: [Bool] where
       FoosPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = FoosPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PFoo [a] where
       type FoosPrec a a a = Apply (Apply (Apply FoosPrec_0123456789876543210Sym0 a) a) a

--- a/singletons-base/tests/compile-and-dump/Singletons/T172.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T172.golden
@@ -4,7 +4,7 @@ Singletons/T172.hs:(0,0)-(0,0): Splicing declarations
           ($>) = (+) |]
   ======>
     type ($>@#@$) :: (~>) Nat ((~>) Nat Nat)
-    data ($>@#@$) a0123456789876543210
+    data ($>@#@$) :: (~>) Nat ((~>) Nat Nat)
       where
         (:$>@#@$###) :: SameKind (Apply ($>@#@$) arg) (($>@#@$$) arg) =>
                         ($>@#@$) a0123456789876543210
@@ -12,7 +12,7 @@ Singletons/T172.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ($>@#@$) where
       suppressUnusedWarnings = snd (((,) (:$>@#@$###)) ())
     type ($>@#@$$) :: Nat -> (~>) Nat Nat
-    data ($>@#@$$) a0123456789876543210 a0123456789876543210
+    data ($>@#@$$) (a0123456789876543210 :: Nat) :: (~>) Nat Nat
       where
         (:$>@#@$$###) :: SameKind (Apply (($>@#@$$) a0123456789876543210) arg) (($>@#@$$$) a0123456789876543210 arg) =>
                          ($>@#@$$) a0123456789876543210 a0123456789876543210
@@ -20,10 +20,10 @@ Singletons/T172.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (($>@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) (:$>@#@$$###)) ())
     type ($>@#@$$$) :: Nat -> Nat -> Nat
-    type family ($>@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family ($>@#@$$$) (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Nat where
       ($>@#@$$$) a0123456789876543210 a0123456789876543210 = ($>) a0123456789876543210 a0123456789876543210
     type ($>) :: Nat -> Nat -> Nat
-    type family ($>) a a where
+    type family ($>) (a :: Nat) (a :: Nat) :: Nat where
       ($>) a_0123456789876543210 a_0123456789876543210 = Apply (Apply (+@#@$) a_0123456789876543210) a_0123456789876543210
     (%$>) ::
       forall (t :: Nat) (t :: Nat).

--- a/singletons-base/tests/compile-and-dump/Singletons/T175.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T175.golden
@@ -19,24 +19,24 @@ Singletons/T175.hs:(0,0)-(0,0): Splicing declarations
     quux2 :: Bar2 a => a
     quux2 = baz
     type Quux2Sym0 :: a
-    type family Quux2Sym0 where
+    type family Quux2Sym0 :: a where
       Quux2Sym0 = Quux2
     type Quux2 :: a
-    type family Quux2 where
+    type family Quux2 :: a where
       Quux2 = BazSym0
     type BazSym0 :: forall a. a
-    type family BazSym0 where
+    type family BazSym0 :: a where
       BazSym0 = Baz
     class PFoo a where
       type Baz :: a
     type Quux1Sym0 :: forall a. a
-    type family Quux1Sym0 where
+    type family Quux1Sym0 :: a where
       Quux1Sym0 = Quux1
     type Quux1_0123456789876543210 :: a
-    type family Quux1_0123456789876543210 where
+    type family Quux1_0123456789876543210 :: a where
       Quux1_0123456789876543210 = BazSym0
     type Quux1_0123456789876543210Sym0 :: a
-    type family Quux1_0123456789876543210Sym0 where
+    type family Quux1_0123456789876543210Sym0 :: a where
       Quux1_0123456789876543210Sym0 = Quux1_0123456789876543210
     class PBar1 a where
       type Quux1 :: a

--- a/singletons-base/tests/compile-and-dump/Singletons/T176.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T176.golden
@@ -45,7 +45,7 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
     type family Lambda_0123456789876543210Sym2 x0123456789876543210 arg_01234567898765432100123456789876543210 where
       Lambda_0123456789876543210Sym2 x0123456789876543210 arg_01234567898765432100123456789876543210 = Lambda_0123456789876543210 x0123456789876543210 arg_01234567898765432100123456789876543210
     type Quux2Sym0 :: (~>) a a
-    data Quux2Sym0 a0123456789876543210
+    data Quux2Sym0 :: (~>) a a
       where
         Quux2Sym0KindInference :: SameKind (Apply Quux2Sym0 arg) (Quux2Sym1 arg) =>
                                   Quux2Sym0 a0123456789876543210
@@ -53,10 +53,10 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Quux2Sym0 where
       suppressUnusedWarnings = snd (((,) Quux2Sym0KindInference) ())
     type Quux2Sym1 :: a -> a
-    type family Quux2Sym1 a0123456789876543210 where
+    type family Quux2Sym1 (a0123456789876543210 :: a) :: a where
       Quux2Sym1 a0123456789876543210 = Quux2 a0123456789876543210
     type Quux1Sym0 :: (~>) a a
-    data Quux1Sym0 a0123456789876543210
+    data Quux1Sym0 :: (~>) a a
       where
         Quux1Sym0KindInference :: SameKind (Apply Quux1Sym0 arg) (Quux1Sym1 arg) =>
                                   Quux1Sym0 a0123456789876543210
@@ -64,16 +64,16 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Quux1Sym0 where
       suppressUnusedWarnings = snd (((,) Quux1Sym0KindInference) ())
     type Quux1Sym1 :: a -> a
-    type family Quux1Sym1 a0123456789876543210 where
+    type family Quux1Sym1 (a0123456789876543210 :: a) :: a where
       Quux1Sym1 a0123456789876543210 = Quux1 a0123456789876543210
     type Quux2 :: a -> a
-    type family Quux2 a where
+    type family Quux2 (a :: a) :: a where
       Quux2 x = Apply (Apply Bar2Sym0 x) Baz2Sym0
     type Quux1 :: a -> a
-    type family Quux1 a where
+    type family Quux1 (a :: a) :: a where
       Quux1 x = Apply (Apply Bar1Sym0 x) (Apply Lambda_0123456789876543210Sym0 x)
     type Bar1Sym0 :: forall a b. (~>) a ((~>) ((~>) a b) b)
-    data Bar1Sym0 a0123456789876543210
+    data Bar1Sym0 :: (~>) a ((~>) ((~>) a b) b)
       where
         Bar1Sym0KindInference :: SameKind (Apply Bar1Sym0 arg) (Bar1Sym1 arg) =>
                                  Bar1Sym0 a0123456789876543210
@@ -81,7 +81,7 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Bar1Sym0 where
       suppressUnusedWarnings = snd (((,) Bar1Sym0KindInference) ())
     type Bar1Sym1 :: forall a b. a -> (~>) ((~>) a b) b
-    data Bar1Sym1 a0123456789876543210 a0123456789876543210
+    data Bar1Sym1 (a0123456789876543210 :: a) :: (~>) ((~>) a b) b
       where
         Bar1Sym1KindInference :: SameKind (Apply (Bar1Sym1 a0123456789876543210) arg) (Bar1Sym2 a0123456789876543210 arg) =>
                                  Bar1Sym1 a0123456789876543210 a0123456789876543210
@@ -89,16 +89,16 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (Bar1Sym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) Bar1Sym1KindInference) ())
     type Bar1Sym2 :: forall a b. a -> (~>) a b -> b
-    type family Bar1Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Bar1Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: (~>) a b) :: b where
       Bar1Sym2 a0123456789876543210 a0123456789876543210 = Bar1 a0123456789876543210 a0123456789876543210
     type Baz1Sym0 :: forall a. a
-    type family Baz1Sym0 where
+    type family Baz1Sym0 :: a where
       Baz1Sym0 = Baz1
     class PFoo1 a where
       type Bar1 (arg :: a) (arg :: (~>) a b) :: b
       type Baz1 :: a
     type Bar2Sym0 :: forall a b. (~>) a ((~>) b b)
-    data Bar2Sym0 a0123456789876543210
+    data Bar2Sym0 :: (~>) a ((~>) b b)
       where
         Bar2Sym0KindInference :: SameKind (Apply Bar2Sym0 arg) (Bar2Sym1 arg) =>
                                  Bar2Sym0 a0123456789876543210
@@ -106,7 +106,7 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Bar2Sym0 where
       suppressUnusedWarnings = snd (((,) Bar2Sym0KindInference) ())
     type Bar2Sym1 :: forall a b. a -> (~>) b b
-    data Bar2Sym1 a0123456789876543210 a0123456789876543210
+    data Bar2Sym1 (a0123456789876543210 :: a) :: (~>) b b
       where
         Bar2Sym1KindInference :: SameKind (Apply (Bar2Sym1 a0123456789876543210) arg) (Bar2Sym2 a0123456789876543210 arg) =>
                                  Bar2Sym1 a0123456789876543210 a0123456789876543210
@@ -114,10 +114,10 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (Bar2Sym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) Bar2Sym1KindInference) ())
     type Bar2Sym2 :: forall a b. a -> b -> b
-    type family Bar2Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Bar2Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: b where
       Bar2Sym2 a0123456789876543210 a0123456789876543210 = Bar2 a0123456789876543210 a0123456789876543210
     type Baz2Sym0 :: forall a. a
-    type family Baz2Sym0 where
+    type family Baz2Sym0 :: a where
       Baz2Sym0 = Baz2
     class PFoo2 a where
       type Bar2 (arg :: a) (arg :: b) :: b

--- a/singletons-base/tests/compile-and-dump/Singletons/T178.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T178.golden
@@ -17,22 +17,22 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
     type family USym0 where
       USym0 = U
     type StrSym0 :: Occ
-    type family StrSym0 where
+    type family StrSym0 :: Occ where
       StrSym0 = Str
     type OptSym0 :: Occ
-    type family OptSym0 where
+    type family OptSym0 :: Occ where
       OptSym0 = Opt
     type ManySym0 :: Occ
-    type family ManySym0 where
+    type family ManySym0 :: Occ where
       ManySym0 = Many
     type EmptySym0 :: [(Symbol, Occ)]
-    type family EmptySym0 where
+    type family EmptySym0 :: [(Symbol, Occ)] where
       EmptySym0 = Empty
     type Empty :: [(Symbol, Occ)]
-    type family Empty where
+    type family Empty :: [(Symbol, Occ)] where
       Empty = NilSym0
     type TFHelper_0123456789876543210 :: Occ -> Occ -> Bool
-    type family TFHelper_0123456789876543210 a a where
+    type family TFHelper_0123456789876543210 (a :: Occ) (a :: Occ) :: Bool where
       TFHelper_0123456789876543210 Str Str = TrueSym0
       TFHelper_0123456789876543210 Str Opt = FalseSym0
       TFHelper_0123456789876543210 Str Many = FalseSym0
@@ -43,7 +43,7 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
       TFHelper_0123456789876543210 Many Opt = FalseSym0
       TFHelper_0123456789876543210 Many Many = TrueSym0
     type TFHelper_0123456789876543210Sym0 :: (~>) Occ ((~>) Occ Bool)
-    data TFHelper_0123456789876543210Sym0 a0123456789876543210
+    data TFHelper_0123456789876543210Sym0 :: (~>) Occ ((~>) Occ Bool)
       where
         TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
                                                          TFHelper_0123456789876543210Sym0 a0123456789876543210
@@ -52,7 +52,7 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym0KindInference) ())
     type TFHelper_0123456789876543210Sym1 :: Occ -> (~>) Occ Bool
-    data TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Occ) :: (~>) Occ Bool
       where
         TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                          TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -61,12 +61,12 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym1KindInference) ())
     type TFHelper_0123456789876543210Sym2 :: Occ -> Occ -> Bool
-    type family TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: Occ) (a0123456789876543210 :: Occ) :: Bool where
       TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq Occ where
       type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
     type Compare_0123456789876543210 :: Occ -> Occ -> Ordering
-    type family Compare_0123456789876543210 a a where
+    type family Compare_0123456789876543210 (a :: Occ) (a :: Occ) :: Ordering where
       Compare_0123456789876543210 Str Str = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) NilSym0
       Compare_0123456789876543210 Opt Opt = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) NilSym0
       Compare_0123456789876543210 Many Many = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) NilSym0
@@ -77,7 +77,7 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
       Compare_0123456789876543210 Many Str = GTSym0
       Compare_0123456789876543210 Many Opt = GTSym0
     type Compare_0123456789876543210Sym0 :: (~>) Occ ((~>) Occ Ordering)
-    data Compare_0123456789876543210Sym0 a0123456789876543210
+    data Compare_0123456789876543210Sym0 :: (~>) Occ ((~>) Occ Ordering)
       where
         Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
                                                         Compare_0123456789876543210Sym0 a0123456789876543210
@@ -86,7 +86,7 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Compare_0123456789876543210Sym0KindInference) ())
     type Compare_0123456789876543210Sym1 :: Occ -> (~>) Occ Ordering
-    data Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Occ) :: (~>) Occ Ordering
       where
         Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                         Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -95,18 +95,18 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Compare_0123456789876543210Sym1KindInference) ())
     type Compare_0123456789876543210Sym2 :: Occ -> Occ -> Ordering
-    type family Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Compare_0123456789876543210Sym2 (a0123456789876543210 :: Occ) (a0123456789876543210 :: Occ) :: Ordering where
       Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd Occ where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type ShowsPrec_0123456789876543210 :: Nat
                                           -> Occ -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210 a a a where
+    type family ShowsPrec_0123456789876543210 (a :: Nat) (a :: Occ) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 _ Str a_0123456789876543210 = Apply (Apply ShowStringSym0 "Str") a_0123456789876543210
       ShowsPrec_0123456789876543210 _ Opt a_0123456789876543210 = Apply (Apply ShowStringSym0 "Opt") a_0123456789876543210
       ShowsPrec_0123456789876543210 _ Many a_0123456789876543210 = Apply (Apply ShowStringSym0 "Many") a_0123456789876543210
     type ShowsPrec_0123456789876543210Sym0 :: (~>) Nat ((~>) Occ ((~>) Symbol Symbol))
-    data ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) Nat ((~>) Occ ((~>) Symbol Symbol))
       where
         ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
                                                           ShowsPrec_0123456789876543210Sym0 a0123456789876543210
@@ -116,7 +116,7 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym0KindInference) ())
     type ShowsPrec_0123456789876543210Sym1 :: Nat
                                               -> (~>) Occ ((~>) Symbol Symbol)
-    data ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: Nat) :: (~>) Occ ((~>) Symbol Symbol)
       where
         ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -126,7 +126,7 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym1KindInference) ())
     type ShowsPrec_0123456789876543210Sym2 :: Nat
                                               -> Occ -> (~>) Symbol Symbol
-    data ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Occ) :: (~>) Symbol Symbol
       where
         ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -136,7 +136,7 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym2KindInference) ())
     type ShowsPrec_0123456789876543210Sym3 :: Nat
                                               -> Occ -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Occ) (a0123456789876543210 :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow Occ where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a

--- a/singletons-base/tests/compile-and-dump/Singletons/T183.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T183.golden
@@ -161,7 +161,7 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
     type family Case_0123456789876543210 x t where
       Case_0123456789876543210 x ('Just y :: Maybe Bool) = y :: Bool
     type Foo9Sym0 :: (~>) a a
-    data Foo9Sym0 a0123456789876543210
+    data Foo9Sym0 :: (~>) a a
       where
         Foo9Sym0KindInference :: SameKind (Apply Foo9Sym0 arg) (Foo9Sym1 arg) =>
                                  Foo9Sym0 a0123456789876543210
@@ -169,10 +169,10 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo9Sym0 where
       suppressUnusedWarnings = snd (((,) Foo9Sym0KindInference) ())
     type Foo9Sym1 :: a -> a
-    type family Foo9Sym1 a0123456789876543210 where
+    type family Foo9Sym1 (a0123456789876543210 :: a) :: a where
       Foo9Sym1 a0123456789876543210 = Foo9 a0123456789876543210
     type Foo8Sym0 :: forall a. (~>) (Maybe a) (Maybe a)
-    data Foo8Sym0 a0123456789876543210
+    data Foo8Sym0 :: (~>) (Maybe a) (Maybe a)
       where
         Foo8Sym0KindInference :: SameKind (Apply Foo8Sym0 arg) (Foo8Sym1 arg) =>
                                  Foo8Sym0 a0123456789876543210
@@ -180,10 +180,10 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo8Sym0 where
       suppressUnusedWarnings = snd (((,) Foo8Sym0KindInference) ())
     type Foo8Sym1 :: forall a. Maybe a -> Maybe a
-    type family Foo8Sym1 a0123456789876543210 where
+    type family Foo8Sym1 (a0123456789876543210 :: Maybe a) :: Maybe a where
       Foo8Sym1 a0123456789876543210 = Foo8 a0123456789876543210
     type Foo7Sym0 :: (~>) a ((~>) b a)
-    data Foo7Sym0 a0123456789876543210
+    data Foo7Sym0 :: (~>) a ((~>) b a)
       where
         Foo7Sym0KindInference :: SameKind (Apply Foo7Sym0 arg) (Foo7Sym1 arg) =>
                                  Foo7Sym0 a0123456789876543210
@@ -191,7 +191,7 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo7Sym0 where
       suppressUnusedWarnings = snd (((,) Foo7Sym0KindInference) ())
     type Foo7Sym1 :: a -> (~>) b a
-    data Foo7Sym1 a0123456789876543210 a0123456789876543210
+    data Foo7Sym1 (a0123456789876543210 :: a) :: (~>) b a
       where
         Foo7Sym1KindInference :: SameKind (Apply (Foo7Sym1 a0123456789876543210) arg) (Foo7Sym2 a0123456789876543210 arg) =>
                                  Foo7Sym1 a0123456789876543210 a0123456789876543210
@@ -199,10 +199,10 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (Foo7Sym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) Foo7Sym1KindInference) ())
     type Foo7Sym2 :: a -> b -> a
-    type family Foo7Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Foo7Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: a where
       Foo7Sym2 a0123456789876543210 a0123456789876543210 = Foo7 a0123456789876543210 a0123456789876543210
     type Foo6Sym0 :: (~>) (Maybe (Maybe a)) (Maybe (Maybe a))
-    data Foo6Sym0 a0123456789876543210
+    data Foo6Sym0 :: (~>) (Maybe (Maybe a)) (Maybe (Maybe a))
       where
         Foo6Sym0KindInference :: SameKind (Apply Foo6Sym0 arg) (Foo6Sym1 arg) =>
                                  Foo6Sym0 a0123456789876543210
@@ -210,10 +210,10 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo6Sym0 where
       suppressUnusedWarnings = snd (((,) Foo6Sym0KindInference) ())
     type Foo6Sym1 :: Maybe (Maybe a) -> Maybe (Maybe a)
-    type family Foo6Sym1 a0123456789876543210 where
+    type family Foo6Sym1 (a0123456789876543210 :: Maybe (Maybe a)) :: Maybe (Maybe a) where
       Foo6Sym1 a0123456789876543210 = Foo6 a0123456789876543210
     type Foo5Sym0 :: (~>) (Maybe (Maybe a)) (Maybe (Maybe a))
-    data Foo5Sym0 a0123456789876543210
+    data Foo5Sym0 :: (~>) (Maybe (Maybe a)) (Maybe (Maybe a))
       where
         Foo5Sym0KindInference :: SameKind (Apply Foo5Sym0 arg) (Foo5Sym1 arg) =>
                                  Foo5Sym0 a0123456789876543210
@@ -221,10 +221,10 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo5Sym0 where
       suppressUnusedWarnings = snd (((,) Foo5Sym0KindInference) ())
     type Foo5Sym1 :: Maybe (Maybe a) -> Maybe (Maybe a)
-    type family Foo5Sym1 a0123456789876543210 where
+    type family Foo5Sym1 (a0123456789876543210 :: Maybe (Maybe a)) :: Maybe (Maybe a) where
       Foo5Sym1 a0123456789876543210 = Foo5 a0123456789876543210
     type Foo4Sym0 :: (~>) (a, b) (b, a)
-    data Foo4Sym0 a0123456789876543210
+    data Foo4Sym0 :: (~>) (a, b) (b, a)
       where
         Foo4Sym0KindInference :: SameKind (Apply Foo4Sym0 arg) (Foo4Sym1 arg) =>
                                  Foo4Sym0 a0123456789876543210
@@ -232,10 +232,11 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo4Sym0 where
       suppressUnusedWarnings = snd (((,) Foo4Sym0KindInference) ())
     type Foo4Sym1 :: (a, b) -> (b, a)
-    type family Foo4Sym1 a0123456789876543210 where
+    type family Foo4Sym1 (a0123456789876543210 :: (a, b)) :: (b,
+                                                              a) where
       Foo4Sym1 a0123456789876543210 = Foo4 a0123456789876543210
     type Foo3Sym0 :: forall a. (~>) (Maybe a) a
-    data Foo3Sym0 a0123456789876543210
+    data Foo3Sym0 :: (~>) (Maybe a) a
       where
         Foo3Sym0KindInference :: SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
                                  Foo3Sym0 a0123456789876543210
@@ -243,10 +244,10 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo3Sym0 where
       suppressUnusedWarnings = snd (((,) Foo3Sym0KindInference) ())
     type Foo3Sym1 :: forall a. Maybe a -> a
-    type family Foo3Sym1 a0123456789876543210 where
+    type family Foo3Sym1 (a0123456789876543210 :: Maybe a) :: a where
       Foo3Sym1 a0123456789876543210 = Foo3 a0123456789876543210
     type Foo2Sym0 :: forall a. (~>) (Maybe a) a
-    data Foo2Sym0 a0123456789876543210
+    data Foo2Sym0 :: (~>) (Maybe a) a
       where
         Foo2Sym0KindInference :: SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) =>
                                  Foo2Sym0 a0123456789876543210
@@ -254,10 +255,10 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo2Sym0 where
       suppressUnusedWarnings = snd (((,) Foo2Sym0KindInference) ())
     type Foo2Sym1 :: forall a. Maybe a -> a
-    type family Foo2Sym1 a0123456789876543210 where
+    type family Foo2Sym1 (a0123456789876543210 :: Maybe a) :: a where
       Foo2Sym1 a0123456789876543210 = Foo2 a0123456789876543210
     type Foo1Sym0 :: (~>) (Maybe a) a
-    data Foo1Sym0 a0123456789876543210
+    data Foo1Sym0 :: (~>) (Maybe a) a
       where
         Foo1Sym0KindInference :: SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
                                  Foo1Sym0 a0123456789876543210
@@ -265,7 +266,7 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Foo1Sym0 where
       suppressUnusedWarnings = snd (((,) Foo1Sym0KindInference) ())
     type Foo1Sym1 :: Maybe a -> a
-    type family Foo1Sym1 a0123456789876543210 where
+    type family Foo1Sym1 (a0123456789876543210 :: Maybe a) :: a where
       Foo1Sym1 a0123456789876543210 = Foo1 a0123456789876543210
     data GSym0 a0123456789876543210
       where
@@ -304,32 +305,32 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
     type family F1Sym1 a0123456789876543210 where
       F1Sym1 a0123456789876543210 = F1 a0123456789876543210
     type Foo9 :: a -> a
-    type family Foo9 a where
+    type family Foo9 (a :: a) :: a where
       Foo9 (x :: a) = Apply (Apply (Let0123456789876543210GSym1 x) x) Tuple0Sym0
     type Foo8 :: forall a. Maybe a -> Maybe a
-    type family Foo8 a where
+    type family Foo8 (a :: Maybe a) :: Maybe a where
       Foo8 ('Just (wild_0123456789876543210 :: a) :: Maybe a) = Let0123456789876543210XSym1 wild_0123456789876543210
       Foo8 ('Nothing :: Maybe a) = Let0123456789876543210XSym0
     type Foo7 :: a -> b -> a
-    type family Foo7 a a where
+    type family Foo7 (a :: a) (a :: b) :: a where
       Foo7 (x :: a) (wild_0123456789876543210 :: b) = x :: a
     type Foo6 :: Maybe (Maybe a) -> Maybe (Maybe a)
-    type family Foo6 a where
+    type family Foo6 (a :: Maybe (Maybe a)) :: Maybe (Maybe a) where
       Foo6 ('Just x :: Maybe (Maybe a)) = Case_0123456789876543210 x (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x)
     type Foo5 :: Maybe (Maybe a) -> Maybe (Maybe a)
-    type family Foo5 a where
+    type family Foo5 (a :: Maybe (Maybe a)) :: Maybe (Maybe a) where
       Foo5 ('Just ('Just (x :: a) :: Maybe a) :: Maybe (Maybe a)) = Apply JustSym0 (Apply JustSym0 (x :: a) :: Maybe a) :: Maybe (Maybe a)
     type Foo4 :: (a, b) -> (b, a)
-    type family Foo4 a where
+    type family Foo4 (a :: (a, b)) :: (b, a) where
       Foo4 a_0123456789876543210 = Apply (Apply Lambda_0123456789876543210Sym0 a_0123456789876543210) a_0123456789876543210
     type Foo3 :: forall a. Maybe a -> a
-    type family Foo3 a where
+    type family Foo3 (a :: Maybe a) :: a where
       Foo3 ('Just x) = x :: a
     type Foo2 :: forall a. Maybe a -> a
-    type family Foo2 a where
+    type family Foo2 (a :: Maybe a) :: a where
       Foo2 ('Just x :: Maybe a) = x :: a
     type Foo1 :: Maybe a -> a
-    type family Foo1 a where
+    type family Foo1 (a :: Maybe a) :: a where
       Foo1 ('Just x :: Maybe a) = x :: a
     type family G a where
       G x = Case_0123456789876543210 x (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x)

--- a/singletons-base/tests/compile-and-dump/Singletons/T184.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T184.golden
@@ -261,7 +261,7 @@ Singletons/T184.hs:(0,0)-(0,0): Splicing declarations
     type family Lambda_0123456789876543210Sym3 ma0123456789876543210 mb0123456789876543210 a0123456789876543210 where
       Lambda_0123456789876543210Sym3 ma0123456789876543210 mb0123456789876543210 a0123456789876543210 = Lambda_0123456789876543210 ma0123456789876543210 mb0123456789876543210 a0123456789876543210
     type TruesSym0 :: (~>) [Bool] [Bool]
-    data TruesSym0 a0123456789876543210
+    data TruesSym0 :: (~>) [Bool] [Bool]
       where
         TruesSym0KindInference :: SameKind (Apply TruesSym0 arg) (TruesSym1 arg) =>
                                   TruesSym0 a0123456789876543210
@@ -269,10 +269,10 @@ Singletons/T184.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings TruesSym0 where
       suppressUnusedWarnings = snd (((,) TruesSym0KindInference) ())
     type TruesSym1 :: [Bool] -> [Bool]
-    type family TruesSym1 a0123456789876543210 where
+    type family TruesSym1 (a0123456789876543210 :: [Bool]) :: [Bool] where
       TruesSym1 a0123456789876543210 = Trues a0123456789876543210
     type CartProdSym0 :: (~>) [a] ((~>) [b] [(a, b)])
-    data CartProdSym0 a0123456789876543210
+    data CartProdSym0 :: (~>) [a] ((~>) [b] [(a, b)])
       where
         CartProdSym0KindInference :: SameKind (Apply CartProdSym0 arg) (CartProdSym1 arg) =>
                                      CartProdSym0 a0123456789876543210
@@ -280,7 +280,8 @@ Singletons/T184.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings CartProdSym0 where
       suppressUnusedWarnings = snd (((,) CartProdSym0KindInference) ())
     type CartProdSym1 :: [a] -> (~>) [b] [(a, b)]
-    data CartProdSym1 a0123456789876543210 a0123456789876543210
+    data CartProdSym1 (a0123456789876543210 :: [a]) :: (~>) [b] [(a,
+                                                                  b)]
       where
         CartProdSym1KindInference :: SameKind (Apply (CartProdSym1 a0123456789876543210) arg) (CartProdSym2 a0123456789876543210 arg) =>
                                      CartProdSym1 a0123456789876543210 a0123456789876543210
@@ -288,10 +289,11 @@ Singletons/T184.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (CartProdSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) CartProdSym1KindInference) ())
     type CartProdSym2 :: [a] -> [b] -> [(a, b)]
-    type family CartProdSym2 a0123456789876543210 a0123456789876543210 where
+    type family CartProdSym2 (a0123456789876543210 :: [a]) (a0123456789876543210 :: [b]) :: [(a,
+                                                                                              b)] where
       CartProdSym2 a0123456789876543210 a0123456789876543210 = CartProd a0123456789876543210 a0123456789876543210
     type Zip'Sym0 :: (~>) [a] ((~>) [b] [(a, b)])
-    data Zip'Sym0 a0123456789876543210
+    data Zip'Sym0 :: (~>) [a] ((~>) [b] [(a, b)])
       where
         Zip'Sym0KindInference :: SameKind (Apply Zip'Sym0 arg) (Zip'Sym1 arg) =>
                                  Zip'Sym0 a0123456789876543210
@@ -299,7 +301,7 @@ Singletons/T184.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Zip'Sym0 where
       suppressUnusedWarnings = snd (((,) Zip'Sym0KindInference) ())
     type Zip'Sym1 :: [a] -> (~>) [b] [(a, b)]
-    data Zip'Sym1 a0123456789876543210 a0123456789876543210
+    data Zip'Sym1 (a0123456789876543210 :: [a]) :: (~>) [b] [(a, b)]
       where
         Zip'Sym1KindInference :: SameKind (Apply (Zip'Sym1 a0123456789876543210) arg) (Zip'Sym2 a0123456789876543210 arg) =>
                                  Zip'Sym1 a0123456789876543210 a0123456789876543210
@@ -307,10 +309,11 @@ Singletons/T184.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (Zip'Sym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) Zip'Sym1KindInference) ())
     type Zip'Sym2 :: [a] -> [b] -> [(a, b)]
-    type family Zip'Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Zip'Sym2 (a0123456789876543210 :: [a]) (a0123456789876543210 :: [b]) :: [(a,
+                                                                                          b)] where
       Zip'Sym2 a0123456789876543210 a0123456789876543210 = Zip' a0123456789876543210 a0123456789876543210
     type BoogieSym0 :: (~>) (Maybe a) ((~>) (Maybe Bool) (Maybe a))
-    data BoogieSym0 a0123456789876543210
+    data BoogieSym0 :: (~>) (Maybe a) ((~>) (Maybe Bool) (Maybe a))
       where
         BoogieSym0KindInference :: SameKind (Apply BoogieSym0 arg) (BoogieSym1 arg) =>
                                    BoogieSym0 a0123456789876543210
@@ -318,7 +321,7 @@ Singletons/T184.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings BoogieSym0 where
       suppressUnusedWarnings = snd (((,) BoogieSym0KindInference) ())
     type BoogieSym1 :: Maybe a -> (~>) (Maybe Bool) (Maybe a)
-    data BoogieSym1 a0123456789876543210 a0123456789876543210
+    data BoogieSym1 (a0123456789876543210 :: Maybe a) :: (~>) (Maybe Bool) (Maybe a)
       where
         BoogieSym1KindInference :: SameKind (Apply (BoogieSym1 a0123456789876543210) arg) (BoogieSym2 a0123456789876543210 arg) =>
                                    BoogieSym1 a0123456789876543210 a0123456789876543210
@@ -326,19 +329,19 @@ Singletons/T184.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (BoogieSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) BoogieSym1KindInference) ())
     type BoogieSym2 :: Maybe a -> Maybe Bool -> Maybe a
-    type family BoogieSym2 a0123456789876543210 a0123456789876543210 where
+    type family BoogieSym2 (a0123456789876543210 :: Maybe a) (a0123456789876543210 :: Maybe Bool) :: Maybe a where
       BoogieSym2 a0123456789876543210 a0123456789876543210 = Boogie a0123456789876543210 a0123456789876543210
     type Trues :: [Bool] -> [Bool]
-    type family Trues a where
+    type family Trues (a :: [Bool]) :: [Bool] where
       Trues xs = Apply (Apply (>>=@#@$) xs) (Apply Lambda_0123456789876543210Sym0 xs)
     type CartProd :: [a] -> [b] -> [(a, b)]
-    type family CartProd a a where
+    type family CartProd (a :: [a]) (a :: [b]) :: [(a, b)] where
       CartProd xs ys = Apply (Apply (>>=@#@$) xs) (Apply (Apply Lambda_0123456789876543210Sym0 xs) ys)
     type Zip' :: [a] -> [b] -> [(a, b)]
-    type family Zip' a a where
+    type family Zip' (a :: [a]) (a :: [b]) :: [(a, b)] where
       Zip' xs ys = Apply (Apply (>>=@#@$) (Apply (Apply MzipSym0 (Apply (Apply (>>=@#@$) xs) (Apply (Apply Lambda_0123456789876543210Sym0 xs) ys))) (Apply (Apply (>>=@#@$) ys) (Apply (Apply Lambda_0123456789876543210Sym0 xs) ys)))) (Apply (Apply Lambda_0123456789876543210Sym0 xs) ys)
     type Boogie :: Maybe a -> Maybe Bool -> Maybe a
-    type family Boogie a a where
+    type family Boogie (a :: Maybe a) (a :: Maybe Bool) :: Maybe a where
       Boogie ma mb = Apply (Apply (>>=@#@$) ma) (Apply (Apply Lambda_0123456789876543210Sym0 ma) mb)
     sTrues ::
       forall (t :: [Bool]). Sing t -> Sing (Apply TruesSym0 t :: [Bool])

--- a/singletons-base/tests/compile-and-dump/Singletons/T187.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T187.golden
@@ -9,10 +9,10 @@ Singletons/T187.hs:(0,0)-(0,0): Splicing declarations
     deriving instance Eq Empty
     deriving instance Ord Empty
     type TFHelper_0123456789876543210 :: Empty -> Empty -> Bool
-    type family TFHelper_0123456789876543210 a a where
+    type family TFHelper_0123456789876543210 (a :: Empty) (a :: Empty) :: Bool where
       TFHelper_0123456789876543210 _ _ = TrueSym0
     type TFHelper_0123456789876543210Sym0 :: (~>) Empty ((~>) Empty Bool)
-    data TFHelper_0123456789876543210Sym0 a0123456789876543210
+    data TFHelper_0123456789876543210Sym0 :: (~>) Empty ((~>) Empty Bool)
       where
         TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
                                                          TFHelper_0123456789876543210Sym0 a0123456789876543210
@@ -21,7 +21,7 @@ Singletons/T187.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym0KindInference) ())
     type TFHelper_0123456789876543210Sym1 :: Empty -> (~>) Empty Bool
-    data TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Empty) :: (~>) Empty Bool
       where
         TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                          TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -30,15 +30,15 @@ Singletons/T187.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym1KindInference) ())
     type TFHelper_0123456789876543210Sym2 :: Empty -> Empty -> Bool
-    type family TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: Empty) (a0123456789876543210 :: Empty) :: Bool where
       TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq Empty where
       type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
     type Compare_0123456789876543210 :: Empty -> Empty -> Ordering
-    type family Compare_0123456789876543210 a a where
+    type family Compare_0123456789876543210 (a :: Empty) (a :: Empty) :: Ordering where
       Compare_0123456789876543210 _ _ = EQSym0
     type Compare_0123456789876543210Sym0 :: (~>) Empty ((~>) Empty Ordering)
-    data Compare_0123456789876543210Sym0 a0123456789876543210
+    data Compare_0123456789876543210Sym0 :: (~>) Empty ((~>) Empty Ordering)
       where
         Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
                                                         Compare_0123456789876543210Sym0 a0123456789876543210
@@ -48,7 +48,7 @@ Singletons/T187.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) Compare_0123456789876543210Sym0KindInference) ())
     type Compare_0123456789876543210Sym1 :: Empty
                                             -> (~>) Empty Ordering
-    data Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Empty) :: (~>) Empty Ordering
       where
         Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                         Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -57,7 +57,7 @@ Singletons/T187.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Compare_0123456789876543210Sym1KindInference) ())
     type Compare_0123456789876543210Sym2 :: Empty -> Empty -> Ordering
-    type family Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Compare_0123456789876543210Sym2 (a0123456789876543210 :: Empty) (a0123456789876543210 :: Empty) :: Ordering where
       Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd Empty where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a

--- a/singletons-base/tests/compile-and-dump/Singletons/T190.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T190.golden
@@ -8,13 +8,13 @@ Singletons/T190.hs:0:0:: Splicing declarations
       = T
       deriving (Eq, Ord, Enum, Bounded, Show)
     type TSym0 :: T
-    type family TSym0 where
+    type family TSym0 :: T where
       TSym0 = T
     type TFHelper_0123456789876543210 :: T -> T -> Bool
-    type family TFHelper_0123456789876543210 a a where
+    type family TFHelper_0123456789876543210 (a :: T) (a :: T) :: Bool where
       TFHelper_0123456789876543210 T T = TrueSym0
     type TFHelper_0123456789876543210Sym0 :: (~>) T ((~>) T Bool)
-    data TFHelper_0123456789876543210Sym0 a0123456789876543210
+    data TFHelper_0123456789876543210Sym0 :: (~>) T ((~>) T Bool)
       where
         TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
                                                          TFHelper_0123456789876543210Sym0 a0123456789876543210
@@ -23,7 +23,7 @@ Singletons/T190.hs:0:0:: Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym0KindInference) ())
     type TFHelper_0123456789876543210Sym1 :: T -> (~>) T Bool
-    data TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: T) :: (~>) T Bool
       where
         TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                          TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -32,15 +32,15 @@ Singletons/T190.hs:0:0:: Splicing declarations
       suppressUnusedWarnings
         = snd (((,) TFHelper_0123456789876543210Sym1KindInference) ())
     type TFHelper_0123456789876543210Sym2 :: T -> T -> Bool
-    type family TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: T) (a0123456789876543210 :: T) :: Bool where
       TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq T where
       type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
     type Compare_0123456789876543210 :: T -> T -> Ordering
-    type family Compare_0123456789876543210 a a where
+    type family Compare_0123456789876543210 (a :: T) (a :: T) :: Ordering where
       Compare_0123456789876543210 T T = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) NilSym0
     type Compare_0123456789876543210Sym0 :: (~>) T ((~>) T Ordering)
-    data Compare_0123456789876543210Sym0 a0123456789876543210
+    data Compare_0123456789876543210Sym0 :: (~>) T ((~>) T Ordering)
       where
         Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
                                                         Compare_0123456789876543210Sym0 a0123456789876543210
@@ -49,7 +49,7 @@ Singletons/T190.hs:0:0:: Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Compare_0123456789876543210Sym0KindInference) ())
     type Compare_0123456789876543210Sym1 :: T -> (~>) T Ordering
-    data Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: T) :: (~>) T Ordering
       where
         Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                         Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -58,7 +58,7 @@ Singletons/T190.hs:0:0:: Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Compare_0123456789876543210Sym1KindInference) ())
     type Compare_0123456789876543210Sym2 :: T -> T -> Ordering
-    type family Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Compare_0123456789876543210Sym2 (a0123456789876543210 :: T) (a0123456789876543210 :: T) :: Ordering where
       Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd T where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
@@ -66,10 +66,10 @@ Singletons/T190.hs:0:0:: Splicing declarations
       Case_0123456789876543210 n 'True = TSym0
       Case_0123456789876543210 n 'False = Apply ErrorSym0 "toEnum: bad argument"
     type ToEnum_0123456789876543210 :: GHC.Types.Nat -> T
-    type family ToEnum_0123456789876543210 a where
+    type family ToEnum_0123456789876543210 (a :: GHC.Types.Nat) :: T where
       ToEnum_0123456789876543210 n = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (FromInteger 0))
     type ToEnum_0123456789876543210Sym0 :: (~>) GHC.Types.Nat T
-    data ToEnum_0123456789876543210Sym0 a0123456789876543210
+    data ToEnum_0123456789876543210Sym0 :: (~>) GHC.Types.Nat T
       where
         ToEnum_0123456789876543210Sym0KindInference :: SameKind (Apply ToEnum_0123456789876543210Sym0 arg) (ToEnum_0123456789876543210Sym1 arg) =>
                                                        ToEnum_0123456789876543210Sym0 a0123456789876543210
@@ -78,13 +78,13 @@ Singletons/T190.hs:0:0:: Splicing declarations
       suppressUnusedWarnings
         = snd (((,) ToEnum_0123456789876543210Sym0KindInference) ())
     type ToEnum_0123456789876543210Sym1 :: GHC.Types.Nat -> T
-    type family ToEnum_0123456789876543210Sym1 a0123456789876543210 where
+    type family ToEnum_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: T where
       ToEnum_0123456789876543210Sym1 a0123456789876543210 = ToEnum_0123456789876543210 a0123456789876543210
     type FromEnum_0123456789876543210 :: T -> GHC.Types.Nat
-    type family FromEnum_0123456789876543210 a where
+    type family FromEnum_0123456789876543210 (a :: T) :: GHC.Types.Nat where
       FromEnum_0123456789876543210 T = FromInteger 0
     type FromEnum_0123456789876543210Sym0 :: (~>) T GHC.Types.Nat
-    data FromEnum_0123456789876543210Sym0 a0123456789876543210
+    data FromEnum_0123456789876543210Sym0 :: (~>) T GHC.Types.Nat
       where
         FromEnum_0123456789876543210Sym0KindInference :: SameKind (Apply FromEnum_0123456789876543210Sym0 arg) (FromEnum_0123456789876543210Sym1 arg) =>
                                                          FromEnum_0123456789876543210Sym0 a0123456789876543210
@@ -93,32 +93,32 @@ Singletons/T190.hs:0:0:: Splicing declarations
       suppressUnusedWarnings
         = snd (((,) FromEnum_0123456789876543210Sym0KindInference) ())
     type FromEnum_0123456789876543210Sym1 :: T -> GHC.Types.Nat
-    type family FromEnum_0123456789876543210Sym1 a0123456789876543210 where
+    type family FromEnum_0123456789876543210Sym1 (a0123456789876543210 :: T) :: GHC.Types.Nat where
       FromEnum_0123456789876543210Sym1 a0123456789876543210 = FromEnum_0123456789876543210 a0123456789876543210
     instance PEnum T where
       type ToEnum a = Apply ToEnum_0123456789876543210Sym0 a
       type FromEnum a = Apply FromEnum_0123456789876543210Sym0 a
     type MinBound_0123456789876543210 :: T
-    type family MinBound_0123456789876543210 where
+    type family MinBound_0123456789876543210 :: T where
       MinBound_0123456789876543210 = TSym0
     type MinBound_0123456789876543210Sym0 :: T
-    type family MinBound_0123456789876543210Sym0 where
+    type family MinBound_0123456789876543210Sym0 :: T where
       MinBound_0123456789876543210Sym0 = MinBound_0123456789876543210
     type MaxBound_0123456789876543210 :: T
-    type family MaxBound_0123456789876543210 where
+    type family MaxBound_0123456789876543210 :: T where
       MaxBound_0123456789876543210 = TSym0
     type MaxBound_0123456789876543210Sym0 :: T
-    type family MaxBound_0123456789876543210Sym0 where
+    type family MaxBound_0123456789876543210Sym0 :: T where
       MaxBound_0123456789876543210Sym0 = MaxBound_0123456789876543210
     instance PBounded T where
       type MinBound = MinBound_0123456789876543210Sym0
       type MaxBound = MaxBound_0123456789876543210Sym0
     type ShowsPrec_0123456789876543210 :: GHC.Types.Nat
                                           -> T -> GHC.Types.Symbol -> GHC.Types.Symbol
-    type family ShowsPrec_0123456789876543210 a a a where
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: T) (a :: GHC.Types.Symbol) :: GHC.Types.Symbol where
       ShowsPrec_0123456789876543210 _ T a_0123456789876543210 = Apply (Apply ShowStringSym0 "T") a_0123456789876543210
     type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) T ((~>) GHC.Types.Symbol GHC.Types.Symbol))
-    data ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) T ((~>) GHC.Types.Symbol GHC.Types.Symbol))
       where
         ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
                                                           ShowsPrec_0123456789876543210Sym0 a0123456789876543210
@@ -128,7 +128,7 @@ Singletons/T190.hs:0:0:: Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym0KindInference) ())
     type ShowsPrec_0123456789876543210Sym1 :: GHC.Types.Nat
                                               -> (~>) T ((~>) GHC.Types.Symbol GHC.Types.Symbol)
-    data ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: (~>) T ((~>) GHC.Types.Symbol GHC.Types.Symbol)
       where
         ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -138,7 +138,7 @@ Singletons/T190.hs:0:0:: Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym1KindInference) ())
     type ShowsPrec_0123456789876543210Sym2 :: GHC.Types.Nat
                                               -> T -> (~>) GHC.Types.Symbol GHC.Types.Symbol
-    data ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: T) :: (~>) GHC.Types.Symbol GHC.Types.Symbol
       where
         ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -148,7 +148,7 @@ Singletons/T190.hs:0:0:: Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym2KindInference) ())
     type ShowsPrec_0123456789876543210Sym3 :: GHC.Types.Nat
                                               -> T -> GHC.Types.Symbol -> GHC.Types.Symbol
-    type family ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: T) (a0123456789876543210 :: GHC.Types.Symbol) :: GHC.Types.Symbol where
       ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow T where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a

--- a/singletons-base/tests/compile-and-dump/Singletons/T197.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T197.golden
@@ -9,7 +9,7 @@ Singletons/T197.hs:(0,0)-(0,0): Splicing declarations
     ($$:) :: Bool -> Bool -> Bool
     ($$:) _ _ = False
     type ($$:@#@$) :: (~>) Bool ((~>) Bool Bool)
-    data ($$:@#@$) a0123456789876543210
+    data ($$:@#@$) :: (~>) Bool ((~>) Bool Bool)
       where
         (:$$:@#@$###) :: SameKind (Apply ($$:@#@$) arg) (($$:@#@$$) arg) =>
                          ($$:@#@$) a0123456789876543210
@@ -18,7 +18,7 @@ Singletons/T197.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) (:$$:@#@$###)) ())
     infixl 5 $$:@#@$
     type ($$:@#@$$) :: Bool -> (~>) Bool Bool
-    data ($$:@#@$$) a0123456789876543210 a0123456789876543210
+    data ($$:@#@$$) (a0123456789876543210 :: Bool) :: (~>) Bool Bool
       where
         (:$$:@#@$$###) :: SameKind (Apply (($$:@#@$$) a0123456789876543210) arg) (($$:@#@$$$) a0123456789876543210 arg) =>
                           ($$:@#@$$) a0123456789876543210 a0123456789876543210
@@ -27,11 +27,11 @@ Singletons/T197.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) (:$$:@#@$$###)) ())
     infixl 5 $$:@#@$$
     type ($$:@#@$$$) :: Bool -> Bool -> Bool
-    type family ($$:@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family ($$:@#@$$$) (a0123456789876543210 :: Bool) (a0123456789876543210 :: Bool) :: Bool where
       ($$:@#@$$$) a0123456789876543210 a0123456789876543210 = ($$:) a0123456789876543210 a0123456789876543210
     infixl 5 $$:@#@$$$
     type ($$:) :: Bool -> Bool -> Bool
-    type family ($$:) a a where
+    type family ($$:) (a :: Bool) (a :: Bool) :: Bool where
       ($$:) _ _ = FalseSym0
     infixl 5 %$$:
     (%$$:) ::

--- a/singletons-base/tests/compile-and-dump/Singletons/T197b.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T197b.golden
@@ -10,7 +10,7 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
     infixr 9 `Pair`
     infixr 9 `MkPair`
     type (:*:@#@$) :: forall a b. (~>) a ((~>) b ((:*:) a b))
-    data (:*:@#@$) a0123456789876543210
+    data (:*:@#@$) :: (~>) a ((~>) b ((:*:) a b))
       where
         (::*:@#@$###) :: SameKind (Apply (:*:@#@$) arg) ((:*:@#@$$) arg) =>
                          (:*:@#@$) a0123456789876543210
@@ -18,7 +18,7 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (:*:@#@$) where
       suppressUnusedWarnings = snd (((,) (::*:@#@$###)) ())
     type (:*:@#@$$) :: forall a b. a -> (~>) b ((:*:) a b)
-    data (:*:@#@$$) a0123456789876543210 a0123456789876543210
+    data (:*:@#@$$) (a0123456789876543210 :: a) :: (~>) b ((:*:) a b)
       where
         (::*:@#@$$###) :: SameKind (Apply ((:*:@#@$$) a0123456789876543210) arg) ((:*:@#@$$$) a0123456789876543210 arg) =>
                           (:*:@#@$$) a0123456789876543210 a0123456789876543210
@@ -26,10 +26,10 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ((:*:@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) (::*:@#@$$###)) ())
     type (:*:@#@$$$) :: forall a b. a -> b -> (:*:) a b
-    type family (:*:@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family (:*:@#@$$$) (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: (:*:) a b where
       (:*:@#@$$$) a0123456789876543210 a0123456789876543210 = (:*:) a0123456789876543210 a0123456789876543210
     type MkPairSym0 :: forall a b. (~>) a ((~>) b (Pair a b))
-    data MkPairSym0 a0123456789876543210
+    data MkPairSym0 :: (~>) a ((~>) b (Pair a b))
       where
         MkPairSym0KindInference :: SameKind (Apply MkPairSym0 arg) (MkPairSym1 arg) =>
                                    MkPairSym0 a0123456789876543210
@@ -38,7 +38,7 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) MkPairSym0KindInference) ())
     infixr 9 `MkPairSym0`
     type MkPairSym1 :: forall a b. a -> (~>) b (Pair a b)
-    data MkPairSym1 a0123456789876543210 a0123456789876543210
+    data MkPairSym1 (a0123456789876543210 :: a) :: (~>) b (Pair a b)
       where
         MkPairSym1KindInference :: SameKind (Apply (MkPairSym1 a0123456789876543210) arg) (MkPairSym2 a0123456789876543210 arg) =>
                                    MkPairSym1 a0123456789876543210 a0123456789876543210
@@ -47,7 +47,7 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) MkPairSym1KindInference) ())
     infixr 9 `MkPairSym1`
     type MkPairSym2 :: forall a b. a -> b -> Pair a b
-    type family MkPairSym2 a0123456789876543210 a0123456789876543210 where
+    type family MkPairSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: Pair a b where
       MkPairSym2 a0123456789876543210 a0123456789876543210 = MkPair a0123456789876543210 a0123456789876543210
     infixr 9 `MkPairSym2`
     infixr 9 `SMkPair`

--- a/singletons-base/tests/compile-and-dump/Singletons/T200.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T200.golden
@@ -19,7 +19,7 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
     (<>:) :: ErrorMessage -> ErrorMessage -> ErrorMessage
     (<>:) x y = (x :<>: y)
     type (:$$:@#@$) :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)
-    data (:$$:@#@$) a0123456789876543210
+    data (:$$:@#@$) :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)
       where
         (::$$:@#@$###) :: SameKind (Apply (:$$:@#@$) arg) ((:$$:@#@$$) arg) =>
                           (:$$:@#@$) a0123456789876543210
@@ -27,7 +27,7 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (:$$:@#@$) where
       suppressUnusedWarnings = snd (((,) (::$$:@#@$###)) ())
     type (:$$:@#@$$) :: ErrorMessage -> (~>) ErrorMessage ErrorMessage
-    data (:$$:@#@$$) a0123456789876543210 a0123456789876543210
+    data (:$$:@#@$$) (a0123456789876543210 :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage
       where
         (::$$:@#@$$###) :: SameKind (Apply ((:$$:@#@$$) a0123456789876543210) arg) ((:$$:@#@$$$) a0123456789876543210 arg) =>
                            (:$$:@#@$$) a0123456789876543210 a0123456789876543210
@@ -35,10 +35,10 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ((:$$:@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) (::$$:@#@$$###)) ())
     type (:$$:@#@$$$) :: ErrorMessage -> ErrorMessage -> ErrorMessage
-    type family (:$$:@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family (:$$:@#@$$$) (a0123456789876543210 :: ErrorMessage) (a0123456789876543210 :: ErrorMessage) :: ErrorMessage where
       (:$$:@#@$$$) a0123456789876543210 a0123456789876543210 = (:$$:) a0123456789876543210 a0123456789876543210
     type (:<>:@#@$) :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)
-    data (:<>:@#@$) a0123456789876543210
+    data (:<>:@#@$) :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)
       where
         (::<>:@#@$###) :: SameKind (Apply (:<>:@#@$) arg) ((:<>:@#@$$) arg) =>
                           (:<>:@#@$) a0123456789876543210
@@ -46,7 +46,7 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (:<>:@#@$) where
       suppressUnusedWarnings = snd (((,) (::<>:@#@$###)) ())
     type (:<>:@#@$$) :: ErrorMessage -> (~>) ErrorMessage ErrorMessage
-    data (:<>:@#@$$) a0123456789876543210 a0123456789876543210
+    data (:<>:@#@$$) (a0123456789876543210 :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage
       where
         (::<>:@#@$$###) :: SameKind (Apply ((:<>:@#@$$) a0123456789876543210) arg) ((:<>:@#@$$$) a0123456789876543210 arg) =>
                            (:<>:@#@$$) a0123456789876543210 a0123456789876543210
@@ -54,10 +54,10 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ((:<>:@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) (::<>:@#@$$###)) ())
     type (:<>:@#@$$$) :: ErrorMessage -> ErrorMessage -> ErrorMessage
-    type family (:<>:@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family (:<>:@#@$$$) (a0123456789876543210 :: ErrorMessage) (a0123456789876543210 :: ErrorMessage) :: ErrorMessage where
       (:<>:@#@$$$) a0123456789876543210 a0123456789876543210 = (:<>:) a0123456789876543210 a0123456789876543210
     type EMSym0 :: (~>) [Bool] ErrorMessage
-    data EMSym0 a0123456789876543210
+    data EMSym0 :: (~>) [Bool] ErrorMessage
       where
         EMSym0KindInference :: SameKind (Apply EMSym0 arg) (EMSym1 arg) =>
                                EMSym0 a0123456789876543210
@@ -65,10 +65,10 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings EMSym0 where
       suppressUnusedWarnings = snd (((,) EMSym0KindInference) ())
     type EMSym1 :: [Bool] -> ErrorMessage
-    type family EMSym1 a0123456789876543210 where
+    type family EMSym1 (a0123456789876543210 :: [Bool]) :: ErrorMessage where
       EMSym1 a0123456789876543210 = EM a0123456789876543210
     type (<>:@#@$) :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)
-    data (<>:@#@$) a0123456789876543210
+    data (<>:@#@$) :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)
       where
         (:<>:@#@$###) :: SameKind (Apply (<>:@#@$) arg) ((<>:@#@$$) arg) =>
                          (<>:@#@$) a0123456789876543210
@@ -76,7 +76,7 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (<>:@#@$) where
       suppressUnusedWarnings = snd (((,) (:<>:@#@$###)) ())
     type (<>:@#@$$) :: ErrorMessage -> (~>) ErrorMessage ErrorMessage
-    data (<>:@#@$$) a0123456789876543210 a0123456789876543210
+    data (<>:@#@$$) (a0123456789876543210 :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage
       where
         (:<>:@#@$$###) :: SameKind (Apply ((<>:@#@$$) a0123456789876543210) arg) ((<>:@#@$$$) a0123456789876543210 arg) =>
                           (<>:@#@$$) a0123456789876543210 a0123456789876543210
@@ -84,10 +84,10 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ((<>:@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) (:<>:@#@$$###)) ())
     type (<>:@#@$$$) :: ErrorMessage -> ErrorMessage -> ErrorMessage
-    type family (<>:@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family (<>:@#@$$$) (a0123456789876543210 :: ErrorMessage) (a0123456789876543210 :: ErrorMessage) :: ErrorMessage where
       (<>:@#@$$$) a0123456789876543210 a0123456789876543210 = (<>:) a0123456789876543210 a0123456789876543210
     type ($$:@#@$) :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)
-    data ($$:@#@$) a0123456789876543210
+    data ($$:@#@$) :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)
       where
         (:$$:@#@$###) :: SameKind (Apply ($$:@#@$) arg) (($$:@#@$$) arg) =>
                          ($$:@#@$) a0123456789876543210
@@ -95,7 +95,7 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ($$:@#@$) where
       suppressUnusedWarnings = snd (((,) (:$$:@#@$###)) ())
     type ($$:@#@$$) :: ErrorMessage -> (~>) ErrorMessage ErrorMessage
-    data ($$:@#@$$) a0123456789876543210 a0123456789876543210
+    data ($$:@#@$$) (a0123456789876543210 :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage
       where
         (:$$:@#@$$###) :: SameKind (Apply (($$:@#@$$) a0123456789876543210) arg) (($$:@#@$$$) a0123456789876543210 arg) =>
                           ($$:@#@$$) a0123456789876543210 a0123456789876543210
@@ -103,13 +103,13 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (($$:@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) (:$$:@#@$$###)) ())
     type ($$:@#@$$$) :: ErrorMessage -> ErrorMessage -> ErrorMessage
-    type family ($$:@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family ($$:@#@$$$) (a0123456789876543210 :: ErrorMessage) (a0123456789876543210 :: ErrorMessage) :: ErrorMessage where
       ($$:@#@$$$) a0123456789876543210 a0123456789876543210 = ($$:) a0123456789876543210 a0123456789876543210
     type (<>:) :: ErrorMessage -> ErrorMessage -> ErrorMessage
-    type family (<>:) a a where
+    type family (<>:) (a :: ErrorMessage) (a :: ErrorMessage) :: ErrorMessage where
       (<>:) x y = Apply (Apply (:<>:@#@$) x) y
     type ($$:) :: ErrorMessage -> ErrorMessage -> ErrorMessage
-    type family ($$:) a a where
+    type family ($$:) (a :: ErrorMessage) (a :: ErrorMessage) :: ErrorMessage where
       ($$:) x y = Apply (Apply (:$$:@#@$) x) y
     (%<>:) ::
       forall (t :: ErrorMessage) (t :: ErrorMessage).

--- a/singletons-base/tests/compile-and-dump/Singletons/T204.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T204.golden
@@ -16,7 +16,7 @@ Singletons/T204.hs:(0,0)-(0,0): Splicing declarations
     data Ratio1 a = a :% a
     data Ratio2 a = a :%% a
     type (:%@#@$) :: forall a. (~>) a ((~>) a (Ratio1 a))
-    data (:%@#@$) a0123456789876543210
+    data (:%@#@$) :: (~>) a ((~>) a (Ratio1 a))
       where
         (::%@#@$###) :: SameKind (Apply (:%@#@$) arg) ((:%@#@$$) arg) =>
                         (:%@#@$) a0123456789876543210
@@ -24,7 +24,7 @@ Singletons/T204.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (:%@#@$) where
       suppressUnusedWarnings = snd (((,) (::%@#@$###)) ())
     type (:%@#@$$) :: forall a. a -> (~>) a (Ratio1 a)
-    data (:%@#@$$) a0123456789876543210 a0123456789876543210
+    data (:%@#@$$) (a0123456789876543210 :: a) :: (~>) a (Ratio1 a)
       where
         (::%@#@$$###) :: SameKind (Apply ((:%@#@$$) a0123456789876543210) arg) ((:%@#@$$$) a0123456789876543210 arg) =>
                          (:%@#@$$) a0123456789876543210 a0123456789876543210
@@ -32,10 +32,10 @@ Singletons/T204.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ((:%@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) (::%@#@$$###)) ())
     type (:%@#@$$$) :: forall a. a -> a -> Ratio1 a
-    type family (:%@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family (:%@#@$$$) (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Ratio1 a where
       (:%@#@$$$) a0123456789876543210 a0123456789876543210 = (:%) a0123456789876543210 a0123456789876543210
     type (:%%@#@$) :: forall a. (~>) a ((~>) a (Ratio2 a))
-    data (:%%@#@$) a0123456789876543210
+    data (:%%@#@$) :: (~>) a ((~>) a (Ratio2 a))
       where
         (::%%@#@$###) :: SameKind (Apply (:%%@#@$) arg) ((:%%@#@$$) arg) =>
                          (:%%@#@$) a0123456789876543210
@@ -43,7 +43,7 @@ Singletons/T204.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (:%%@#@$) where
       suppressUnusedWarnings = snd (((,) (::%%@#@$###)) ())
     type (:%%@#@$$) :: forall a. a -> (~>) a (Ratio2 a)
-    data (:%%@#@$$) a0123456789876543210 a0123456789876543210
+    data (:%%@#@$$) (a0123456789876543210 :: a) :: (~>) a (Ratio2 a)
       where
         (::%%@#@$$###) :: SameKind (Apply ((:%%@#@$$) a0123456789876543210) arg) ((:%%@#@$$$) a0123456789876543210 arg) =>
                           (:%%@#@$$) a0123456789876543210 a0123456789876543210
@@ -51,7 +51,7 @@ Singletons/T204.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ((:%%@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) (::%%@#@$$###)) ())
     type (:%%@#@$$$) :: forall a. a -> a -> Ratio2 a
-    type family (:%%@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family (:%%@#@$$$) (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Ratio2 a where
       (:%%@#@$$$) a0123456789876543210 a0123456789876543210 = (:%%) a0123456789876543210 a0123456789876543210
     data SRatio1 :: forall a. Ratio1 a -> GHC.Types.Type
       where

--- a/singletons-base/tests/compile-and-dump/Singletons/T209.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T209.golden
@@ -18,10 +18,10 @@ Singletons/T209.hs:(0,0)-(0,0): Splicing declarations
       deriving anyclass (C Bool)
     deriving anyclass instance C a a => C a (Maybe a)
     type HmSym0 :: Hm
-    type family HmSym0 where
+    type family HmSym0 :: Hm where
       HmSym0 = Hm
     type MSym0 :: (~>) a ((~>) b ((~>) Bool Bool))
-    data MSym0 a0123456789876543210
+    data MSym0 :: (~>) a ((~>) b ((~>) Bool Bool))
       where
         MSym0KindInference :: SameKind (Apply MSym0 arg) (MSym1 arg) =>
                               MSym0 a0123456789876543210
@@ -29,7 +29,7 @@ Singletons/T209.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings MSym0 where
       suppressUnusedWarnings = snd (((,) MSym0KindInference) ())
     type MSym1 :: a -> (~>) b ((~>) Bool Bool)
-    data MSym1 a0123456789876543210 a0123456789876543210
+    data MSym1 (a0123456789876543210 :: a) :: (~>) b ((~>) Bool Bool)
       where
         MSym1KindInference :: SameKind (Apply (MSym1 a0123456789876543210) arg) (MSym2 a0123456789876543210 arg) =>
                               MSym1 a0123456789876543210 a0123456789876543210
@@ -37,7 +37,7 @@ Singletons/T209.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (MSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) MSym1KindInference) ())
     type MSym2 :: a -> b -> (~>) Bool Bool
-    data MSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data MSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: (~>) Bool Bool
       where
         MSym2KindInference :: SameKind (Apply (MSym2 a0123456789876543210 a0123456789876543210) arg) (MSym3 a0123456789876543210 a0123456789876543210 arg) =>
                               MSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -45,10 +45,10 @@ Singletons/T209.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (MSym2 a0123456789876543210 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) MSym2KindInference) ())
     type MSym3 :: a -> b -> Bool -> Bool
-    type family MSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family MSym3 (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: Bool) :: Bool where
       MSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = M a0123456789876543210 a0123456789876543210 a0123456789876543210
     type M :: a -> b -> Bool -> Bool
-    type family M a a a where
+    type family M (a :: a) (a :: b) (a :: Bool) :: Bool where
       M _ _ x = x
     class PC a b
     instance PC Bool Hm

--- a/singletons-base/tests/compile-and-dump/Singletons/T229.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T229.golden
@@ -6,7 +6,7 @@ Singletons/T229.hs:(0,0)-(0,0): Splicing declarations
     ___foo :: Bool -> Bool
     ___foo _ = True
     type US___fooSym0 :: (~>) Bool Bool
-    data US___fooSym0 a0123456789876543210
+    data US___fooSym0 :: (~>) Bool Bool
       where
         US___fooSym0KindInference :: SameKind (Apply US___fooSym0 arg) (US___fooSym1 arg) =>
                                      US___fooSym0 a0123456789876543210
@@ -14,10 +14,10 @@ Singletons/T229.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings US___fooSym0 where
       suppressUnusedWarnings = snd (((,) US___fooSym0KindInference) ())
     type US___fooSym1 :: Bool -> Bool
-    type family US___fooSym1 a0123456789876543210 where
+    type family US___fooSym1 (a0123456789876543210 :: Bool) :: Bool where
       US___fooSym1 a0123456789876543210 = US___foo a0123456789876543210
     type US___foo :: Bool -> Bool
-    type family US___foo a where
+    type family US___foo (a :: Bool) :: Bool where
       US___foo _ = TrueSym0
     ___sfoo ::
       forall (t :: Bool). Sing t -> Sing (Apply US___fooSym0 t :: Bool)

--- a/singletons-base/tests/compile-and-dump/Singletons/T249.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T249.golden
@@ -8,7 +8,7 @@ Singletons/T249.hs:(0,0)-(0,0): Splicing declarations
     data Foo2 a where MkFoo2 :: x -> Foo2 x
     data Foo3 a where MkFoo3 :: forall x. x -> Foo3 x
     type MkFoo1Sym0 :: forall a. (~>) a (Foo1 a)
-    data MkFoo1Sym0 a0123456789876543210
+    data MkFoo1Sym0 :: (~>) a (Foo1 a)
       where
         MkFoo1Sym0KindInference :: SameKind (Apply MkFoo1Sym0 arg) (MkFoo1Sym1 arg) =>
                                    MkFoo1Sym0 a0123456789876543210
@@ -16,10 +16,10 @@ Singletons/T249.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings MkFoo1Sym0 where
       suppressUnusedWarnings = snd (((,) MkFoo1Sym0KindInference) ())
     type MkFoo1Sym1 :: forall a. a -> Foo1 a
-    type family MkFoo1Sym1 a0123456789876543210 where
+    type family MkFoo1Sym1 (a0123456789876543210 :: a) :: Foo1 a where
       MkFoo1Sym1 a0123456789876543210 = MkFoo1 a0123456789876543210
     type MkFoo2Sym0 :: (~>) x (Foo2 x)
-    data MkFoo2Sym0 a0123456789876543210
+    data MkFoo2Sym0 :: (~>) x (Foo2 x)
       where
         MkFoo2Sym0KindInference :: SameKind (Apply MkFoo2Sym0 arg) (MkFoo2Sym1 arg) =>
                                    MkFoo2Sym0 a0123456789876543210
@@ -27,10 +27,10 @@ Singletons/T249.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings MkFoo2Sym0 where
       suppressUnusedWarnings = snd (((,) MkFoo2Sym0KindInference) ())
     type MkFoo2Sym1 :: x -> Foo2 x
-    type family MkFoo2Sym1 a0123456789876543210 where
+    type family MkFoo2Sym1 (a0123456789876543210 :: x) :: Foo2 x where
       MkFoo2Sym1 a0123456789876543210 = MkFoo2 a0123456789876543210
     type MkFoo3Sym0 :: forall x. (~>) x (Foo3 x)
-    data MkFoo3Sym0 a0123456789876543210
+    data MkFoo3Sym0 :: (~>) x (Foo3 x)
       where
         MkFoo3Sym0KindInference :: SameKind (Apply MkFoo3Sym0 arg) (MkFoo3Sym1 arg) =>
                                    MkFoo3Sym0 a0123456789876543210
@@ -38,7 +38,7 @@ Singletons/T249.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings MkFoo3Sym0 where
       suppressUnusedWarnings = snd (((,) MkFoo3Sym0KindInference) ())
     type MkFoo3Sym1 :: forall x. x -> Foo3 x
-    type family MkFoo3Sym1 a0123456789876543210 where
+    type family MkFoo3Sym1 (a0123456789876543210 :: x) :: Foo3 x where
       MkFoo3Sym1 a0123456789876543210 = MkFoo3 a0123456789876543210
     data SFoo1 :: forall a. Foo1 a -> Type
       where

--- a/singletons-base/tests/compile-and-dump/Singletons/T271.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T271.golden
@@ -15,7 +15,7 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
       deriving (Eq, Ord)
     type ConstantSym0 :: forall (a :: Type) (b :: Type).
                          (~>) a (Constant (a :: Type) (b :: Type))
-    data ConstantSym0 a0123456789876543210
+    data ConstantSym0 :: (~>) a (Constant (a :: Type) (b :: Type))
       where
         ConstantSym0KindInference :: SameKind (Apply ConstantSym0 arg) (ConstantSym1 arg) =>
                                      ConstantSym0 a0123456789876543210
@@ -24,10 +24,10 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) ConstantSym0KindInference) ())
     type ConstantSym1 :: forall (a :: Type) (b :: Type).
                          a -> Constant (a :: Type) (b :: Type)
-    type family ConstantSym1 a0123456789876543210 where
+    type family ConstantSym1 (a0123456789876543210 :: a) :: Constant (a :: Type) (b :: Type) where
       ConstantSym1 a0123456789876543210 = Constant a0123456789876543210
     type IdentitySym0 :: (~>) a (Identity a)
-    data IdentitySym0 a0123456789876543210
+    data IdentitySym0 :: (~>) a (Identity a)
       where
         IdentitySym0KindInference :: SameKind (Apply IdentitySym0 arg) (IdentitySym1 arg) =>
                                      IdentitySym0 a0123456789876543210
@@ -35,14 +35,14 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings IdentitySym0 where
       suppressUnusedWarnings = snd (((,) IdentitySym0KindInference) ())
     type IdentitySym1 :: a -> Identity a
-    type family IdentitySym1 a0123456789876543210 where
+    type family IdentitySym1 (a0123456789876543210 :: a) :: Identity a where
       IdentitySym1 a0123456789876543210 = Identity a0123456789876543210
     type TFHelper_0123456789876543210 :: Constant a b
                                          -> Constant a b -> Bool
-    type family TFHelper_0123456789876543210 a a where
+    type family TFHelper_0123456789876543210 (a :: Constant a b) (a :: Constant a b) :: Bool where
       TFHelper_0123456789876543210 (Constant a_0123456789876543210) (Constant b_0123456789876543210) = Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210
     type TFHelper_0123456789876543210Sym0 :: (~>) (Constant a b) ((~>) (Constant a b) Bool)
-    data TFHelper_0123456789876543210Sym0 a0123456789876543210
+    data TFHelper_0123456789876543210Sym0 :: (~>) (Constant a b) ((~>) (Constant a b) Bool)
       where
         TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
                                                          TFHelper_0123456789876543210Sym0 a0123456789876543210
@@ -52,7 +52,7 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) TFHelper_0123456789876543210Sym0KindInference) ())
     type TFHelper_0123456789876543210Sym1 :: Constant a b
                                              -> (~>) (Constant a b) Bool
-    data TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Constant a b) :: (~>) (Constant a b) Bool
       where
         TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                          TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -62,16 +62,16 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) TFHelper_0123456789876543210Sym1KindInference) ())
     type TFHelper_0123456789876543210Sym2 :: Constant a b
                                              -> Constant a b -> Bool
-    type family TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: Constant a b) (a0123456789876543210 :: Constant a b) :: Bool where
       TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq (Constant a b) where
       type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
     type Compare_0123456789876543210 :: Constant a b
                                         -> Constant a b -> Ordering
-    type family Compare_0123456789876543210 a a where
+    type family Compare_0123456789876543210 (a :: Constant a b) (a :: Constant a b) :: Ordering where
       Compare_0123456789876543210 (Constant a_0123456789876543210) (Constant b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0)
     type Compare_0123456789876543210Sym0 :: (~>) (Constant a b) ((~>) (Constant a b) Ordering)
-    data Compare_0123456789876543210Sym0 a0123456789876543210
+    data Compare_0123456789876543210Sym0 :: (~>) (Constant a b) ((~>) (Constant a b) Ordering)
       where
         Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
                                                         Compare_0123456789876543210Sym0 a0123456789876543210
@@ -81,7 +81,7 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) Compare_0123456789876543210Sym0KindInference) ())
     type Compare_0123456789876543210Sym1 :: Constant a b
                                             -> (~>) (Constant a b) Ordering
-    data Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Constant a b) :: (~>) (Constant a b) Ordering
       where
         Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                         Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -91,16 +91,16 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) Compare_0123456789876543210Sym1KindInference) ())
     type Compare_0123456789876543210Sym2 :: Constant a b
                                             -> Constant a b -> Ordering
-    type family Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Compare_0123456789876543210Sym2 (a0123456789876543210 :: Constant a b) (a0123456789876543210 :: Constant a b) :: Ordering where
       Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd (Constant a b) where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     type TFHelper_0123456789876543210 :: Identity a
                                          -> Identity a -> Bool
-    type family TFHelper_0123456789876543210 a a where
+    type family TFHelper_0123456789876543210 (a :: Identity a) (a :: Identity a) :: Bool where
       TFHelper_0123456789876543210 (Identity a_0123456789876543210) (Identity b_0123456789876543210) = Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210
     type TFHelper_0123456789876543210Sym0 :: (~>) (Identity a) ((~>) (Identity a) Bool)
-    data TFHelper_0123456789876543210Sym0 a0123456789876543210
+    data TFHelper_0123456789876543210Sym0 :: (~>) (Identity a) ((~>) (Identity a) Bool)
       where
         TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
                                                          TFHelper_0123456789876543210Sym0 a0123456789876543210
@@ -110,7 +110,7 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) TFHelper_0123456789876543210Sym0KindInference) ())
     type TFHelper_0123456789876543210Sym1 :: Identity a
                                              -> (~>) (Identity a) Bool
-    data TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Identity a) :: (~>) (Identity a) Bool
       where
         TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                          TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -120,16 +120,16 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) TFHelper_0123456789876543210Sym1KindInference) ())
     type TFHelper_0123456789876543210Sym2 :: Identity a
                                              -> Identity a -> Bool
-    type family TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: Identity a) (a0123456789876543210 :: Identity a) :: Bool where
       TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq (Identity a) where
       type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
     type Compare_0123456789876543210 :: Identity a
                                         -> Identity a -> Ordering
-    type family Compare_0123456789876543210 a a where
+    type family Compare_0123456789876543210 (a :: Identity a) (a :: Identity a) :: Ordering where
       Compare_0123456789876543210 (Identity a_0123456789876543210) (Identity b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 ThenCmpSym0) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0)
     type Compare_0123456789876543210Sym0 :: (~>) (Identity a) ((~>) (Identity a) Ordering)
-    data Compare_0123456789876543210Sym0 a0123456789876543210
+    data Compare_0123456789876543210Sym0 :: (~>) (Identity a) ((~>) (Identity a) Ordering)
       where
         Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
                                                         Compare_0123456789876543210Sym0 a0123456789876543210
@@ -139,7 +139,7 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) Compare_0123456789876543210Sym0KindInference) ())
     type Compare_0123456789876543210Sym1 :: Identity a
                                             -> (~>) (Identity a) Ordering
-    data Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Identity a) :: (~>) (Identity a) Ordering
       where
         Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                         Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -149,7 +149,7 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) Compare_0123456789876543210Sym1KindInference) ())
     type Compare_0123456789876543210Sym2 :: Identity a
                                             -> Identity a -> Ordering
-    type family Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Compare_0123456789876543210Sym2 (a0123456789876543210 :: Identity a) (a0123456789876543210 :: Identity a) :: Ordering where
       Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd (Identity a) where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a

--- a/singletons-base/tests/compile-and-dump/Singletons/T287.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T287.golden
@@ -11,7 +11,7 @@ Singletons/T287.hs:(0,0)-(0,0): Splicing declarations
     instance S b => S (a -> b) where
       (<<>>) f g = \ x -> (f x <<>> g x)
     type (<<>>@#@$) :: forall a. (~>) a ((~>) a a)
-    data (<<>>@#@$) a0123456789876543210
+    data (<<>>@#@$) :: (~>) a ((~>) a a)
       where
         (:<<>>@#@$###) :: SameKind (Apply (<<>>@#@$) arg) ((<<>>@#@$$) arg) =>
                           (<<>>@#@$) a0123456789876543210
@@ -19,7 +19,7 @@ Singletons/T287.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (<<>>@#@$) where
       suppressUnusedWarnings = snd (((,) (:<<>>@#@$###)) ())
     type (<<>>@#@$$) :: forall a. a -> (~>) a a
-    data (<<>>@#@$$) a0123456789876543210 a0123456789876543210
+    data (<<>>@#@$$) (a0123456789876543210 :: a) :: (~>) a a
       where
         (:<<>>@#@$$###) :: SameKind (Apply ((<<>>@#@$$) a0123456789876543210) arg) ((<<>>@#@$$$) a0123456789876543210 arg) =>
                            (<<>>@#@$$) a0123456789876543210 a0123456789876543210
@@ -27,7 +27,7 @@ Singletons/T287.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ((<<>>@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) (:<<>>@#@$$###)) ())
     type (<<>>@#@$$$) :: forall a. a -> a -> a
-    type family (<<>>@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family (<<>>@#@$$$) (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: a where
       (<<>>@#@$$$) a0123456789876543210 a0123456789876543210 = (<<>>) a0123456789876543210 a0123456789876543210
     class PS a where
       type (<<>>) (arg :: a) (arg :: a) :: a
@@ -61,10 +61,10 @@ Singletons/T287.hs:(0,0)-(0,0): Splicing declarations
       Lambda_0123456789876543210Sym3 f0123456789876543210 g0123456789876543210 x0123456789876543210 = Lambda_0123456789876543210 f0123456789876543210 g0123456789876543210 x0123456789876543210
     type TFHelper_0123456789876543210 :: (~>) a b
                                          -> (~>) a b -> (~>) a b
-    type family TFHelper_0123456789876543210 a a where
+    type family TFHelper_0123456789876543210 (a :: (~>) a b) (a :: (~>) a b) :: (~>) a b where
       TFHelper_0123456789876543210 f g = Apply (Apply Lambda_0123456789876543210Sym0 f) g
     type TFHelper_0123456789876543210Sym0 :: (~>) ((~>) a b) ((~>) ((~>) a b) ((~>) a b))
-    data TFHelper_0123456789876543210Sym0 a0123456789876543210
+    data TFHelper_0123456789876543210Sym0 :: (~>) ((~>) a b) ((~>) ((~>) a b) ((~>) a b))
       where
         TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
                                                          TFHelper_0123456789876543210Sym0 a0123456789876543210
@@ -74,7 +74,7 @@ Singletons/T287.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) TFHelper_0123456789876543210Sym0KindInference) ())
     type TFHelper_0123456789876543210Sym1 :: (~>) a b
                                              -> (~>) ((~>) a b) ((~>) a b)
-    data TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: (~>) a b) :: (~>) ((~>) a b) ((~>) a b)
       where
         TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                          TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -84,7 +84,7 @@ Singletons/T287.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) TFHelper_0123456789876543210Sym1KindInference) ())
     type TFHelper_0123456789876543210Sym2 :: (~>) a b
                                              -> (~>) a b -> (~>) a b
-    type family TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: (~>) a b) (a0123456789876543210 :: (~>) a b) :: (~>) a b where
       TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PS ((~>) a b) where
       type (<<>>) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a

--- a/singletons-base/tests/compile-and-dump/Singletons/T29.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T29.golden
@@ -18,7 +18,7 @@ Singletons/T29.hs:(0,0)-(0,0): Splicing declarations
     ban :: Bool -> Bool
     ban x = ((not . (not . not)) $! x)
     type BanSym0 :: (~>) Bool Bool
-    data BanSym0 a0123456789876543210
+    data BanSym0 :: (~>) Bool Bool
       where
         BanSym0KindInference :: SameKind (Apply BanSym0 arg) (BanSym1 arg) =>
                                 BanSym0 a0123456789876543210
@@ -26,10 +26,10 @@ Singletons/T29.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings BanSym0 where
       suppressUnusedWarnings = snd (((,) BanSym0KindInference) ())
     type BanSym1 :: Bool -> Bool
-    type family BanSym1 a0123456789876543210 where
+    type family BanSym1 (a0123456789876543210 :: Bool) :: Bool where
       BanSym1 a0123456789876543210 = Ban a0123456789876543210
     type BazSym0 :: (~>) Bool Bool
-    data BazSym0 a0123456789876543210
+    data BazSym0 :: (~>) Bool Bool
       where
         BazSym0KindInference :: SameKind (Apply BazSym0 arg) (BazSym1 arg) =>
                                 BazSym0 a0123456789876543210
@@ -37,10 +37,10 @@ Singletons/T29.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings BazSym0 where
       suppressUnusedWarnings = snd (((,) BazSym0KindInference) ())
     type BazSym1 :: Bool -> Bool
-    type family BazSym1 a0123456789876543210 where
+    type family BazSym1 (a0123456789876543210 :: Bool) :: Bool where
       BazSym1 a0123456789876543210 = Baz a0123456789876543210
     type BarSym0 :: (~>) Bool Bool
-    data BarSym0 a0123456789876543210
+    data BarSym0 :: (~>) Bool Bool
       where
         BarSym0KindInference :: SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
                                 BarSym0 a0123456789876543210
@@ -48,10 +48,10 @@ Singletons/T29.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings BarSym0 where
       suppressUnusedWarnings = snd (((,) BarSym0KindInference) ())
     type BarSym1 :: Bool -> Bool
-    type family BarSym1 a0123456789876543210 where
+    type family BarSym1 (a0123456789876543210 :: Bool) :: Bool where
       BarSym1 a0123456789876543210 = Bar a0123456789876543210
     type FooSym0 :: (~>) Bool Bool
-    data FooSym0 a0123456789876543210
+    data FooSym0 :: (~>) Bool Bool
       where
         FooSym0KindInference :: SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
                                 FooSym0 a0123456789876543210
@@ -59,19 +59,19 @@ Singletons/T29.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings = snd (((,) FooSym0KindInference) ())
     type FooSym1 :: Bool -> Bool
-    type family FooSym1 a0123456789876543210 where
+    type family FooSym1 (a0123456789876543210 :: Bool) :: Bool where
       FooSym1 a0123456789876543210 = Foo a0123456789876543210
     type Ban :: Bool -> Bool
-    type family Ban a where
+    type family Ban (a :: Bool) :: Bool where
       Ban x = Apply (Apply ($!@#@$) (Apply (Apply (.@#@$) NotSym0) (Apply (Apply (.@#@$) NotSym0) NotSym0))) x
     type Baz :: Bool -> Bool
-    type family Baz a where
+    type family Baz (a :: Bool) :: Bool where
       Baz x = Apply (Apply ($!@#@$) NotSym0) x
     type Bar :: Bool -> Bool
-    type family Bar a where
+    type family Bar (a :: Bool) :: Bool where
       Bar x = Apply (Apply ($@#@$) (Apply (Apply (.@#@$) NotSym0) (Apply (Apply (.@#@$) NotSym0) NotSym0))) x
     type Foo :: Bool -> Bool
-    type family Foo a where
+    type family Foo (a :: Bool) :: Bool where
       Foo x = Apply (Apply ($@#@$) NotSym0) x
     sBan ::
       forall (t :: Bool). Sing t -> Sing (Apply BanSym0 t :: Bool)

--- a/singletons-base/tests/compile-and-dump/Singletons/T296.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T296.golden
@@ -21,20 +21,20 @@ Singletons/T296.hs:(0,0)-(0,0): Splicing declarations
               in z
         in x
     type MyProxySym0 :: forall (a :: Type). MyProxy (a :: Type)
-    type family MyProxySym0 where
+    type family MyProxySym0 :: MyProxy (a :: Type) where
       MyProxySym0 = MyProxy
     type Let0123456789876543210ZSym0 :: MyProxy a
-    type family Let0123456789876543210ZSym0 where
+    type family Let0123456789876543210ZSym0 :: MyProxy a where
       Let0123456789876543210ZSym0 = Let0123456789876543210Z
     type Let0123456789876543210Z :: MyProxy a
-    type family Let0123456789876543210Z where
+    type family Let0123456789876543210Z :: MyProxy a where
       Let0123456789876543210Z = MyProxySym0
     type family Let0123456789876543210XSym0 where
       Let0123456789876543210XSym0 = Let0123456789876543210X
     type family Let0123456789876543210X where
       Let0123456789876543210X = Let0123456789876543210ZSym0
     type FSym0 :: forall a. (~>) (MyProxy a) (MyProxy a)
-    data FSym0 a0123456789876543210
+    data FSym0 :: (~>) (MyProxy a) (MyProxy a)
       where
         FSym0KindInference :: SameKind (Apply FSym0 arg) (FSym1 arg) =>
                               FSym0 a0123456789876543210
@@ -42,10 +42,10 @@ Singletons/T296.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FSym0 where
       suppressUnusedWarnings = snd (((,) FSym0KindInference) ())
     type FSym1 :: forall a. MyProxy a -> MyProxy a
-    type family FSym1 a0123456789876543210 where
+    type family FSym1 (a0123456789876543210 :: MyProxy a) :: MyProxy a where
       FSym1 a0123456789876543210 = F a0123456789876543210
     type F :: forall a. MyProxy a -> MyProxy a
-    type family F a where
+    type family F (a :: MyProxy a) :: MyProxy a where
       F MyProxy = Let0123456789876543210XSym0
     sF ::
       forall a (t :: MyProxy a).

--- a/singletons-base/tests/compile-and-dump/Singletons/T297.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T297.golden
@@ -19,13 +19,13 @@ Singletons/T297.hs:(0,0)-(0,0): Splicing declarations
               in z
         in x
     type MyProxySym0 :: forall (a :: Type). MyProxy (a :: Type)
-    type family MyProxySym0 where
+    type family MyProxySym0 :: MyProxy (a :: Type) where
       MyProxySym0 = MyProxy
     type Let0123456789876543210ZSym0 :: MyProxy a
-    type family Let0123456789876543210ZSym0 where
+    type family Let0123456789876543210ZSym0 :: MyProxy a where
       Let0123456789876543210ZSym0 = Let0123456789876543210Z
     type Let0123456789876543210Z :: MyProxy a
-    type family Let0123456789876543210Z where
+    type family Let0123456789876543210Z :: MyProxy a where
       Let0123456789876543210Z = MyProxySym0
     type family Let0123456789876543210XSym0 where
       Let0123456789876543210XSym0 = Let0123456789876543210X

--- a/singletons-base/tests/compile-and-dump/Singletons/T312.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T312.golden
@@ -20,7 +20,7 @@ Singletons/T312.hs:(0,0)-(0,0): Splicing declarations
             h :: forall c. c -> b -> b
             h _ x = x
     type BarSym0 :: forall a b. (~>) a ((~>) b b)
-    data BarSym0 a0123456789876543210
+    data BarSym0 :: (~>) a ((~>) b b)
       where
         BarSym0KindInference :: SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
                                 BarSym0 a0123456789876543210
@@ -28,7 +28,7 @@ Singletons/T312.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings BarSym0 where
       suppressUnusedWarnings = snd (((,) BarSym0KindInference) ())
     type BarSym1 :: forall a b. a -> (~>) b b
-    data BarSym1 a0123456789876543210 a0123456789876543210
+    data BarSym1 (a0123456789876543210 :: a) :: (~>) b b
       where
         BarSym1KindInference :: SameKind (Apply (BarSym1 a0123456789876543210) arg) (BarSym2 a0123456789876543210 arg) =>
                                 BarSym1 a0123456789876543210 a0123456789876543210
@@ -36,10 +36,10 @@ Singletons/T312.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (BarSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) BarSym1KindInference) ())
     type BarSym2 :: forall a b. a -> b -> b
-    type family BarSym2 a0123456789876543210 a0123456789876543210 where
+    type family BarSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: b where
       BarSym2 a0123456789876543210 a0123456789876543210 = Bar a0123456789876543210 a0123456789876543210
     type BazSym0 :: forall a b. (~>) a ((~>) b b)
-    data BazSym0 a0123456789876543210
+    data BazSym0 :: (~>) a ((~>) b b)
       where
         BazSym0KindInference :: SameKind (Apply BazSym0 arg) (BazSym1 arg) =>
                                 BazSym0 a0123456789876543210
@@ -47,7 +47,7 @@ Singletons/T312.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings BazSym0 where
       suppressUnusedWarnings = snd (((,) BazSym0KindInference) ())
     type BazSym1 :: forall a b. a -> (~>) b b
-    data BazSym1 a0123456789876543210 a0123456789876543210
+    data BazSym1 (a0123456789876543210 :: a) :: (~>) b b
       where
         BazSym1KindInference :: SameKind (Apply (BazSym1 a0123456789876543210) arg) (BazSym2 a0123456789876543210 arg) =>
                                 BazSym1 a0123456789876543210 a0123456789876543210
@@ -55,13 +55,13 @@ Singletons/T312.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (BazSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) BazSym1KindInference) ())
     type BazSym2 :: forall a b. a -> b -> b
-    type family BazSym2 a0123456789876543210 a0123456789876543210 where
+    type family BazSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: b where
       BazSym2 a0123456789876543210 a0123456789876543210 = Baz a0123456789876543210 a0123456789876543210
     type Bar_0123456789876543210 :: a -> b -> b
-    type family Bar_0123456789876543210 a a where
+    type family Bar_0123456789876543210 (a :: a) (a :: b) :: b where
       Bar_0123456789876543210 _ x = x
     type Bar_0123456789876543210Sym0 :: (~>) a ((~>) b b)
-    data Bar_0123456789876543210Sym0 a0123456789876543210
+    data Bar_0123456789876543210Sym0 :: (~>) a ((~>) b b)
       where
         Bar_0123456789876543210Sym0KindInference :: SameKind (Apply Bar_0123456789876543210Sym0 arg) (Bar_0123456789876543210Sym1 arg) =>
                                                     Bar_0123456789876543210Sym0 a0123456789876543210
@@ -70,7 +70,7 @@ Singletons/T312.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Bar_0123456789876543210Sym0KindInference) ())
     type Bar_0123456789876543210Sym1 :: a -> (~>) b b
-    data Bar_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Bar_0123456789876543210Sym1 (a0123456789876543210 :: a) :: (~>) b b
       where
         Bar_0123456789876543210Sym1KindInference :: SameKind (Apply (Bar_0123456789876543210Sym1 a0123456789876543210) arg) (Bar_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                     Bar_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -79,7 +79,7 @@ Singletons/T312.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Bar_0123456789876543210Sym1KindInference) ())
     type Bar_0123456789876543210Sym2 :: a -> b -> b
-    type family Bar_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Bar_0123456789876543210Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: b where
       Bar_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Bar_0123456789876543210 a0123456789876543210 a0123456789876543210
     data Let0123456789876543210HSym0 a_01234567898765432100123456789876543210
       where
@@ -118,10 +118,10 @@ Singletons/T312.hs:(0,0)-(0,0): Splicing declarations
     type family Let0123456789876543210H a_0123456789876543210 a_0123456789876543210 (a :: c) (a :: b) :: b where
       Let0123456789876543210H a_0123456789876543210 a_0123456789876543210 _ x = x
     type Baz_0123456789876543210 :: a -> b -> b
-    type family Baz_0123456789876543210 a a where
+    type family Baz_0123456789876543210 (a :: a) (a :: b) :: b where
       Baz_0123456789876543210 a_0123456789876543210 a_0123456789876543210 = Apply (Apply (Let0123456789876543210HSym2 a_0123456789876543210 a_0123456789876543210) a_0123456789876543210) a_0123456789876543210
     type Baz_0123456789876543210Sym0 :: (~>) a ((~>) b b)
-    data Baz_0123456789876543210Sym0 a0123456789876543210
+    data Baz_0123456789876543210Sym0 :: (~>) a ((~>) b b)
       where
         Baz_0123456789876543210Sym0KindInference :: SameKind (Apply Baz_0123456789876543210Sym0 arg) (Baz_0123456789876543210Sym1 arg) =>
                                                     Baz_0123456789876543210Sym0 a0123456789876543210
@@ -130,7 +130,7 @@ Singletons/T312.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Baz_0123456789876543210Sym0KindInference) ())
     type Baz_0123456789876543210Sym1 :: a -> (~>) b b
-    data Baz_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Baz_0123456789876543210Sym1 (a0123456789876543210 :: a) :: (~>) b b
       where
         Baz_0123456789876543210Sym1KindInference :: SameKind (Apply (Baz_0123456789876543210Sym1 a0123456789876543210) arg) (Baz_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                     Baz_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -139,7 +139,7 @@ Singletons/T312.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Baz_0123456789876543210Sym1KindInference) ())
     type Baz_0123456789876543210Sym2 :: a -> b -> b
-    type family Baz_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Baz_0123456789876543210Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: b where
       Baz_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Baz_0123456789876543210 a0123456789876543210 a0123456789876543210
     class PFoo a where
       type Bar (arg :: a) (arg :: b) :: b

--- a/singletons-base/tests/compile-and-dump/Singletons/T316.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T316.golden
@@ -4,7 +4,7 @@ Singletons/T316.hs:(0,0)-(0,0): Splicing declarations
           replaceAllGTypes f types as = zipWith f as types |]
   ======>
     type ReplaceAllGTypesSym0 :: (~>) ((~>) a ((~>) Type a)) ((~>) [Type] ((~>) [a] [a]))
-    data ReplaceAllGTypesSym0 a0123456789876543210
+    data ReplaceAllGTypesSym0 :: (~>) ((~>) a ((~>) Type a)) ((~>) [Type] ((~>) [a] [a]))
       where
         ReplaceAllGTypesSym0KindInference :: SameKind (Apply ReplaceAllGTypesSym0 arg) (ReplaceAllGTypesSym1 arg) =>
                                              ReplaceAllGTypesSym0 a0123456789876543210
@@ -14,7 +14,7 @@ Singletons/T316.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ReplaceAllGTypesSym0KindInference) ())
     type ReplaceAllGTypesSym1 :: (~>) a ((~>) Type a)
                                  -> (~>) [Type] ((~>) [a] [a])
-    data ReplaceAllGTypesSym1 a0123456789876543210 a0123456789876543210
+    data ReplaceAllGTypesSym1 (a0123456789876543210 :: (~>) a ((~>) Type a)) :: (~>) [Type] ((~>) [a] [a])
       where
         ReplaceAllGTypesSym1KindInference :: SameKind (Apply (ReplaceAllGTypesSym1 a0123456789876543210) arg) (ReplaceAllGTypesSym2 a0123456789876543210 arg) =>
                                              ReplaceAllGTypesSym1 a0123456789876543210 a0123456789876543210
@@ -24,7 +24,7 @@ Singletons/T316.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ReplaceAllGTypesSym1KindInference) ())
     type ReplaceAllGTypesSym2 :: (~>) a ((~>) Type a)
                                  -> [Type] -> (~>) [a] [a]
-    data ReplaceAllGTypesSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data ReplaceAllGTypesSym2 (a0123456789876543210 :: (~>) a ((~>) Type a)) (a0123456789876543210 :: [Type]) :: (~>) [a] [a]
       where
         ReplaceAllGTypesSym2KindInference :: SameKind (Apply (ReplaceAllGTypesSym2 a0123456789876543210 a0123456789876543210) arg) (ReplaceAllGTypesSym3 a0123456789876543210 a0123456789876543210 arg) =>
                                              ReplaceAllGTypesSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -34,9 +34,9 @@ Singletons/T316.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ReplaceAllGTypesSym2KindInference) ())
     type ReplaceAllGTypesSym3 :: (~>) a ((~>) Type a)
                                  -> [Type] -> [a] -> [a]
-    type family ReplaceAllGTypesSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family ReplaceAllGTypesSym3 (a0123456789876543210 :: (~>) a ((~>) Type a)) (a0123456789876543210 :: [Type]) (a0123456789876543210 :: [a]) :: [a] where
       ReplaceAllGTypesSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ReplaceAllGTypes a0123456789876543210 a0123456789876543210 a0123456789876543210
     type ReplaceAllGTypes :: (~>) a ((~>) Type a)
                              -> [Type] -> [a] -> [a]
-    type family ReplaceAllGTypes a a a where
+    type family ReplaceAllGTypes (a :: (~>) a ((~>) Type a)) (a :: [Type]) (a :: [a]) :: [a] where
       ReplaceAllGTypes f types as = Apply (Apply (Apply ZipWithSym0 f) as) types

--- a/singletons-base/tests/compile-and-dump/Singletons/T322.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T322.golden
@@ -9,7 +9,7 @@ Singletons/T322.hs:(0,0)-(0,0): Splicing declarations
     (!) = (||)
     infixr 2 !
     type (!@#@$) :: (~>) Bool ((~>) Bool Bool)
-    data (!@#@$) a0123456789876543210
+    data (!@#@$) :: (~>) Bool ((~>) Bool Bool)
       where
         (:!@#@$###) :: SameKind (Apply (!@#@$) arg) ((!@#@$$) arg) =>
                        (!@#@$) a0123456789876543210
@@ -18,7 +18,7 @@ Singletons/T322.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) (:!@#@$###)) ())
     infixr 2 !@#@$
     type (!@#@$$) :: Bool -> (~>) Bool Bool
-    data (!@#@$$) a0123456789876543210 a0123456789876543210
+    data (!@#@$$) (a0123456789876543210 :: Bool) :: (~>) Bool Bool
       where
         (:!@#@$$###) :: SameKind (Apply ((!@#@$$) a0123456789876543210) arg) ((!@#@$$$) a0123456789876543210 arg) =>
                         (!@#@$$) a0123456789876543210 a0123456789876543210
@@ -27,11 +27,11 @@ Singletons/T322.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) (:!@#@$$###)) ())
     infixr 2 !@#@$$
     type (!@#@$$$) :: Bool -> Bool -> Bool
-    type family (!@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family (!@#@$$$) (a0123456789876543210 :: Bool) (a0123456789876543210 :: Bool) :: Bool where
       (!@#@$$$) a0123456789876543210 a0123456789876543210 = (!) a0123456789876543210 a0123456789876543210
     infixr 2 !@#@$$$
     type (!) :: Bool -> Bool -> Bool
-    type family (!) a a where
+    type family (!) (a :: Bool) (a :: Bool) :: Bool where
       (!) a_0123456789876543210 a_0123456789876543210 = Apply (Apply (||@#@$) a_0123456789876543210) a_0123456789876543210
     infixr 2 %!
     (%!) ::

--- a/singletons-base/tests/compile-and-dump/Singletons/T326.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T326.golden
@@ -2,7 +2,7 @@ Singletons/T326.hs:0:0:: Splicing declarations
     genPromotions [''C1]
   ======>
     type (<%>@#@$) :: forall a. (~>) a ((~>) a a)
-    data (<%>@#@$) a0123456789876543210
+    data (<%>@#@$) :: (~>) a ((~>) a a)
       where
         (:<%>@#@$###) :: SameKind (Apply (<%>@#@$) arg) ((<%>@#@$$) arg) =>
                          (<%>@#@$) a0123456789876543210
@@ -11,7 +11,7 @@ Singletons/T326.hs:0:0:: Splicing declarations
       suppressUnusedWarnings = snd (((,) (:<%>@#@$###)) ())
     infixl 9 <%>@#@$
     type (<%>@#@$$) :: forall a. a -> (~>) a a
-    data (<%>@#@$$) a0123456789876543210 a0123456789876543210
+    data (<%>@#@$$) (a0123456789876543210 :: a) :: (~>) a a
       where
         (:<%>@#@$$###) :: SameKind (Apply ((<%>@#@$$) a0123456789876543210) arg) ((<%>@#@$$$) a0123456789876543210 arg) =>
                           (<%>@#@$$) a0123456789876543210 a0123456789876543210
@@ -20,7 +20,7 @@ Singletons/T326.hs:0:0:: Splicing declarations
       suppressUnusedWarnings = snd (((,) (:<%>@#@$$###)) ())
     infixl 9 <%>@#@$$
     type (<%>@#@$$$) :: forall a. a -> a -> a
-    type family (<%>@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family (<%>@#@$$$) (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: a where
       (<%>@#@$$$) a0123456789876543210 a0123456789876543210 = (<%>) a0123456789876543210 a0123456789876543210
     infixl 9 <%>@#@$$$
     type PC1 :: GHC.Types.Type -> Constraint
@@ -31,7 +31,7 @@ Singletons/T326.hs:0:0:: Splicing declarations
     genSingletons [''C2]
   ======>
     type (<%%>@#@$) :: forall a. (~>) a ((~>) a a)
-    data (<%%>@#@$) a0123456789876543210
+    data (<%%>@#@$) :: (~>) a ((~>) a a)
       where
         (:<%%>@#@$###) :: SameKind (Apply (<%%>@#@$) arg) ((<%%>@#@$$) arg) =>
                           (<%%>@#@$) a0123456789876543210
@@ -40,7 +40,7 @@ Singletons/T326.hs:0:0:: Splicing declarations
       suppressUnusedWarnings = snd (((,) (:<%%>@#@$###)) ())
     infixl 9 <%%>@#@$
     type (<%%>@#@$$) :: forall a. a -> (~>) a a
-    data (<%%>@#@$$) a0123456789876543210 a0123456789876543210
+    data (<%%>@#@$$) (a0123456789876543210 :: a) :: (~>) a a
       where
         (:<%%>@#@$$###) :: SameKind (Apply ((<%%>@#@$$) a0123456789876543210) arg) ((<%%>@#@$$$) a0123456789876543210 arg) =>
                            (<%%>@#@$$) a0123456789876543210 a0123456789876543210
@@ -49,7 +49,7 @@ Singletons/T326.hs:0:0:: Splicing declarations
       suppressUnusedWarnings = snd (((,) (:<%%>@#@$$###)) ())
     infixl 9 <%%>@#@$$
     type (<%%>@#@$$$) :: forall a. a -> a -> a
-    type family (<%%>@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family (<%%>@#@$$$) (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: a where
       (<%%>@#@$$$) a0123456789876543210 a0123456789876543210 = (<%%>) a0123456789876543210 a0123456789876543210
     infixl 9 <%%>@#@$$$
     type PC2 :: GHC.Types.Type -> Constraint

--- a/singletons-base/tests/compile-and-dump/Singletons/T33.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T33.golden
@@ -6,7 +6,7 @@ Singletons/T33.hs:(0,0)-(0,0): Splicing declarations
     foo :: (Bool, Bool) -> ()
     foo ~(_, _) = ()
     type FooSym0 :: (~>) (Bool, Bool) ()
-    data FooSym0 a0123456789876543210
+    data FooSym0 :: (~>) (Bool, Bool) ()
       where
         FooSym0KindInference :: SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
                                 FooSym0 a0123456789876543210
@@ -14,10 +14,11 @@ Singletons/T33.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings = snd (((,) FooSym0KindInference) ())
     type FooSym1 :: (Bool, Bool) -> ()
-    type family FooSym1 a0123456789876543210 where
+    type family FooSym1 (a0123456789876543210 :: (Bool,
+                                                  Bool)) :: () where
       FooSym1 a0123456789876543210 = Foo a0123456789876543210
     type Foo :: (Bool, Bool) -> ()
-    type family Foo a where
+    type family Foo (a :: (Bool, Bool)) :: () where
       Foo '(_, _) = Tuple0Sym0
     sFoo ::
       forall (t :: (Bool, Bool)). Sing t -> Sing (Apply FooSym0 t :: ())

--- a/singletons-base/tests/compile-and-dump/Singletons/T332.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T332.golden
@@ -9,10 +9,10 @@ Singletons/T332.hs:(0,0)-(0,0): Splicing declarations
     f :: Foo -> ()
     f MkFoo {} = ()
     type MkFooSym0 :: Foo
-    type family MkFooSym0 where
+    type family MkFooSym0 :: Foo where
       MkFooSym0 = MkFoo
     type FSym0 :: (~>) Foo ()
-    data FSym0 a0123456789876543210
+    data FSym0 :: (~>) Foo ()
       where
         FSym0KindInference :: SameKind (Apply FSym0 arg) (FSym1 arg) =>
                               FSym0 a0123456789876543210
@@ -20,10 +20,10 @@ Singletons/T332.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FSym0 where
       suppressUnusedWarnings = snd (((,) FSym0KindInference) ())
     type FSym1 :: Foo -> ()
-    type family FSym1 a0123456789876543210 where
+    type family FSym1 (a0123456789876543210 :: Foo) :: () where
       FSym1 a0123456789876543210 = F a0123456789876543210
     type F :: Foo -> ()
-    type family F a where
+    type family F (a :: Foo) :: () where
       F MkFoo = Tuple0Sym0
 Singletons/T332.hs:(0,0)-(0,0): Splicing declarations
     singletons
@@ -36,10 +36,10 @@ Singletons/T332.hs:(0,0)-(0,0): Splicing declarations
     b :: Bar -> ()
     b MkBar {} = ()
     type MkBarSym0 :: Bar
-    type family MkBarSym0 where
+    type family MkBarSym0 :: Bar where
       MkBarSym0 = MkBar
     type BSym0 :: (~>) Bar ()
-    data BSym0 a0123456789876543210
+    data BSym0 :: (~>) Bar ()
       where
         BSym0KindInference :: SameKind (Apply BSym0 arg) (BSym1 arg) =>
                               BSym0 a0123456789876543210
@@ -47,10 +47,10 @@ Singletons/T332.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings BSym0 where
       suppressUnusedWarnings = snd (((,) BSym0KindInference) ())
     type BSym1 :: Bar -> ()
-    type family BSym1 a0123456789876543210 where
+    type family BSym1 (a0123456789876543210 :: Bar) :: () where
       BSym1 a0123456789876543210 = B a0123456789876543210
     type B :: Bar -> ()
-    type family B a where
+    type family B (a :: Bar) :: () where
       B MkBar = Tuple0Sym0
     sB :: forall (t :: Bar). Sing t -> Sing (Apply BSym0 t :: ())
     sB SMkBar = STuple0

--- a/singletons-base/tests/compile-and-dump/Singletons/T353.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T353.golden
@@ -39,7 +39,8 @@ Singletons/T353.hs:0:0:: Splicing declarations
                               (p :: k).
                        (~>) (f p) ((~>) (g p) (Prod (f :: k -> Type) (g :: k
                                                                            -> Type) (p :: k)))
-    data MkProdSym0 a0123456789876543210
+    data MkProdSym0 :: (~>) (f p) ((~>) (g p) (Prod (f :: k
+                                                          -> Type) (g :: k -> Type) (p :: k)))
       where
         MkProdSym0KindInference :: SameKind (Apply MkProdSym0 arg) (MkProdSym1 arg) =>
                                    MkProdSym0 a0123456789876543210
@@ -51,7 +52,9 @@ Singletons/T353.hs:0:0:: Splicing declarations
                               (g :: k -> Type)
                               (p :: k).
                        f p -> (~>) (g p) (Prod (f :: k -> Type) (g :: k -> Type) (p :: k))
-    data MkProdSym1 a0123456789876543210 a0123456789876543210
+    data MkProdSym1 (a0123456789876543210 :: f p) :: (~>) (g p) (Prod (f :: k
+                                                                            -> Type) (g :: k
+                                                                                           -> Type) (p :: k))
       where
         MkProdSym1KindInference :: SameKind (Apply (MkProdSym1 a0123456789876543210) arg) (MkProdSym2 a0123456789876543210 arg) =>
                                    MkProdSym1 a0123456789876543210 a0123456789876543210
@@ -63,14 +66,16 @@ Singletons/T353.hs:0:0:: Splicing declarations
                               (g :: k -> Type)
                               (p :: k).
                        f p -> g p -> Prod (f :: k -> Type) (g :: k -> Type) (p :: k)
-    type family MkProdSym2 a0123456789876543210 a0123456789876543210 where
+    type family MkProdSym2 (a0123456789876543210 :: f p) (a0123456789876543210 :: g p) :: Prod (f :: k
+                                                                                                     -> Type) (g :: k
+                                                                                                                    -> Type) (p :: k) where
       MkProdSym2 a0123456789876543210 a0123456789876543210 = 'MkProd a0123456789876543210 a0123456789876543210
 Singletons/T353.hs:0:0:: Splicing declarations
     genDefunSymbols [''Foo]
   ======>
     type MkFooSym0 :: forall k k (a :: k) (b :: k).
                       (~>) (Proxy a) ((~>) (Proxy b) (Foo (a :: k) (b :: k)))
-    data MkFooSym0 a0123456789876543210
+    data MkFooSym0 :: (~>) (Proxy a) ((~>) (Proxy b) (Foo (a :: k) (b :: k)))
       where
         MkFooSym0KindInference :: SameKind (Apply MkFooSym0 arg) (MkFooSym1 arg) =>
                                   MkFooSym0 a0123456789876543210
@@ -79,7 +84,7 @@ Singletons/T353.hs:0:0:: Splicing declarations
       suppressUnusedWarnings = snd (((,) MkFooSym0KindInference) ())
     type MkFooSym1 :: forall k k (a :: k) (b :: k).
                       Proxy a -> (~>) (Proxy b) (Foo (a :: k) (b :: k))
-    data MkFooSym1 a0123456789876543210 a0123456789876543210
+    data MkFooSym1 (a0123456789876543210 :: Proxy a) :: (~>) (Proxy b) (Foo (a :: k) (b :: k))
       where
         MkFooSym1KindInference :: SameKind (Apply (MkFooSym1 a0123456789876543210) arg) (MkFooSym2 a0123456789876543210 arg) =>
                                   MkFooSym1 a0123456789876543210 a0123456789876543210
@@ -88,5 +93,5 @@ Singletons/T353.hs:0:0:: Splicing declarations
       suppressUnusedWarnings = snd (((,) MkFooSym1KindInference) ())
     type MkFooSym2 :: forall k k (a :: k) (b :: k).
                       Proxy a -> Proxy b -> Foo (a :: k) (b :: k)
-    type family MkFooSym2 a0123456789876543210 a0123456789876543210 where
+    type family MkFooSym2 (a0123456789876543210 :: Proxy a) (a0123456789876543210 :: Proxy b) :: Foo (a :: k) (b :: k) where
       MkFooSym2 a0123456789876543210 a0123456789876543210 = 'MkFoo a0123456789876543210 a0123456789876543210

--- a/singletons-base/tests/compile-and-dump/Singletons/T358.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T358.golden
@@ -26,12 +26,12 @@ Singletons/T358.hs:(0,0)-(0,0): Splicing declarations
       method2a _ = []
       method2b _ = []
     type Method1Sym0 :: forall f a. f a
-    type family Method1Sym0 where
+    type family Method1Sym0 :: f a where
       Method1Sym0 = Method1
     class PC1 (f :: k -> Type) where
       type Method1 :: f a
     type Method2aSym0 :: forall b a. (~>) b a
-    data Method2aSym0 a0123456789876543210
+    data Method2aSym0 :: (~>) b a
       where
         Method2aSym0KindInference :: SameKind (Apply Method2aSym0 arg) (Method2aSym1 arg) =>
                                      Method2aSym0 a0123456789876543210
@@ -39,10 +39,10 @@ Singletons/T358.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Method2aSym0 where
       suppressUnusedWarnings = snd (((,) Method2aSym0KindInference) ())
     type Method2aSym1 :: forall b a. b -> a
-    type family Method2aSym1 a0123456789876543210 where
+    type family Method2aSym1 (a0123456789876543210 :: b) :: a where
       Method2aSym1 a0123456789876543210 = Method2a a0123456789876543210
     type Method2bSym0 :: forall b a. (~>) b a
-    data Method2bSym0 a0123456789876543210
+    data Method2bSym0 :: (~>) b a
       where
         Method2bSym0KindInference :: SameKind (Apply Method2bSym0 arg) (Method2bSym1 arg) =>
                                      Method2bSym0 a0123456789876543210
@@ -50,24 +50,24 @@ Singletons/T358.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Method2bSym0 where
       suppressUnusedWarnings = snd (((,) Method2bSym0KindInference) ())
     type Method2bSym1 :: forall b a. b -> a
-    type family Method2bSym1 a0123456789876543210 where
+    type family Method2bSym1 (a0123456789876543210 :: b) :: a where
       Method2bSym1 a0123456789876543210 = Method2b a0123456789876543210
     class PC2 a where
       type Method2a (arg :: b) :: a
       type Method2b (arg :: b) :: a
     type Method1_0123456789876543210 :: [a]
-    type family Method1_0123456789876543210 where
+    type family Method1_0123456789876543210 :: [a] where
       Method1_0123456789876543210 = NilSym0
     type Method1_0123456789876543210Sym0 :: [a]
-    type family Method1_0123456789876543210Sym0 where
+    type family Method1_0123456789876543210Sym0 :: [a] where
       Method1_0123456789876543210Sym0 = Method1_0123456789876543210
     instance PC1 [] where
       type Method1 = Method1_0123456789876543210Sym0
     type Method2a_0123456789876543210 :: b -> [a]
-    type family Method2a_0123456789876543210 a where
+    type family Method2a_0123456789876543210 (a :: b) :: [a] where
       Method2a_0123456789876543210 _ = NilSym0
     type Method2a_0123456789876543210Sym0 :: (~>) b [a]
-    data Method2a_0123456789876543210Sym0 a0123456789876543210
+    data Method2a_0123456789876543210Sym0 :: (~>) b [a]
       where
         Method2a_0123456789876543210Sym0KindInference :: SameKind (Apply Method2a_0123456789876543210Sym0 arg) (Method2a_0123456789876543210Sym1 arg) =>
                                                          Method2a_0123456789876543210Sym0 a0123456789876543210
@@ -76,13 +76,13 @@ Singletons/T358.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Method2a_0123456789876543210Sym0KindInference) ())
     type Method2a_0123456789876543210Sym1 :: b -> [a]
-    type family Method2a_0123456789876543210Sym1 a0123456789876543210 where
+    type family Method2a_0123456789876543210Sym1 (a0123456789876543210 :: b) :: [a] where
       Method2a_0123456789876543210Sym1 a0123456789876543210 = Method2a_0123456789876543210 a0123456789876543210
     type Method2b_0123456789876543210 :: b -> [a]
-    type family Method2b_0123456789876543210 a where
+    type family Method2b_0123456789876543210 (a :: b) :: [a] where
       Method2b_0123456789876543210 _ = NilSym0
     type Method2b_0123456789876543210Sym0 :: (~>) b [a]
-    data Method2b_0123456789876543210Sym0 a0123456789876543210
+    data Method2b_0123456789876543210Sym0 :: (~>) b [a]
       where
         Method2b_0123456789876543210Sym0KindInference :: SameKind (Apply Method2b_0123456789876543210Sym0 arg) (Method2b_0123456789876543210Sym1 arg) =>
                                                          Method2b_0123456789876543210Sym0 a0123456789876543210
@@ -91,7 +91,7 @@ Singletons/T358.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) Method2b_0123456789876543210Sym0KindInference) ())
     type Method2b_0123456789876543210Sym1 :: b -> [a]
-    type family Method2b_0123456789876543210Sym1 a0123456789876543210 where
+    type family Method2b_0123456789876543210Sym1 (a0123456789876543210 :: b) :: [a] where
       Method2b_0123456789876543210Sym1 a0123456789876543210 = Method2b_0123456789876543210 a0123456789876543210
     instance PC2 [a] where
       type Method2a a = Apply Method2a_0123456789876543210Sym0 a

--- a/singletons-base/tests/compile-and-dump/Singletons/T367.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T367.golden
@@ -4,7 +4,7 @@ Singletons/T367.hs:(0,0)-(0,0): Splicing declarations
           const' x _ = x |]
   ======>
     type Const'Sym0 :: (~>) a ((~>) b a)
-    data Const'Sym0 a0123456789876543210
+    data Const'Sym0 :: (~>) a ((~>) b a)
       where
         Const'Sym0KindInference :: SameKind (Apply Const'Sym0 arg) (Const'Sym1 arg) =>
                                    Const'Sym0 a0123456789876543210
@@ -13,7 +13,7 @@ Singletons/T367.hs:(0,0)-(0,0): Splicing declarations
       Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings
         = snd (((,) Const'Sym0KindInference) ())
     type Const'Sym1 :: a -> (~>) b a
-    data Const'Sym1 a0123456789876543210 a0123456789876543210
+    data Const'Sym1 (a0123456789876543210 :: a) :: (~>) b a
       where
         Const'Sym1KindInference :: SameKind (Apply (Const'Sym1 a0123456789876543210) arg) (Const'Sym2 a0123456789876543210 arg) =>
                                    Const'Sym1 a0123456789876543210 a0123456789876543210
@@ -22,10 +22,10 @@ Singletons/T367.hs:(0,0)-(0,0): Splicing declarations
       Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings
         = snd (((,) Const'Sym1KindInference) ())
     type Const'Sym2 :: a -> b -> a
-    type family Const'Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Const'Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: a where
       Const'Sym2 a0123456789876543210 a0123456789876543210 = Const' a0123456789876543210 a0123456789876543210
     type Const' :: a -> b -> a
-    type family Const' a a where
+    type family Const' (a :: a) (a :: b) :: a where
       Const' x _ = x
     sConst' ::
       forall a b (t :: a) (t :: b).

--- a/singletons-base/tests/compile-and-dump/Singletons/T371.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T371.golden
@@ -14,10 +14,10 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
       = Y1 | Y2 (X a)
       deriving Show
     type X1Sym0 :: forall (a :: Type). X (a :: Type)
-    type family X1Sym0 where
+    type family X1Sym0 :: X (a :: Type) where
       X1Sym0 = X1
     type X2Sym0 :: forall (a :: Type). (~>) (Y a) (X (a :: Type))
-    data X2Sym0 a0123456789876543210
+    data X2Sym0 :: (~>) (Y a) (X (a :: Type))
       where
         X2Sym0KindInference :: SameKind (Apply X2Sym0 arg) (X2Sym1 arg) =>
                                X2Sym0 a0123456789876543210
@@ -25,13 +25,13 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings X2Sym0 where
       suppressUnusedWarnings = snd (((,) X2Sym0KindInference) ())
     type X2Sym1 :: forall (a :: Type). Y a -> X (a :: Type)
-    type family X2Sym1 a0123456789876543210 where
+    type family X2Sym1 (a0123456789876543210 :: Y a) :: X (a :: Type) where
       X2Sym1 a0123456789876543210 = X2 a0123456789876543210
     type Y1Sym0 :: forall (a :: Type). Y (a :: Type)
-    type family Y1Sym0 where
+    type family Y1Sym0 :: Y (a :: Type) where
       Y1Sym0 = Y1
     type Y2Sym0 :: forall (a :: Type). (~>) (X a) (Y (a :: Type))
-    data Y2Sym0 a0123456789876543210
+    data Y2Sym0 :: (~>) (X a) (Y (a :: Type))
       where
         Y2Sym0KindInference :: SameKind (Apply Y2Sym0 arg) (Y2Sym1 arg) =>
                                Y2Sym0 a0123456789876543210
@@ -39,15 +39,15 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings Y2Sym0 where
       suppressUnusedWarnings = snd (((,) Y2Sym0KindInference) ())
     type Y2Sym1 :: forall (a :: Type). X a -> Y (a :: Type)
-    type family Y2Sym1 a0123456789876543210 where
+    type family Y2Sym1 (a0123456789876543210 :: X a) :: Y (a :: Type) where
       Y2Sym1 a0123456789876543210 = Y2 a0123456789876543210
     type ShowsPrec_0123456789876543210 :: GHC.Types.Nat
                                           -> X a -> GHC.Types.Symbol -> GHC.Types.Symbol
-    type family ShowsPrec_0123456789876543210 a a a where
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: X a) (a :: GHC.Types.Symbol) :: GHC.Types.Symbol where
       ShowsPrec_0123456789876543210 _ X1 a_0123456789876543210 = Apply (Apply ShowStringSym0 "X1") a_0123456789876543210
       ShowsPrec_0123456789876543210 p_0123456789876543210 (X2 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "X2 ")) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
     type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) (X a) ((~>) GHC.Types.Symbol GHC.Types.Symbol))
-    data ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) (X a) ((~>) GHC.Types.Symbol GHC.Types.Symbol))
       where
         ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
                                                           ShowsPrec_0123456789876543210Sym0 a0123456789876543210
@@ -57,7 +57,7 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym0KindInference) ())
     type ShowsPrec_0123456789876543210Sym1 :: GHC.Types.Nat
                                               -> (~>) (X a) ((~>) GHC.Types.Symbol GHC.Types.Symbol)
-    data ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: (~>) (X a) ((~>) GHC.Types.Symbol GHC.Types.Symbol)
       where
         ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -67,7 +67,7 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym1KindInference) ())
     type ShowsPrec_0123456789876543210Sym2 :: GHC.Types.Nat
                                               -> X a -> (~>) GHC.Types.Symbol GHC.Types.Symbol
-    data ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: X a) :: (~>) GHC.Types.Symbol GHC.Types.Symbol
       where
         ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -77,17 +77,17 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym2KindInference) ())
     type ShowsPrec_0123456789876543210Sym3 :: GHC.Types.Nat
                                               -> X a -> GHC.Types.Symbol -> GHC.Types.Symbol
-    type family ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: X a) (a0123456789876543210 :: GHC.Types.Symbol) :: GHC.Types.Symbol where
       ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow (X a) where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
     type ShowsPrec_0123456789876543210 :: GHC.Types.Nat
                                           -> Y a -> GHC.Types.Symbol -> GHC.Types.Symbol
-    type family ShowsPrec_0123456789876543210 a a a where
+    type family ShowsPrec_0123456789876543210 (a :: GHC.Types.Nat) (a :: Y a) (a :: GHC.Types.Symbol) :: GHC.Types.Symbol where
       ShowsPrec_0123456789876543210 _ Y1 a_0123456789876543210 = Apply (Apply ShowStringSym0 "Y1") a_0123456789876543210
       ShowsPrec_0123456789876543210 p_0123456789876543210 (Y2 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Y2 ")) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
     type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) (Y a) ((~>) GHC.Types.Symbol GHC.Types.Symbol))
-    data ShowsPrec_0123456789876543210Sym0 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Types.Nat ((~>) (Y a) ((~>) GHC.Types.Symbol GHC.Types.Symbol))
       where
         ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
                                                           ShowsPrec_0123456789876543210Sym0 a0123456789876543210
@@ -97,7 +97,7 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym0KindInference) ())
     type ShowsPrec_0123456789876543210Sym1 :: GHC.Types.Nat
                                               -> (~>) (Y a) ((~>) GHC.Types.Symbol GHC.Types.Symbol)
-    data ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Types.Nat) :: (~>) (Y a) ((~>) GHC.Types.Symbol GHC.Types.Symbol)
       where
         ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -107,7 +107,7 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym1KindInference) ())
     type ShowsPrec_0123456789876543210Sym2 :: GHC.Types.Nat
                                               -> Y a -> (~>) GHC.Types.Symbol GHC.Types.Symbol
-    data ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Y a) :: (~>) GHC.Types.Symbol GHC.Types.Symbol
       where
         ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
                                                           ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
@@ -117,7 +117,7 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ShowsPrec_0123456789876543210Sym2KindInference) ())
     type ShowsPrec_0123456789876543210Sym3 :: GHC.Types.Nat
                                               -> Y a -> GHC.Types.Symbol -> GHC.Types.Symbol
-    type family ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 where
+    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Types.Nat) (a0123456789876543210 :: Y a) (a0123456789876543210 :: GHC.Types.Symbol) :: GHC.Types.Symbol where
       ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow (Y a) where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a

--- a/singletons-base/tests/compile-and-dump/Singletons/T376.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T376.golden
@@ -6,7 +6,7 @@ Singletons/T376.hs:(0,0)-(0,0): Splicing declarations
     f :: (() -> ()) -> () -> ()
     f g = g :: () -> ()
     type FSym0 :: (~>) ((~>) () ()) ((~>) () ())
-    data FSym0 a0123456789876543210
+    data FSym0 :: (~>) ((~>) () ()) ((~>) () ())
       where
         FSym0KindInference :: SameKind (Apply FSym0 arg) (FSym1 arg) =>
                               FSym0 a0123456789876543210
@@ -14,7 +14,7 @@ Singletons/T376.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FSym0 where
       suppressUnusedWarnings = snd (((,) FSym0KindInference) ())
     type FSym1 :: (~>) () () -> (~>) () ()
-    data FSym1 a0123456789876543210 a0123456789876543210
+    data FSym1 (a0123456789876543210 :: (~>) () ()) :: (~>) () ()
       where
         FSym1KindInference :: SameKind (Apply (FSym1 a0123456789876543210) arg) (FSym2 a0123456789876543210 arg) =>
                               FSym1 a0123456789876543210 a0123456789876543210
@@ -22,10 +22,10 @@ Singletons/T376.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (FSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) FSym1KindInference) ())
     type FSym2 :: (~>) () () -> () -> ()
-    type family FSym2 a0123456789876543210 a0123456789876543210 where
+    type family FSym2 (a0123456789876543210 :: (~>) () ()) (a0123456789876543210 :: ()) :: () where
       FSym2 a0123456789876543210 a0123456789876543210 = F a0123456789876543210 a0123456789876543210
     type F :: (~>) () () -> () -> ()
-    type family F a a where
+    type family F (a :: (~>) () ()) (a :: ()) :: () where
       F g a_0123456789876543210 = Apply (g :: (~>) () ()) a_0123456789876543210
     sF ::
       forall (t :: (~>) () ()) (t :: ()).

--- a/singletons-base/tests/compile-and-dump/Singletons/T378a.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T378a.golden
@@ -19,19 +19,19 @@ Singletons/T378a.hs:(0,0)-(0,0): Splicing declarations
         Proxy3 :: forall a. Proxy a
         Proxy4 :: forall k (a :: k). Proxy a
     type Proxy1Sym0 :: Proxy a
-    type family Proxy1Sym0 where
+    type family Proxy1Sym0 :: Proxy a where
       Proxy1Sym0 = Proxy1
     type Proxy2Sym0 :: Proxy (a :: k)
-    type family Proxy2Sym0 where
+    type family Proxy2Sym0 :: Proxy (a :: k) where
       Proxy2Sym0 = Proxy2
     type Proxy3Sym0 :: forall a. Proxy a
-    type family Proxy3Sym0 where
+    type family Proxy3Sym0 :: Proxy a where
       Proxy3Sym0 = Proxy3
     type Proxy4Sym0 :: forall k (a :: k). Proxy a
-    type family Proxy4Sym0 where
+    type family Proxy4Sym0 :: Proxy a where
       Proxy4Sym0 = Proxy4
     type ConstBASym0 :: forall b a. (~>) a ((~>) b a)
-    data ConstBASym0 a0123456789876543210
+    data ConstBASym0 :: (~>) a ((~>) b a)
       where
         ConstBASym0KindInference :: SameKind (Apply ConstBASym0 arg) (ConstBASym1 arg) =>
                                     ConstBASym0 a0123456789876543210
@@ -39,7 +39,7 @@ Singletons/T378a.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ConstBASym0 where
       suppressUnusedWarnings = snd (((,) ConstBASym0KindInference) ())
     type ConstBASym1 :: forall b a. a -> (~>) b a
-    data ConstBASym1 a0123456789876543210 a0123456789876543210
+    data ConstBASym1 (a0123456789876543210 :: a) :: (~>) b a
       where
         ConstBASym1KindInference :: SameKind (Apply (ConstBASym1 a0123456789876543210) arg) (ConstBASym2 a0123456789876543210 arg) =>
                                     ConstBASym1 a0123456789876543210 a0123456789876543210
@@ -47,10 +47,10 @@ Singletons/T378a.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (ConstBASym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) ConstBASym1KindInference) ())
     type ConstBASym2 :: forall b a. a -> b -> a
-    type family ConstBASym2 a0123456789876543210 a0123456789876543210 where
+    type family ConstBASym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: a where
       ConstBASym2 a0123456789876543210 a0123456789876543210 = ConstBA a0123456789876543210 a0123456789876543210
     type ConstBA :: forall b a. a -> b -> a
-    type family ConstBA a a where
+    type family ConstBA (a :: a) (a :: b) :: a where
       ConstBA x _ = x
     sConstBA ::
       forall b a (t :: a) (t :: b).

--- a/singletons-base/tests/compile-and-dump/Singletons/T378b.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T378b.golden
@@ -36,7 +36,7 @@ Singletons/T378b.hs:(0,0)-(0,0): Splicing declarations
     type family Let0123456789876543210A wild_0123456789876543210 where
       Let0123456789876543210A wild_0123456789876543210 = Apply SuccSym0 wild_0123456789876543210
     type NatMinusSym0 :: (~>) Nat ((~>) Nat Nat)
-    data NatMinusSym0 a0123456789876543210
+    data NatMinusSym0 :: (~>) Nat ((~>) Nat Nat)
       where
         NatMinusSym0KindInference :: SameKind (Apply NatMinusSym0 arg) (NatMinusSym1 arg) =>
                                      NatMinusSym0 a0123456789876543210
@@ -44,7 +44,7 @@ Singletons/T378b.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings NatMinusSym0 where
       suppressUnusedWarnings = snd (((,) NatMinusSym0KindInference) ())
     type NatMinusSym1 :: Nat -> (~>) Nat Nat
-    data NatMinusSym1 a0123456789876543210 a0123456789876543210
+    data NatMinusSym1 (a0123456789876543210 :: Nat) :: (~>) Nat Nat
       where
         NatMinusSym1KindInference :: SameKind (Apply (NatMinusSym1 a0123456789876543210) arg) (NatMinusSym2 a0123456789876543210 arg) =>
                                      NatMinusSym1 a0123456789876543210 a0123456789876543210
@@ -52,10 +52,10 @@ Singletons/T378b.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (NatMinusSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) NatMinusSym1KindInference) ())
     type NatMinusSym2 :: Nat -> Nat -> Nat
-    type family NatMinusSym2 a0123456789876543210 a0123456789876543210 where
+    type family NatMinusSym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Nat where
       NatMinusSym2 a0123456789876543210 a0123456789876543210 = NatMinus a0123456789876543210 a0123456789876543210
     type FSym0 :: forall b a. (~>) a ((~>) b ())
-    data FSym0 a0123456789876543210
+    data FSym0 :: (~>) a ((~>) b ())
       where
         FSym0KindInference :: SameKind (Apply FSym0 arg) (FSym1 arg) =>
                               FSym0 a0123456789876543210
@@ -63,7 +63,7 @@ Singletons/T378b.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FSym0 where
       suppressUnusedWarnings = snd (((,) FSym0KindInference) ())
     type FSym1 :: forall b a. a -> (~>) b ()
-    data FSym1 a0123456789876543210 a0123456789876543210
+    data FSym1 (a0123456789876543210 :: a) :: (~>) b ()
       where
         FSym1KindInference :: SameKind (Apply (FSym1 a0123456789876543210) arg) (FSym2 a0123456789876543210 arg) =>
                               FSym1 a0123456789876543210 a0123456789876543210
@@ -71,15 +71,15 @@ Singletons/T378b.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (FSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) FSym1KindInference) ())
     type FSym2 :: forall b a. a -> b -> ()
-    type family FSym2 a0123456789876543210 a0123456789876543210 where
+    type family FSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: () where
       FSym2 a0123456789876543210 a0123456789876543210 = F a0123456789876543210 a0123456789876543210
     type NatMinus :: Nat -> Nat -> Nat
-    type family NatMinus a a where
+    type family NatMinus (a :: Nat) (a :: Nat) :: Nat where
       NatMinus 'Zero _ = ZeroSym0
       NatMinus ('Succ a) ('Succ b) = Apply (Apply NatMinusSym0 a) b
       NatMinus ('Succ wild_0123456789876543210) 'Zero = Let0123456789876543210ASym1 wild_0123456789876543210
     type F :: forall b a. a -> b -> ()
-    type family F a a where
+    type family F (a :: a) (a :: b) :: () where
       F _ _ = Tuple0Sym0
     type PC :: forall b a. a -> b -> Constraint
     class PC x y
@@ -114,7 +114,7 @@ Singletons/T378b.hs:(0,0)-(0,0): Splicing declarations
     instance SingI d => SingI (FSym1 (d :: a) :: (~>) b ()) where
       sing = (singFun1 @(FSym1 (d :: a))) (sF (sing @d))
     type SD :: forall b a (x :: a) (y :: b). D x y -> Type
-    data SD z
+    data SD :: forall b a (x :: a) (y :: b). D x y -> Type
     type instance Sing @(D x y) = SD
     instance (SingKind x, SingKind y) => SingKind (D x y) where
       type Demote (D x y) = D (Demote x) (Demote y)

--- a/singletons-base/tests/compile-and-dump/Singletons/T410.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T410.golden
@@ -11,7 +11,7 @@ Singletons/T410.hs:(0,0)-(0,0): Splicing declarations
     instance Eq () where
       equals () () = True
     type EqualsSym0 :: forall a. (~>) a ((~>) a Bool)
-    data EqualsSym0 a0123456789876543210
+    data EqualsSym0 :: (~>) a ((~>) a Bool)
       where
         EqualsSym0KindInference :: SameKind (Apply EqualsSym0 arg) (EqualsSym1 arg) =>
                                    EqualsSym0 a0123456789876543210
@@ -20,7 +20,7 @@ Singletons/T410.hs:(0,0)-(0,0): Splicing declarations
       Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings
         = snd (((,) EqualsSym0KindInference) ())
     type EqualsSym1 :: forall a. a -> (~>) a Bool
-    data EqualsSym1 a0123456789876543210 a0123456789876543210
+    data EqualsSym1 (a0123456789876543210 :: a) :: (~>) a Bool
       where
         EqualsSym1KindInference :: SameKind (Apply (EqualsSym1 a0123456789876543210) arg) (EqualsSym2 a0123456789876543210 arg) =>
                                    EqualsSym1 a0123456789876543210 a0123456789876543210
@@ -29,15 +29,15 @@ Singletons/T410.hs:(0,0)-(0,0): Splicing declarations
       Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings
         = snd (((,) EqualsSym1KindInference) ())
     type EqualsSym2 :: forall a. a -> a -> Bool
-    type family EqualsSym2 a0123456789876543210 a0123456789876543210 where
+    type family EqualsSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Bool where
       EqualsSym2 a0123456789876543210 a0123456789876543210 = Equals a0123456789876543210 a0123456789876543210
     class PEq a where
       type Equals (arg :: a) (arg :: a) :: Bool
     type Equals_0123456789876543210 :: () -> () -> Bool
-    type family Equals_0123456789876543210 a a where
+    type family Equals_0123456789876543210 (a :: ()) (a :: ()) :: Bool where
       Equals_0123456789876543210 '() '() = TrueSym0
     type Equals_0123456789876543210Sym0 :: (~>) () ((~>) () Bool)
-    data Equals_0123456789876543210Sym0 a0123456789876543210
+    data Equals_0123456789876543210Sym0 :: (~>) () ((~>) () Bool)
       where
         Equals_0123456789876543210Sym0KindInference :: SameKind (Apply Equals_0123456789876543210Sym0 arg) (Equals_0123456789876543210Sym1 arg) =>
                                                        Equals_0123456789876543210Sym0 a0123456789876543210
@@ -46,7 +46,7 @@ Singletons/T410.hs:(0,0)-(0,0): Splicing declarations
       Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings
         = snd (((,) Equals_0123456789876543210Sym0KindInference) ())
     type Equals_0123456789876543210Sym1 :: () -> (~>) () Bool
-    data Equals_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
+    data Equals_0123456789876543210Sym1 (a0123456789876543210 :: ()) :: (~>) () Bool
       where
         Equals_0123456789876543210Sym1KindInference :: SameKind (Apply (Equals_0123456789876543210Sym1 a0123456789876543210) arg) (Equals_0123456789876543210Sym2 a0123456789876543210 arg) =>
                                                        Equals_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
@@ -55,7 +55,7 @@ Singletons/T410.hs:(0,0)-(0,0): Splicing declarations
       Data.Singletons.SuppressUnusedWarnings.suppressUnusedWarnings
         = snd (((,) Equals_0123456789876543210Sym1KindInference) ())
     type Equals_0123456789876543210Sym2 :: () -> () -> Bool
-    type family Equals_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 where
+    type family Equals_0123456789876543210Sym2 (a0123456789876543210 :: ()) (a0123456789876543210 :: ()) :: Bool where
       Equals_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Equals_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq () where
       type Equals a a = Apply (Apply Equals_0123456789876543210Sym0 a) a

--- a/singletons-base/tests/compile-and-dump/Singletons/T412.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T412.golden
@@ -66,7 +66,7 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
       T1bSym2 a0123456789876543210 b0123456789876543210 = T1b a0123456789876543210 b0123456789876543210
     infixl 5 `T1bSym2`
     type MkD1Sym0 :: forall a b. (~>) a ((~>) b (D1 a b))
-    data MkD1Sym0 a0123456789876543210
+    data MkD1Sym0 :: (~>) a ((~>) b (D1 a b))
       where
         MkD1Sym0KindInference :: SameKind (Apply MkD1Sym0 arg) (MkD1Sym1 arg) =>
                                  MkD1Sym0 a0123456789876543210
@@ -75,7 +75,7 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) MkD1Sym0KindInference) ())
     infixr 5 `MkD1Sym0`
     type MkD1Sym1 :: forall a b. a -> (~>) b (D1 a b)
-    data MkD1Sym1 a0123456789876543210 a0123456789876543210
+    data MkD1Sym1 (a0123456789876543210 :: a) :: (~>) b (D1 a b)
       where
         MkD1Sym1KindInference :: SameKind (Apply (MkD1Sym1 a0123456789876543210) arg) (MkD1Sym2 a0123456789876543210 arg) =>
                                  MkD1Sym1 a0123456789876543210 a0123456789876543210
@@ -84,11 +84,11 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) MkD1Sym1KindInference) ())
     infixr 5 `MkD1Sym1`
     type MkD1Sym2 :: forall a b. a -> b -> D1 a b
-    type family MkD1Sym2 a0123456789876543210 a0123456789876543210 where
+    type family MkD1Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: D1 a b where
       MkD1Sym2 a0123456789876543210 a0123456789876543210 = MkD1 a0123456789876543210 a0123456789876543210
     infixr 5 `MkD1Sym2`
     type D1BSym0 :: forall a b. (~>) (D1 a b) b
-    data D1BSym0 a0123456789876543210
+    data D1BSym0 :: (~>) (D1 a b) b
       where
         D1BSym0KindInference :: SameKind (Apply D1BSym0 arg) (D1BSym1 arg) =>
                                 D1BSym0 a0123456789876543210
@@ -97,11 +97,11 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) D1BSym0KindInference) ())
     infixr 5 `D1BSym0`
     type D1BSym1 :: forall a b. D1 a b -> b
-    type family D1BSym1 a0123456789876543210 where
+    type family D1BSym1 (a0123456789876543210 :: D1 a b) :: b where
       D1BSym1 a0123456789876543210 = D1B a0123456789876543210
     infixr 5 `D1BSym1`
     type D1ASym0 :: forall a b. (~>) (D1 a b) a
-    data D1ASym0 a0123456789876543210
+    data D1ASym0 :: (~>) (D1 a b) a
       where
         D1ASym0KindInference :: SameKind (Apply D1ASym0 arg) (D1ASym1 arg) =>
                                 D1ASym0 a0123456789876543210
@@ -110,21 +110,21 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) D1ASym0KindInference) ())
     infixr 5 `D1ASym0`
     type D1ASym1 :: forall a b. D1 a b -> a
-    type family D1ASym1 a0123456789876543210 where
+    type family D1ASym1 (a0123456789876543210 :: D1 a b) :: a where
       D1ASym1 a0123456789876543210 = D1A a0123456789876543210
     infixr 5 `D1ASym1`
     type D1B :: forall a b. D1 a b -> b
-    type family D1B a where
+    type family D1B (a :: D1 a b) :: b where
       D1B (MkD1 _ field) = field
     type D1A :: forall a b. D1 a b -> a
-    type family D1A a where
+    type family D1A (a :: D1 a b) :: a where
       D1A (MkD1 field _) = field
     infixr 5 `D1B`
     infixr 5 `D1A`
     infix 6 `M1`
     infix 5 `PC1`
     type M1Sym0 :: forall a b. (~>) a ((~>) b Bool)
-    data M1Sym0 a0123456789876543210
+    data M1Sym0 :: (~>) a ((~>) b Bool)
       where
         M1Sym0KindInference :: SameKind (Apply M1Sym0 arg) (M1Sym1 arg) =>
                                M1Sym0 a0123456789876543210
@@ -133,7 +133,7 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) M1Sym0KindInference) ())
     infix 6 `M1Sym0`
     type M1Sym1 :: forall a b. a -> (~>) b Bool
-    data M1Sym1 a0123456789876543210 a0123456789876543210
+    data M1Sym1 (a0123456789876543210 :: a) :: (~>) b Bool
       where
         M1Sym1KindInference :: SameKind (Apply (M1Sym1 a0123456789876543210) arg) (M1Sym2 a0123456789876543210 arg) =>
                                M1Sym1 a0123456789876543210 a0123456789876543210
@@ -142,7 +142,7 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings = snd (((,) M1Sym1KindInference) ())
     infix 6 `M1Sym1`
     type M1Sym2 :: forall a b. a -> b -> Bool
-    type family M1Sym2 a0123456789876543210 a0123456789876543210 where
+    type family M1Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: Bool where
       M1Sym2 a0123456789876543210 a0123456789876543210 = M1 a0123456789876543210 a0123456789876543210
     infix 6 `M1Sym2`
     class PC1 a b where
@@ -193,7 +193,7 @@ Singletons/T412.hs:0:0:: Splicing declarations
     genSingletons [''C2, ''T2a, ''T2b, ''D2]
   ======>
     type M2Sym0 :: forall a b. (~>) a ((~>) b Bool)
-    data M2Sym0 a0123456789876543210
+    data M2Sym0 :: (~>) a ((~>) b Bool)
       where
         M2Sym0KindInference :: SameKind (Apply M2Sym0 arg) (M2Sym1 arg) =>
                                M2Sym0 a0123456789876543210
@@ -202,7 +202,7 @@ Singletons/T412.hs:0:0:: Splicing declarations
       suppressUnusedWarnings = snd (((,) M2Sym0KindInference) ())
     infix 6 `M2Sym0`
     type M2Sym1 :: forall a b. a -> (~>) b Bool
-    data M2Sym1 a0123456789876543210 a0123456789876543210
+    data M2Sym1 (a0123456789876543210 :: a) :: (~>) b Bool
       where
         M2Sym1KindInference :: SameKind (Apply (M2Sym1 a0123456789876543210) arg) (M2Sym2 a0123456789876543210 arg) =>
                                M2Sym1 a0123456789876543210 a0123456789876543210
@@ -211,7 +211,7 @@ Singletons/T412.hs:0:0:: Splicing declarations
       suppressUnusedWarnings = snd (((,) M2Sym1KindInference) ())
     infix 6 `M2Sym1`
     type M2Sym2 :: forall a b. a -> b -> Bool
-    type family M2Sym2 a0123456789876543210 a0123456789876543210 where
+    type family M2Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: Bool where
       M2Sym2 a0123456789876543210 a0123456789876543210 = M2 a0123456789876543210 a0123456789876543210
     infix 6 `M2Sym2`
     type PC2 :: GHC.Types.Type -> GHC.Types.Type -> Constraint
@@ -232,7 +232,7 @@ Singletons/T412.hs:0:0:: Splicing declarations
              SingI (M2Sym1 (d :: a) :: (~>) b Bool) where
       sing = (singFun1 @(M2Sym1 (d :: a))) (sM2 (sing @d))
     type T2aSym0 :: (~>) GHC.Types.Type ((~>) GHC.Types.Type GHC.Types.Type)
-    data T2aSym0 a0123456789876543210
+    data T2aSym0 :: (~>) GHC.Types.Type ((~>) GHC.Types.Type GHC.Types.Type)
       where
         T2aSym0KindInference :: SameKind (Apply T2aSym0 arg) (T2aSym1 arg) =>
                                 T2aSym0 a0123456789876543210
@@ -242,7 +242,7 @@ Singletons/T412.hs:0:0:: Splicing declarations
     infixl 5 `T2aSym0`
     type T2aSym1 :: GHC.Types.Type
                     -> (~>) GHC.Types.Type GHC.Types.Type
-    data T2aSym1 a0123456789876543210 a0123456789876543210
+    data T2aSym1 (a0123456789876543210 :: GHC.Types.Type) :: (~>) GHC.Types.Type GHC.Types.Type
       where
         T2aSym1KindInference :: SameKind (Apply (T2aSym1 a0123456789876543210) arg) (T2aSym2 a0123456789876543210 arg) =>
                                 T2aSym1 a0123456789876543210 a0123456789876543210
@@ -251,11 +251,11 @@ Singletons/T412.hs:0:0:: Splicing declarations
       suppressUnusedWarnings = snd (((,) T2aSym1KindInference) ())
     infixl 5 `T2aSym1`
     type T2aSym2 :: GHC.Types.Type -> GHC.Types.Type -> GHC.Types.Type
-    type family T2aSym2 a0123456789876543210 a0123456789876543210 where
+    type family T2aSym2 (a0123456789876543210 :: GHC.Types.Type) (a0123456789876543210 :: GHC.Types.Type) :: GHC.Types.Type where
       T2aSym2 a0123456789876543210 a0123456789876543210 = T2a a0123456789876543210 a0123456789876543210
     infixl 5 `T2aSym2`
     type T2bSym0 :: (~>) GHC.Types.Type ((~>) GHC.Types.Type GHC.Types.Type)
-    data T2bSym0 a0123456789876543210
+    data T2bSym0 :: (~>) GHC.Types.Type ((~>) GHC.Types.Type GHC.Types.Type)
       where
         T2bSym0KindInference :: SameKind (Apply T2bSym0 arg) (T2bSym1 arg) =>
                                 T2bSym0 a0123456789876543210
@@ -265,7 +265,7 @@ Singletons/T412.hs:0:0:: Splicing declarations
     infixl 5 `T2bSym0`
     type T2bSym1 :: GHC.Types.Type
                     -> (~>) GHC.Types.Type GHC.Types.Type
-    data T2bSym1 a0123456789876543210 a0123456789876543210
+    data T2bSym1 (a0123456789876543210 :: GHC.Types.Type) :: (~>) GHC.Types.Type GHC.Types.Type
       where
         T2bSym1KindInference :: SameKind (Apply (T2bSym1 a0123456789876543210) arg) (T2bSym2 a0123456789876543210 arg) =>
                                 T2bSym1 a0123456789876543210 a0123456789876543210
@@ -274,13 +274,13 @@ Singletons/T412.hs:0:0:: Splicing declarations
       suppressUnusedWarnings = snd (((,) T2bSym1KindInference) ())
     infixl 5 `T2bSym1`
     type T2bSym2 :: GHC.Types.Type -> GHC.Types.Type -> GHC.Types.Type
-    type family T2bSym2 a0123456789876543210 a0123456789876543210 where
+    type family T2bSym2 (a0123456789876543210 :: GHC.Types.Type) (a0123456789876543210 :: GHC.Types.Type) :: GHC.Types.Type where
       T2bSym2 a0123456789876543210 a0123456789876543210 = T2b a0123456789876543210 a0123456789876543210
     infixl 5 `T2bSym2`
     type MkD2Sym0 :: forall (a :: GHC.Types.Type)
                             (b :: GHC.Types.Type).
                      (~>) a ((~>) b (D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type)))
-    data MkD2Sym0 a0123456789876543210
+    data MkD2Sym0 :: (~>) a ((~>) b (D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type)))
       where
         MkD2Sym0KindInference :: SameKind (Apply MkD2Sym0 arg) (MkD2Sym1 arg) =>
                                  MkD2Sym0 a0123456789876543210
@@ -291,7 +291,7 @@ Singletons/T412.hs:0:0:: Splicing declarations
     type MkD2Sym1 :: forall (a :: GHC.Types.Type)
                             (b :: GHC.Types.Type).
                      a -> (~>) b (D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type))
-    data MkD2Sym1 a0123456789876543210 a0123456789876543210
+    data MkD2Sym1 (a0123456789876543210 :: a) :: (~>) b (D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type))
       where
         MkD2Sym1KindInference :: SameKind (Apply (MkD2Sym1 a0123456789876543210) arg) (MkD2Sym2 a0123456789876543210 arg) =>
                                  MkD2Sym1 a0123456789876543210 a0123456789876543210
@@ -302,14 +302,14 @@ Singletons/T412.hs:0:0:: Splicing declarations
     type MkD2Sym2 :: forall (a :: GHC.Types.Type)
                             (b :: GHC.Types.Type).
                      a -> b -> D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type)
-    type family MkD2Sym2 a0123456789876543210 a0123456789876543210 where
+    type family MkD2Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type) where
       MkD2Sym2 a0123456789876543210 a0123456789876543210 = 'MkD2 a0123456789876543210 a0123456789876543210
     infixr 5 `MkD2Sym2`
     infixr 5 `D2A`
     infixr 5 `D2B`
     type D2BSym0 :: forall (a :: GHC.Types.Type) (b :: GHC.Types.Type).
                     (~>) (D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type)) b
-    data D2BSym0 a0123456789876543210
+    data D2BSym0 :: (~>) (D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type)) b
       where
         D2BSym0KindInference :: SameKind (Apply D2BSym0 arg) (D2BSym1 arg) =>
                                 D2BSym0 a0123456789876543210
@@ -318,11 +318,11 @@ Singletons/T412.hs:0:0:: Splicing declarations
       suppressUnusedWarnings = snd (((,) D2BSym0KindInference) ())
     type D2BSym1 :: forall (a :: GHC.Types.Type) (b :: GHC.Types.Type).
                     D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type) -> b
-    type family D2BSym1 a0123456789876543210 where
+    type family D2BSym1 (a0123456789876543210 :: D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type)) :: b where
       D2BSym1 a0123456789876543210 = D2B a0123456789876543210
     type D2ASym0 :: forall (a :: GHC.Types.Type) (b :: GHC.Types.Type).
                     (~>) (D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type)) a
-    data D2ASym0 a0123456789876543210
+    data D2ASym0 :: (~>) (D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type)) a
       where
         D2ASym0KindInference :: SameKind (Apply D2ASym0 arg) (D2ASym1 arg) =>
                                 D2ASym0 a0123456789876543210
@@ -331,15 +331,15 @@ Singletons/T412.hs:0:0:: Splicing declarations
       suppressUnusedWarnings = snd (((,) D2ASym0KindInference) ())
     type D2ASym1 :: forall (a :: GHC.Types.Type) (b :: GHC.Types.Type).
                     D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type) -> a
-    type family D2ASym1 a0123456789876543210 where
+    type family D2ASym1 (a0123456789876543210 :: D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type)) :: a where
       D2ASym1 a0123456789876543210 = D2A a0123456789876543210
     type D2B :: forall (a :: GHC.Types.Type) (b :: GHC.Types.Type).
                 D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type) -> b
-    type family D2B a where
+    type family D2B (a :: D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type)) :: b where
       D2B ('MkD2 _ field) = field
     type D2A :: forall (a :: GHC.Types.Type) (b :: GHC.Types.Type).
                 D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type) -> a
-    type family D2A a where
+    type family D2A (a :: D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type)) :: a where
       D2A ('MkD2 field _) = field
     sD2B ::
       forall (a :: GHC.Types.Type)
@@ -359,7 +359,8 @@ Singletons/T412.hs:0:0:: Splicing declarations
       sing = (singFun1 @D2ASym0) sD2A
     type SD2 :: forall (a :: GHC.Types.Type) (b :: GHC.Types.Type).
                 D2 a b -> GHC.Types.Type
-    data SD2 z
+    data SD2 :: forall (a :: GHC.Types.Type) (b :: GHC.Types.Type).
+                D2 a b -> GHC.Types.Type
       where
         SMkD2 :: forall (a :: GHC.Types.Type)
                         (b :: GHC.Types.Type)

--- a/singletons-base/tests/compile-and-dump/Singletons/T414.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T414.golden
@@ -51,7 +51,7 @@ Singletons/T414.hs:(0,0)-(0,0): Splicing declarations
       T2Sym2 a0123456789876543210 b0123456789876543210 = T2 a0123456789876543210 b0123456789876543210
     class PC2 a
     type T3Sym0 :: (~>) Bool ((~>) Type Type)
-    data T3Sym0 a0123456789876543210
+    data T3Sym0 :: (~>) Bool ((~>) Type Type)
       where
         T3Sym0KindInference :: SameKind (Apply T3Sym0 arg) (T3Sym1 arg) =>
                                T3Sym0 a0123456789876543210
@@ -59,7 +59,7 @@ Singletons/T414.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings T3Sym0 where
       suppressUnusedWarnings = snd (((,) T3Sym0KindInference) ())
     type T3Sym1 :: Bool -> (~>) Type Type
-    data T3Sym1 a0123456789876543210 a0123456789876543210
+    data T3Sym1 (a0123456789876543210 :: Bool) :: (~>) Type Type
       where
         T3Sym1KindInference :: SameKind (Apply (T3Sym1 a0123456789876543210) arg) (T3Sym2 a0123456789876543210 arg) =>
                                T3Sym1 a0123456789876543210 a0123456789876543210
@@ -67,7 +67,7 @@ Singletons/T414.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (T3Sym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) T3Sym1KindInference) ())
     type T3Sym2 :: Bool -> Type -> Type
-    type family T3Sym2 a0123456789876543210 a0123456789876543210 where
+    type family T3Sym2 (a0123456789876543210 :: Bool) (a0123456789876543210 :: Type) :: Type where
       T3Sym2 a0123456789876543210 a0123456789876543210 = T3 a0123456789876543210 a0123456789876543210
     type PC3 :: Bool -> Constraint
     class PC3 a

--- a/singletons-base/tests/compile-and-dump/Singletons/T443.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T443.golden
@@ -14,10 +14,10 @@ Singletons/T443.hs:(0,0)-(0,0): Splicing declarations
         VNil :: Vec 'Z a
         (:>) :: {head :: a, tail :: (Vec n a)} -> Vec ('S n) a
     type ZSym0 :: Nat
-    type family ZSym0 where
+    type family ZSym0 :: Nat where
       ZSym0 = Z
     type SSym0 :: (~>) Nat Nat
-    data SSym0 a0123456789876543210
+    data SSym0 :: (~>) Nat Nat
       where
         SSym0KindInference :: SameKind (Apply SSym0 arg) (SSym1 arg) =>
                               SSym0 a0123456789876543210
@@ -25,13 +25,13 @@ Singletons/T443.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings SSym0 where
       suppressUnusedWarnings = snd (((,) SSym0KindInference) ())
     type SSym1 :: Nat -> Nat
-    type family SSym1 a0123456789876543210 where
+    type family SSym1 (a0123456789876543210 :: Nat) :: Nat where
       SSym1 a0123456789876543210 = S a0123456789876543210
     type VNilSym0 :: Vec Z a
-    type family VNilSym0 where
+    type family VNilSym0 :: Vec Z a where
       VNilSym0 = VNil
     type (:>@#@$) :: (~>) a ((~>) (Vec n a) (Vec (S n) a))
-    data (:>@#@$) a0123456789876543210
+    data (:>@#@$) :: (~>) a ((~>) (Vec n a) (Vec (S n) a))
       where
         (::>@#@$###) :: SameKind (Apply (:>@#@$) arg) ((:>@#@$$) arg) =>
                         (:>@#@$) a0123456789876543210
@@ -39,7 +39,7 @@ Singletons/T443.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (:>@#@$) where
       suppressUnusedWarnings = snd (((,) (::>@#@$###)) ())
     type (:>@#@$$) :: a -> (~>) (Vec n a) (Vec (S n) a)
-    data (:>@#@$$) a0123456789876543210 a0123456789876543210
+    data (:>@#@$$) (a0123456789876543210 :: a) :: (~>) (Vec n a) (Vec (S n) a)
       where
         (::>@#@$$###) :: SameKind (Apply ((:>@#@$$) a0123456789876543210) arg) ((:>@#@$$$) a0123456789876543210 arg) =>
                          (:>@#@$$) a0123456789876543210 a0123456789876543210
@@ -47,10 +47,10 @@ Singletons/T443.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings ((:>@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) (::>@#@$$###)) ())
     type (:>@#@$$$) :: a -> Vec n a -> Vec (S n) a
-    type family (:>@#@$$$) a0123456789876543210 a0123456789876543210 where
+    type family (:>@#@$$$) (a0123456789876543210 :: a) (a0123456789876543210 :: Vec n a) :: Vec (S n) a where
       (:>@#@$$$) a0123456789876543210 a0123456789876543210 = (:>) a0123456789876543210 a0123456789876543210
     type TailSym0 :: (~>) (Vec (S n) a) (Vec n a)
-    data TailSym0 a0123456789876543210
+    data TailSym0 :: (~>) (Vec (S n) a) (Vec n a)
       where
         TailSym0KindInference :: SameKind (Apply TailSym0 arg) (TailSym1 arg) =>
                                  TailSym0 a0123456789876543210
@@ -58,10 +58,10 @@ Singletons/T443.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings TailSym0 where
       suppressUnusedWarnings = snd (((,) TailSym0KindInference) ())
     type TailSym1 :: Vec (S n) a -> Vec n a
-    type family TailSym1 a0123456789876543210 where
+    type family TailSym1 (a0123456789876543210 :: Vec (S n) a) :: Vec n a where
       TailSym1 a0123456789876543210 = Tail a0123456789876543210
     type HeadSym0 :: (~>) (Vec (S n) a) a
-    data HeadSym0 a0123456789876543210
+    data HeadSym0 :: (~>) (Vec (S n) a) a
       where
         HeadSym0KindInference :: SameKind (Apply HeadSym0 arg) (HeadSym1 arg) =>
                                  HeadSym0 a0123456789876543210
@@ -69,13 +69,13 @@ Singletons/T443.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings HeadSym0 where
       suppressUnusedWarnings = snd (((,) HeadSym0KindInference) ())
     type HeadSym1 :: Vec (S n) a -> a
-    type family HeadSym1 a0123456789876543210 where
+    type family HeadSym1 (a0123456789876543210 :: Vec (S n) a) :: a where
       HeadSym1 a0123456789876543210 = Head a0123456789876543210
     type Tail :: Vec (S n) a -> Vec n a
-    type family Tail a where
+    type family Tail (a :: Vec (S n) a) :: Vec n a where
       Tail ((:>) _ field) = field
     type Head :: Vec (S n) a -> a
-    type family Head a where
+    type family Head (a :: Vec (S n) a) :: a where
       Head ((:>) field _) = field
     sTail ::
       forall n a (t :: Vec (S n) a).

--- a/singletons-base/tests/compile-and-dump/Singletons/T445.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T445.golden
@@ -2,7 +2,7 @@ Singletons/T445.hs:0:0:: Splicing declarations
     genDefunSymbols [''Lit]
   ======>
     type LitSym0 :: (~>) Lit.Nat Nat
-    data LitSym0 a0123456789876543210
+    data LitSym0 :: (~>) Lit.Nat Nat
       where
         LitSym0KindInference :: SameKind (Apply LitSym0 arg) (LitSym1 arg) =>
                                 LitSym0 a0123456789876543210
@@ -10,7 +10,7 @@ Singletons/T445.hs:0:0:: Splicing declarations
     instance SuppressUnusedWarnings LitSym0 where
       suppressUnusedWarnings = snd (((,) LitSym0KindInference) ())
     type LitSym1 :: Lit.Nat -> Nat
-    type family LitSym1 a0123456789876543210 where
+    type family LitSym1 (a0123456789876543210 :: Lit.Nat) :: Nat where
       LitSym1 a0123456789876543210 = Lit a0123456789876543210
 Singletons/T445.hs:(0,0)-(0,0): Splicing declarations
     promoteOnly
@@ -42,7 +42,7 @@ Singletons/T445.hs:(0,0)-(0,0): Splicing declarations
     type family Lambda_0123456789876543210Sym2 a_01234567898765432100123456789876543210 x0123456789876543210 where
       Lambda_0123456789876543210Sym2 a_01234567898765432100123456789876543210 x0123456789876543210 = Lambda_0123456789876543210 a_01234567898765432100123456789876543210 x0123456789876543210
     type FilterEvenGt7Sym0 :: (~>) [Nat] [Nat]
-    data FilterEvenGt7Sym0 a0123456789876543210
+    data FilterEvenGt7Sym0 :: (~>) [Nat] [Nat]
       where
         FilterEvenGt7Sym0KindInference :: SameKind (Apply FilterEvenGt7Sym0 arg) (FilterEvenGt7Sym1 arg) =>
                                           FilterEvenGt7Sym0 a0123456789876543210
@@ -51,10 +51,10 @@ Singletons/T445.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) FilterEvenGt7Sym0KindInference) ())
     type FilterEvenGt7Sym1 :: [Nat] -> [Nat]
-    type family FilterEvenGt7Sym1 a0123456789876543210 where
+    type family FilterEvenGt7Sym1 (a0123456789876543210 :: [Nat]) :: [Nat] where
       FilterEvenGt7Sym1 a0123456789876543210 = FilterEvenGt7 a0123456789876543210
     type EvenbSym0 :: (~>) Nat Bool
-    data EvenbSym0 a0123456789876543210
+    data EvenbSym0 :: (~>) Nat Bool
       where
         EvenbSym0KindInference :: SameKind (Apply EvenbSym0 arg) (EvenbSym1 arg) =>
                                   EvenbSym0 a0123456789876543210
@@ -62,13 +62,13 @@ Singletons/T445.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings EvenbSym0 where
       suppressUnusedWarnings = snd (((,) EvenbSym0KindInference) ())
     type EvenbSym1 :: Nat -> Bool
-    type family EvenbSym1 a0123456789876543210 where
+    type family EvenbSym1 (a0123456789876543210 :: Nat) :: Bool where
       EvenbSym1 a0123456789876543210 = Evenb a0123456789876543210
     type FilterEvenGt7 :: [Nat] -> [Nat]
-    type family FilterEvenGt7 a where
+    type family FilterEvenGt7 (a :: [Nat]) :: [Nat] where
       FilterEvenGt7 a_0123456789876543210 = Apply (Apply FilterSym0 (Apply Lambda_0123456789876543210Sym0 a_0123456789876543210)) a_0123456789876543210
     type Evenb :: Nat -> Bool
-    type family Evenb a where
+    type family Evenb (a :: Nat) :: Bool where
       Evenb 'Zero = TrueSym0
       Evenb ('Succ 'Zero) = FalseSym0
       Evenb ('Succ ('Succ n)) = Apply EvenbSym0 n

--- a/singletons-base/tests/compile-and-dump/Singletons/T450.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T450.golden
@@ -51,7 +51,7 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
        pure $ ageDecs ++ messageDecs ++ functionDecs
   ======>
     type PMkAgeSym0 :: (~>) Nat PAge
-    data PMkAgeSym0 a0123456789876543210
+    data PMkAgeSym0 :: (~>) Nat PAge
       where
         PMkAgeSym0KindInference :: SameKind (Apply PMkAgeSym0 arg) (PMkAgeSym1 arg) =>
                                    PMkAgeSym0 a0123456789876543210
@@ -59,10 +59,10 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings PMkAgeSym0 where
       suppressUnusedWarnings = snd (((,) PMkAgeSym0KindInference) ())
     type PMkAgeSym1 :: Nat -> PAge
-    type family PMkAgeSym1 a0123456789876543210 where
+    type family PMkAgeSym1 (a0123456789876543210 :: Nat) :: PAge where
       PMkAgeSym1 a0123456789876543210 = 'PMkAge a0123456789876543210
     type SAge :: PAge -> GHC.Types.Type
-    data SAge z
+    data SAge :: PAge -> GHC.Types.Type
       where
         SMkAge :: forall (n :: Nat). (Sing n) -> SAge ('PMkAge n :: PAge)
     type instance Sing @PAge = SAge
@@ -80,7 +80,7 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
     addAge (MkAge (x :: Natural)) (MkAge (y :: Natural))
       = MkAge ((x + y) :: Natural)
     type AddAgeSym0 :: (~>) PAge ((~>) PAge PAge)
-    data AddAgeSym0 a0123456789876543210
+    data AddAgeSym0 :: (~>) PAge ((~>) PAge PAge)
       where
         AddAgeSym0KindInference :: SameKind (Apply AddAgeSym0 arg) (AddAgeSym1 arg) =>
                                    AddAgeSym0 a0123456789876543210
@@ -88,7 +88,7 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings AddAgeSym0 where
       suppressUnusedWarnings = snd (((,) AddAgeSym0KindInference) ())
     type AddAgeSym1 :: PAge -> (~>) PAge PAge
-    data AddAgeSym1 a0123456789876543210 a0123456789876543210
+    data AddAgeSym1 (a0123456789876543210 :: PAge) :: (~>) PAge PAge
       where
         AddAgeSym1KindInference :: SameKind (Apply (AddAgeSym1 a0123456789876543210) arg) (AddAgeSym2 a0123456789876543210 arg) =>
                                    AddAgeSym1 a0123456789876543210 a0123456789876543210
@@ -96,10 +96,10 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings (AddAgeSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd (((,) AddAgeSym1KindInference) ())
     type AddAgeSym2 :: PAge -> PAge -> PAge
-    type family AddAgeSym2 a0123456789876543210 a0123456789876543210 where
+    type family AddAgeSym2 (a0123456789876543210 :: PAge) (a0123456789876543210 :: PAge) :: PAge where
       AddAgeSym2 a0123456789876543210 a0123456789876543210 = AddAge a0123456789876543210 a0123456789876543210
     type AddAge :: PAge -> PAge -> PAge
-    type family AddAge a a where
+    type family AddAge (a :: PAge) (a :: PAge) :: PAge where
       AddAge ('PMkAge (x :: Nat)) ('PMkAge (y :: Nat)) = Apply PMkAgeSym0 (Apply (Apply (+@#@$) x) y :: Nat)
     sAddAge ::
       forall (t :: PAge) (t :: PAge).
@@ -116,7 +116,7 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
              SingI (AddAgeSym1 (d :: PAge) :: (~>) PAge PAge) where
       sing = (singFun1 @(AddAgeSym1 (d :: PAge))) (sAddAge (sing @d))
     type PMkMessageSym0 :: (~>) Symbol PMessage
-    data PMkMessageSym0 a0123456789876543210
+    data PMkMessageSym0 :: (~>) Symbol PMessage
       where
         PMkMessageSym0KindInference :: SameKind (Apply PMkMessageSym0 arg) (PMkMessageSym1 arg) =>
                                        PMkMessageSym0 a0123456789876543210
@@ -124,10 +124,10 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings PMkMessageSym0 where
       suppressUnusedWarnings = snd (((,) PMkMessageSym0KindInference) ())
     type PMkMessageSym1 :: Symbol -> PMessage
-    type family PMkMessageSym1 a0123456789876543210 where
+    type family PMkMessageSym1 (a0123456789876543210 :: Symbol) :: PMessage where
       PMkMessageSym1 a0123456789876543210 = 'PMkMessage a0123456789876543210
     type SMessage :: PMessage -> GHC.Types.Type
-    data SMessage z
+    data SMessage :: PMessage -> GHC.Types.Type
       where
         SMkMessage :: forall (n :: Symbol).
                       (Sing n) -> SMessage ('PMkMessage n :: PMessage)
@@ -146,7 +146,7 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
     appendMessage (MkMessage (x :: Text)) (MkMessage (y :: Text))
       = MkMessage ((x <> y) :: Text)
     type AppendMessageSym0 :: (~>) PMessage ((~>) PMessage PMessage)
-    data AppendMessageSym0 a0123456789876543210
+    data AppendMessageSym0 :: (~>) PMessage ((~>) PMessage PMessage)
       where
         AppendMessageSym0KindInference :: SameKind (Apply AppendMessageSym0 arg) (AppendMessageSym1 arg) =>
                                           AppendMessageSym0 a0123456789876543210
@@ -155,7 +155,7 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) AppendMessageSym0KindInference) ())
     type AppendMessageSym1 :: PMessage -> (~>) PMessage PMessage
-    data AppendMessageSym1 a0123456789876543210 a0123456789876543210
+    data AppendMessageSym1 (a0123456789876543210 :: PMessage) :: (~>) PMessage PMessage
       where
         AppendMessageSym1KindInference :: SameKind (Apply (AppendMessageSym1 a0123456789876543210) arg) (AppendMessageSym2 a0123456789876543210 arg) =>
                                           AppendMessageSym1 a0123456789876543210 a0123456789876543210
@@ -164,10 +164,10 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = snd (((,) AppendMessageSym1KindInference) ())
     type AppendMessageSym2 :: PMessage -> PMessage -> PMessage
-    type family AppendMessageSym2 a0123456789876543210 a0123456789876543210 where
+    type family AppendMessageSym2 (a0123456789876543210 :: PMessage) (a0123456789876543210 :: PMessage) :: PMessage where
       AppendMessageSym2 a0123456789876543210 a0123456789876543210 = AppendMessage a0123456789876543210 a0123456789876543210
     type AppendMessage :: PMessage -> PMessage -> PMessage
-    type family AppendMessage a a where
+    type family AppendMessage (a :: PMessage) (a :: PMessage) :: PMessage where
       AppendMessage ('PMkMessage (x :: Symbol)) ('PMkMessage (y :: Symbol)) = Apply PMkMessageSym0 (Apply (Apply (<>@#@$) x) y :: Symbol)
     sAppendMessage ::
       forall (t :: PMessage) (t :: PMessage).
@@ -191,7 +191,7 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
     type PMkFunctionSym0 :: forall (a :: GHC.Types.Type)
                                    (b :: GHC.Types.Type).
                             (~>) ((~>) a b) (PFunction (a :: GHC.Types.Type) (b :: GHC.Types.Type))
-    data PMkFunctionSym0 a0123456789876543210
+    data PMkFunctionSym0 :: (~>) ((~>) a b) (PFunction (a :: GHC.Types.Type) (b :: GHC.Types.Type))
       where
         PMkFunctionSym0KindInference :: SameKind (Apply PMkFunctionSym0 arg) (PMkFunctionSym1 arg) =>
                                         PMkFunctionSym0 a0123456789876543210
@@ -202,12 +202,14 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
     type PMkFunctionSym1 :: forall (a :: GHC.Types.Type)
                                    (b :: GHC.Types.Type).
                             (~>) a b -> PFunction (a :: GHC.Types.Type) (b :: GHC.Types.Type)
-    type family PMkFunctionSym1 a0123456789876543210 where
+    type family PMkFunctionSym1 (a0123456789876543210 :: (~>) a b) :: PFunction (a :: GHC.Types.Type) (b :: GHC.Types.Type) where
       PMkFunctionSym1 a0123456789876543210 = 'PMkFunction a0123456789876543210
     type SFunction :: forall (a :: GHC.Types.Type)
                              (b :: GHC.Types.Type).
                       PFunction a b -> GHC.Types.Type
-    data SFunction z
+    data SFunction :: forall (a :: GHC.Types.Type)
+                             (b :: GHC.Types.Type).
+                      PFunction a b -> GHC.Types.Type
       where
         SMkFunction :: forall (a :: GHC.Types.Type)
                               (b :: GHC.Types.Type)
@@ -231,7 +233,7 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
       (MkFunction (g :: a -> b))
       = MkFunction ((f . g) :: a -> c)
     type ComposeFunctionSym0 :: (~>) (PFunction b c) ((~>) (PFunction a b) (PFunction a c))
-    data ComposeFunctionSym0 a0123456789876543210
+    data ComposeFunctionSym0 :: (~>) (PFunction b c) ((~>) (PFunction a b) (PFunction a c))
       where
         ComposeFunctionSym0KindInference :: SameKind (Apply ComposeFunctionSym0 arg) (ComposeFunctionSym1 arg) =>
                                             ComposeFunctionSym0 a0123456789876543210
@@ -241,7 +243,7 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ComposeFunctionSym0KindInference) ())
     type ComposeFunctionSym1 :: PFunction b c
                                 -> (~>) (PFunction a b) (PFunction a c)
-    data ComposeFunctionSym1 a0123456789876543210 a0123456789876543210
+    data ComposeFunctionSym1 (a0123456789876543210 :: PFunction b c) :: (~>) (PFunction a b) (PFunction a c)
       where
         ComposeFunctionSym1KindInference :: SameKind (Apply (ComposeFunctionSym1 a0123456789876543210) arg) (ComposeFunctionSym2 a0123456789876543210 arg) =>
                                             ComposeFunctionSym1 a0123456789876543210 a0123456789876543210
@@ -251,11 +253,11 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
         = snd (((,) ComposeFunctionSym1KindInference) ())
     type ComposeFunctionSym2 :: PFunction b c
                                 -> PFunction a b -> PFunction a c
-    type family ComposeFunctionSym2 a0123456789876543210 a0123456789876543210 where
+    type family ComposeFunctionSym2 (a0123456789876543210 :: PFunction b c) (a0123456789876543210 :: PFunction a b) :: PFunction a c where
       ComposeFunctionSym2 a0123456789876543210 a0123456789876543210 = ComposeFunction a0123456789876543210 a0123456789876543210
     type ComposeFunction :: PFunction b c
                             -> PFunction a b -> PFunction a c
-    type family ComposeFunction a a where
+    type family ComposeFunction (a :: PFunction b c) (a :: PFunction a b) :: PFunction a c where
       ComposeFunction ('PMkFunction (f :: (~>) b c)) ('PMkFunction (g :: (~>) a b)) = Apply PMkFunctionSym0 (Apply (Apply (.@#@$) f) g :: (~>) a c)
     sComposeFunction ::
       forall b c a (t :: PFunction b c) (t :: PFunction a b).

--- a/singletons-base/tests/compile-and-dump/Singletons/T453.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T453.golden
@@ -13,8 +13,8 @@ Singletons/T453.hs:(0,0)-(0,0): Splicing declarations
     type T2 :: k -> Type
     data T2 a
     type ST1 :: forall k (a :: k). T1 a -> Type
-    data ST1 z
+    data ST1 :: forall k (a :: k). T1 a -> Type
     type instance Sing @(T1 a) = ST1
     type ST2 :: forall k (a :: k). T2 a -> Type
-    data ST2 z
+    data ST2 :: forall k (a :: k). T2 a -> Type
     type instance Sing @(T2 a) = ST2

--- a/singletons-base/tests/compile-and-dump/Singletons/T54.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T54.golden
@@ -23,7 +23,7 @@ Singletons/T54.hs:(0,0)-(0,0): Splicing declarations
     type family Case_0123456789876543210 e t where
       Case_0123456789876543210 e '[_] = NotSym0
     type GSym0 :: (~>) Bool Bool
-    data GSym0 a0123456789876543210
+    data GSym0 :: (~>) Bool Bool
       where
         GSym0KindInference :: SameKind (Apply GSym0 arg) (GSym1 arg) =>
                               GSym0 a0123456789876543210
@@ -31,10 +31,10 @@ Singletons/T54.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings GSym0 where
       suppressUnusedWarnings = snd (((,) GSym0KindInference) ())
     type GSym1 :: Bool -> Bool
-    type family GSym1 a0123456789876543210 where
+    type family GSym1 (a0123456789876543210 :: Bool) :: Bool where
       GSym1 a0123456789876543210 = G a0123456789876543210
     type G :: Bool -> Bool
-    type family G a where
+    type family G (a :: Bool) :: Bool where
       G e = Apply (Case_0123456789876543210 e (Let0123456789876543210Scrutinee_0123456789876543210Sym1 e)) e
     sG :: forall (t :: Bool). Sing t -> Sing (Apply GSym0 t :: Bool)
     sG (sE :: Sing e)

--- a/singletons-base/tests/compile-and-dump/Singletons/T78.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T78.golden
@@ -10,7 +10,7 @@ Singletons/T78.hs:(0,0)-(0,0): Splicing declarations
     foo (Just True) = True
     foo Nothing = False
     type FooSym0 :: (~>) (Maybe Bool) Bool
-    data FooSym0 a0123456789876543210
+    data FooSym0 :: (~>) (Maybe Bool) Bool
       where
         FooSym0KindInference :: SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
                                 FooSym0 a0123456789876543210
@@ -18,10 +18,10 @@ Singletons/T78.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings = snd (((,) FooSym0KindInference) ())
     type FooSym1 :: Maybe Bool -> Bool
-    type family FooSym1 a0123456789876543210 where
+    type family FooSym1 (a0123456789876543210 :: Maybe Bool) :: Bool where
       FooSym1 a0123456789876543210 = Foo a0123456789876543210
     type Foo :: Maybe Bool -> Bool
-    type family Foo a where
+    type family Foo (a :: Maybe Bool) :: Bool where
       Foo ('Just 'False) = FalseSym0
       Foo ('Just 'True) = TrueSym0
       Foo 'Nothing = FalseSym0

--- a/singletons-base/tests/compile-and-dump/Singletons/TopLevelPatterns.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/TopLevelPatterns.golden
@@ -6,13 +6,13 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
     data Bool = False | True
     data Foo = Bar Bool Bool
     type FalseSym0 :: Bool
-    type family FalseSym0 where
+    type family FalseSym0 :: Bool where
       FalseSym0 = False
     type TrueSym0 :: Bool
-    type family TrueSym0 where
+    type family TrueSym0 :: Bool where
       TrueSym0 = True
     type BarSym0 :: (~>) Bool ((~>) Bool Foo)
-    data BarSym0 a0123456789876543210
+    data BarSym0 :: (~>) Bool ((~>) Bool Foo)
       where
         BarSym0KindInference :: SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
                                 BarSym0 a0123456789876543210
@@ -21,7 +21,7 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = Data.Tuple.snd (((,) BarSym0KindInference) ())
     type BarSym1 :: Bool -> (~>) Bool Foo
-    data BarSym1 a0123456789876543210 a0123456789876543210
+    data BarSym1 (a0123456789876543210 :: Bool) :: (~>) Bool Foo
       where
         BarSym1KindInference :: SameKind (Apply (BarSym1 a0123456789876543210) arg) (BarSym2 a0123456789876543210 arg) =>
                                 BarSym1 a0123456789876543210 a0123456789876543210
@@ -30,7 +30,7 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = Data.Tuple.snd (((,) BarSym1KindInference) ())
     type BarSym2 :: Bool -> Bool -> Foo
-    type family BarSym2 a0123456789876543210 a0123456789876543210 where
+    type family BarSym2 (a0123456789876543210 :: Bool) (a0123456789876543210 :: Bool) :: Foo where
       BarSym2 a0123456789876543210 a0123456789876543210 = Bar a0123456789876543210 a0123456789876543210
     data SBool :: Bool -> GHC.Types.Type
       where
@@ -130,23 +130,23 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
       Case_0123456789876543210 a_0123456789876543210 '[y_0123456789876543210,
                                                        _] = y_0123456789876543210
     type MSym0 :: Bool
-    type family MSym0 where
+    type family MSym0 :: Bool where
       MSym0 = M
     type LSym0 :: Bool
-    type family LSym0 where
+    type family LSym0 :: Bool where
       LSym0 = L
     type family X_0123456789876543210Sym0 where
       X_0123456789876543210Sym0 = X_0123456789876543210
     type KSym0 :: Bool
-    type family KSym0 where
+    type family KSym0 :: Bool where
       KSym0 = K
     type JSym0 :: Bool
-    type family JSym0 where
+    type family JSym0 :: Bool where
       JSym0 = J
     type family X_0123456789876543210Sym0 where
       X_0123456789876543210Sym0 = X_0123456789876543210
     type ISym0 :: (~>) Bool Bool
-    data ISym0 a0123456789876543210
+    data ISym0 :: (~>) Bool Bool
       where
         ISym0KindInference :: SameKind (Apply ISym0 arg) (ISym1 arg) =>
                               ISym0 a0123456789876543210
@@ -155,10 +155,10 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = Data.Tuple.snd (((,) ISym0KindInference) ())
     type ISym1 :: Bool -> Bool
-    type family ISym1 a0123456789876543210 where
+    type family ISym1 (a0123456789876543210 :: Bool) :: Bool where
       ISym1 a0123456789876543210 = I a0123456789876543210
     type HSym0 :: (~>) Bool Bool
-    data HSym0 a0123456789876543210
+    data HSym0 :: (~>) Bool Bool
       where
         HSym0KindInference :: SameKind (Apply HSym0 arg) (HSym1 arg) =>
                               HSym0 a0123456789876543210
@@ -167,12 +167,12 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = Data.Tuple.snd (((,) HSym0KindInference) ())
     type HSym1 :: Bool -> Bool
-    type family HSym1 a0123456789876543210 where
+    type family HSym1 (a0123456789876543210 :: Bool) :: Bool where
       HSym1 a0123456789876543210 = H a0123456789876543210
     type family X_0123456789876543210Sym0 where
       X_0123456789876543210Sym0 = X_0123456789876543210
     type GSym0 :: (~>) Bool Bool
-    data GSym0 a0123456789876543210
+    data GSym0 :: (~>) Bool Bool
       where
         GSym0KindInference :: SameKind (Apply GSym0 arg) (GSym1 arg) =>
                               GSym0 a0123456789876543210
@@ -181,10 +181,10 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = Data.Tuple.snd (((,) GSym0KindInference) ())
     type GSym1 :: Bool -> Bool
-    type family GSym1 a0123456789876543210 where
+    type family GSym1 (a0123456789876543210 :: Bool) :: Bool where
       GSym1 a0123456789876543210 = G a0123456789876543210
     type FSym0 :: (~>) Bool Bool
-    data FSym0 a0123456789876543210
+    data FSym0 :: (~>) Bool Bool
       where
         FSym0KindInference :: SameKind (Apply FSym0 arg) (FSym1 arg) =>
                               FSym0 a0123456789876543210
@@ -193,14 +193,14 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = Data.Tuple.snd (((,) FSym0KindInference) ())
     type FSym1 :: Bool -> Bool
-    type family FSym1 a0123456789876543210 where
+    type family FSym1 (a0123456789876543210 :: Bool) :: Bool where
       FSym1 a0123456789876543210 = F a0123456789876543210
     type family X_0123456789876543210Sym0 where
       X_0123456789876543210Sym0 = X_0123456789876543210
     type family False_Sym0 where
       False_Sym0 = False_
     type NotSym0 :: (~>) Bool Bool
-    data NotSym0 a0123456789876543210
+    data NotSym0 :: (~>) Bool Bool
       where
         NotSym0KindInference :: SameKind (Apply NotSym0 arg) (NotSym1 arg) =>
                                 NotSym0 a0123456789876543210
@@ -209,10 +209,10 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = Data.Tuple.snd (((,) NotSym0KindInference) ())
     type NotSym1 :: Bool -> Bool
-    type family NotSym1 a0123456789876543210 where
+    type family NotSym1 (a0123456789876543210 :: Bool) :: Bool where
       NotSym1 a0123456789876543210 = Not a0123456789876543210
     type IdSym0 :: (~>) a a
-    data IdSym0 a0123456789876543210
+    data IdSym0 :: (~>) a a
       where
         IdSym0KindInference :: SameKind (Apply IdSym0 arg) (IdSym1 arg) =>
                                IdSym0 a0123456789876543210
@@ -221,54 +221,54 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
       suppressUnusedWarnings
         = Data.Tuple.snd (((,) IdSym0KindInference) ())
     type IdSym1 :: a -> a
-    type family IdSym1 a0123456789876543210 where
+    type family IdSym1 (a0123456789876543210 :: a) :: a where
       IdSym1 a0123456789876543210 = Id a0123456789876543210
     type OtherwiseSym0 :: Bool
-    type family OtherwiseSym0 where
+    type family OtherwiseSym0 :: Bool where
       OtherwiseSym0 = Otherwise
     type M :: Bool
-    type family M where
+    type family M :: Bool where
       M = Case_0123456789876543210 X_0123456789876543210Sym0
     type L :: Bool
-    type family L where
+    type family L :: Bool where
       L = Case_0123456789876543210 X_0123456789876543210Sym0
     type family X_0123456789876543210 where
       X_0123456789876543210 = Apply (Apply (:@#@$) (Apply NotSym0 TrueSym0)) (Apply (Apply (:@#@$) (Apply IdSym0 FalseSym0)) NilSym0)
     type K :: Bool
-    type family K where
+    type family K :: Bool where
       K = Case_0123456789876543210 X_0123456789876543210Sym0
     type J :: Bool
-    type family J where
+    type family J :: Bool where
       J = Case_0123456789876543210 X_0123456789876543210Sym0
     type family X_0123456789876543210 where
       X_0123456789876543210 = Apply (Apply BarSym0 TrueSym0) (Apply HSym0 FalseSym0)
     type I :: Bool -> Bool
-    type family I a where
+    type family I (a :: Bool) :: Bool where
       I a_0123456789876543210 = Apply (Case_0123456789876543210 a_0123456789876543210 X_0123456789876543210Sym0) a_0123456789876543210
     type H :: Bool -> Bool
-    type family H a where
+    type family H (a :: Bool) :: Bool where
       H a_0123456789876543210 = Apply (Case_0123456789876543210 a_0123456789876543210 X_0123456789876543210Sym0) a_0123456789876543210
     type family X_0123456789876543210 where
       X_0123456789876543210 = Apply (Apply Tuple2Sym0 FSym0) GSym0
     type G :: Bool -> Bool
-    type family G a where
+    type family G (a :: Bool) :: Bool where
       G a_0123456789876543210 = Apply (Case_0123456789876543210 a_0123456789876543210 X_0123456789876543210Sym0) a_0123456789876543210
     type F :: Bool -> Bool
-    type family F a where
+    type family F (a :: Bool) :: Bool where
       F a_0123456789876543210 = Apply (Case_0123456789876543210 a_0123456789876543210 X_0123456789876543210Sym0) a_0123456789876543210
     type family X_0123456789876543210 where
       X_0123456789876543210 = Apply (Apply (:@#@$) NotSym0) (Apply (Apply (:@#@$) IdSym0) NilSym0)
     type family False_ where
       False_ = FalseSym0
     type Not :: Bool -> Bool
-    type family Not a where
+    type family Not (a :: Bool) :: Bool where
       Not 'True = FalseSym0
       Not 'False = TrueSym0
     type Id :: a -> a
-    type family Id a where
+    type family Id (a :: a) :: a where
       Id x = x
     type Otherwise :: Bool
-    type family Otherwise where
+    type family Otherwise :: Bool where
       Otherwise = TrueSym0
     sM :: Sing (MSym0 :: Bool)
     sL :: Sing (LSym0 :: Bool)

--- a/singletons-base/tests/compile-and-dump/Singletons/Undef.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Undef.golden
@@ -10,7 +10,7 @@ Singletons/Undef.hs:(0,0)-(0,0): Splicing declarations
     bar :: Bool -> Bool
     bar = error "urk"
     type BarSym0 :: (~>) Bool Bool
-    data BarSym0 a0123456789876543210
+    data BarSym0 :: (~>) Bool Bool
       where
         BarSym0KindInference :: SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
                                 BarSym0 a0123456789876543210
@@ -18,10 +18,10 @@ Singletons/Undef.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings BarSym0 where
       suppressUnusedWarnings = snd (((,) BarSym0KindInference) ())
     type BarSym1 :: Bool -> Bool
-    type family BarSym1 a0123456789876543210 where
+    type family BarSym1 (a0123456789876543210 :: Bool) :: Bool where
       BarSym1 a0123456789876543210 = Bar a0123456789876543210
     type FooSym0 :: (~>) Bool Bool
-    data FooSym0 a0123456789876543210
+    data FooSym0 :: (~>) Bool Bool
       where
         FooSym0KindInference :: SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
                                 FooSym0 a0123456789876543210
@@ -29,13 +29,13 @@ Singletons/Undef.hs:(0,0)-(0,0): Splicing declarations
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings = snd (((,) FooSym0KindInference) ())
     type FooSym1 :: Bool -> Bool
-    type family FooSym1 a0123456789876543210 where
+    type family FooSym1 (a0123456789876543210 :: Bool) :: Bool where
       FooSym1 a0123456789876543210 = Foo a0123456789876543210
     type Bar :: Bool -> Bool
-    type family Bar a where
+    type family Bar (a :: Bool) :: Bool where
       Bar a_0123456789876543210 = Apply (Apply ErrorSym0 "urk") a_0123456789876543210
     type Foo :: Bool -> Bool
-    type family Foo a where
+    type family Foo (a :: Bool) :: Bool where
       Foo a_0123456789876543210 = Apply UndefinedSym0 a_0123456789876543210
     sBar ::
       forall (t :: Bool). Sing t -> Sing (Apply BarSym0 t :: Bool)

--- a/singletons-th/src/Data/Singletons/SuppressUnusedWarnings.hs
+++ b/singletons-th/src/Data/Singletons/SuppressUnusedWarnings.hs
@@ -17,5 +17,5 @@ import Data.Kind
 -- to use an otherwise-unused data constructor, such as the "kind-inference"
 -- data constructor for defunctionalization symbols.
 type SuppressUnusedWarnings :: k -> Constraint
-class SuppressUnusedWarnings t where
+class SuppressUnusedWarnings (t :: k) where
   suppressUnusedWarnings :: ()


### PR DESCRIPTION
Unfortunately, a Haddock limitation (discussed in #466) causes standalone kind signatures not to be rendered at all, which makes the Haddocks for much of `singletons-base` omit crucial kind information. To work around this Haddock limitation, this patch generates extra argument and result kinds in the bodies of type-level declarations. See `Note [Keep redundant kind information for Haddocks]` in `D.S.Promote`.