### PR TITLE
Make Prelude.Singletons mirror the Prelude more closely

### DIFF
--- a/singletons-base/CHANGES.md
+++ b/singletons-base/CHANGES.md
@@ -64,6 +64,33 @@ Changelog for singletons-base project
   and `Pred`). This is done in an effort to make importing `Prelude.Singletons`
   less likely to induce name clashes with code that works over unary natural
   numbers, which often use the names "`Succ`" and "`Pred`".
+* An effort has been made to make the API of `Prelude.Singletons` more closely
+  mirror that of the `Prelude` in `base`. As a result, `Prelude.Singletons` now
+  exports some different functions than it used to. In particular, it now
+  exports the following:
+
+  * `Until`/`sUntil`/`UntilSym{N}`
+  * `type (++@#@$$$)`
+  * `type (.@#@$$$$)`
+  * `FlipSym3`
+  * `type (!!)`/`(%!!)`/`type (!!@#@{$})`
+  * `Length`/`sLength`/`LengthSym{N}`
+  * `DropWhile`/`sDropWhile`
+  * `LookupSym{N}`
+  * `Unzip3Sym{N}`
+
+  `Prelude.Singletons` also used to export some things that were _not_ exported
+  by the `Prelude`. Accordingly, these exports have been removed from
+  `Prelude.Singletons`. They are:
+
+  * `(^)`/`(%^)`/`type (^@#@{$})`. Although the `Prelude` does define a
+    function named `(^)`, it is more general than the one defined in
+    `singletons-base`, which only works on `Nat`s. Import
+    `GHC.TypeLits.Singletons` if you wish to use the `Nat`-specific versions.
+  * `DefaultEq`, which has no counterpart in the `Prelude`.
+    Import `Data.Eq.Singletons` if you wish to use this.
+  * `bool_`, which has no counterpart in the `Prelude`.
+    Import `Data.Bool.Singletons` if you wish to use this.
 * Two previously public-facing modules—`Data.Singletons.Prelude.Base` and
   `Data.Singletons.Prelude.Num`—have been turned into internal modules. The
   contents of these modules are re-exported from `Prelude.Singletons`, so that

--- a/singletons-base/src/Prelude/Singletons.hs
+++ b/singletons-base/src/Prelude/Singletons.hs
@@ -18,62 +18,115 @@
 ----------------------------------------------------------------------------
 
 {-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE NoStarIsType #-}
 module Prelude.Singletons (
   -- * Basic singleton definitions
   module Data.Singletons,
 
-  -- * Singleton types
+  -- * Promoted and singled types, classes, and related functions
 
-  SBool(..), SList(..), SMaybe(..), SEither(..), SOrdering(..),
+  -- ** Basic data types
+  SBool(SFalse, STrue),
+  If, sIf,
+  type (&&), (%&&), type (||), (%||), Not, sNot, Otherwise, sOtherwise,
+
+  SMaybe(SNothing, SJust),
+  -- | 'maybe_' is a reimplementation of the 'maybe' function with a different
+  -- name to avoid clashing with the 'Maybe' data type when promoted.
+  maybe_, Maybe_, sMaybe_,
+
+  SEither(SLeft, SRight),
+  -- | 'either_' is a reimplementation of the 'either' function with a different
+  -- name to avoid clashing with the 'Either' data type when promoted.
+  either_, Either_, sEither_,
+
+  SOrdering(SLT, SEQ, SGT),
+  SChar, Symbol, -- The closest things we have to Char and String
+  SList(..),
+
+  -- *** Tuples
   STuple0(..), STuple2(..), STuple3(..), STuple4(..),
   STuple5(..), STuple6(..), STuple7(..),
+  Fst, sFst, Snd, sSnd, Curry, sCurry, Uncurry, sUncurry,
 
-  -- * Functions working with 'Bool'
-  If, sIf, Not, sNot, type (&&), type (||), (%&&), (%||), Otherwise, sOtherwise,
-
-  -- * Error reporting
-  Error, sError,
-  ErrorWithoutStackTrace, sErrorWithoutStackTrace,
-  Undefined, sUndefined,
-
-  -- * Singleton equality
-  module Data.Eq.Singletons,
-
-  -- * Singleton comparisons
-  POrd(..), SOrd(..),
-
-  -- * Singleton Enum and Bounded
-  -- | As a matter of convenience, the @singletons-base@ Prelude does /not/ export
+  -- ** Basic type classes
+  PEq(type (==), type (/=)), SEq((%==), (%/=)),
+  POrd(Compare, type (<), type (<=), type (>=), type (>), Max, Min),
+  SOrd(sCompare, (%<), (%<=), (%>=), (%>), sMax, sMin),
+  -- | As a matter of convenience, the "Prelude.Singletons" does /not/ export
   -- promoted/singletonized @succ@ and @pred@, due to likely conflicts with
   -- unary numbers. Please import "Data.Singletons.Base.Enum" directly if
   -- you want these.
-  module Data.Singletons.Base.Enum,
+  PEnum( -- Succ, Pred,
+         ToEnum, FromEnum,
+         {-
+         See the comments in Data.Singletons.Base.Enum for why these are not defined.
+         -}
+         -- EnumFrom, EnumFromThen,
+         EnumFromTo, EnumFromThenTo),
+  SEnum( -- sSucc, sPred,
+         sToEnum, sFromEnum,
+         {-
+         See the comments in Data.Singletons.Base.Enum for why these are not defined.
+         -}
+         -- sEnumFrom, sEnumFromThen,
+         sEnumFromTo, sEnumFromThenTo),
+  PBounded(MinBound, MaxBound), SBounded(sMinBound, sMaxBound),
 
-  -- * Singletons numbers
-  module GHC.Num.Singletons,
-  type (^), (%^),
+  -- ** Numbers
 
-  -- * Singleton 'Show'
-  PShow(..), SShow(..), ShowS, SChar,
-  Shows, sShows, ShowChar, sShowChar, ShowString, sShowString, ShowParen, sShowParen,
+  {-
+  There are no singled counterparts to any of the following numeric types. The
+  closest thing is Nat, which we deliberately do not export to avoid clashing
+  with unary natural number data types.
 
-  -- * Singleton 'Semigroup' and 'Monoid'
+  -- *** Numeric types
+  Int, Integer, Float, Double,
+  Rational, Word,
+  -}
+
+  -- *** Numeric type classes
+  PNum(type (+), type (-), type (*), Negate, Abs, Signum, FromInteger),
+  SNum((%+), (%-), (%*), sNegate, sAbs, sSignum, sFromInteger),
+  {-
+  We currently do not promote or single any of the following classes. Some
+  of these functions have Nat-specialized versions in GHC.TypeLits.Singletons,
+  however (e.g., Div and Mod).
+  -}
+  -- Real(toRational),
+  -- Integral(quot, rem, div, mod, quotRem, divMod, toInteger),
+  -- Fractional((/), recip, fromRational),
+  -- Floating(pi, exp, log, sqrt, (**), logBase, sin, cos, tan,
+  --          asin, acos, atan, sinh, cosh, tanh, asinh, acosh, atanh),
+  -- RealFrac(properFraction, truncate, round, ceiling, floor),
+  -- RealFloat(floatRadix, floatDigits, floatRange, decodeFloat,
+  --           encodeFloat, exponent, significand, scaleFloat, isNaN,
+  --           isInfinite, isDenormalized, isIEEE, isNegativeZero, atan2),
+
+  -- *** Numeric functions
+  Subtract, sSubtract,
+  {-
+  The following functions require classes such as Integral, Real, and
+  Fractional, which we do not promote or single. Some of these functions have
+  Nat-specialized versions in GHC.TypeLits.Singletons, however (e.g., (^)).
+  -}
+  -- even, odd, gcd, lcm, (^), (^^),
+  -- fromIntegral, realToFrac,
+
+  -- ** Semigroups and Monoids
   PSemigroup(type (<>)), SSemigroup((%<>)),
-  PMonoid(..), SMonoid(..),
+  PMonoid(Mempty, Mappend, Mconcat), SMonoid(sMempty, sMappend, sMconcat),
 
-  -- * Singleton 'Functor', 'Applicative', 'Monad', and 'MonadFail'
+  -- ** Monads and functors
   PFunctor(Fmap, type (<$)), SFunctor(sFmap, (%<$)), type (<$>), (%<$>),
   PApplicative(Pure, type (<*>), type (*>), type (<*)),
   SApplicative(sPure, (%<*>), (%*>), (%<*)),
   PMonad(type (>>=), type (>>), Return),
   SMonad((%>>=), (%>>), sReturn),
   PMonadFail(Fail), SMonadFail(sFail),
+  MapM_, sMapM_, Sequence_, sSequence_, type (=<<), (%=<<),
 
-  MapM_, sMapM_,
-  Sequence_, sSequence_,
-  type (=<<), (%=<<),
-
-  -- * Singleton 'Foldable' and 'Traversable'
+  -- ** Folds and traversals
   PFoldable(Elem, FoldMap, Foldr, Foldl, Foldr1, Foldl1,
             Maximum, Minimum, Product, Sum),
   SFoldable(sElem, sFoldMap, sFoldr, sFoldl, sFoldr1, sFoldl1,
@@ -82,49 +135,99 @@ module Prelude.Singletons (
   STraversable(sTraverse, sSequenceA, sMapM, sSequence),
 
   -- ** Miscellaneous functions
-  Id, sId, Const, sConst, type (.), (%.), type ($), (%$), type ($!), (%$!),
-  Flip, sFlip, AsTypeOf, sAsTypeOf,
-  Seq, sSeq,
+  Id, sId, Const, sConst, type (.), (%.), Flip, sFlip, type ($), (%$), Until, sUntil,
+  AsTypeOf, sAsTypeOf,
+  Error, sError, ErrorWithoutStackTrace, sErrorWithoutStackTrace,
+  Undefined, sUndefined,
+  Seq, sSeq, type ($!), (%$!),
 
   -- * List operations
   Map, sMap, type (++), (%++), Filter, sFilter,
-  Head, sHead, Last, sLast, Tail, sTail,
-  Init, sInit, Null, sNull, Reverse, sReverse,
+  Head, sHead, Last, sLast, Tail, sTail, Init, sInit, type (!!), (%!!),
+  Null, sNull, Length, sLength,
+  Reverse, sReverse,
   -- *** Special folds
   And, sAnd, Or, sOr, Any, sAny, All, sAll,
   Concat, sConcat, ConcatMap, sConcatMap,
+  -- ** Building lists
   -- *** Scans
   Scanl, sScanl, Scanl1, sScanl1, Scanr, sScanr, Scanr1, sScanr1,
   -- *** Infinite lists
+  {-
+  Unsurprisingly, most operations on infinite lists won't promote.
+  The `replicate` function is the lone exception.
+  -}
+  -- iterate, repeat,
   Replicate, sReplicate,
+  -- cycle,
   -- ** Sublists
-  Take, sTake, Drop, sDrop, SplitAt, sSplitAt, TakeWhile, sTakeWhile,
+  Take, sTake, Drop, sDrop,
+  TakeWhile, sTakeWhile, DropWhile, sDropWhile,
   Span, sSpan, Break, sBreak,
+  SplitAt, sSplitAt,
   -- ** Searching lists
-  NotElem, sNotElem, Lookup, sLookup,
+  NotElem, sNotElem,
+  Lookup, sLookup,
   -- ** Zipping and unzipping lists
-  Zip, sZip, Zip3, sZip3, ZipWith, sZipWith, ZipWith3, sZipWith3,
+  Zip, sZip, Zip3, sZip3,
+  ZipWith, sZipWith, ZipWith3, sZipWith3,
   Unzip, sUnzip, Unzip3, sUnzip3,
-  -- ** Functions on 'Symbol's
+  -- ** Functions on @Symbol@s
+  {-
+  The `lines` and `words` functions cannot yet be promoted.
+  See the comments in `Data.List.Singletons.Internal`.
+  -}
+  -- lines, words,
   Unlines, sUnlines, Unwords, sUnwords,
 
-  -- * Other datatypes
-  Maybe_, sMaybe_,
-  Either_, sEither_,
-  Fst, sFst, Snd, sSnd, Curry, sCurry, Uncurry, sUncurry,
-  Symbol,
-
-  -- * Other functions
-  either_, -- reimplementation of either to be used with singletons-base library
-  maybe_,
-  bool_,
+  -- * Converting to and from @Symbol@
+  -- ** Converting to @Symbol@
+  SymbolS,
   show_,
+  PShow(ShowsPrec, ShowList, Show_), SShow(sShowsPrec, sShowList, sShow_),
+  Shows, sShows,
+  ShowChar, sShowChar, ShowString, sShowString, ShowParen, sShowParen,
+  {-
+  We do not currently promote or single the Read class.
+
+  -- ** Converting from @Symbol@
+  ReadS,
+  Read(readsPrec, readList),
+  reads, readParen, read, lex,
+  -}
+
+  {-
+  We do not promote or single anything involving IO.
+
+  -- * Basic Input and output
+  IO,
+  -- ** Simple I\/O operations
+  -- All I/O functions defined here are character oriented.  The
+  -- treatment of the newline character will vary on different systems.
+  -- For example, two characters of input, return and linefeed, may
+  -- read as a single newline character.  These functions cannot be
+  -- used portably for binary I/O.
+  -- *** Output functions
+  putChar,
+  putStr, putStrLn, print,
+  -- *** Input functions
+  getChar,
+  getLine, getContents, interact,
+  -- *** Files
+  FilePath,
+  readFile, writeFile, appendFile, readIO, readLn,
+  -- ** Exception handling in the I\/O monad
+  IOError, ioError, userError,
+  -}
 
   -- * Defunctionalization symbols
+
+  -- ** Basic data types
   FalseSym0, TrueSym0,
-  NotSym0, NotSym1,
+  IfSym0, IfSym1, IfSym2, IfSym3,
   type (&&@#@$), type (&&@#@$$), type (&&@#@$$$),
   type (||@#@$), type (||@#@$$), type (||@#@$$$),
+  NotSym0, NotSym1,
   OtherwiseSym0,
 
   NothingSym0, JustSym0, JustSym1,
@@ -133,6 +236,10 @@ module Prelude.Singletons (
   LeftSym0, LeftSym1, RightSym0, RightSym1,
   Either_Sym0, Either_Sym1, Either_Sym2, Either_Sym3,
 
+  LTSym0, EQSym0, GTSym0,
+  (:@#@$), (:@#@$$), (:@#@$$$), NilSym0,
+
+  -- *** Tuples
   Tuple0Sym0,
   Tuple2Sym0, Tuple2Sym1, Tuple2Sym2,
   Tuple3Sym0, Tuple3Sym1, Tuple3Sym2, Tuple3Sym3,
@@ -144,11 +251,10 @@ module Prelude.Singletons (
   CurrySym0, CurrySym1, CurrySym2, CurrySym3,
   UncurrySym0, UncurrySym1, UncurrySym2,
 
-  ErrorSym0, ErrorSym1,
-  ErrorWithoutStackTraceSym0, ErrorWithoutStackTraceSym1,
-  UndefinedSym0,
+  -- ** Basic type classes
+  type (==@#@$), type (==@#@$$), type (==@#@$$$),
+  type (/=@#@$), type (/=@#@$$), type (/=@#@$$$),
 
-  LTSym0, EQSym0, GTSym0,
   CompareSym0, CompareSym1, CompareSym2,
   type (<@#@$),  type (<@#@$$),  type (<@#@$$$),
   type (<=@#@$), type (<=@#@$$), type (<=@#@$$$),
@@ -157,21 +263,34 @@ module Prelude.Singletons (
   MaxSym0, MaxSym1, MaxSym2,
   MinSym0, MinSym1, MinSym2,
 
-  type (^@#@$), type (^@#@$$), type (^@#@$$$),
+  ToEnumSym0, ToEnumSym1,
+  FromEnumSym0, FromEnumSym1,
+  EnumFromToSym0, EnumFromToSym1, EnumFromToSym2,
+  EnumFromThenToSym0, EnumFromThenToSym1, EnumFromThenToSym2, EnumFromThenToSym3,
 
-  ShowsPrecSym0, ShowsPrecSym1, ShowsPrecSym2, ShowsPrecSym3,
-  Show_Sym0, Show_Sym1,
-  ShowListSym0, ShowListSym1, ShowListSym2,
-  ShowsSym0, ShowsSym1, ShowsSym2,
-  ShowCharSym0, ShowCharSym1, ShowCharSym2,
-  ShowStringSym0, ShowStringSym1, ShowStringSym2,
-  ShowParenSym0, ShowParenSym1, ShowParenSym2,
+  MinBoundSym0, MaxBoundSym0,
 
+  -- ** Numbers
+
+  -- *** Numeric type classes
+  type (+@#@$), type (+@#@$$), type (+@#@$$$),
+  type (-@#@$), type (-@#@$$), type (-@#@$$$),
+  type (*@#@$), type (*@#@$$), type (*@#@$$$),
+  NegateSym0, NegateSym1,
+  AbsSym0, AbsSym1,
+  SignumSym0, SignumSym1,
+  FromIntegerSym0, FromIntegerSym1,
+
+  -- *** Numeric functions
+  SubtractSym0, SubtractSym1, SubtractSym2,
+
+  -- ** Semigroups and Monoids
   type (<>@#@$), type (<>@#@$$), type (<>@#@$$$),
   MemptySym0,
   MappendSym0, MappendSym1, MappendSym2,
   MconcatSym0, MconcatSym1,
 
+  -- ** Monads and functors
   FmapSym0, FmapSym1, FmapSym2,
   type (<$@#@$),  type (<$@#@$$),  type (<$@#@$$$),
   type (<$>@#@$), type (<$>@#@$$), type (<$>@#@$$$),
@@ -186,6 +305,7 @@ module Prelude.Singletons (
   Sequence_Sym0, Sequence_Sym1,
   type (=<<@#@$), type (=<<@#@$$), type (=<<@#@$$$),
 
+  -- ** Folds and traversals
   ElemSym0, ElemSym1, ElemSym2,
   FoldMapSym0, FoldMapSym1, FoldMapSym2,
   FoldrSym0, FoldrSym1, FoldrSym2, FoldrSym3,
@@ -194,58 +314,81 @@ module Prelude.Singletons (
   Foldl1Sym0, Foldl1Sym1, Foldl1Sym2,
   MaximumSym0, MaximumSym1,
   MinimumSym0, MinimumSym1,
-  SumSym0, SumSym1,
   ProductSym0, ProductSym1,
+  SumSym0, SumSym1,
 
   TraverseSym0, TraverseSym1, TraverseSym2,
   SequenceASym0, SequenceASym1,
   MapMSym0, MapMSym1, MapMSym2,
   SequenceSym0, SequenceSym1,
 
+  -- ** Miscellaneous functions
   IdSym0, IdSym1, ConstSym0, ConstSym1, ConstSym2,
-  type (.@#@$),  type (.@#@$$),  type (.@#@$$$),
+  type (.@#@$),  type (.@#@$$),  type (.@#@$$$), type (.@#@$$$$),
+  FlipSym0, FlipSym1, FlipSym2, FlipSym3,
   type ($@#@$),  type ($@#@$$),  type ($@#@$$$),
+  UntilSym0, UntilSym1, UntilSym2, UntilSym3,
+  AsTypeOfSym0, AsTypeOfSym1, AsTypeOfSym2,
+  ErrorSym0, ErrorSym1,
+  ErrorWithoutStackTraceSym0, ErrorWithoutStackTraceSym1,
+  UndefinedSym0,
+  SeqSym0, SeqSym1, SeqSym2,
   type ($!@#@$), type ($!@#@$$), type ($!@#@$$$),
-  FlipSym0, FlipSym1, FlipSym2,
-  AsTypeOfSym0, AsTypeOfSym1, AsTypeOfSym2, SeqSym0, SeqSym1, SeqSym2,
 
-  (:@#@$), (:@#@$$), (:@#@$$$), NilSym0,
-  MapSym0, MapSym1, MapSym2, ReverseSym0, ReverseSym1,
-  type (++@#@$$), type (++@#@$), FilterSym0, FilterSym1, FilterSym2,
+  -- * List operations
+  MapSym0, MapSym1, MapSym2,
+  type (++@#@$), type (++@#@$$), type (++@#@$$$),
+  FilterSym0, FilterSym1, FilterSym2,
   HeadSym0, HeadSym1, LastSym0, LastSym1,
-  TailSym0, TailSym1, InitSym0, InitSym1, NullSym0, NullSym1,
-
-  ConcatSym0, ConcatSym1,
-  ConcatMapSym0, ConcatMapSym1, ConcatMapSym2,
+  TailSym0, TailSym1, InitSym0, InitSym1,
+  type (!!@#@$), type (!!@#@$$), type (!!@#@$$$),
+  NullSym0, NullSym1,
+  LengthSym0, LengthSym1,
+  ReverseSym0, ReverseSym1,
+  -- *** Special folds
   AndSym0, AndSym1, OrSym0, OrSym1,
   AnySym0, AnySym1, AnySym2,
   AllSym0, AllSym1, AllSym2,
-
+  ConcatSym0, ConcatSym1,
+  ConcatMapSym0, ConcatMapSym1, ConcatMapSym2,
+  -- ** Building lists
+  -- *** Scans
   ScanlSym0, ScanlSym1, ScanlSym2, ScanlSym3,
   Scanl1Sym0, Scanl1Sym1, Scanl1Sym2,
   ScanrSym0, ScanrSym1, ScanrSym2, ScanrSym3,
   Scanr1Sym0, Scanr1Sym1, Scanr1Sym2,
-
+  -- *** Infinite lists
   ReplicateSym0, ReplicateSym1, ReplicateSym2,
-
+  -- ** Sublists
   TakeSym0, TakeSym1, TakeSym2,
   DropSym0, DropSym1, DropSym2,
-  SplitAtSym0, SplitAtSym1, SplitAtSym2,
   TakeWhileSym0, TakeWhileSym1, TakeWhileSym2,
   DropWhileSym0, DropWhileSym1, DropWhileSym2,
   DropWhileEndSym0, DropWhileEndSym1, DropWhileEndSym2,
   SpanSym0, SpanSym1, SpanSym2,
   BreakSym0, BreakSym1, BreakSym2,
-
+  SplitAtSym0, SplitAtSym1, SplitAtSym2,
+  -- ** Searching lists
   NotElemSym0, NotElemSym1, NotElemSym2,
-
+  LookupSym0, LookupSym1, LookupSym2,
+  -- ** Zipping and unzipping lists
   ZipSym0, ZipSym1, ZipSym2,
   Zip3Sym0, Zip3Sym1, Zip3Sym2, Zip3Sym3,
   ZipWithSym0, ZipWithSym1, ZipWithSym2, ZipWithSym3,
   ZipWith3Sym0, ZipWith3Sym1, ZipWith3Sym2, ZipWith3Sym3,
-  UnzipSym0, UnzipSym1,
+  UnzipSym0, UnzipSym1, Unzip3Sym0, Unzip3Sym1,
+  -- ** Functions on @Symbol@s
+  UnlinesSym0, UnlinesSym1, UnwordsSym0, UnwordsSym1,
 
-  UnlinesSym0, UnlinesSym1, UnwordsSym0, UnwordsSym1
+  -- * Converting to and from @Symbol@
+  -- ** Converting to @Symbol@
+  ShowsPrecSym0, ShowsPrecSym1, ShowsPrecSym2, ShowsPrecSym3,
+  ShowListSym0, ShowListSym1, ShowListSym2,
+  Show_Sym0, Show_Sym1,
+  ShowsSym0, ShowsSym1, ShowsSym2,
+  ShowCharSym0, ShowCharSym1, ShowCharSym2,
+  ShowStringSym0, ShowStringSym1, ShowStringSym2,
+  ShowParenSym0, ShowParenSym1, ShowParenSym2
   ) where
 
 import Control.Applicative.Singletons

--- a/singletons-base/tests/compile-and-dump/GradingClient/Database.hs
+++ b/singletons-base/tests/compile-and-dump/GradingClient/Database.hs
@@ -28,7 +28,7 @@ import Data.Kind (Type)
 import Data.List hiding ( tail )
 import Data.Singletons.Base.TH
 import Prelude hiding ( tail, id )
-import Prelude.Singletons hiding ( Lookup, sLookup )
+import Prelude.Singletons hiding ( Lookup, sLookup, LookupSym0, LookupSym1, LookupSym2 )
 import Text.Show.Singletons
 
 $(singletons [d|


### PR DESCRIPTION
A recent perusal of `Prelude.Singletons` revealed that there were several functions from the `Prelude` that `Prelude.Singletons` didn't export, and conversely, there were various functions that `Prelude.Singletons` does export that the `Prelude` doesn't! Part of the reason why this went unnoticed for so long is that the structure of `Prelude.Singletons`' exports is rather haphazard, so attempting to eyeball the differences between the export lists of `Prelude.Singletons` and the `Prelude` was unnecessarily difficult.

This cleans things up by restructuring `Prelude.Singletons`' export list to very closely mirror the `Prelude`'s export list. For each exported item in the `Prelude` that `Prelude.Singletons` _doesn't_ export, a comment has been left in the corresponding place in `Prelude.Singletons`. This made it easy to tell which things should (and shouldn't) have been exported from the `Prelude.Singletons`. All such changes have been recorded in the `CHANGES.md` file.

Fixes #465.