### PR TITLE
Enable FlexibleContexts in more places to support GHC 9.2

### DIFF
--- a/singletons-base/src/Data/Monoid/Singletons.hs
+++ b/singletons-base/src/Data/Monoid/Singletons.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE InstanceSigs #-}

--- a/singletons-base/src/Data/Semigroup/Singletons.hs
+++ b/singletons-base/src/Data/Semigroup/Singletons.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE InstanceSigs #-}

--- a/singletons-base/src/Data/Semigroup/Singletons/Internal.hs
+++ b/singletons-base/src/Data/Semigroup/Singletons/Internal.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE InstanceSigs #-}

--- a/singletons-base/src/Text/Show/Singletons.hs
+++ b/singletons-base/src/Text/Show/Singletons.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE PolyKinds #-}


### PR DESCRIPTION
`UndecidableInstances` no longer implies `FlexibleContexts` in instance declarations as of GHC 9.2 (see https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.2#undecidableinstances-no-longer-implies-flexiblecontexts-in-instance-declarations), so we need to enable `FlexibleContexts` in a handful of additional places to make `singletons` compile with GHC 9.2. Luckily, this is a backwards compatible change, so I decided to just make this change now.

(Originally noticed in `head.hackage` in https://gitlab.haskell.org/ghc/head.hackage/-/merge_requests/138.)