### PR TITLE
Update Note [Preserve the order of type variables during singling]

### DIFF
--- a/singletons-base/src/Data/Functor/Const/Singletons.hs
+++ b/singletons-base/src/Data/Functor/Const/Singletons.hs
@@ -68,7 +68,10 @@ tries to generate:
 
 Assumes that `b` is of kind Type. Until we get a more reliable story for
 poly-kinded Sing instances (see #150), we simply write the singleton type by
-hand.
+hand. Note that we cannot use genSingletons to generate this code because we
+would end up with the wrong specificity for the kind of `a` when singling the
+Const constructor. See Note [Preserve the order of type variables during
+singling] in D.S.TH.Single.Type, wrinkle 2.
 -}
 type SConst :: Const a b -> Type
 data SConst :: Const a b -> Type where


### PR DESCRIPTION
Wrinkles 2 and 3 are still relevant in this Note, even after the advent of explicit specificity, but only in more limited circumstances. This updates the Note to point out these circumstances.

Addresses one bullet point of #439.