### PR TITLE
Update th-desugar submodule to ca76128

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.10.1
+# version: 0.10.3
 #
 version: ~> 1.0
 language: c
@@ -125,7 +125,7 @@ install:
     echo "source-repository-package"                            >> cabal.project
     echo "  type:     git"                                      >> cabal.project
     echo "  location: https://github.com/goldfirere/th-desugar" >> cabal.project
-    echo "  tag:      5eef50aad9a7db9ad284a427b791891398304fa8" >> cabal.project
+    echo "  tag:      ca761285741c16c704a4044f551faf4292432d6a" >> cabal.project
     echo ""                                                     >> cabal.project
     echo "package th-desugar"                                   >> cabal.project
     echo "  tests:      False"                                  >> cabal.project
@@ -169,7 +169,7 @@ script:
     echo "source-repository-package"                            >> cabal.project
     echo "  type:     git"                                      >> cabal.project
     echo "  location: https://github.com/goldfirere/th-desugar" >> cabal.project
-    echo "  tag:      5eef50aad9a7db9ad284a427b791891398304fa8" >> cabal.project
+    echo "  tag:      ca761285741c16c704a4044f551faf4292432d6a" >> cabal.project
     echo ""                                                     >> cabal.project
     echo "package th-desugar"                                   >> cabal.project
     echo "  tests:      False"                                  >> cabal.project
@@ -189,5 +189,5 @@ script:
   # haddock...
   - if ! $GHCJS ; then ${CABAL} v2-haddock $WITHCOMPILER --with-haddock $HADDOCK ${TEST} ${BENCH} all ; fi
 
-# REGENDATA ("0.10.1",["--output=.travis.yml","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.10.3",["--output=.travis.yml","--config=cabal.haskell-ci","cabal.project"])
 # EOF

--- a/cabal.project
+++ b/cabal.project
@@ -5,4 +5,4 @@ packages: ./singletons
 source-repository-package
   type: git
   location: https://github.com/goldfirere/th-desugar
-  tag: 5eef50aad9a7db9ad284a427b791891398304fa8
+  tag: ca761285741c16c704a4044f551faf4292432d6a

--- a/singletons-base/tests/compile-and-dump/Singletons/T342.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T342.golden
@@ -1,7 +1,8 @@
 Singletons/T342.hs:(0,0)-(0,0): Splicing declarations
     do synName <- newName "MyId"
        a <- newName "a"
-       let syn = TySynD synName [PlainTV a] (VarT a)
+       let dsyn = DTySynD synName [DPlainTV a ()] (DVarT a)
+           syn = decToTH dsyn
        defuns <- withLocalDeclarations [syn] $ genDefunSymbols [synName]
        pure $ syn : defuns
   ======>

--- a/singletons-base/tests/compile-and-dump/Singletons/T342.hs
+++ b/singletons-base/tests/compile-and-dump/Singletons/T342.hs
@@ -6,7 +6,8 @@ import Language.Haskell.TH.Desugar
 
 $(do synName <- newName "MyId"
      a       <- newName "a"
-     let syn = TySynD synName [PlainTV a] (VarT a)
+     let dsyn = DTySynD synName [DPlainTV a ()] (DVarT a)
+         syn  = decToTH dsyn
      defuns <- withLocalDeclarations [syn] $
                genDefunSymbols [synName]
      pure $ syn:defuns)

--- a/singletons-th/src/Data/Singletons/TH/CustomStar.hs
+++ b/singletons-th/src/Data/Singletons/TH/CustomStar.hs
@@ -86,7 +86,7 @@ singletonStar names = do
   -- expanding type synonyms when deriving instances for Rep, which requires
   -- reifying Rep itself. Since Rep hasn't been spliced in yet, we must put it
   -- into the local declarations.
-  withLocalDeclarations (decToTH repDecl) $ do
+  withLocalDeclarations [decToTH repDecl] $ do
     -- We opt to infer the constraints for the Eq instance here so that when it's
     -- promoted, Rep will be promoted to Type.
     dataDeclEqCxt <- inferConstraints (DConT ''Eq) (DConT repName) fakeCtors
@@ -127,7 +127,7 @@ singletonStar names = do
         mkCtor real name args = do
           (types, vars) <- evalForPair $ mapM (kindToType []) args
           dataName <- if real then mkDataName (nameBase name) else return name
-          return $ DCon (map DPlainTV vars) [] dataName
+          return $ DCon (map (`DPlainTV` SpecifiedSpec) vars) [] dataName
                         (DNormalC False (map (\ty -> (noBang, ty)) types))
                         (DConT repName)
             where
@@ -135,7 +135,7 @@ singletonStar names = do
 
         -- demote a kind back to a type, accumulating any unbound parameters
         kindToType :: DsMonad q => [DTypeArg] -> DKind -> QWithAux [Name] q DType
-        kindToType _    (DForallT _ _ _)    = fail "Explicit forall encountered in kind"
+        kindToType _    (DForallT _ _)      = fail "Explicit forall encountered in kind"
         kindToType _    (DConstrainedT _ _) = fail "Explicit constraint encountered in kind"
         kindToType args (DAppT f a) = do
           a' <- kindToType [] a

--- a/singletons-th/src/Data/Singletons/TH/Names.hs
+++ b/singletons-th/src/Data/Singletons/TH/Names.hs
@@ -216,7 +216,7 @@ modifyConNameDType :: (Name -> Name) -> DType -> DType
 modifyConNameDType mod_con_name = go
   where
     go :: DType -> DType
-    go (DForallT fvf tvbs p) = DForallT fvf tvbs (go p)
+    go (DForallT tele p)     = DForallT tele (go p)
     go (DConstrainedT cxt p) = DConstrainedT (map go cxt) (go p)
     go (DAppT     p t)       = DAppT     (go p) t
     go (DAppKindT p k)       = DAppKindT (go p) k

--- a/singletons-th/src/Data/Singletons/TH/Promote/Type.hs
+++ b/singletons-th/src/Data/Singletons/TH/Promote/Type.hs
@@ -29,9 +29,9 @@ promoteType_NC :: OptionsMonad m => DType -> m DKind
 promoteType_NC = go []
   where
     go :: OptionsMonad m => [DTypeArg] -> DType -> m DKind
-    go []       (DForallT fvf tvbs ty) = do
+    go []       (DForallT tele ty) = do
       ty' <- go [] ty
-      pure $ DForallT fvf tvbs ty'
+      pure $ DForallT tele ty'
     -- We don't need to worry about constraints: they are used to express
     -- static guarantees at runtime. But, because we don't need to do
     -- anything special to keep static guarantees at compile time, we don't
@@ -75,7 +75,7 @@ promoteTypeArg_NC ta@(DTyArg _) = pure ta -- Kinds are already promoted
 -- | Promote a DType to the kind level, splitting it into its type variable
 -- binders, argument types, and result type in the process.
 promoteUnraveled :: OptionsMonad m
-                 => DType -> m ([DTyVarBndr], [DKind], DKind)
+                 => DType -> m ([DTyVarBndrSpec], [DKind], DKind)
 promoteUnraveled ty = do
   (tvbs, _, arg_tys, res_ty) <- unravelVanillaDType ty
   arg_kis <- mapM promoteType_NC arg_tys

--- a/singletons-th/src/Data/Singletons/TH/Single/Defun.hs
+++ b/singletons-th/src/Data/Singletons/TH/Single/Defun.hs
@@ -102,7 +102,7 @@ singDefuns n ns ty_ctxt mb_ty_args mb_ty_res =
     -- the @arg_tvbs@ list at each iteration. In practice, this is unlikely
     -- to be a performance bottleneck since the number of arguments rarely
     -- gets to be that large.
-    go :: Options -> Int -> DCxt -> [DTyVarBndr] -> [DTyVarBndr]
+    go :: Options -> Int -> DCxt -> [DTyVarBndrUnit] -> [DTyVarBndrUnit]
        -> (Maybe DKind, [DDec])
     go _    _       _        _        []                 = (mb_ty_res, [])
     go opts sym_num sty_ctxt arg_tvbs (res_tvb:res_tvbs) =
@@ -142,7 +142,7 @@ singDefuns n ns ty_ctxt mb_ty_args mb_ty_res =
         -- If any of the argument kinds or result kind isn't known (i.e., is
         -- Nothing), then we opt not to construct this arrow kind altogether.
         -- See Note [singDefuns and type inference]
-        mk_inst_kind :: DTyVarBndr -> Maybe DKind -> Maybe DKind
+        mk_inst_kind :: DTyVarBndrUnit -> Maybe DKind -> Maybe DKind
         mk_inst_kind tvb' = buildTyFunArrow_maybe (extractTvbKind tvb')
 
         new_inst :: DDec

--- a/singletons-th/src/Data/Singletons/TH/Syntax.hs
+++ b/singletons-th/src/Data/Singletons/TH/Syntax.hs
@@ -46,10 +46,10 @@ instance Monoid PromDPatInfos where
 type SingDSigPaInfos = [(DExp, DType)]
 
 -- The parts of data declarations that are relevant to singletons-th.
-data DataDecl = DataDecl Name [DTyVarBndr] [DCon]
+data DataDecl = DataDecl Name [DTyVarBndrUnit] [DCon]
 
 -- The parts of type synonyms that are relevant to singletons-th.
-data TySynDecl = TySynDecl Name [DTyVarBndr] DType
+data TySynDecl = TySynDecl Name [DTyVarBndrUnit] DType
 
 -- The parts of open type families that are relevant to singletons-th.
 type OpenTypeFamilyDecl = TypeFamilyDecl 'Open
@@ -66,7 +66,7 @@ data FamilyInfo = Open | Closed
 data ClassDecl ann
   = ClassDecl { cd_cxt  :: DCxt
               , cd_name :: Name
-              , cd_tvbs :: [DTyVarBndr]
+              , cd_tvbs :: [DTyVarBndrUnit]
               , cd_fds  :: [FunDep]
               , cd_lde  :: LetDecEnv ann
               , cd_atfs :: [OpenTypeFamilyDecl]


### PR DESCRIPTION
This updates the `th-desugar` submodule to commit goldfirere/th-desugar@ca761285741c16c704a4044f551faf4292432d6a, which incorporates several recent developments:

* `DTyVarBndr`s are now parameterized by a `flag` type parameter. This has several ripple effects throughout `singletons`, as various functions now need to care about `Specificity`.
* `decToTH` returns a `Dec` rather than `[Dec]`. This is used in a handful of places in `singletons` and need to be updated accordingly.
* The type of `dsTvb` is different on pre-9.0 versions of GHC, so we replace uses of `dsTvb` with `dsTvbUnit` in `singletons-th` to ensure backwards compatibility. When we drop support for pre-9.0 versions of GHC in `singletons-th`, we can revisit this.