### PR TITLE
Delete dead code from D.S.TH.Util

### DIFF
--- a/singletons-th/src/Data/Singletons/TH/Util.hs
+++ b/singletons-th/src/Data/Singletons/TH/Util.hs
@@ -443,12 +443,6 @@ buildDataDTvbs tvbs mk = do
 foldExp :: DExp -> [DExp] -> DExp
 foldExp = foldl DAppE
 
--- is a function type?
-isFunTy :: DType -> Bool
-isFunTy (DAppT (DAppT DArrowT _) _) = True
-isFunTy (DForallT _ _ _)            = True
-isFunTy _                           = False
-
 -- choose the first non-empty list
 orIfEmpty :: [a] -> [a] -> [a]
 orIfEmpty [] x = x


### PR DESCRIPTION
The `D.S.TH.Util.isFunTy` function is rather suspicious, as it returns `True` for `DForallT`. But more to the point, it is not used anywhere. Let's just delete it.