### PR TITLE
Remove use of Data.Semigroup.Option

### DIFF
--- a/singletons-base/CHANGES.md
+++ b/singletons-base/CHANGES.md
@@ -107,3 +107,7 @@ Changelog for singletons-base project
   [this GitHub issue](https://github.com/goldfirere/singletons/issues/457)
   for more information). `(==)`'s default is now defined in terms of `(/=)`,
   just like its term-level counterpart in the `Eq` class.
+* Since `base-4.15.0.0` now deprecates `Data.Singletons.Option` (in
+  anticipation of its removal in a future version of `base`), this library no
+  longer offers a singleton type for `Option`. Accordingly, the `option_`
+  function has also been removed.

--- a/singletons-base/src/Data/Semigroup/Singletons.hs
+++ b/singletons-base/src/Data/Semigroup/Singletons.hs
@@ -33,13 +33,11 @@ module Data.Semigroup.Singletons (
 
   Sing, SMin(..), SMax(..), SFirst(..), SLast(..),
   SWrappedMonoid(..), SDual(..), SAll(..), SAny(..),
-  SSum(..), SProduct(..), SOption(..), SArg(..),
+  SSum(..), SProduct(..), SArg(..),
   GetMin, GetMax, GetFirst, GetLast, UnwrapMonoid, GetDual,
-  GetAll, GetAny, GetSum, GetProduct, GetOption,
+  GetAll, GetAny, GetSum, GetProduct,
   sGetMin, sGetMax, sGetFirst, sGetLast, sUnwrapMonoid, sGetDual,
-  sGetAll, sGetAny, sGetSum, sGetProduct, sGetOption,
-
-  option_, sOption_, Option_,
+  sGetAll, sGetAny, sGetSum, sGetProduct,
 
   -- ** Defunctionalization symbols
   type (<>@#@$), type (<>@#@$$), type (<>@#@$$$),
@@ -54,12 +52,10 @@ module Data.Semigroup.Singletons (
   AnySym0, AnySym1, GetAnySym0, GetAnySym1,
   SumSym0, SumSym1, GetSumSym0, GetSumSym1,
   ProductSym0, ProductSym1, GetProductSym0, GetProductSym1,
-  OptionSym0, OptionSym1, GetOptionSym0, GetOptionSym1,
   ArgSym0, ArgSym1, ArgSym2
   ) where
 
 import Control.Applicative
-import Control.Monad
 import Control.Monad.Singletons.Internal
 import Data.Eq.Singletons
 import Data.Foldable.Singletons hiding
@@ -67,7 +63,6 @@ import Data.Foldable.Singletons hiding
        , Any,     AnySym0,     AnySym1
        , Product, ProductSym0, ProductSym1
        , Sum,     SumSym0,     SumSym1 )
-import Data.Functor.Singletons
 import Data.Monoid.Singletons hiding
        (SFirst(..), SLast(..),
         FirstSym0, FirstSym1, LastSym0, LastSym1,
@@ -76,9 +71,8 @@ import Data.Monoid.Singletons hiding
 import Data.Ord.Singletons hiding
        (MinSym0, MinSym1, MaxSym0, MaxSym1)
 import Data.Ord.Singletons.Disambiguation
-import Data.Maybe.Singletons
 import qualified Data.Semigroup as Semi (Min(..), Max(..))
-import Data.Semigroup (First(..), Last(..), WrappedMonoid(..), Option(..), Arg(..))
+import Data.Semigroup (First(..), Last(..), WrappedMonoid(..), Arg(..))
 import Data.Semigroup.Singletons.Internal
 import Data.Singletons.Base.Enum
 import Data.Singletons.Base.Instances
@@ -91,8 +85,8 @@ import GHC.Num.Singletons
 import Text.Show.Singletons
 
 $(genSingletons [''Arg])
-$(showSingInstances $ ''Option : semigroupBasicTypes)
-$(singShowInstances $ ''Option : semigroupBasicTypes)
+$(showSingInstances semigroupBasicTypes)
+$(singShowInstances semigroupBasicTypes)
 
 $(singletonsOnly [d|
   instance Applicative Semi.Min where
@@ -259,48 +253,4 @@ $(singletonsOnly [d|
     enumFromTo (WrapMonoid a) (WrapMonoid b) = WrapMonoid `map` enumFromTo a b
     enumFromThenTo (WrapMonoid a) (WrapMonoid b) (WrapMonoid c) =
         WrapMonoid `map` enumFromThenTo a b c
-
-  instance Alternative Option where
-    empty = Option Nothing
-    Option Nothing    <|> b = b
-    a@(Option Just{}) <|> _ = a
-
-  instance Applicative Option where
-    pure a = Option (Just a)
-    Option a <*> Option b = Option (a <*> b)
-    liftA2 f (Option x) (Option y) = Option (liftA2 f x y)
-
-    Option Nothing  *>  _ = Option Nothing
-    Option Just{}   *>  b = b
-
-  deriving instance Functor Option
-
-  instance Monad Option where
-    Option (Just a) >>= k = k a
-    Option Nothing  >>= _ = Option Nothing
-    (>>) = (*>)
-
-  instance MonadPlus Option
-
-  -- deriving newtype instance Semigroup a => Semigroup (Option a)
-  instance Semigroup a => Semigroup (Option a) where
-    Option a <> Option b = Option (a <> b)
-
-  instance Semigroup a => Monoid (Option a) where
-    mempty = Option Nothing
-
-  instance Foldable Option where
-    foldMap f (Option (Just m)) = f m
-    foldMap _ (Option Nothing)  = mempty
-
-  instance Traversable Option where
-    traverse f (Option (Just a)) = Option . Just <$> f a
-    traverse _ (Option Nothing)  = pure (Option Nothing)
-  |])
-
-$(singletons [d|
-  -- Renamed to avoid name clash
-  -- -| Fold an 'Option' case-wise, just like 'maybe'.
-  option_ :: b -> (a -> b) -> Option a -> b
-  option_ n j (Option m) = maybe_ n j m
   |])

--- a/singletons-base/src/Data/Semigroup/Singletons/Internal.hs
+++ b/singletons-base/src/Data/Semigroup/Singletons/Internal.hs
@@ -42,7 +42,7 @@ import Data.List.NonEmpty (NonEmpty(..))
 import Data.Ord (Down(..))
 import Data.Ord.Singletons hiding (MinSym0, MinSym1, MaxSym0, MaxSym1)
 import Data.Proxy
-import Data.Semigroup (Dual(..), All(..), Any(..), Sum(..), Product(..), Option(..))
+import Data.Semigroup (Dual(..), All(..), Any(..), Sum(..), Product(..))
 import Data.Singletons
 import Data.Singletons.Base.Enum
 import Data.Singletons.Base.Instances
@@ -145,11 +145,11 @@ $(singletonsOnly [d|
     Down a <> Down b = Down (a <> b)
   |])
 
-$(genSingletons       $ ''Option : semigroupBasicTypes)
-$(singBoundedInstances             semigroupBasicTypes)
-$(singEqInstances     $ ''Option : semigroupBasicTypes)
-$(singDecideInstances $ ''Option : semigroupBasicTypes)
-$(singOrdInstances    $ ''Option : semigroupBasicTypes)
+$(genSingletons        semigroupBasicTypes)
+$(singBoundedInstances semigroupBasicTypes)
+$(singEqInstances      semigroupBasicTypes)
+$(singDecideInstances  semigroupBasicTypes)
+$(singOrdInstances     semigroupBasicTypes)
 
 $(singletonsOnly [d|
   instance Applicative Dual where


### PR DESCRIPTION
`Option` has been deprecated in `base-4.15.0.0` (in anticipation of its eventual removal from `base`). To avoid `-Wdeprecations` warnings, let's just remove its use from `singletons-base`.