### PR TITLE
Tweak ShowSing' so that Show instances for singletons can be derived

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ includes, but is not necessarily limited to, the following:
 * `PolyKinds`
 * `RankNTypes`
 * `ScopedTypeVariables`
+* `StandaloneDeriving`
 * `StandaloneKindSignatures`
 * `TemplateHaskell`
 * `TypeApplications`

--- a/singletons-base/src/Data/Singletons/Base/Instances.hs
+++ b/singletons-base/src/Data/Singletons/Base/Instances.hs
@@ -11,7 +11,7 @@ re-exported from various places.
 {-# LANGUAGE DataKinds, PolyKinds, RankNTypes, GADTs, TypeFamilies, EmptyCase,
              FlexibleContexts, TemplateHaskell, ScopedTypeVariables,
              UndecidableInstances, TypeOperators, FlexibleInstances,
-             TypeApplications, StandaloneKindSignatures #-}
+             TypeApplications, StandaloneKindSignatures, StandaloneDeriving #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Data.Singletons.Base.Instances (

--- a/singletons-base/src/Data/Singletons/Base/SomeSing.hs
+++ b/singletons-base/src/Data/Singletons/Base/SomeSing.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -----------------------------------------------------------------------------
@@ -73,10 +74,7 @@ instance SNum k => Num (SomeSing k) where
   signum (SomeSing a) = SomeSing (sSignum a)
   fromInteger n = withSomeSing (fromIntegral n) (SomeSing . sFromInteger)
 
-instance ShowSing k => Show (SomeSing k) where
-  showsPrec p (SomeSing (s :: Sing a)) =
-    showParen (p > 10) $ showString "SomeSing " . showsPrec 11 s
-      :: ShowSing' a => ShowS
+deriving instance ShowSing k => Show (SomeSing k)
 
 instance SSemigroup k => Semigroup (SomeSing k) where
   SomeSing a <> SomeSing b = SomeSing (a %<> b)

--- a/singletons-base/tests/compile-and-dump/GradingClient/Database.golden
+++ b/singletons-base/tests/compile-and-dump/GradingClient/Database.golden
@@ -3357,51 +3357,10 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
                                                         -> Type) where
       Data.Type.Coercion.testCoercion
         = Data.Singletons.Decide.decideCoercion
-    instance (Data.Singletons.ShowSing.ShowSing U,
-              Data.Singletons.ShowSing.ShowSing Nat) =>
-             Show (SU (z :: U)) where
-      showsPrec _ SBOOL = showString "SBOOL"
-      showsPrec _ SSTRING = showString "SSTRING"
-      showsPrec _ SNAT = showString "SNAT"
-      showsPrec
-        p_0123456789876543210
-        (SVEC (arg_0123456789876543210 :: Sing argTy_0123456789876543210)
-              (arg_0123456789876543210 :: Sing argTy_0123456789876543210))
-        = (showParen (((>) p_0123456789876543210) 10))
-            (((.) (showString "SVEC "))
-               (((.) ((showsPrec 11) arg_0123456789876543210))
-                  (((.) GHC.Show.showSpace)
-                     ((showsPrec 11) arg_0123456789876543210)))) ::
-            (Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210,
-             Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210) =>
-            ShowS
-    instance Show (SAChar (z :: AChar)) where
-      showsPrec _ SCA = showString "SCA"
-      showsPrec _ SCB = showString "SCB"
-      showsPrec _ SCC = showString "SCC"
-      showsPrec _ SCD = showString "SCD"
-      showsPrec _ SCE = showString "SCE"
-      showsPrec _ SCF = showString "SCF"
-      showsPrec _ SCG = showString "SCG"
-      showsPrec _ SCH = showString "SCH"
-      showsPrec _ SCI = showString "SCI"
-      showsPrec _ SCJ = showString "SCJ"
-      showsPrec _ SCK = showString "SCK"
-      showsPrec _ SCL = showString "SCL"
-      showsPrec _ SCM = showString "SCM"
-      showsPrec _ SCN = showString "SCN"
-      showsPrec _ SCO = showString "SCO"
-      showsPrec _ SCP = showString "SCP"
-      showsPrec _ SCQ = showString "SCQ"
-      showsPrec _ SCR = showString "SCR"
-      showsPrec _ SCS = showString "SCS"
-      showsPrec _ SCT = showString "SCT"
-      showsPrec _ SCU = showString "SCU"
-      showsPrec _ SCV = showString "SCV"
-      showsPrec _ SCW = showString "SCW"
-      showsPrec _ SCX = showString "SCX"
-      showsPrec _ SCY = showString "SCY"
-      showsPrec _ SCZ = showString "SCZ"
+    deriving instance (Data.Singletons.ShowSing.ShowSing U,
+                       Data.Singletons.ShowSing.ShowSing Nat) =>
+                      Show (SU (z :: U))
+    deriving instance Show (SAChar (z :: AChar))
     instance SingI BOOL where
       sing = SBOOL
     instance SingI STRING where

--- a/singletons-base/tests/compile-and-dump/Singletons/DataValues.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/DataValues.golden
@@ -170,21 +170,9 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
                                 (sFromInteger (sing :: Sing 11))))
                             sArg_0123456789876543210))))))
             sA_0123456789876543210
-    instance (Data.Singletons.ShowSing.ShowSing a,
-              Data.Singletons.ShowSing.ShowSing b) =>
-             Show (SPair (z :: Pair a b)) where
-      showsPrec
-        p_0123456789876543210
-        (SPair (arg_0123456789876543210 :: Sing argTy_0123456789876543210)
-               (arg_0123456789876543210 :: Sing argTy_0123456789876543210))
-        = (showParen (((>) p_0123456789876543210) 10))
-            (((.) (showString "SPair "))
-               (((.) ((showsPrec 11) arg_0123456789876543210))
-                  (((.) GHC.Show.showSpace)
-                     ((showsPrec 11) arg_0123456789876543210)))) ::
-            (Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210,
-             Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210) =>
-            ShowS
+    deriving instance (Data.Singletons.ShowSing.ShowSing a,
+                       Data.Singletons.ShowSing.ShowSing b) =>
+                      Show (SPair (z :: Pair a b))
     instance (SingI n, SingI n) => SingI (Pair (n :: a) (n :: b)) where
       sing = (SPair sing) sing
     instance SingI (PairSym0 :: (~>) a ((~>) b (Pair a b))) where

--- a/singletons-base/tests/compile-and-dump/Singletons/EmptyShowDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/EmptyShowDeriving.golden
@@ -69,5 +69,4 @@ Singletons/EmptyShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                  @(Sing (Case_0123456789876543210 v_0123456789876543210 a_0123456789876543210 v_0123456789876543210)))
                 (case sV_0123456789876543210 of)))
             sA_0123456789876543210
-    instance Show (SFoo (z :: Foo)) where
-      showsPrec _ v_0123456789876543210 = case v_0123456789876543210 of
+    deriving instance Show (SFoo (z :: Foo))

--- a/singletons-base/tests/compile-and-dump/Singletons/Maybe.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Maybe.golden
@@ -176,17 +176,8 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
                                                         -> GHC.Types.Type) where
       Data.Type.Coercion.testCoercion
         = Data.Singletons.Decide.decideCoercion
-    instance Data.Singletons.ShowSing.ShowSing a =>
-             Show (SMaybe (z :: Maybe a)) where
-      showsPrec _ SNothing = showString "SNothing"
-      showsPrec
-        p_0123456789876543210
-        (SJust (arg_0123456789876543210 :: Sing argTy_0123456789876543210))
-        = (showParen (((>) p_0123456789876543210) 10))
-            (((.) (showString "SJust "))
-               ((showsPrec 11) arg_0123456789876543210)) ::
-            Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210 =>
-            ShowS
+    deriving instance Data.Singletons.ShowSing.ShowSing a =>
+                      Show (SMaybe (z :: Maybe a))
     instance SingI Nothing where
       sing = SNothing
     instance SingI n => SingI (Just (n :: a)) where

--- a/singletons-base/tests/compile-and-dump/Singletons/Nat.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Nat.golden
@@ -306,17 +306,8 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
                                                       -> GHC.Types.Type) where
       Data.Type.Coercion.testCoercion
         = Data.Singletons.Decide.decideCoercion
-    instance Data.Singletons.ShowSing.ShowSing Nat =>
-             Show (SNat (z :: Nat)) where
-      showsPrec _ SZero = showString "SZero"
-      showsPrec
-        p_0123456789876543210
-        (SSucc (arg_0123456789876543210 :: Sing argTy_0123456789876543210))
-        = (showParen (((>) p_0123456789876543210) 10))
-            (((.) (showString "SSucc "))
-               ((showsPrec 11) arg_0123456789876543210)) ::
-            Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210 =>
-            ShowS
+    deriving instance Data.Singletons.ShowSing.ShowSing Nat =>
+                      Show (SNat (z :: Nat))
     instance SingI Zero where
       sing = SZero
     instance SingI n => SingI (Succ (n :: Nat)) where

--- a/singletons-base/tests/compile-and-dump/Singletons/PatternMatching.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/PatternMatching.golden
@@ -170,21 +170,9 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
                                 (sFromInteger (sing :: Sing 11))))
                             sArg_0123456789876543210))))))
             sA_0123456789876543210
-    instance (Data.Singletons.ShowSing.ShowSing a,
-              Data.Singletons.ShowSing.ShowSing b) =>
-             Show (SPair (z :: Pair a b)) where
-      showsPrec
-        p_0123456789876543210
-        (SPair (arg_0123456789876543210 :: Sing argTy_0123456789876543210)
-               (arg_0123456789876543210 :: Sing argTy_0123456789876543210))
-        = (showParen (((>) p_0123456789876543210) 10))
-            (((.) (showString "SPair "))
-               (((.) ((showsPrec 11) arg_0123456789876543210))
-                  (((.) GHC.Show.showSpace)
-                     ((showsPrec 11) arg_0123456789876543210)))) ::
-            (Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210,
-             Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210) =>
-            ShowS
+    deriving instance (Data.Singletons.ShowSing.ShowSing a,
+                       Data.Singletons.ShowSing.ShowSing b) =>
+                      Show (SPair (z :: Pair a b))
     instance (SingI n, SingI n) => SingI (Pair (n :: a) (n :: b)) where
       sing = (SPair sing) sing
     instance SingI (PairSym0 :: (~>) a ((~>) b (Pair a b))) where

--- a/singletons-base/tests/compile-and-dump/Singletons/ShowDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/ShowDeriving.golden
@@ -528,74 +528,11 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                                      ((applySing ((singFun2 @ShowCharSym0) sShowChar))
                                         (sing :: Sing "}")))))))))))
             sA_0123456789876543210
-    instance Show (SFoo1 (z :: Foo1)) where
-      showsPrec _ SMkFoo1 = showString "SMkFoo1"
-    instance Data.Singletons.ShowSing.ShowSing a =>
-             Show (SFoo2 (z :: Foo2 a)) where
-      showsPrec
-        p_0123456789876543210
-        (SMkFoo2a (arg_0123456789876543210 :: Sing argTy_0123456789876543210)
-                  (arg_0123456789876543210 :: Sing argTy_0123456789876543210))
-        = (showParen (((>) p_0123456789876543210) 10))
-            (((.) (showString "SMkFoo2a "))
-               (((.) ((showsPrec 11) arg_0123456789876543210))
-                  (((.) GHC.Show.showSpace)
-                     ((showsPrec 11) arg_0123456789876543210)))) ::
-            (Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210,
-             Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210) =>
-            ShowS
-      showsPrec
-        p_0123456789876543210
-        (SMkFoo2b (argL_0123456789876543210 :: Sing argTyL_0123456789876543210)
-                  (argR_0123456789876543210 :: Sing argTyR_0123456789876543210))
-        = (showParen (((>) p_0123456789876543210) 9))
-            (((.) ((showsPrec 10) argL_0123456789876543210))
-               (((.) (showString " `SMkFoo2b` "))
-                  ((showsPrec 10) argR_0123456789876543210))) ::
-            (Data.Singletons.ShowSing.ShowSing' argTyL_0123456789876543210,
-             Data.Singletons.ShowSing.ShowSing' argTyR_0123456789876543210) =>
-            ShowS
-      showsPrec
-        p_0123456789876543210
-        ((:%*:) (arg_0123456789876543210 :: Sing argTy_0123456789876543210)
-                (arg_0123456789876543210 :: Sing argTy_0123456789876543210))
-        = (showParen (((>) p_0123456789876543210) 10))
-            (((.) (showString "(:%*:) "))
-               (((.) ((showsPrec 11) arg_0123456789876543210))
-                  (((.) GHC.Show.showSpace)
-                     ((showsPrec 11) arg_0123456789876543210)))) ::
-            (Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210,
-             Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210) =>
-            ShowS
-      showsPrec
-        p_0123456789876543210
-        ((:%&:) (argL_0123456789876543210 :: Sing argTyL_0123456789876543210)
-                (argR_0123456789876543210 :: Sing argTyR_0123456789876543210))
-        = (showParen (((>) p_0123456789876543210) 9))
-            (((.) ((showsPrec 10) argL_0123456789876543210))
-               (((.) (showString " :%&: "))
-                  ((showsPrec 10) argR_0123456789876543210))) ::
-            (Data.Singletons.ShowSing.ShowSing' argTyL_0123456789876543210,
-             Data.Singletons.ShowSing.ShowSing' argTyR_0123456789876543210) =>
-            ShowS
-    instance Data.Singletons.ShowSing.ShowSing Bool =>
-             Show (SFoo3 (z :: Foo3)) where
-      showsPrec
-        p_0123456789876543210
-        (SMkFoo3 (arg_0123456789876543210 :: Sing argTy_0123456789876543210)
-                 (arg_0123456789876543210 :: Sing argTy_0123456789876543210))
-        = (showParen (((>) p_0123456789876543210) 10))
-            (((.) (showString "SMkFoo3 "))
-               (((.) (showChar '{'))
-                  (((.) (showString "sGetFoo3a = "))
-                     (((.) ((showsPrec 0) arg_0123456789876543210))
-                        (((.) GHC.Show.showCommaSpace)
-                           (((.) (showString "(%***) = "))
-                              (((.) ((showsPrec 0) arg_0123456789876543210))
-                                 (showChar '}')))))))) ::
-            (Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210,
-             Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210) =>
-            ShowS
+    deriving instance Show (SFoo1 (z :: Foo1))
+    deriving instance Data.Singletons.ShowSing.ShowSing a =>
+                      Show (SFoo2 (z :: Foo2 a))
+    deriving instance Data.Singletons.ShowSing.ShowSing Bool =>
+                      Show (SFoo3 (z :: Foo3))
     instance SingI MkFoo1 where
       sing = SMkFoo1
     instance (SingI n, SingI n) =>

--- a/singletons-base/tests/compile-and-dump/Singletons/StandaloneDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/StandaloneDeriving.golden
@@ -531,22 +531,9 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
                                                     -> GHC.Types.Type) where
       Data.Type.Coercion.testCoercion
         = Data.Singletons.Decide.decideCoercion
-    instance Data.Singletons.ShowSing.ShowSing a =>
-             Show (ST (z :: T a ())) where
-      showsPrec
-        p_0123456789876543210
-        ((:%*:) (argL_0123456789876543210 :: Sing argTyL_0123456789876543210)
-                (argR_0123456789876543210 :: Sing argTyR_0123456789876543210))
-        = (showParen (((>) p_0123456789876543210) 9))
-            (((.) ((showsPrec 10) argL_0123456789876543210))
-               (((.) (showString " :%*: "))
-                  ((showsPrec 10) argR_0123456789876543210))) ::
-            (Data.Singletons.ShowSing.ShowSing' argTyL_0123456789876543210,
-             Data.Singletons.ShowSing.ShowSing' argTyR_0123456789876543210) =>
-            ShowS
-    instance Show (SS (z :: S)) where
-      showsPrec _ SS1 = showString "SS1"
-      showsPrec _ SS2 = showString "SS2"
+    deriving instance Data.Singletons.ShowSing.ShowSing a =>
+                      Show (ST (z :: T a ()))
+    deriving instance Show (SS (z :: S))
     instance (SingI n, SingI n) =>
              SingI ((:*:) (n :: a) (n :: b)) where
       sing = ((:%*:) sing) sing

--- a/singletons-base/tests/compile-and-dump/Singletons/T178.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T178.golden
@@ -256,10 +256,7 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
                                                       -> GHC.Types.Type) where
       Data.Type.Coercion.testCoercion
         = Data.Singletons.Decide.decideCoercion
-    instance Show (SOcc (z :: Occ)) where
-      showsPrec _ SStr = showString "SStr"
-      showsPrec _ SOpt = showString "SOpt"
-      showsPrec _ SMany = showString "SMany"
+    deriving instance Show (SOcc (z :: Occ))
     instance SingI Str where
       sing = SStr
     instance SingI Opt where

--- a/singletons-base/tests/compile-and-dump/Singletons/T190.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T190.golden
@@ -232,7 +232,6 @@ Singletons/T190.hs:0:0:: Splicing declarations
                                                     -> GHC.Types.Type) where
       Data.Type.Coercion.testCoercion
         = Data.Singletons.Decide.decideCoercion
-    instance Show (ST (z :: T)) where
-      showsPrec _ ST = showString "ST"
+    deriving instance Show (ST (z :: T))
     instance SingI T where
       sing = ST

--- a/singletons-base/tests/compile-and-dump/Singletons/T371.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T371.golden
@@ -219,28 +219,10 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
                           (sFromInteger (sing :: Sing 11))))
                       sArg_0123456789876543210))))
             sA_0123456789876543210
-    instance Data.Singletons.ShowSing.ShowSing (Y a) =>
-             Show (SX (z :: X a)) where
-      showsPrec _ SX1 = showString "SX1"
-      showsPrec
-        p_0123456789876543210
-        (SX2 (arg_0123456789876543210 :: Sing argTy_0123456789876543210))
-        = (showParen (((>) p_0123456789876543210) 10))
-            (((.) (showString "SX2 "))
-               ((showsPrec 11) arg_0123456789876543210)) ::
-            Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210 =>
-            ShowS
-    instance Data.Singletons.ShowSing.ShowSing (X a) =>
-             Show (SY (z :: Y a)) where
-      showsPrec _ SY1 = showString "SY1"
-      showsPrec
-        p_0123456789876543210
-        (SY2 (arg_0123456789876543210 :: Sing argTy_0123456789876543210))
-        = (showParen (((>) p_0123456789876543210) 10))
-            (((.) (showString "SY2 "))
-               ((showsPrec 11) arg_0123456789876543210)) ::
-            Data.Singletons.ShowSing.ShowSing' argTy_0123456789876543210 =>
-            ShowS
+    deriving instance Data.Singletons.ShowSing.ShowSing (Y a) =>
+                      Show (SX (z :: X a))
+    deriving instance Data.Singletons.ShowSing.ShowSing (X a) =>
+                      Show (SY (z :: Y a))
     instance SingI X1 where
       sing = SX1
     instance SingI n => SingI (X2 (n :: Y a)) where

--- a/singletons-th/src/Data/Singletons/TH/CustomStar.hs
+++ b/singletons-th/src/Data/Singletons/TH/CustomStar.hs
@@ -93,7 +93,7 @@ singletonStar names = do
     let dataDeclEqInst = DerivedDecl (Just dataDeclEqCxt) (DConT repName) repName dataDecl
     eqInst   <- mkEqInstance Nothing (DConT repName) dataDecl
     ordInst  <- mkOrdInstance Nothing (DConT repName) dataDecl
-    showInst <- mkShowInstance ForPromotion Nothing (DConT repName) dataDecl
+    showInst <- mkShowInstance Nothing (DConT repName) dataDecl
     (pInsts, promDecls) <- promoteM [] $ do _ <- promoteDataDec dataDecl
                                             traverse (promoteInstanceDec mempty mempty)
                                               [eqInst, ordInst, showInst]

--- a/singletons-th/src/Data/Singletons/TH/Deriving/Show.hs
+++ b/singletons-th/src/Data/Singletons/TH/Deriving/Show.hs
@@ -13,7 +13,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module Data.Singletons.TH.Deriving.Show (
     mkShowInstance
-  , ShowMode(..)
   , mkShowSingContext
   ) where
 
@@ -29,88 +28,62 @@ import Data.Maybe (fromMaybe)
 import GHC.Lexeme (startsConSym, startsVarSym)
 import GHC.Show (appPrec, appPrec1)
 
-mkShowInstance :: OptionsMonad q => ShowMode -> DerivDesc q
-mkShowInstance mode mb_ctxt ty (DataDecl _ _ cons) = do
-  clauses <- mk_showsPrec mode cons
-  constraints <- inferConstraintsDef (fmap (mkShowSingContext mode) mb_ctxt)
-                                     (DConT (mk_Show_name mode))
-                                     ty cons
-  ty' <- mk_Show_inst_ty mode ty
+mkShowInstance :: OptionsMonad q => DerivDesc q
+mkShowInstance mb_ctxt ty (DataDecl _ _ cons) = do
+  clauses <- mk_showsPrec cons
+  constraints <- inferConstraintsDef mb_ctxt (DConT showName) ty cons
   return $ InstDecl { id_cxt = constraints
                     , id_name = showName
-                    , id_arg_tys = [ty']
+                    , id_arg_tys = [ty]
                     , id_sigs  = mempty
                     , id_meths = [ (showsPrecName, UFunction clauses) ] }
 
-mk_showsPrec :: OptionsMonad q => ShowMode -> [DCon] -> q [DClause]
-mk_showsPrec mode cons = do
+mk_showsPrec :: OptionsMonad q => [DCon] -> q [DClause]
+mk_showsPrec cons = do
     p <- newUniqueName "p" -- The precedence argument (not always used)
     if null cons
        then do v <- newUniqueName "v"
                pure [DClause [DWildP, DVarP v] (DCaseE (DVarE v) [])]
-       else mapM (mk_showsPrec_clause mode p) cons
+       else mapM (mk_showsPrec_clause p) cons
 
-mk_showsPrec_clause :: forall q. OptionsMonad q
-                    => ShowMode -> Name -> DCon
+mk_showsPrec_clause :: forall q. DsMonad q
+                    => Name -> DCon
                     -> q DClause
-mk_showsPrec_clause mode p (DCon _ _ con_name con_fields _) = go con_fields
+mk_showsPrec_clause p (DCon _ _ con_name con_fields _) = go con_fields
   where
     go :: DConFields -> q DClause
     go con_fields' = do
-      opts <- getOptions
-
-      let con_name' :: Name
-          con_name' = case mode of
-                        ForPromotion  -> con_name
-                        ForShowSing{} -> singledDataConName opts con_name
-
       case con_fields' of
 
         -- No fields: print just the constructor name, with no parentheses
         DNormalC _ [] -> return $
-          DClause [DWildP, DConP con_name' []] $
-            DVarE showStringName `DAppE` dStringE (parenInfixConName con_name' "")
+          DClause [DWildP, DConP con_name []] $
+            DVarE showStringName `DAppE` dStringE (parenInfixConName con_name "")
 
         -- Infix constructors have special Show treatment.
-        DNormalC True tys@[_, _]
-            -- Although the (:) constructor is infix, its singled counterpart SCons
-            -- is not, which matters if we're deriving a ShowSing instance.
-            -- Unless we remove this special case (see #234), we will simply
-            -- shunt it along as if we were dealing with a prefix constructor.
-          |  ForShowSing{} <- mode
-          ,  con_name == consName
-          -> go (DNormalC False tys)
-
-          |  otherwise
-          -> do argL   <- newUniqueName "argL"
-                argR   <- newUniqueName "argR"
-                argTyL <- newUniqueName "argTyL"
-                argTyR <- newUniqueName "argTyR"
-                fi <- fromMaybe defaultFixity <$> reifyFixityWithLocals con_name'
-                let con_prec = case fi of Fixity prec _ -> prec
-                    op_name  = nameBase con_name'
-                    infixOpE = DAppE (DVarE showStringName) . dStringE $
-                                 if isInfixDataCon op_name
-                                    then " "  ++ op_name ++ " "
-                                    -- Make sure to handle infix data constructors
-                                    -- like (Int `Foo` Int)
-                                    else " `" ++ op_name ++ "` "
-                return $ DClause [ DVarP p
-                                 , DConP con_name' $
-                                   zipWith (mk_Show_arg_pat mode) [argL, argR] [argTyL, argTyR]
-                                 ] $
-                  mk_Show_rhs_sig mode [argTyL, argTyR] $
-                  (DVarE showParenName `DAppE` (DVarE gtName `DAppE` DVarE p
-                                                             `DAppE` dIntegerE con_prec))
-                    `DAppE` (DVarE composeName
-                               `DAppE` showsPrecE (con_prec + 1) argL
-                               `DAppE` (DVarE composeName
-                                          `DAppE` infixOpE
-                                          `DAppE` showsPrecE (con_prec + 1) argR))
+        DNormalC True [_, _] -> do
+          argL   <- newUniqueName "argL"
+          argR   <- newUniqueName "argR"
+          fi <- fromMaybe defaultFixity <$> reifyFixityWithLocals con_name
+          let con_prec = case fi of Fixity prec _ -> prec
+              op_name  = nameBase con_name
+              infixOpE = DAppE (DVarE showStringName) . dStringE $
+                           if isInfixDataCon op_name
+                              then " "  ++ op_name ++ " "
+                              -- Make sure to handle infix data constructors
+                              -- like (Int `Foo` Int)
+                              else " `" ++ op_name ++ "` "
+          return $ DClause [DVarP p, DConP con_name [DVarP argL, DVarP argR]] $
+            (DVarE showParenName `DAppE` (DVarE gtName `DAppE` DVarE p
+                                                       `DAppE` dIntegerE con_prec))
+              `DAppE` (DVarE composeName
+                         `DAppE` showsPrecE (con_prec + 1) argL
+                         `DAppE` (DVarE composeName
+                                    `DAppE` infixOpE
+                                    `DAppE` showsPrecE (con_prec + 1) argR))
 
         DNormalC _ tys -> do
-          args   <- mapM (const $ newUniqueName "arg")   tys
-          argTys <- mapM (const $ newUniqueName "argTy") tys
+          args <- mapM (const $ newUniqueName "arg")   tys
           let show_args     = map (showsPrecE appPrec1) args
               composed_args = foldr1 (\v q -> DVarE composeName
                                                `DAppE` v
@@ -119,13 +92,9 @@ mk_showsPrec_clause mode p (DCon _ _ con_name con_fields _) = go con_fields
                                                          `DAppE` q)) show_args
               named_args = DVarE composeName
                              `DAppE` (DVarE showStringName
-                                       `DAppE` dStringE (parenInfixConName con_name' " "))
+                                       `DAppE` dStringE (parenInfixConName con_name " "))
                              `DAppE` composed_args
-          return $ DClause [ DVarP p
-                           , DConP con_name' $
-                             zipWith (mk_Show_arg_pat mode) args argTys
-                           ] $
-            mk_Show_rhs_sig mode argTys $
+          return $ DClause [DVarP p, DConP con_name $ map DVarP args] $
             DVarE showParenName
               `DAppE` (DVarE gtName `DAppE` DVarE p `DAppE` dIntegerE appPrec)
               `DAppE` named_args
@@ -135,14 +104,10 @@ mk_showsPrec_clause mode p (DCon _ _ con_name con_fields _) = go con_fields
         DRecC [] -> go (DNormalC False [])
 
         DRecC tys -> do
-          args   <- mapM (const $ newUniqueName "arg")   tys
-          argTys <- mapM (const $ newUniqueName "argTy") tys
+          args <- mapM (const $ newUniqueName "arg") tys
           let show_args =
                 concatMap (\((arg_name, _, _), arg) ->
-                            let arg_name'    = case mode of
-                                                 ForPromotion  -> arg_name
-                                                 ForShowSing{} -> singledValueName opts arg_name
-                                arg_nameBase = nameBase arg_name'
+                            let arg_nameBase = nameBase arg_name
                                 infix_rec    = showParen (isSym arg_nameBase)
                                                          (showString arg_nameBase) ""
                             in [ DVarE showStringName `DAppE` dStringE (infix_rec ++ " = ")
@@ -150,20 +115,16 @@ mk_showsPrec_clause mode p (DCon _ _ con_name con_fields _) = go con_fields
                                , DVarE showCommaSpaceName
                                ])
                           (zip tys args)
-              brace_comma_args =   (DVarE showCharName `DAppE` dCharE mode '{')
+              brace_comma_args =   (DVarE showCharName `DAppE` dCharE '{')
                                  : take (length show_args - 1) show_args
               composed_args = foldr (\x y -> DVarE composeName `DAppE` x `DAppE` y)
-                                    (DVarE showCharName `DAppE` dCharE mode '}')
+                                    (DVarE showCharName `DAppE` dCharE '}')
                                     brace_comma_args
               named_args = DVarE composeName
                              `DAppE` (DVarE showStringName
-                                       `DAppE` dStringE (parenInfixConName con_name' " "))
+                                       `DAppE` dStringE (parenInfixConName con_name " "))
                              `DAppE` composed_args
-          return $ DClause [ DVarP p
-                           , DConP con_name' $
-                             zipWith (mk_Show_arg_pat mode) args argTys
-                           ] $
-            mk_Show_rhs_sig mode argTys $
+          return $ DClause [DVarP p, DConP con_name $ map DVarP args] $
             DVarE showParenName
               `DAppE` (DVarE gtName `DAppE` DVarE p `DAppE` dIntegerE appPrec)
               `DAppE` named_args
@@ -178,14 +139,9 @@ parenInfixConName conName =
 showsPrecE :: Int -> Name -> DExp
 showsPrecE prec n = DVarE showsPrecName `DAppE` dIntegerE prec `DAppE` DVarE n
 
-dCharE :: ShowMode -> Char -> DExp
-dCharE mode = DLitE . to_lit
-  where
-    to_lit :: Char -> Lit
-    to_lit c = case mode of
-                 ForPromotion  -> StringL [c] -- There aren't type-level characters yet,
-                                              -- so fake it with a string
-                 ForShowSing{} -> CharL c
+dCharE :: Char -> DExp
+dCharE c = DLitE $ StringL [c] -- There aren't type-level characters yet,
+                               -- so fake it with a string
 
 dStringE :: String -> DExp
 dStringE = DLitE . StringL
@@ -197,55 +153,13 @@ isSym :: String -> Bool
 isSym ""      = False
 isSym (c : _) = startsVarSym c || startsConSym c
 
------
--- ShowMode
------
-
--- | Is a 'Show' instance being generated to be promoted/singled, or is it
--- being generated to create a 'Show' instance for a singleton type?
-data ShowMode = ForPromotion      -- ^ For promotion/singling
-              | ForShowSing Name  -- ^ For a 'Show' instance.
-                                  --   Bundles the 'Name' of the data type.
-
 -- | Turn a context like @('Show' a, 'Show' b)@ into @('ShowSing' a, 'ShowSing' b)@.
--- This is necessary for 'Show' instances for singleton types.
-mkShowSingContext :: ShowMode -> DCxt -> DCxt
-mkShowSingContext ForPromotion  = id
-mkShowSingContext ForShowSing{} = map show_to_SingShow
+-- This is necessary for standalone-derived 'Show' instances for singleton types.
+mkShowSingContext :: DCxt -> DCxt
+mkShowSingContext = map show_to_SingShow
   where
     show_to_SingShow :: DPred -> DPred
     show_to_SingShow = modifyConNameDType $ \n ->
                          if n == showName
                             then showSingName
                             else n
-
-mk_Show_name :: ShowMode -> Name
-mk_Show_name ForPromotion  = showName
-mk_Show_name ForShowSing{} = showSingName
-
--- If we're creating a 'Show' instance for a singleton type, decorate the type
--- appropriately (e.g., turn @Maybe a@ into @SMaybe (z :: Maybe a)@).
--- Otherwise, return the type (@Maybe a@) unchanged.
-mk_Show_inst_ty :: OptionsMonad q => ShowMode -> DType -> q DType
-mk_Show_inst_ty ForPromotion           ty = pure ty
-mk_Show_inst_ty (ForShowSing ty_tycon) ty = do
-  opts <- getOptions
-  z <- qNewName "z"
-  pure $ DConT (singledDataTypeName opts ty_tycon) `DAppT` (DVarT z `DSigT` ty)
-
--- If we're creating a 'Show' instance for a singleton type, create a pattern
--- of the form @(sx :: Sing x)@. Otherwise, simply return the pattern @sx@.
-mk_Show_arg_pat :: ShowMode -> Name -> Name -> DPat
-mk_Show_arg_pat ForPromotion  arg _      = DVarP arg
-mk_Show_arg_pat ForShowSing{} arg arg_ty =
-  DSigP (DVarP arg) (DConT singFamilyName `DAppT` DVarT arg_ty)
-
--- If we're creating a 'Show' instance for a singleton type, decorate the
--- expression with an explicit signature of the form
--- @e :: (ShowSing' a_1, ..., ShowSing' a_n) => ShowS@. Otherwise, return
--- the expression (@e@) unchanged.
-mk_Show_rhs_sig :: ShowMode -> [Name] -> DExp -> DExp
-mk_Show_rhs_sig ForPromotion  _            e = e
-mk_Show_rhs_sig ForShowSing{} arg_ty_names e =
-  e `DSigE` DConstrainedT (map (DAppT (DConT showSing'Name) . DVarT) arg_ty_names)
-                          (DConT showSName)

--- a/singletons-th/src/Data/Singletons/TH/Names.hs
+++ b/singletons-th/src/Data/Singletons/TH/Names.hs
@@ -74,7 +74,7 @@ boolName, andName, compareName, minBoundName,
   toEnumName, fromEnumName, enumName,
   equalsName, constraintName,
   showName, showSName, showCharName, showCommaSpaceName, showParenName, showsPrecName,
-  showSpaceName, showStringName, showSingName, showSing'Name,
+  showSpaceName, showStringName, showSingName,
   composeName, gtName, fromStringName,
   foldableName, foldMapName, memptyName, mappendName, foldrName,
   functorName, fmapName, replaceName,
@@ -146,7 +146,6 @@ showSpaceName = 'showSpace
 showsPrecName = 'showsPrec
 showStringName = 'showString
 showSingName = ''ShowSing
-showSing'Name = ''ShowSing'
 composeName = '(.)
 gtName = '(>)
 showCommaSpaceName = 'showCommaSpace

--- a/singletons-th/src/Data/Singletons/TH/Partition.hs
+++ b/singletons-th/src/Data/Singletons/TH/Partition.hs
@@ -295,7 +295,7 @@ partitionDeriving mb_strat deriv_pred mb_ctxt ty data_decl =
                          return $ mempty { pd_instance_decs   = [inst_for_promotion]
                                          , pd_derived_eq_decs = [inst_for_decide] } )
         , ( showName, do -- These will become PShow/SShow instances...
-                         inst_for_promotion <- mk_instance $ mkShowInstance ForPromotion
+                         inst_for_promotion <- mk_instance mkShowInstance
                          -- ...and this will become a Show instance.
                          let inst_for_show = derived_decl
                          pure $ mempty { pd_instance_decs     = [inst_for_promotion]

--- a/singletons-th/src/Data/Singletons/TH/Promote.hs
+++ b/singletons-th/src/Data/Singletons/TH/Promote.hs
@@ -156,7 +156,7 @@ promoteShowInstances = concatMapM promoteShowInstance
 
 -- | Produce an instance for 'PShow' from the given type
 promoteShowInstance :: OptionsMonad q => Name -> q [Dec]
-promoteShowInstance = promoteInstance (mkShowInstance ForPromotion) "Show"
+promoteShowInstance = promoteInstance mkShowInstance "Show"
 
 promoteInstance :: OptionsMonad q => DerivDesc q -> String -> Name -> q [Dec]
 promoteInstance mk_inst class_name name = do

--- a/singletons/CHANGES.md
+++ b/singletons/CHANGES.md
@@ -19,6 +19,17 @@ Changelog for singletons project
   Consult the changelogs for `singletons-th` and `singletons-base` for changes
   specific to those libraries. For more information on this split, see the
   [relevant GitHub discussion](https://github.com/goldfirere/singletons/issues/420).
+* The internals of `ShowSing` have been tweaked to make it possible to derive
+  `Show` instances for singleton types, e.g.,
+
+  ```hs
+  deriving instance ShowSing a => Show (SList (z :: [a]))
+  ```
+
+  For the most part, this is a backwards-compatible change, although there
+  exists at least one corner case where the new internals of `ShowSing` require
+  extra work to play nicely with GHC's constraint solver. For more details,
+  refer to the Haddocks for `ShowSing'` in `Data.Singletons.ShowSing`.
 
 2.7
 ---

--- a/singletons/src/Data/Singletons/Sigma.hs
+++ b/singletons/src/Data/Singletons/Sigma.hs
@@ -194,7 +194,7 @@ uncurrySigma f (x :%&: y) = f x y
 instance (ShowSing s, ShowApply t) => Show (Sigma s t) where
   showsPrec p ((a :: Sing (fst :: s)) :&: b) = showParen (p >= 5) $
     showsPrec 5 a . showString " :&: " . showsPrec 5 b
-      :: (ShowSing' fst, ShowApply' t fst) => ShowS
+      :: ShowApply' t fst => ShowS
 
 instance forall s (t :: s ~> Type) (sig :: Sigma s t).
          (ShowSing s, ShowSingApply t)
@@ -202,7 +202,7 @@ instance forall s (t :: s ~> Type) (sig :: Sigma s t).
   showsPrec p ((sa :: Sing ('WrapSing (sfst :: Sing fst))) :%&: (sb :: Sing snd)) =
     showParen (p >= 5) $
       showsPrec 5 sa . showString " :&: " . showsPrec 5 sb
-        :: (ShowSing' fst, ShowSingApply' t fst snd) => ShowS
+        :: ShowSingApply' t fst snd => ShowS
 
 ------------------------------------------------------------
 -- Internal utilities


### PR DESCRIPTION
By giving `ShowSing'` a quantified superclass constraint, it becomes possible to derive `Show` instances for singleton types that mention `ShowSing` in the instance context. This is a remarkably backwards-compatible change except for one corner case, which I have documented in the Haddocks for `ShowSing'` in `Data.Singletons.ShowSing`.

Fixes #426, as well as one bullet point of #439.