### PR TITLE
Add a Quote instance for OptionsM

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,7 +744,6 @@ how this module can be used to prefix a singled data constructor with `MyS`
 instead of `S`:
 
 ```hs
-import Control.Monad.Trans.Class
 import Data.Singletons.TH
 import Data.Singletons.TH.Options
 import Language.Haskell.TH (Name, mkName, nameBase)
@@ -753,7 +752,7 @@ $(let myPrefix :: Name -> Name
       myPrefix name = mkName ("MyS" ++ nameBase name) in
 
       withOptions defaultOptions{singledDataConName = myPrefix} $
-      singletons $ lift [d| data T = MkT |])
+      singletons [d| data T = MkT |])
 ```
 
 Haskell constructs supported by `singletons-th`
@@ -1101,7 +1100,6 @@ The example below demonstrates this workaround in the context of a data type
 that has a `Nat` field:
 
 ```hs
-import Control.Monad.Trans.Class
 import Data.Kind
 import Data.Singletons.TH
 import Data.Singletons.TH.Options
@@ -1128,7 +1126,7 @@ $(let customPromote :: Name -> Name
                             , defunctionalizedName      = customDefun
                             } $ do
     decs1 <- genSingletons [''Age]
-    decs2 <- singletons $ lift [d|
+    decs2 <- singletons [d|
                fortyTwo :: Age
                fortyTwo = MkAge 42
                |]

--- a/singletons-base/tests/compile-and-dump/Singletons/T443.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T443.golden
@@ -1,12 +1,11 @@
 Singletons/T443.hs:(0,0)-(0,0): Splicing declarations
     withOptions defaultOptions {genSingKindInsts = False}
       $ singletons
-          $ lift
-              [d| data Nat = Z | S Nat
-                  data Vec :: Nat -> Type -> Type
-                    where
-                      VNil :: Vec Z a
-                      (:>) :: {head :: a, tail :: Vec n a} -> Vec (S n) a |]
+          [d| data Nat = Z | S Nat
+              data Vec :: Nat -> Type -> Type
+                where
+                  VNil :: Vec Z a
+                  (:>) :: {head :: a, tail :: Vec n a} -> Vec (S n) a |]
   ======>
     data Nat = Z | S Nat
     data Vec :: Nat -> Type -> Type

--- a/singletons-base/tests/compile-and-dump/Singletons/T443.hs
+++ b/singletons-base/tests/compile-and-dump/Singletons/T443.hs
@@ -1,12 +1,11 @@
 module T443 where
 
-import Control.Monad.Trans.Class
 import Data.Kind
 import Data.Singletons.TH
 import Data.Singletons.TH.Options
 
 $(withOptions defaultOptions{genSingKindInsts = False} $
-  singletons $ lift [d|
+  singletons [d|
   data Nat = Z | S Nat
 
   data Vec :: Nat -> Type -> Type where

--- a/singletons-base/tests/compile-and-dump/Singletons/T450.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T450.golden
@@ -15,10 +15,9 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
                        [(''Age, ''PAge), ('MkAge, 'PMkAge), (''Natural, ''Nat)])
                     $ do ageDecs1 <- genSingletons [''Age]
                          ageDecs2 <- singletons
-                                       $ lift
-                                           [d| addAge :: Age -> Age -> Age
-                                               addAge (MkAge (x :: Natural)) (MkAge (y :: Natural))
-                                                 = MkAge (x + y :: Natural) |]
+                                       [d| addAge :: Age -> Age -> Age
+                                           addAge (MkAge (x :: Natural)) (MkAge (y :: Natural))
+                                             = MkAge (x + y :: Natural) |]
                          pure $ ageDecs1 ++ ageDecs2
        messageDecs <- withOptions
                         (customOptions
@@ -26,27 +25,23 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
                             (''Text, ''Symbol)])
                         $ do messageDecs1 <- genSingletons [''Message]
                              messageDecs2 <- singletons
-                                               $ lift
-                                                   [d| appendMessage ::
-                                                         Message -> Message -> Message
-                                                       appendMessage
-                                                         (MkMessage (x :: Text))
-                                                         (MkMessage (y :: Text))
-                                                         = MkMessage (x <> y :: Text) |]
+                                               [d| appendMessage :: Message -> Message -> Message
+                                                   appendMessage
+                                                     (MkMessage (x :: Text))
+                                                     (MkMessage (y :: Text))
+                                                     = MkMessage (x <> y :: Text) |]
                              pure $ messageDecs1 ++ messageDecs2
        functionDecs <- withOptions
                          (customOptions
                             [(''Function, ''PFunction), ('MkFunction, 'PMkFunction)])
                          $ do functionDecs1 <- genSingletons [''Function]
                               functionDecs2 <- singletons
-                                                 $ lift
-                                                     [d| composeFunction ::
-                                                           Function b c
-                                                           -> Function a b -> Function a c
-                                                         composeFunction
-                                                           (MkFunction (f :: b -> c))
-                                                           (MkFunction (g :: a -> b))
-                                                           = MkFunction (f . g :: a -> c) |]
+                                                 [d| composeFunction ::
+                                                       Function b c -> Function a b -> Function a c
+                                                     composeFunction
+                                                       (MkFunction (f :: b -> c))
+                                                       (MkFunction (g :: a -> b))
+                                                       = MkFunction (f . g :: a -> c) |]
                               pure $ functionDecs1 ++ functionDecs2
        pure $ ageDecs ++ messageDecs ++ functionDecs
   ======>

--- a/singletons-base/tests/compile-and-dump/Singletons/T450.hs
+++ b/singletons-base/tests/compile-and-dump/Singletons/T450.hs
@@ -1,6 +1,5 @@
 module T450 where
 
-import Control.Monad.Trans.Class
 import Data.Maybe
 import Data.Singletons.TH
 import Data.Singletons.TH.Options
@@ -38,7 +37,7 @@ $(do let customPromote :: [(Name, Name)] -> Name -> Name
                                   , (''Natural, ''Nat)
                                   ]) $ do
          ageDecs1 <- genSingletons [''Age]
-         ageDecs2 <- singletons $ lift [d|
+         ageDecs2 <- singletons [d|
            addAge :: Age -> Age -> Age
            addAge (MkAge (x :: Natural)) (MkAge (y :: Natural)) =
              MkAge (x + y :: Natural)
@@ -51,7 +50,7 @@ $(do let customPromote :: [(Name, Name)] -> Name -> Name
                                   , (''Text, ''Symbol)
                                   ]) $ do
          messageDecs1 <- genSingletons [''Message]
-         messageDecs2 <- singletons $ lift [d|
+         messageDecs2 <- singletons [d|
            appendMessage :: Message -> Message -> Message
            appendMessage (MkMessage (x :: Text)) (MkMessage (y :: Text)) =
              MkMessage (x <> y :: Text)
@@ -63,7 +62,7 @@ $(do let customPromote :: [(Name, Name)] -> Name -> Name
                                   , ('MkFunction, 'PMkFunction)
                                   ]) $ do
          functionDecs1 <- genSingletons [''Function]
-         functionDecs2 <- singletons $ lift [d|
+         functionDecs2 <- singletons [d|
            composeFunction :: Function b c -> Function a b -> Function a c
            composeFunction (MkFunction (f :: b -> c)) (MkFunction (g :: a -> b)) =
              MkFunction (f . g :: a -> c)

--- a/singletons-base/tests/compile-and-dump/Singletons/T453.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T453.golden
@@ -1,12 +1,11 @@
 Singletons/T453.hs:(0,0)-(0,0): Splicing declarations
     withOptions defaultOptions {genSingKindInsts = False}
       $ singletons
-          $ lift
-              [d| type T1 :: forall k. k -> Type
-                  type T2 :: k -> Type
-                  
-                  data T1 a
-                  data T2 a |]
+          [d| type T1 :: forall k. k -> Type
+              type T2 :: k -> Type
+              
+              data T1 a
+              data T2 a |]
   ======>
     type T1 :: forall k. k -> Type
     data T1 a

--- a/singletons-base/tests/compile-and-dump/Singletons/T453.hs
+++ b/singletons-base/tests/compile-and-dump/Singletons/T453.hs
@@ -6,7 +6,7 @@ import Data.Singletons.TH
 import Data.Singletons.TH.Options
 
 $(withOptions defaultOptions{genSingKindInsts = False} $
-  singletons $ lift [d|
+  singletons [d|
     type T1 :: forall k. k -> Type
     data T1 a
 

--- a/singletons-th/CHANGES.md
+++ b/singletons-th/CHANGES.md
@@ -110,3 +110,21 @@ Changelog for singletons-th project
   data types built on top of them. See the
   "Arrows, `Nat`, `Symbol`, and literals" section of the `README` for more
   information.
+* Define a `Quote` instance for `OptionsM`. A notable benefit of this instance
+  is that it avoids the need to explicitly `lift` TH quotes into `OptionsM`.
+  Before, you would have to do this:
+
+  ```hs
+  import Control.Monad.Trans.Class (lift)
+
+  withOptions defaultOptions
+    $ singletons
+    $ lift [d| data T = MkT |]
+  ```
+
+  But now, it suffices to simply do this:
+
+  ```hs
+  withOptions defaultOptions
+    $ singletons [d| data T = MkT |]
+  ```

--- a/singletons-th/singletons-th.cabal
+++ b/singletons-th/singletons-th.cabal
@@ -60,6 +60,7 @@ library
                       syb              >= 0.4,
                       template-haskell >= 2.17 && < 2.18,
                       th-desugar       >= 1.12 && < 1.13,
+                      th-orphans       >= 0.13.11 && < 0.14,
                       transformers     >= 0.5.2
   default-language:   Haskell2010
   other-extensions:   TemplateHaskellQuotes

--- a/singletons-th/src/Data/Singletons/TH/Options.hs
+++ b/singletons-th/src/Data/Singletons/TH/Options.hs
@@ -48,6 +48,7 @@ import Control.Monad.Writer (WriterT)
 import Data.Singletons.TH.Names
 import Data.Singletons.TH.Util
 import Language.Haskell.TH.Desugar
+import Language.Haskell.TH.Instances () -- To obtain a Quote instance for ReaderT
 import Language.Haskell.TH.Syntax hiding (Lift(..))
 
 -- | Options that control the finer details of how @singletons-th@'s Template
@@ -191,7 +192,7 @@ instance (OptionsMonad m, Monoid w) => OptionsMonad (RWST r w s m) where
 -- 'withOptions'.
 newtype OptionsM m a = OptionsM (ReaderT Options m a)
   deriving ( Functor, Applicative, Monad, MonadTrans
-           , Quasi, MonadFail, MonadIO, DsMonad )
+           , Quote, Quasi, MonadFail, MonadIO, DsMonad )
 
 -- | Turn any 'DsMonad' into an 'OptionsMonad'.
 instance DsMonad m => OptionsMonad (OptionsM m) where


### PR DESCRIPTION
This avoids the need to explicitly `lift` quoted declarations into `OptionsM` in combination with `withOptions`.

Addresses one bullet point of #439.