### PR TITLE
Correct the specificities of SConst{,Sym0,Sym1} and ProxySym0

### DIFF
--- a/singletons-base/CHANGES.md
+++ b/singletons-base/CHANGES.md
@@ -1,6 +1,26 @@
 Changelog for the `singletons-base` project
 ===========================================
 
+next [????.??.??]
+-----------------
+* The types of various entities in `Data.Functor.Const.Singletons` and
+  `Data.Proxy.Singletons` have been tweaked slightly such that their
+  specificities match their term-level counterparts:
+
+  ```diff
+  -SConst :: forall {k} {a} {b :: k} (x :: a). Sing x -> Sing ('Const @a @b x)
+  +SConst :: forall {k}  a  (b :: k) (x :: a). Sing x -> Sing ('Const @a @b x)
+
+  -type ConstSym0 :: forall  k  a (b :: k). a ~> Const a b
+  +type ConstSym0 :: forall {k} a (b :: k). a ~> Const a b
+
+  -type ConstSym1 :: forall  k a  (b :: k). a -> Const a b
+  +type ConstSym1 :: forall {k} a (b :: k). a -> Const a b
+
+  -type ProxySym0 :: forall  k  (t :: k). Proxy t
+  +type ProxySym0 :: forall {k} (t :: k). Proxy t
+  ```
+
 3.0 [2021.03.12]
 ----------------
 * The `singletons` library has been split into three libraries:

--- a/singletons-base/src/Data/Proxy/Singletons.hs
+++ b/singletons-base/src/Data/Proxy/Singletons.hs
@@ -57,8 +57,9 @@ import GHC.TypeLits.Singletons.Internal
 import Text.Show.Singletons
 
 {-
-In order to keep the type argument to Proxy poly-kinded, we define the
-singleton version of Proxy by hand. This is very much in the spirit of the
+In order to keep the type argument to Proxy poly-kinded and with an inferred
+specificity, we define the singleton version of Proxy, as well as its
+defunctionalization symbols, by hand. This is very much in the spirit of the
 code in Data.Functor.Const.Singletons. (See the comments above SConst in that
 module for more details on this choice.)
 -}
@@ -73,7 +74,9 @@ instance SingKind (Proxy t) where
 instance SingI 'Proxy where
   sing = SProxy
 
-$(genDefunSymbols [''Proxy])
+type ProxySym0 :: Proxy t
+type family ProxySym0 where
+  ProxySym0 = 'Proxy
 
 instance SDecide (Proxy t) where
   SProxy %~ SProxy = Proved Refl

--- a/singletons-base/tests/SingletonsBaseTestSuite.hs
+++ b/singletons-base/tests/SingletonsBaseTestSuite.hs
@@ -138,6 +138,7 @@ tests =
     , compileAndDumpStdTest "T453"
     , compileAndDumpStdTest "NegativeLiterals"
     , compileAndDumpStdTest "T470"
+    , compileAndDumpStdTest "T492"
     ],
     testCompileAndDumpGroup "Promote"
     [ compileAndDumpStdTest "Constructors"

--- a/singletons-base/tests/compile-and-dump/Singletons/T492.hs
+++ b/singletons-base/tests/compile-and-dump/Singletons/T492.hs
@@ -1,0 +1,25 @@
+module T492 where
+
+import Data.Functor.Const
+import Data.Functor.Const.Singletons
+import Data.Proxy
+import Data.Proxy.Singletons
+import Prelude.Singletons hiding (Const, ConstSym0, ConstSym1)
+
+f :: Const Bool Ordering
+f = Const @Bool @Ordering True
+
+sF1 :: SConst ('Const @Bool @Ordering True)
+sF1 = SConst @Bool @Ordering STrue
+
+sF2 :: SConst (ConstSym0 @Bool @Ordering @@ True)
+sF2 = singFun1 @(ConstSym0 @Bool @Ordering) SConst @@ STrue
+
+sF3 :: SConst (ConstSym1 @Bool @Ordering True)
+sF3 = SConst @Bool @Ordering STrue
+
+sP1 :: SProxy ('Proxy @Bool)
+sP1 = SProxy @Bool
+
+sP2 :: SProxy (ProxySym0 @Bool)
+sP2 = SProxy @Bool


### PR DESCRIPTION
Since these are defined in modules where we already define many things by hand, this is straightforward to accomplish. Fixes #492.