### PR TITLE
Add `SingI1` and `SingI2` classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ The type family of singleton types. A new instance of this type family is
 generated for every new singleton type.
 
 ```haskell
+type SingI :: forall {k}. k -> Constraint
 class SingI a where
   sing :: Sing a
 ```
@@ -229,6 +230,19 @@ one (a dictionary for `SingI`). The `SingInstance` type simply wraps a `SingI`
 dictionary, and the `singInstance` function produces this dictionary from an
 explicit singleton. The `singInstance` function runs in constant time, using
 a little magic.
+
+In addition to `SingI`, there are also higher-order versions named `SingI1`
+and `SingI2`:
+
+```haskell
+type SingI1 :: forall {k1 k2}. (k1 -> k2) -> Constraint
+class (forall x. SingI x => SingI (f x)) => SingI1 f where
+  liftSing :: Sing x -> Sing (f x)
+
+type SingI2 :: forall {k1 k2 k3}. (k1 -> k2 -> k3) -> Constraint
+class (forall x y. (SingI x, SingI y) => SingI (f x y)) => SingI2 f where
+  liftSing2 :: Sing x -> Sing y -> Sing (f x y)
+```
 
 
 Equality classes

--- a/singletons-base/CHANGES.md
+++ b/singletons-base/CHANGES.md
@@ -21,6 +21,7 @@ next [????.??.??]
   -type ProxySym0 :: forall  k  (t :: k). Proxy t
   +type ProxySym0 :: forall {k} (t :: k). Proxy t
   ```
+* Define instances of `SingI1` and `SingI2` when possible.
 
 3.0 [2021.03.12]
 ----------------

--- a/singletons-base/singletons-base.cabal
+++ b/singletons-base/singletons-base.cabal
@@ -74,7 +74,7 @@ library
   hs-source-dirs:     src
   build-depends:      base             >= 4.15 && < 4.16,
                       pretty,
-                      singletons       == 3.0.*,
+                      singletons       == 3.0.1,
                       singletons-th    == 3.0.*,
                       template-haskell >= 2.17 && < 2.18,
                       text >= 1.2,

--- a/singletons-base/src/Data/Bool/Singletons.hs
+++ b/singletons-base/src/Data/Bool/Singletons.hs
@@ -104,3 +104,9 @@ instance SingI c => SingI (IfSym1 c) where
   sing = singFun2 $ sIf (sing @c)
 instance (SingI c, SingI t) => SingI (IfSym2 c t) where
   sing = singFun1 $ sIf (sing @c) (sing @t)
+instance SingI1 IfSym1 where
+  liftSing s = singFun2 $ sIf s
+instance SingI c => SingI1 (IfSym2 c) where
+  liftSing s = singFun1 $ sIf (sing @c) s
+instance SingI2 IfSym2 where
+  liftSing2 s1 s2 = singFun1 $ sIf s1 s2

--- a/singletons-base/src/Data/Functor/Compose/Singletons.hs
+++ b/singletons-base/src/Data/Functor/Compose/Singletons.hs
@@ -58,11 +58,15 @@ data SCompose :: Compose f g a -> Type where
 type instance Sing = SCompose
 instance SingI x => SingI ('Compose x) where
   sing = SCompose sing
+instance SingI1 'Compose where
+  liftSing = SCompose
 
 infixr 9 `ComposeSym0`
 type ComposeSym0 :: f (g a) ~> Compose f g a
 data ComposeSym0 z
 type instance Apply ComposeSym0 x = 'Compose x
+instance SingI ComposeSym0 where
+  sing = singFun1 SCompose
 
 infixr 9 `ComposeSym1`
 type ComposeSym1 :: f (g a) -> Compose f g a

--- a/singletons-base/src/Data/Functor/Const/Singletons.hs
+++ b/singletons-base/src/Data/Functor/Const/Singletons.hs
@@ -88,6 +88,8 @@ instance SingKind a => SingKind (Const a b) where
   toSing (Const a) = withSomeSing a $ SomeSing . SConst
 instance SingI a => SingI ('Const a) where
   sing = SConst sing
+instance SingI1 'Const where
+  liftSing = SConst
 
 type ConstSym0 :: a ~> Const a b
 data ConstSym0 z

--- a/singletons-base/src/Data/Functor/Product/Singletons.hs
+++ b/singletons-base/src/Data/Functor/Product/Singletons.hs
@@ -61,14 +61,24 @@ data SProduct :: Product f g a -> Type where
 type instance Sing = SProduct
 instance (SingI x, SingI y) => SingI ('Pair x y) where
   sing = SPair sing sing
+instance SingI x => SingI1 ('Pair x) where
+  liftSing = SPair sing
+instance SingI2 'Pair where
+  liftSing2 = SPair
 
 type PairSym0 :: forall f g a. f a ~> g a ~> Product f g a
 data PairSym0 z
 type instance Apply PairSym0 x = PairSym1 x
+instance SingI PairSym0 where
+  sing = singFun2 SPair
 
 type PairSym1 :: forall f g a. f a -> g a ~> Product f g a
 data PairSym1 fa z
 type instance Apply (PairSym1 x) y = 'Pair x y
+instance SingI x => SingI (PairSym1 x) where
+  sing = singFun1 $ SPair (sing @x)
+instance SingI1 PairSym1 where
+  liftSing s = singFun1 $ SPair s
 
 type PairSym2 :: forall f g a. f a -> g a -> Product f g a
 type family PairSym2 x y where

--- a/singletons-base/src/Data/Functor/Sum/Singletons.hs
+++ b/singletons-base/src/Data/Functor/Sum/Singletons.hs
@@ -57,12 +57,18 @@ data SSum :: Sum f g a -> Type where
 type instance Sing = SSum
 instance SingI x => SingI ('InL x) where
   sing = SInL sing
+instance SingI1 'InL where
+  liftSing = SInL
 instance SingI y => SingI ('InR y) where
   sing = SInR sing
+instance SingI1 'InR where
+  liftSing = SInR
 
 type InLSym0 :: forall f g a. f a ~> Sum f g a
 data InLSym0 z
 type instance Apply InLSym0 x = 'InL x
+instance SingI InLSym0 where
+  sing = singFun1 SInL
 
 type InLSym1 :: forall f g a. f a -> Sum f g a
 type family InLSym1 x where
@@ -71,6 +77,8 @@ type family InLSym1 x where
 type InRSym0 :: forall f g a. g a ~> Sum f g a
 data InRSym0 z
 type instance Apply InRSym0 y = 'InR y
+instance SingI InRSym0 where
+  sing = singFun1 SInR
 
 type InRSym1 :: forall f g a. g a -> Sum f g a
 type family InRSym1 x where

--- a/singletons-base/src/Data/Singletons/Base/TypeError.hs
+++ b/singletons-base/src/Data/Singletons/Base/TypeError.hs
@@ -107,15 +107,27 @@ instance SingKind PErrorMessage where
 
 instance SingI t => SingI ('Text t :: PErrorMessage) where
   sing = SText sing
+instance SingI1 ('Text :: Symbol -> PErrorMessage) where
+  liftSing = SText
 
 instance SingI ty => SingI ('ShowType ty :: PErrorMessage) where
   sing = SShowType sing
+instance SingI1 ('ShowType :: t -> PErrorMessage) where
+  liftSing = SShowType
 
 instance (SingI e1, SingI e2) => SingI (e1 ':<>: e2 :: PErrorMessage) where
   sing = sing :%<>: sing
+instance SingI e1 => SingI1 ('(:<>:) e1 :: PErrorMessage -> PErrorMessage) where
+  liftSing s = sing :%<>: s
+instance SingI2 ('(:<>:) :: PErrorMessage -> PErrorMessage -> PErrorMessage) where
+  liftSing2 s1 s2 = s1 :%<>: s2
 
 instance (SingI e1, SingI e2) => SingI (e1 ':$$: e2 :: PErrorMessage) where
   sing = sing :%$$: sing
+instance SingI e1 => SingI1 ('(:$$:) e1 :: PErrorMessage -> PErrorMessage) where
+  liftSing s = sing :%$$: s
+instance SingI2 ('(:$$:) :: PErrorMessage -> PErrorMessage -> PErrorMessage) where
+  liftSing2 s1 s2 = s1 :%$$: s2
 
 -- | Convert an 'ErrorMessage' into a human-readable 'String'.
 showErrorMessage :: ErrorMessage -> String
@@ -169,11 +181,15 @@ instance SingI ((:<>:@#@$) :: PErrorMessage ~> PErrorMessage ~> PErrorMessage) w
   sing = singFun2 (:%<>:)
 instance SingI x => SingI ((:<>:@#@$$) x :: PErrorMessage ~> PErrorMessage) where
   sing = singFun1 (sing @x :%<>:)
+instance SingI1 ((:<>:@#@$$) :: PErrorMessage -> PErrorMessage ~> PErrorMessage) where
+  liftSing s = singFun1 (s :%<>:)
 
 instance SingI ((:$$:@#@$) :: PErrorMessage ~> PErrorMessage ~> PErrorMessage) where
   sing = singFun2 (:%$$:)
 instance SingI x => SingI ((:$$:@#@$$) x :: PErrorMessage ~> PErrorMessage) where
   sing = singFun1 (sing @x :%$$:)
+instance SingI1 ((:$$:@#@$$) :: PErrorMessage -> PErrorMessage ~> PErrorMessage) where
+  liftSing s = singFun1 (s :%$$:)
 
 instance SingI TypeErrorSym0 where
   sing = singFun1 sTypeError

--- a/singletons-base/src/GHC/TypeLits/Singletons.hs
+++ b/singletons-base/src/GHC/TypeLits/Singletons.hs
@@ -167,6 +167,8 @@ instance SingI DivSym0 where
   sing = singFun2 sDiv
 instance SingI x => SingI (DivSym1 x) where
   sing = singFun1 $ sDiv (sing @x)
+instance SingI1 DivSym1 where
+  liftSing s = singFun1 $ sDiv s
 
 sMod :: Sing x -> Sing y -> Sing (Mod x y)
 sMod sx sy =
@@ -181,6 +183,8 @@ instance SingI ModSym0 where
   sing = singFun2 sMod
 instance SingI x => SingI (ModSym1 x) where
   sing = singFun1 $ sMod $ sing @x
+instance SingI1 ModSym1 where
+  liftSing s = singFun1 $ sMod s
 
 $(promoteOnly [d|
   divMod :: Nat -> Nat -> (Nat, Nat)

--- a/singletons-base/src/GHC/TypeLits/Singletons/Internal.hs
+++ b/singletons-base/src/GHC/TypeLits/Singletons/Internal.hs
@@ -226,6 +226,8 @@ instance SingI (^@#@$) where
   sing = singFun2 (%^)
 instance SingI x => SingI ((^@#@$$) x) where
   sing = singFun1 (sing @x %^)
+instance SingI1 (^@#@$$) where
+  liftSing s = singFun1 (s %^)
 
 -- | The singleton analogue of 'TN.<=?'
 --
@@ -254,3 +256,5 @@ instance SingI (<=?@#@$) where
   sing = singFun2 (%<=?)
 instance SingI x => SingI ((<=?@#@$$) x) where
   sing = singFun1 (sing @x %<=?)
+instance SingI1 (<=?@#@$$) where
+  liftSing s = singFun1 (s %<=?)

--- a/singletons-base/tests/compile-and-dump/GradingClient/Database.golden
+++ b/singletons-base/tests/compile-and-dump/GradingClient/Database.golden
@@ -160,6 +160,8 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       sing = SZero
     instance SingI n => SingI (Succ (n :: Nat)) where
       sing = SSucc sing
+    instance SingI1 Succ where
+      liftSing = SSucc
     instance SingI (SuccSym0 :: (~>) Nat Nat) where
       sing = (singFun1 @SuccSym0) SSucc
 GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
@@ -1494,17 +1496,26 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance SingI d =>
              SingI (LookupSym1 (d :: [AChar]) :: (~>) Schema U) where
       sing = (singFun1 @(LookupSym1 (d :: [AChar]))) (sLookup (sing @d))
+    instance SingI1 (LookupSym1 :: [AChar] -> (~>) Schema U) where
+      liftSing (s :: Sing (d :: [AChar]))
+        = (singFun1 @(LookupSym1 (d :: [AChar]))) (sLookup s)
     instance SingI (OccursSym0 :: (~>) [AChar] ((~>) Schema Bool)) where
       sing = (singFun2 @OccursSym0) sOccurs
     instance SingI d =>
              SingI (OccursSym1 (d :: [AChar]) :: (~>) Schema Bool) where
       sing = (singFun1 @(OccursSym1 (d :: [AChar]))) (sOccurs (sing @d))
+    instance SingI1 (OccursSym1 :: [AChar] -> (~>) Schema Bool) where
+      liftSing (s :: Sing (d :: [AChar]))
+        = (singFun1 @(OccursSym1 (d :: [AChar]))) (sOccurs s)
     instance SingI (DisjointSym0 :: (~>) Schema ((~>) Schema Bool)) where
       sing = (singFun2 @DisjointSym0) sDisjoint
     instance SingI d =>
              SingI (DisjointSym1 (d :: Schema) :: (~>) Schema Bool) where
       sing
         = (singFun1 @(DisjointSym1 (d :: Schema))) (sDisjoint (sing @d))
+    instance SingI1 (DisjointSym1 :: Schema -> (~>) Schema Bool) where
+      liftSing (s :: Sing (d :: Schema))
+        = (singFun1 @(DisjointSym1 (d :: Schema))) (sDisjoint s)
     instance SingI (AttrNotInSym0 :: (~>) Attribute ((~>) Schema Bool)) where
       sing = (singFun2 @AttrNotInSym0) sAttrNotIn
     instance SingI d =>
@@ -1512,11 +1523,18 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       sing
         = (singFun1 @(AttrNotInSym1 (d :: Attribute)))
             (sAttrNotIn (sing @d))
+    instance SingI1 (AttrNotInSym1 :: Attribute
+                                      -> (~>) Schema Bool) where
+      liftSing (s :: Sing (d :: Attribute))
+        = (singFun1 @(AttrNotInSym1 (d :: Attribute))) (sAttrNotIn s)
     instance SingI (AppendSym0 :: (~>) Schema ((~>) Schema Schema)) where
       sing = (singFun2 @AppendSym0) sAppend
     instance SingI d =>
              SingI (AppendSym1 (d :: Schema) :: (~>) Schema Schema) where
       sing = (singFun1 @(AppendSym1 (d :: Schema))) (sAppend (sing @d))
+    instance SingI1 (AppendSym1 :: Schema -> (~>) Schema Schema) where
+      liftSing (s :: Sing (d :: Schema))
+        = (singFun1 @(AppendSym1 (d :: Schema))) (sAppend s)
     data SU :: U -> Type
       where
         SBOOL :: SU (BOOL :: U)
@@ -3370,10 +3388,17 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance (SingI n, SingI n) =>
              SingI (VEC (n :: U) (n :: Nat)) where
       sing = (SVEC sing) sing
+    instance SingI n => SingI1 (VEC (n :: U)) where
+      liftSing = SVEC sing
+    instance SingI2 VEC where
+      liftSing2 = SVEC
     instance SingI (VECSym0 :: (~>) U ((~>) Nat U)) where
       sing = (singFun2 @VECSym0) SVEC
     instance SingI d => SingI (VECSym1 (d :: U) :: (~>) Nat U) where
       sing = (singFun1 @(VECSym1 (d :: U))) (SVEC (sing @d))
+    instance SingI1 (VECSym1 :: U -> (~>) Nat U) where
+      liftSing (s :: Sing (d :: U))
+        = (singFun1 @(VECSym1 (d :: U))) (SVEC s)
     instance SingI CA where
       sing = SCA
     instance SingI CB where
@@ -3429,13 +3454,22 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance (SingI n, SingI n) =>
              SingI (Attr (n :: [AChar]) (n :: U)) where
       sing = (SAttr sing) sing
+    instance SingI n => SingI1 (Attr (n :: [AChar])) where
+      liftSing = SAttr sing
+    instance SingI2 Attr where
+      liftSing2 = SAttr
     instance SingI (AttrSym0 :: (~>) [AChar] ((~>) U Attribute)) where
       sing = (singFun2 @AttrSym0) SAttr
     instance SingI d =>
              SingI (AttrSym1 (d :: [AChar]) :: (~>) U Attribute) where
       sing = (singFun1 @(AttrSym1 (d :: [AChar]))) (SAttr (sing @d))
+    instance SingI1 (AttrSym1 :: [AChar] -> (~>) U Attribute) where
+      liftSing (s :: Sing (d :: [AChar]))
+        = (singFun1 @(AttrSym1 (d :: [AChar]))) (SAttr s)
     instance SingI n => SingI (Sch (n :: [Attribute])) where
       sing = SSch sing
+    instance SingI1 Sch where
+      liftSing = SSch
     instance SingI (SchSym0 :: (~>) [Attribute] Schema) where
       sing = (singFun1 @SchSym0) SSch
 GradingClient/Database.hs:0:0:: Splicing declarations

--- a/singletons-base/tests/compile-and-dump/InsertionSort/InsertionSortImp.golden
+++ b/singletons-base/tests/compile-and-dump/InsertionSort/InsertionSortImp.golden
@@ -33,6 +33,8 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
       sing = SZero
     instance SingI n => SingI (Succ (n :: Nat)) where
       sing = SSucc sing
+    instance SingI1 Succ where
+      liftSing = SSucc
     instance SingI (SuccSym0 :: (~>) Nat Nat) where
       sing = (singFun1 @SuccSym0) SSucc
 InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
@@ -205,8 +207,14 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
     instance SingI d =>
              SingI (InsertSym1 (d :: Nat) :: (~>) [Nat] [Nat]) where
       sing = (singFun1 @(InsertSym1 (d :: Nat))) (sInsert (sing @d))
+    instance SingI1 (InsertSym1 :: Nat -> (~>) [Nat] [Nat]) where
+      liftSing (s :: Sing (d :: Nat))
+        = (singFun1 @(InsertSym1 (d :: Nat))) (sInsert s)
     instance SingI (LeqSym0 :: (~>) Nat ((~>) Nat Bool)) where
       sing = (singFun2 @LeqSym0) sLeq
     instance SingI d =>
              SingI (LeqSym1 (d :: Nat) :: (~>) Nat Bool) where
       sing = (singFun1 @(LeqSym1 (d :: Nat))) (sLeq (sing @d))
+    instance SingI1 (LeqSym1 :: Nat -> (~>) Nat Bool) where
+      liftSing (s :: Sing (d :: Nat))
+        = (singFun1 @(LeqSym1 (d :: Nat))) (sLeq s)

--- a/singletons-base/tests/compile-and-dump/Singletons/AsPattern.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/AsPattern.golden
@@ -379,13 +379,28 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
     instance (SingI n, SingI n, SingI n) =>
              SingI (Baz (n :: Nat) (n :: Nat) (n :: Nat)) where
       sing = ((SBaz sing) sing) sing
+    instance (SingI n, SingI n) =>
+             SingI1 (Baz (n :: Nat) (n :: Nat)) where
+      liftSing = (SBaz sing) sing
+    instance SingI n => SingI2 (Baz (n :: Nat)) where
+      liftSing2 = SBaz sing
     instance SingI (BazSym0 :: (~>) Nat ((~>) Nat ((~>) Nat Baz))) where
       sing = (singFun3 @BazSym0) SBaz
     instance SingI d =>
              SingI (BazSym1 (d :: Nat) :: (~>) Nat ((~>) Nat Baz)) where
       sing = (singFun2 @(BazSym1 (d :: Nat))) (SBaz (sing @d))
+    instance SingI1 (BazSym1 :: Nat -> (~>) Nat ((~>) Nat Baz)) where
+      liftSing (s :: Sing (d :: Nat))
+        = (singFun2 @(BazSym1 (d :: Nat))) (SBaz s)
     instance (SingI d, SingI d) =>
              SingI (BazSym2 (d :: Nat) (d :: Nat) :: (~>) Nat Baz) where
       sing
         = (singFun1 @(BazSym2 (d :: Nat) (d :: Nat)))
             ((SBaz (sing @d)) (sing @d))
+    instance SingI d =>
+             SingI1 (BazSym2 (d :: Nat) :: Nat -> (~>) Nat Baz) where
+      liftSing (s :: Sing (d :: Nat))
+        = (singFun1 @(BazSym2 (d :: Nat) (d :: Nat))) ((SBaz (sing @d)) s)
+    instance SingI2 (BazSym2 :: Nat -> Nat -> (~>) Nat Baz) where
+      liftSing2 (s :: Sing (d :: Nat)) (s :: Sing (d :: Nat))
+        = (singFun1 @(BazSym2 (d :: Nat) (d :: Nat))) ((SBaz s) s)

--- a/singletons-base/tests/compile-and-dump/Singletons/BoundedDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/BoundedDeriving.golden
@@ -267,6 +267,8 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
       sing = SE
     instance SingI n => SingI (Foo3 (n :: a)) where
       sing = SFoo3 sing
+    instance SingI1 Foo3 where
+      liftSing = SFoo3
     instance SingI (Foo3Sym0 :: (~>) a (Foo3 a)) where
       sing = (singFun1 @Foo3Sym0) SFoo3
     instance SingI Foo41 where
@@ -276,8 +278,15 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance (SingI n, SingI n) =>
              SingI (Pair (n :: Bool) (n :: Bool)) where
       sing = (SPair sing) sing
+    instance SingI n => SingI1 (Pair (n :: Bool)) where
+      liftSing = SPair sing
+    instance SingI2 Pair where
+      liftSing2 = SPair
     instance SingI (PairSym0 :: (~>) Bool ((~>) Bool Pair)) where
       sing = (singFun2 @PairSym0) SPair
     instance SingI d =>
              SingI (PairSym1 (d :: Bool) :: (~>) Bool Pair) where
       sing = (singFun1 @(PairSym1 (d :: Bool))) (SPair (sing @d))
+    instance SingI1 (PairSym1 :: Bool -> (~>) Bool Pair) where
+      liftSing (s :: Sing (d :: Bool))
+        = (singFun1 @(PairSym1 (d :: Bool))) (SPair s)

--- a/singletons-base/tests/compile-and-dump/Singletons/BoxUnBox.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/BoxUnBox.golden
@@ -50,5 +50,7 @@ Singletons/BoxUnBox.hs:(0,0)-(0,0): Splicing declarations
             SomeSing c -> SomeSing (SFBox c) }
     instance SingI n => SingI (FBox (n :: a)) where
       sing = SFBox sing
+    instance SingI1 FBox where
+      liftSing = SFBox
     instance SingI (FBoxSym0 :: (~>) a (Box a)) where
       sing = (singFun1 @FBoxSym0) SFBox

--- a/singletons-base/tests/compile-and-dump/Singletons/CaseExpressions.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/CaseExpressions.golden
@@ -300,13 +300,22 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @Foo3Sym0) sFoo3
     instance SingI d => SingI (Foo3Sym1 (d :: a) :: (~>) b a) where
       sing = (singFun1 @(Foo3Sym1 (d :: a))) (sFoo3 (sing @d))
+    instance SingI1 (Foo3Sym1 :: a -> (~>) b a) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(Foo3Sym1 (d :: a))) (sFoo3 s)
     instance SingI (Foo2Sym0 :: (~>) a ((~>) (Maybe a) a)) where
       sing = (singFun2 @Foo2Sym0) sFoo2
     instance SingI d =>
              SingI (Foo2Sym1 (d :: a) :: (~>) (Maybe a) a) where
       sing = (singFun1 @(Foo2Sym1 (d :: a))) (sFoo2 (sing @d))
+    instance SingI1 (Foo2Sym1 :: a -> (~>) (Maybe a) a) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(Foo2Sym1 (d :: a))) (sFoo2 s)
     instance SingI (Foo1Sym0 :: (~>) a ((~>) (Maybe a) a)) where
       sing = (singFun2 @Foo1Sym0) sFoo1
     instance SingI d =>
              SingI (Foo1Sym1 (d :: a) :: (~>) (Maybe a) a) where
       sing = (singFun1 @(Foo1Sym1 (d :: a))) (sFoo1 (sing @d))
+    instance SingI1 (Foo1Sym1 :: a -> (~>) (Maybe a) a) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(Foo1Sym1 (d :: a))) (sFoo1 s)

--- a/singletons-base/tests/compile-and-dump/Singletons/Classes.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Classes.golden
@@ -315,10 +315,16 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
              SingI (FooCompareSym1 (d :: Foo) :: (~>) Foo Ordering) where
       sing
         = (singFun1 @(FooCompareSym1 (d :: Foo))) (sFooCompare (sing @d))
+    instance SingI1 (FooCompareSym1 :: Foo -> (~>) Foo Ordering) where
+      liftSing (s :: Sing (d :: Foo))
+        = (singFun1 @(FooCompareSym1 (d :: Foo))) (sFooCompare s)
     instance SingI (ConstSym0 :: (~>) a ((~>) b a)) where
       sing = (singFun2 @ConstSym0) sConst
     instance SingI d => SingI (ConstSym1 (d :: a) :: (~>) b a) where
       sing = (singFun1 @(ConstSym1 (d :: a))) (sConst (sing @d))
+    instance SingI1 (ConstSym1 :: a -> (~>) b a) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(ConstSym1 (d :: a))) (sConst s)
     data SFoo :: Foo -> GHC.Types.Type
       where
         SA :: SFoo (A :: Foo)
@@ -420,11 +426,19 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
              SingI (MycompareSym1 (d :: a) :: (~>) a Ordering) where
       sing = (singFun1 @(MycompareSym1 (d :: a))) (sMycompare (sing @d))
     instance SMyOrd a =>
+             SingI1 (MycompareSym1 :: a -> (~>) a Ordering) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(MycompareSym1 (d :: a))) (sMycompare s)
+    instance SMyOrd a =>
              SingI ((<=>@#@$) :: (~>) a ((~>) a Ordering)) where
       sing = (singFun2 @(<=>@#@$)) (%<=>)
     instance (SMyOrd a, SingI d) =>
              SingI ((<=>@#@$$) (d :: a) :: (~>) a Ordering) where
       sing = (singFun1 @((<=>@#@$$) (d :: a))) ((%<=>) (sing @d))
+    instance SMyOrd a =>
+             SingI1 ((<=>@#@$$) :: a -> (~>) a Ordering) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @((<=>@#@$$) (d :: a))) ((%<=>) s)
 Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     promote
       [d| instance Ord Foo2 where
@@ -592,5 +606,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       sing = SZero'
     instance SingI n => SingI (Succ' (n :: Nat')) where
       sing = SSucc' sing
+    instance SingI1 Succ' where
+      liftSing = SSucc'
     instance SingI (Succ'Sym0 :: (~>) Nat' Nat') where
       sing = (singFun1 @Succ'Sym0) SSucc'

--- a/singletons-base/tests/compile-and-dump/Singletons/Classes2.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Classes2.golden
@@ -91,5 +91,7 @@ Singletons/Classes2.hs:(0,0)-(0,0): Splicing declarations
       sing = SZeroFoo
     instance SingI n => SingI (SuccFoo (n :: NatFoo)) where
       sing = SSuccFoo sing
+    instance SingI1 SuccFoo where
+      liftSing = SSuccFoo
     instance SingI (SuccFooSym0 :: (~>) NatFoo NatFoo) where
       sing = (singFun1 @SuccFooSym0) SSuccFoo

--- a/singletons-base/tests/compile-and-dump/Singletons/Contains.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Contains.golden
@@ -48,3 +48,6 @@ Singletons/Contains.hs:(0,0)-(0,0): Splicing declarations
     instance (SEq a, SingI d) =>
              SingI (ContainsSym1 (d :: a) :: (~>) [a] Bool) where
       sing = (singFun1 @(ContainsSym1 (d :: a))) (sContains (sing @d))
+    instance SEq a => SingI1 (ContainsSym1 :: a -> (~>) [a] Bool) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(ContainsSym1 (d :: a))) (sContains s)

--- a/singletons-base/tests/compile-and-dump/Singletons/DataValues.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/DataValues.golden
@@ -175,8 +175,15 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
                       Show (SPair (z :: Pair a b))
     instance (SingI n, SingI n) => SingI (Pair (n :: a) (n :: b)) where
       sing = (SPair sing) sing
+    instance SingI n => SingI1 (Pair (n :: a)) where
+      liftSing = SPair sing
+    instance SingI2 Pair where
+      liftSing2 = SPair
     instance SingI (PairSym0 :: (~>) a ((~>) b (Pair a b))) where
       sing = (singFun2 @PairSym0) SPair
     instance SingI d =>
              SingI (PairSym1 (d :: a) :: (~>) b (Pair a b)) where
       sing = (singFun1 @(PairSym1 (d :: a))) (SPair (sing @d))
+    instance SingI1 (PairSym1 :: a -> (~>) b (Pair a b)) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(PairSym1 (d :: a))) (SPair s)

--- a/singletons-base/tests/compile-and-dump/Singletons/Fixity.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Fixity.golden
@@ -73,6 +73,9 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @(====@#@$)) (%====)
     instance SingI d => SingI ((====@#@$$) (d :: a) :: (~>) a a) where
       sing = (singFun1 @((====@#@$$) (d :: a))) ((%====) (sing @d))
+    instance SingI1 ((====@#@$$) :: a -> (~>) a a) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @((====@#@$$) (d :: a))) ((%====) s)
     class SMyOrd a where
       (%<=>) ::
         forall (t :: a) (t :: a).
@@ -84,3 +87,7 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
     instance (SMyOrd a, SingI d) =>
              SingI ((<=>@#@$$) (d :: a) :: (~>) a Ordering) where
       sing = (singFun1 @((<=>@#@$$) (d :: a))) ((%<=>) (sing @d))
+    instance SMyOrd a =>
+             SingI1 ((<=>@#@$$) :: a -> (~>) a Ordering) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @((<=>@#@$$) (d :: a))) ((%<=>) s)

--- a/singletons-base/tests/compile-and-dump/Singletons/FunctorLikeDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/FunctorLikeDeriving.golden
@@ -1316,22 +1316,55 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance (SingI n, SingI n, SingI n, SingI n) =>
              SingI (MkT1 (n :: x) (n :: a) (n :: Maybe a) (n :: Maybe (Maybe a))) where
       sing = (((SMkT1 sing) sing) sing) sing
+    instance (SingI n, SingI n, SingI n) =>
+             SingI1 (MkT1 (n :: x) (n :: a) (n :: Maybe a)) where
+      liftSing = ((SMkT1 sing) sing) sing
+    instance (SingI n, SingI n) =>
+             SingI2 (MkT1 (n :: x) (n :: a)) where
+      liftSing2 = (SMkT1 sing) sing
     instance SingI (MkT1Sym0 :: (~>) x ((~>) a ((~>) (Maybe a) ((~>) (Maybe (Maybe a)) (T x a))))) where
       sing = (singFun4 @MkT1Sym0) SMkT1
     instance SingI d =>
              SingI (MkT1Sym1 (d :: x) :: (~>) a ((~>) (Maybe a) ((~>) (Maybe (Maybe a)) (T x a)))) where
       sing = (singFun3 @(MkT1Sym1 (d :: x))) (SMkT1 (sing @d))
+    instance SingI1 (MkT1Sym1 :: x
+                                 -> (~>) a ((~>) (Maybe a) ((~>) (Maybe (Maybe a)) (T x a)))) where
+      liftSing (s :: Sing (d :: x))
+        = (singFun3 @(MkT1Sym1 (d :: x))) (SMkT1 s)
     instance (SingI d, SingI d) =>
              SingI (MkT1Sym2 (d :: x) (d :: a) :: (~>) (Maybe a) ((~>) (Maybe (Maybe a)) (T x a))) where
       sing
         = (singFun2 @(MkT1Sym2 (d :: x) (d :: a)))
             ((SMkT1 (sing @d)) (sing @d))
+    instance SingI d =>
+             SingI1 (MkT1Sym2 (d :: x) :: a
+                                          -> (~>) (Maybe a) ((~>) (Maybe (Maybe a)) (T x a))) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun2 @(MkT1Sym2 (d :: x) (d :: a))) ((SMkT1 (sing @d)) s)
+    instance SingI2 (MkT1Sym2 :: x
+                                 -> a -> (~>) (Maybe a) ((~>) (Maybe (Maybe a)) (T x a))) where
+      liftSing2 (s :: Sing (d :: x)) (s :: Sing (d :: a))
+        = (singFun2 @(MkT1Sym2 (d :: x) (d :: a))) ((SMkT1 s) s)
     instance (SingI d, SingI d, SingI d) =>
              SingI (MkT1Sym3 (d :: x) (d :: a) (d :: Maybe a) :: (~>) (Maybe (Maybe a)) (T x a)) where
       sing
         = (singFun1 @(MkT1Sym3 (d :: x) (d :: a) (d :: Maybe a)))
             (((SMkT1 (sing @d)) (sing @d)) (sing @d))
+    instance (SingI d, SingI d) =>
+             SingI1 (MkT1Sym3 (d :: x) (d :: a) :: Maybe a
+                                                   -> (~>) (Maybe (Maybe a)) (T x a)) where
+      liftSing (s :: Sing (d :: Maybe a))
+        = (singFun1 @(MkT1Sym3 (d :: x) (d :: a) (d :: Maybe a)))
+            (((SMkT1 (sing @d)) (sing @d)) s)
+    instance SingI d =>
+             SingI2 (MkT1Sym3 (d :: x) :: a
+                                          -> Maybe a -> (~>) (Maybe (Maybe a)) (T x a)) where
+      liftSing2 (s :: Sing (d :: a)) (s :: Sing (d :: Maybe a))
+        = (singFun1 @(MkT1Sym3 (d :: x) (d :: a) (d :: Maybe a)))
+            (((SMkT1 (sing @d)) s) s)
     instance SingI n => SingI (MkT2 (n :: Maybe x)) where
       sing = SMkT2 sing
+    instance SingI1 MkT2 where
+      liftSing = SMkT2
     instance SingI (MkT2Sym0 :: (~>) (Maybe x) (T x a)) where
       sing = (singFun1 @MkT2Sym0) SMkT2

--- a/singletons-base/tests/compile-and-dump/Singletons/HigherOrder.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/HigherOrder.golden
@@ -386,11 +386,17 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     instance SingI d =>
              SingI (EtadSym1 (d :: [Nat]) :: (~>) [Bool] [Nat]) where
       sing = (singFun1 @(EtadSym1 (d :: [Nat]))) (sEtad (sing @d))
+    instance SingI1 (EtadSym1 :: [Nat] -> (~>) [Bool] [Nat]) where
+      liftSing (s :: Sing (d :: [Nat]))
+        = (singFun1 @(EtadSym1 (d :: [Nat]))) (sEtad s)
     instance SingI (SplungeSym0 :: (~>) [Nat] ((~>) [Bool] [Nat])) where
       sing = (singFun2 @SplungeSym0) sSplunge
     instance SingI d =>
              SingI (SplungeSym1 (d :: [Nat]) :: (~>) [Bool] [Nat]) where
       sing = (singFun1 @(SplungeSym1 (d :: [Nat]))) (sSplunge (sing @d))
+    instance SingI1 (SplungeSym1 :: [Nat] -> (~>) [Bool] [Nat]) where
+      liftSing (s :: Sing (d :: [Nat]))
+        = (singFun1 @(SplungeSym1 (d :: [Nat]))) (sSplunge s)
     instance SingI (FooSym0 :: (~>) ((~>) ((~>) a b) ((~>) a b)) ((~>) ((~>) a b) ((~>) a b))) where
       sing = (singFun3 @FooSym0) sFoo
     instance SingI d =>
@@ -398,12 +404,31 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
       sing
         = (singFun2 @(FooSym1 (d :: (~>) ((~>) a b) ((~>) a b))))
             (sFoo (sing @d))
+    instance SingI1 (FooSym1 :: (~>) ((~>) a b) ((~>) a b)
+                                -> (~>) ((~>) a b) ((~>) a b)) where
+      liftSing (s :: Sing (d :: (~>) ((~>) a b) ((~>) a b)))
+        = (singFun2 @(FooSym1 (d :: (~>) ((~>) a b) ((~>) a b)))) (sFoo s)
     instance (SingI d, SingI d) =>
              SingI (FooSym2 (d :: (~>) ((~>) a b) ((~>) a b)) (d :: (~>) a b) :: (~>) a b) where
       sing
         = (singFun1
              @(FooSym2 (d :: (~>) ((~>) a b) ((~>) a b)) (d :: (~>) a b)))
             ((sFoo (sing @d)) (sing @d))
+    instance SingI d =>
+             SingI1 (FooSym2 (d :: (~>) ((~>) a b) ((~>) a b)) :: (~>) a b
+                                                                  -> (~>) a b) where
+      liftSing (s :: Sing (d :: (~>) a b))
+        = (singFun1
+             @(FooSym2 (d :: (~>) ((~>) a b) ((~>) a b)) (d :: (~>) a b)))
+            ((sFoo (sing @d)) s)
+    instance SingI2 (FooSym2 :: (~>) ((~>) a b) ((~>) a b)
+                                -> (~>) a b -> (~>) a b) where
+      liftSing2
+        (s :: Sing (d :: (~>) ((~>) a b) ((~>) a b)))
+        (s :: Sing (d :: (~>) a b))
+        = (singFun1
+             @(FooSym2 (d :: (~>) ((~>) a b) ((~>) a b)) (d :: (~>) a b)))
+            ((sFoo s) s)
     instance SingI (ZipWithSym0 :: (~>) ((~>) a ((~>) b c)) ((~>) [a] ((~>) [b] [c]))) where
       sing = (singFun3 @ZipWithSym0) sZipWith
     instance SingI d =>
@@ -411,11 +436,28 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
       sing
         = (singFun2 @(ZipWithSym1 (d :: (~>) a ((~>) b c))))
             (sZipWith (sing @d))
+    instance SingI1 (ZipWithSym1 :: (~>) a ((~>) b c)
+                                    -> (~>) [a] ((~>) [b] [c])) where
+      liftSing (s :: Sing (d :: (~>) a ((~>) b c)))
+        = (singFun2 @(ZipWithSym1 (d :: (~>) a ((~>) b c)))) (sZipWith s)
     instance (SingI d, SingI d) =>
              SingI (ZipWithSym2 (d :: (~>) a ((~>) b c)) (d :: [a]) :: (~>) [b] [c]) where
       sing
         = (singFun1 @(ZipWithSym2 (d :: (~>) a ((~>) b c)) (d :: [a])))
             ((sZipWith (sing @d)) (sing @d))
+    instance SingI d =>
+             SingI1 (ZipWithSym2 (d :: (~>) a ((~>) b c)) :: [a]
+                                                             -> (~>) [b] [c]) where
+      liftSing (s :: Sing (d :: [a]))
+        = (singFun1 @(ZipWithSym2 (d :: (~>) a ((~>) b c)) (d :: [a])))
+            ((sZipWith (sing @d)) s)
+    instance SingI2 (ZipWithSym2 :: (~>) a ((~>) b c)
+                                    -> [a] -> (~>) [b] [c]) where
+      liftSing2
+        (s :: Sing (d :: (~>) a ((~>) b c)))
+        (s :: Sing (d :: [a]))
+        = (singFun1 @(ZipWithSym2 (d :: (~>) a ((~>) b c)) (d :: [a])))
+            ((sZipWith s) s)
     instance SingI (LiftMaybeSym0 :: (~>) ((~>) a b) ((~>) (Maybe a) (Maybe b))) where
       sing = (singFun2 @LiftMaybeSym0) sLiftMaybe
     instance SingI d =>
@@ -423,11 +465,18 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
       sing
         = (singFun1 @(LiftMaybeSym1 (d :: (~>) a b)))
             (sLiftMaybe (sing @d))
+    instance SingI1 (LiftMaybeSym1 :: (~>) a b
+                                      -> (~>) (Maybe a) (Maybe b)) where
+      liftSing (s :: Sing (d :: (~>) a b))
+        = (singFun1 @(LiftMaybeSym1 (d :: (~>) a b))) (sLiftMaybe s)
     instance SingI (MapSym0 :: (~>) ((~>) a b) ((~>) [a] [b])) where
       sing = (singFun2 @MapSym0) sMap
     instance SingI d =>
              SingI (MapSym1 (d :: (~>) a b) :: (~>) [a] [b]) where
       sing = (singFun1 @(MapSym1 (d :: (~>) a b))) (sMap (sing @d))
+    instance SingI1 (MapSym1 :: (~>) a b -> (~>) [a] [b]) where
+      liftSing (s :: Sing (d :: (~>) a b))
+        = (singFun1 @(MapSym1 (d :: (~>) a b))) (sMap s)
     data SEither :: forall a b. Either a b -> GHC.Types.Type
       where
         SLeft :: forall a b (n :: a).
@@ -447,9 +496,13 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
             SomeSing c -> SomeSing (SRight c) }
     instance SingI n => SingI (Left (n :: a)) where
       sing = SLeft sing
+    instance SingI1 Left where
+      liftSing = SLeft
     instance SingI (LeftSym0 :: (~>) a (Either a b)) where
       sing = (singFun1 @LeftSym0) SLeft
     instance SingI n => SingI (Right (n :: b)) where
       sing = SRight sing
+    instance SingI1 Right where
+      liftSing = SRight
     instance SingI (RightSym0 :: (~>) b (Either a b)) where
       sing = (singFun1 @RightSym0) SRight

--- a/singletons-base/tests/compile-and-dump/Singletons/LambdaCase.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/LambdaCase.golden
@@ -227,13 +227,22 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @Foo3Sym0) sFoo3
     instance SingI d => SingI (Foo3Sym1 (d :: a) :: (~>) b a) where
       sing = (singFun1 @(Foo3Sym1 (d :: a))) (sFoo3 (sing @d))
+    instance SingI1 (Foo3Sym1 :: a -> (~>) b a) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(Foo3Sym1 (d :: a))) (sFoo3 s)
     instance SingI (Foo2Sym0 :: (~>) a ((~>) (Maybe a) a)) where
       sing = (singFun2 @Foo2Sym0) sFoo2
     instance SingI d =>
              SingI (Foo2Sym1 (d :: a) :: (~>) (Maybe a) a) where
       sing = (singFun1 @(Foo2Sym1 (d :: a))) (sFoo2 (sing @d))
+    instance SingI1 (Foo2Sym1 :: a -> (~>) (Maybe a) a) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(Foo2Sym1 (d :: a))) (sFoo2 s)
     instance SingI (Foo1Sym0 :: (~>) a ((~>) (Maybe a) a)) where
       sing = (singFun2 @Foo1Sym0) sFoo1
     instance SingI d =>
              SingI (Foo1Sym1 (d :: a) :: (~>) (Maybe a) a) where
       sing = (singFun1 @(Foo1Sym1 (d :: a))) (sFoo1 (sing @d))
+    instance SingI1 (Foo1Sym1 :: a -> (~>) (Maybe a) a) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(Foo1Sym1 (d :: a))) (sFoo1 s)

--- a/singletons-base/tests/compile-and-dump/Singletons/Lambdas.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Lambdas.golden
@@ -696,38 +696,66 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @Foo7Sym0) sFoo7
     instance SingI d => SingI (Foo7Sym1 (d :: a) :: (~>) b b) where
       sing = (singFun1 @(Foo7Sym1 (d :: a))) (sFoo7 (sing @d))
+    instance SingI1 (Foo7Sym1 :: a -> (~>) b b) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(Foo7Sym1 (d :: a))) (sFoo7 s)
     instance SingI (Foo6Sym0 :: (~>) a ((~>) b a)) where
       sing = (singFun2 @Foo6Sym0) sFoo6
     instance SingI d => SingI (Foo6Sym1 (d :: a) :: (~>) b a) where
       sing = (singFun1 @(Foo6Sym1 (d :: a))) (sFoo6 (sing @d))
+    instance SingI1 (Foo6Sym1 :: a -> (~>) b a) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(Foo6Sym1 (d :: a))) (sFoo6 s)
     instance SingI (Foo5Sym0 :: (~>) a ((~>) b b)) where
       sing = (singFun2 @Foo5Sym0) sFoo5
     instance SingI d => SingI (Foo5Sym1 (d :: a) :: (~>) b b) where
       sing = (singFun1 @(Foo5Sym1 (d :: a))) (sFoo5 (sing @d))
+    instance SingI1 (Foo5Sym1 :: a -> (~>) b b) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(Foo5Sym1 (d :: a))) (sFoo5 s)
     instance SingI (Foo4Sym0 :: (~>) a ((~>) b ((~>) c a))) where
       sing = (singFun3 @Foo4Sym0) sFoo4
     instance SingI d =>
              SingI (Foo4Sym1 (d :: a) :: (~>) b ((~>) c a)) where
       sing = (singFun2 @(Foo4Sym1 (d :: a))) (sFoo4 (sing @d))
+    instance SingI1 (Foo4Sym1 :: a -> (~>) b ((~>) c a)) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun2 @(Foo4Sym1 (d :: a))) (sFoo4 s)
     instance (SingI d, SingI d) =>
              SingI (Foo4Sym2 (d :: a) (d :: b) :: (~>) c a) where
       sing
         = (singFun1 @(Foo4Sym2 (d :: a) (d :: b)))
             ((sFoo4 (sing @d)) (sing @d))
+    instance SingI d =>
+             SingI1 (Foo4Sym2 (d :: a) :: b -> (~>) c a) where
+      liftSing (s :: Sing (d :: b))
+        = (singFun1 @(Foo4Sym2 (d :: a) (d :: b))) ((sFoo4 (sing @d)) s)
+    instance SingI2 (Foo4Sym2 :: a -> b -> (~>) c a) where
+      liftSing2 (s :: Sing (d :: a)) (s :: Sing (d :: b))
+        = (singFun1 @(Foo4Sym2 (d :: a) (d :: b))) ((sFoo4 s) s)
     instance SingI (Foo3Sym0 :: (~>) a a) where
       sing = (singFun1 @Foo3Sym0) sFoo3
     instance SingI (Foo2Sym0 :: (~>) a ((~>) b a)) where
       sing = (singFun2 @Foo2Sym0) sFoo2
     instance SingI d => SingI (Foo2Sym1 (d :: a) :: (~>) b a) where
       sing = (singFun1 @(Foo2Sym1 (d :: a))) (sFoo2 (sing @d))
+    instance SingI1 (Foo2Sym1 :: a -> (~>) b a) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(Foo2Sym1 (d :: a))) (sFoo2 s)
     instance SingI (Foo1Sym0 :: (~>) a ((~>) b a)) where
       sing = (singFun2 @Foo1Sym0) sFoo1
     instance SingI d => SingI (Foo1Sym1 (d :: a) :: (~>) b a) where
       sing = (singFun1 @(Foo1Sym1 (d :: a))) (sFoo1 (sing @d))
+    instance SingI1 (Foo1Sym1 :: a -> (~>) b a) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(Foo1Sym1 (d :: a))) (sFoo1 s)
     instance SingI (Foo0Sym0 :: (~>) a ((~>) b a)) where
       sing = (singFun2 @Foo0Sym0) sFoo0
     instance SingI d => SingI (Foo0Sym1 (d :: a) :: (~>) b a) where
       sing = (singFun1 @(Foo0Sym1 (d :: a))) (sFoo0 (sing @d))
+    instance SingI1 (Foo0Sym1 :: a -> (~>) b a) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(Foo0Sym1 (d :: a))) (sFoo0 s)
     data SFoo :: forall a b. Foo a b -> GHC.Types.Type
       where
         SFoo :: forall a b (n :: a) (n :: b).
@@ -741,8 +769,15 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
             (,) (SomeSing c) (SomeSing c) -> SomeSing ((SFoo c) c) }
     instance (SingI n, SingI n) => SingI (Foo (n :: a) (n :: b)) where
       sing = (SFoo sing) sing
+    instance SingI n => SingI1 (Foo (n :: a)) where
+      liftSing = SFoo sing
+    instance SingI2 Foo where
+      liftSing2 = SFoo
     instance SingI (FooSym0 :: (~>) a ((~>) b (Foo a b))) where
       sing = (singFun2 @FooSym0) SFoo
     instance SingI d =>
              SingI (FooSym1 (d :: a) :: (~>) b (Foo a b)) where
       sing = (singFun1 @(FooSym1 (d :: a))) (SFoo (sing @d))
+    instance SingI1 (FooSym1 :: a -> (~>) b (Foo a b)) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(FooSym1 (d :: a))) (SFoo s)

--- a/singletons-base/tests/compile-and-dump/Singletons/Maybe.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Maybe.golden
@@ -182,5 +182,7 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
       sing = SNothing
     instance SingI n => SingI (Just (n :: a)) where
       sing = SJust sing
+    instance SingI1 Just where
+      liftSing = SJust
     instance SingI (JustSym0 :: (~>) a (Maybe a)) where
       sing = (singFun1 @JustSym0) SJust

--- a/singletons-base/tests/compile-and-dump/Singletons/Nat.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Nat.golden
@@ -192,6 +192,9 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
     instance SingI d =>
              SingI (PlusSym1 (d :: Nat) :: (~>) Nat Nat) where
       sing = (singFun1 @(PlusSym1 (d :: Nat))) (sPlus (sing @d))
+    instance SingI1 (PlusSym1 :: Nat -> (~>) Nat Nat) where
+      liftSing (s :: Sing (d :: Nat))
+        = (singFun1 @(PlusSym1 (d :: Nat))) (sPlus s)
     data SNat :: Nat -> GHC.Types.Type
       where
         SZero :: SNat (Zero :: Nat)
@@ -312,5 +315,7 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
       sing = SZero
     instance SingI n => SingI (Succ (n :: Nat)) where
       sing = SSucc sing
+    instance SingI1 Succ where
+      liftSing = SSucc
     instance SingI (SuccSym0 :: (~>) Nat Nat) where
       sing = (singFun1 @SuccSym0) SSucc

--- a/singletons-base/tests/compile-and-dump/Singletons/Operators.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Operators.golden
@@ -98,6 +98,9 @@ Singletons/Operators.hs:(0,0)-(0,0): Splicing declarations
     instance SingI d =>
              SingI ((+@#@$$) (d :: Nat) :: (~>) Nat Nat) where
       sing = (singFun1 @((+@#@$$) (d :: Nat))) ((%+) (sing @d))
+    instance SingI1 ((+@#@$$) :: Nat -> (~>) Nat Nat) where
+      liftSing (s :: Sing (d :: Nat))
+        = (singFun1 @((+@#@$$) (d :: Nat))) ((%+) s)
     instance SingI (ChildSym0 :: (~>) Foo Foo) where
       sing = (singFun1 @ChildSym0) sChild
     data SFoo :: Foo -> GHC.Types.Type
@@ -121,8 +124,15 @@ Singletons/Operators.hs:(0,0)-(0,0): Splicing declarations
     instance (SingI n, SingI n) =>
              SingI ((:+:) (n :: Foo) (n :: Foo)) where
       sing = ((:%+:) sing) sing
+    instance SingI n => SingI1 ((:+:) (n :: Foo)) where
+      liftSing = (:%+:) sing
+    instance SingI2 (:+:) where
+      liftSing2 = (:%+:)
     instance SingI ((:+:@#@$) :: (~>) Foo ((~>) Foo Foo)) where
       sing = (singFun2 @(:+:@#@$)) (:%+:)
     instance SingI d =>
              SingI ((:+:@#@$$) (d :: Foo) :: (~>) Foo Foo) where
       sing = (singFun1 @((:+:@#@$$) (d :: Foo))) ((:%+:) (sing @d))
+    instance SingI1 ((:+:@#@$$) :: Foo -> (~>) Foo Foo) where
+      liftSing (s :: Sing (d :: Foo))
+        = (singFun1 @((:+:@#@$$) (d :: Foo))) ((:%+:) s)

--- a/singletons-base/tests/compile-and-dump/Singletons/OrdDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/OrdDeriving.golden
@@ -1239,107 +1239,265 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       sing = SZero
     instance SingI n => SingI (Succ (n :: Nat)) where
       sing = SSucc sing
+    instance SingI1 Succ where
+      liftSing = SSucc
     instance SingI (SuccSym0 :: (~>) Nat Nat) where
       sing = (singFun1 @SuccSym0) SSucc
     instance (SingI n, SingI n, SingI n, SingI n) =>
              SingI (A (n :: a) (n :: b) (n :: c) (n :: d)) where
       sing = (((SA sing) sing) sing) sing
+    instance (SingI n, SingI n, SingI n) =>
+             SingI1 (A (n :: a) (n :: b) (n :: c)) where
+      liftSing = ((SA sing) sing) sing
+    instance (SingI n, SingI n) => SingI2 (A (n :: a) (n :: b)) where
+      liftSing2 = (SA sing) sing
     instance SingI (ASym0 :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))) where
       sing = (singFun4 @ASym0) SA
     instance SingI d =>
              SingI (ASym1 (d :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
       sing = (singFun3 @(ASym1 (d :: a))) (SA (sing @d))
+    instance SingI1 (ASym1 :: a
+                              -> (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
+      liftSing (s :: Sing (d :: a)) = (singFun3 @(ASym1 (d :: a))) (SA s)
     instance (SingI d, SingI d) =>
              SingI (ASym2 (d :: a) (d :: b) :: (~>) c ((~>) d (Foo a b c d))) where
       sing
         = (singFun2 @(ASym2 (d :: a) (d :: b))) ((SA (sing @d)) (sing @d))
+    instance SingI d =>
+             SingI1 (ASym2 (d :: a) :: b -> (~>) c ((~>) d (Foo a b c d))) where
+      liftSing (s :: Sing (d :: b))
+        = (singFun2 @(ASym2 (d :: a) (d :: b))) ((SA (sing @d)) s)
+    instance SingI2 (ASym2 :: a
+                              -> b -> (~>) c ((~>) d (Foo a b c d))) where
+      liftSing2 (s :: Sing (d :: a)) (s :: Sing (d :: b))
+        = (singFun2 @(ASym2 (d :: a) (d :: b))) ((SA s) s)
     instance (SingI d, SingI d, SingI d) =>
              SingI (ASym3 (d :: a) (d :: b) (d :: c) :: (~>) d (Foo a b c d)) where
       sing
         = (singFun1 @(ASym3 (d :: a) (d :: b) (d :: c)))
             (((SA (sing @d)) (sing @d)) (sing @d))
+    instance (SingI d, SingI d) =>
+             SingI1 (ASym3 (d :: a) (d :: b) :: c -> (~>) d (Foo a b c d)) where
+      liftSing (s :: Sing (d :: c))
+        = (singFun1 @(ASym3 (d :: a) (d :: b) (d :: c)))
+            (((SA (sing @d)) (sing @d)) s)
+    instance SingI d =>
+             SingI2 (ASym3 (d :: a) :: b -> c -> (~>) d (Foo a b c d)) where
+      liftSing2 (s :: Sing (d :: b)) (s :: Sing (d :: c))
+        = (singFun1 @(ASym3 (d :: a) (d :: b) (d :: c)))
+            (((SA (sing @d)) s) s)
     instance (SingI n, SingI n, SingI n, SingI n) =>
              SingI (B (n :: a) (n :: b) (n :: c) (n :: d)) where
       sing = (((SB sing) sing) sing) sing
+    instance (SingI n, SingI n, SingI n) =>
+             SingI1 (B (n :: a) (n :: b) (n :: c)) where
+      liftSing = ((SB sing) sing) sing
+    instance (SingI n, SingI n) => SingI2 (B (n :: a) (n :: b)) where
+      liftSing2 = (SB sing) sing
     instance SingI (BSym0 :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))) where
       sing = (singFun4 @BSym0) SB
     instance SingI d =>
              SingI (BSym1 (d :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
       sing = (singFun3 @(BSym1 (d :: a))) (SB (sing @d))
+    instance SingI1 (BSym1 :: a
+                              -> (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
+      liftSing (s :: Sing (d :: a)) = (singFun3 @(BSym1 (d :: a))) (SB s)
     instance (SingI d, SingI d) =>
              SingI (BSym2 (d :: a) (d :: b) :: (~>) c ((~>) d (Foo a b c d))) where
       sing
         = (singFun2 @(BSym2 (d :: a) (d :: b))) ((SB (sing @d)) (sing @d))
+    instance SingI d =>
+             SingI1 (BSym2 (d :: a) :: b -> (~>) c ((~>) d (Foo a b c d))) where
+      liftSing (s :: Sing (d :: b))
+        = (singFun2 @(BSym2 (d :: a) (d :: b))) ((SB (sing @d)) s)
+    instance SingI2 (BSym2 :: a
+                              -> b -> (~>) c ((~>) d (Foo a b c d))) where
+      liftSing2 (s :: Sing (d :: a)) (s :: Sing (d :: b))
+        = (singFun2 @(BSym2 (d :: a) (d :: b))) ((SB s) s)
     instance (SingI d, SingI d, SingI d) =>
              SingI (BSym3 (d :: a) (d :: b) (d :: c) :: (~>) d (Foo a b c d)) where
       sing
         = (singFun1 @(BSym3 (d :: a) (d :: b) (d :: c)))
             (((SB (sing @d)) (sing @d)) (sing @d))
+    instance (SingI d, SingI d) =>
+             SingI1 (BSym3 (d :: a) (d :: b) :: c -> (~>) d (Foo a b c d)) where
+      liftSing (s :: Sing (d :: c))
+        = (singFun1 @(BSym3 (d :: a) (d :: b) (d :: c)))
+            (((SB (sing @d)) (sing @d)) s)
+    instance SingI d =>
+             SingI2 (BSym3 (d :: a) :: b -> c -> (~>) d (Foo a b c d)) where
+      liftSing2 (s :: Sing (d :: b)) (s :: Sing (d :: c))
+        = (singFun1 @(BSym3 (d :: a) (d :: b) (d :: c)))
+            (((SB (sing @d)) s) s)
     instance (SingI n, SingI n, SingI n, SingI n) =>
              SingI (C (n :: a) (n :: b) (n :: c) (n :: d)) where
       sing = (((SC sing) sing) sing) sing
+    instance (SingI n, SingI n, SingI n) =>
+             SingI1 (C (n :: a) (n :: b) (n :: c)) where
+      liftSing = ((SC sing) sing) sing
+    instance (SingI n, SingI n) => SingI2 (C (n :: a) (n :: b)) where
+      liftSing2 = (SC sing) sing
     instance SingI (CSym0 :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))) where
       sing = (singFun4 @CSym0) SC
     instance SingI d =>
              SingI (CSym1 (d :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
       sing = (singFun3 @(CSym1 (d :: a))) (SC (sing @d))
+    instance SingI1 (CSym1 :: a
+                              -> (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
+      liftSing (s :: Sing (d :: a)) = (singFun3 @(CSym1 (d :: a))) (SC s)
     instance (SingI d, SingI d) =>
              SingI (CSym2 (d :: a) (d :: b) :: (~>) c ((~>) d (Foo a b c d))) where
       sing
         = (singFun2 @(CSym2 (d :: a) (d :: b))) ((SC (sing @d)) (sing @d))
+    instance SingI d =>
+             SingI1 (CSym2 (d :: a) :: b -> (~>) c ((~>) d (Foo a b c d))) where
+      liftSing (s :: Sing (d :: b))
+        = (singFun2 @(CSym2 (d :: a) (d :: b))) ((SC (sing @d)) s)
+    instance SingI2 (CSym2 :: a
+                              -> b -> (~>) c ((~>) d (Foo a b c d))) where
+      liftSing2 (s :: Sing (d :: a)) (s :: Sing (d :: b))
+        = (singFun2 @(CSym2 (d :: a) (d :: b))) ((SC s) s)
     instance (SingI d, SingI d, SingI d) =>
              SingI (CSym3 (d :: a) (d :: b) (d :: c) :: (~>) d (Foo a b c d)) where
       sing
         = (singFun1 @(CSym3 (d :: a) (d :: b) (d :: c)))
             (((SC (sing @d)) (sing @d)) (sing @d))
+    instance (SingI d, SingI d) =>
+             SingI1 (CSym3 (d :: a) (d :: b) :: c -> (~>) d (Foo a b c d)) where
+      liftSing (s :: Sing (d :: c))
+        = (singFun1 @(CSym3 (d :: a) (d :: b) (d :: c)))
+            (((SC (sing @d)) (sing @d)) s)
+    instance SingI d =>
+             SingI2 (CSym3 (d :: a) :: b -> c -> (~>) d (Foo a b c d)) where
+      liftSing2 (s :: Sing (d :: b)) (s :: Sing (d :: c))
+        = (singFun1 @(CSym3 (d :: a) (d :: b) (d :: c)))
+            (((SC (sing @d)) s) s)
     instance (SingI n, SingI n, SingI n, SingI n) =>
              SingI (D (n :: a) (n :: b) (n :: c) (n :: d)) where
       sing = (((SD sing) sing) sing) sing
+    instance (SingI n, SingI n, SingI n) =>
+             SingI1 (D (n :: a) (n :: b) (n :: c)) where
+      liftSing = ((SD sing) sing) sing
+    instance (SingI n, SingI n) => SingI2 (D (n :: a) (n :: b)) where
+      liftSing2 = (SD sing) sing
     instance SingI (DSym0 :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))) where
       sing = (singFun4 @DSym0) SD
     instance SingI d =>
              SingI (DSym1 (d :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
       sing = (singFun3 @(DSym1 (d :: a))) (SD (sing @d))
+    instance SingI1 (DSym1 :: a
+                              -> (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
+      liftSing (s :: Sing (d :: a)) = (singFun3 @(DSym1 (d :: a))) (SD s)
     instance (SingI d, SingI d) =>
              SingI (DSym2 (d :: a) (d :: b) :: (~>) c ((~>) d (Foo a b c d))) where
       sing
         = (singFun2 @(DSym2 (d :: a) (d :: b))) ((SD (sing @d)) (sing @d))
+    instance SingI d =>
+             SingI1 (DSym2 (d :: a) :: b -> (~>) c ((~>) d (Foo a b c d))) where
+      liftSing (s :: Sing (d :: b))
+        = (singFun2 @(DSym2 (d :: a) (d :: b))) ((SD (sing @d)) s)
+    instance SingI2 (DSym2 :: a
+                              -> b -> (~>) c ((~>) d (Foo a b c d))) where
+      liftSing2 (s :: Sing (d :: a)) (s :: Sing (d :: b))
+        = (singFun2 @(DSym2 (d :: a) (d :: b))) ((SD s) s)
     instance (SingI d, SingI d, SingI d) =>
              SingI (DSym3 (d :: a) (d :: b) (d :: c) :: (~>) d (Foo a b c d)) where
       sing
         = (singFun1 @(DSym3 (d :: a) (d :: b) (d :: c)))
             (((SD (sing @d)) (sing @d)) (sing @d))
+    instance (SingI d, SingI d) =>
+             SingI1 (DSym3 (d :: a) (d :: b) :: c -> (~>) d (Foo a b c d)) where
+      liftSing (s :: Sing (d :: c))
+        = (singFun1 @(DSym3 (d :: a) (d :: b) (d :: c)))
+            (((SD (sing @d)) (sing @d)) s)
+    instance SingI d =>
+             SingI2 (DSym3 (d :: a) :: b -> c -> (~>) d (Foo a b c d)) where
+      liftSing2 (s :: Sing (d :: b)) (s :: Sing (d :: c))
+        = (singFun1 @(DSym3 (d :: a) (d :: b) (d :: c)))
+            (((SD (sing @d)) s) s)
     instance (SingI n, SingI n, SingI n, SingI n) =>
              SingI (E (n :: a) (n :: b) (n :: c) (n :: d)) where
       sing = (((SE sing) sing) sing) sing
+    instance (SingI n, SingI n, SingI n) =>
+             SingI1 (E (n :: a) (n :: b) (n :: c)) where
+      liftSing = ((SE sing) sing) sing
+    instance (SingI n, SingI n) => SingI2 (E (n :: a) (n :: b)) where
+      liftSing2 = (SE sing) sing
     instance SingI (ESym0 :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))) where
       sing = (singFun4 @ESym0) SE
     instance SingI d =>
              SingI (ESym1 (d :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
       sing = (singFun3 @(ESym1 (d :: a))) (SE (sing @d))
+    instance SingI1 (ESym1 :: a
+                              -> (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
+      liftSing (s :: Sing (d :: a)) = (singFun3 @(ESym1 (d :: a))) (SE s)
     instance (SingI d, SingI d) =>
              SingI (ESym2 (d :: a) (d :: b) :: (~>) c ((~>) d (Foo a b c d))) where
       sing
         = (singFun2 @(ESym2 (d :: a) (d :: b))) ((SE (sing @d)) (sing @d))
+    instance SingI d =>
+             SingI1 (ESym2 (d :: a) :: b -> (~>) c ((~>) d (Foo a b c d))) where
+      liftSing (s :: Sing (d :: b))
+        = (singFun2 @(ESym2 (d :: a) (d :: b))) ((SE (sing @d)) s)
+    instance SingI2 (ESym2 :: a
+                              -> b -> (~>) c ((~>) d (Foo a b c d))) where
+      liftSing2 (s :: Sing (d :: a)) (s :: Sing (d :: b))
+        = (singFun2 @(ESym2 (d :: a) (d :: b))) ((SE s) s)
     instance (SingI d, SingI d, SingI d) =>
              SingI (ESym3 (d :: a) (d :: b) (d :: c) :: (~>) d (Foo a b c d)) where
       sing
         = (singFun1 @(ESym3 (d :: a) (d :: b) (d :: c)))
             (((SE (sing @d)) (sing @d)) (sing @d))
+    instance (SingI d, SingI d) =>
+             SingI1 (ESym3 (d :: a) (d :: b) :: c -> (~>) d (Foo a b c d)) where
+      liftSing (s :: Sing (d :: c))
+        = (singFun1 @(ESym3 (d :: a) (d :: b) (d :: c)))
+            (((SE (sing @d)) (sing @d)) s)
+    instance SingI d =>
+             SingI2 (ESym3 (d :: a) :: b -> c -> (~>) d (Foo a b c d)) where
+      liftSing2 (s :: Sing (d :: b)) (s :: Sing (d :: c))
+        = (singFun1 @(ESym3 (d :: a) (d :: b) (d :: c)))
+            (((SE (sing @d)) s) s)
     instance (SingI n, SingI n, SingI n, SingI n) =>
              SingI (F (n :: a) (n :: b) (n :: c) (n :: d)) where
       sing = (((SF sing) sing) sing) sing
+    instance (SingI n, SingI n, SingI n) =>
+             SingI1 (F (n :: a) (n :: b) (n :: c)) where
+      liftSing = ((SF sing) sing) sing
+    instance (SingI n, SingI n) => SingI2 (F (n :: a) (n :: b)) where
+      liftSing2 = (SF sing) sing
     instance SingI (FSym0 :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))) where
       sing = (singFun4 @FSym0) SF
     instance SingI d =>
              SingI (FSym1 (d :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
       sing = (singFun3 @(FSym1 (d :: a))) (SF (sing @d))
+    instance SingI1 (FSym1 :: a
+                              -> (~>) b ((~>) c ((~>) d (Foo a b c d)))) where
+      liftSing (s :: Sing (d :: a)) = (singFun3 @(FSym1 (d :: a))) (SF s)
     instance (SingI d, SingI d) =>
              SingI (FSym2 (d :: a) (d :: b) :: (~>) c ((~>) d (Foo a b c d))) where
       sing
         = (singFun2 @(FSym2 (d :: a) (d :: b))) ((SF (sing @d)) (sing @d))
+    instance SingI d =>
+             SingI1 (FSym2 (d :: a) :: b -> (~>) c ((~>) d (Foo a b c d))) where
+      liftSing (s :: Sing (d :: b))
+        = (singFun2 @(FSym2 (d :: a) (d :: b))) ((SF (sing @d)) s)
+    instance SingI2 (FSym2 :: a
+                              -> b -> (~>) c ((~>) d (Foo a b c d))) where
+      liftSing2 (s :: Sing (d :: a)) (s :: Sing (d :: b))
+        = (singFun2 @(FSym2 (d :: a) (d :: b))) ((SF s) s)
     instance (SingI d, SingI d, SingI d) =>
              SingI (FSym3 (d :: a) (d :: b) (d :: c) :: (~>) d (Foo a b c d)) where
       sing
         = (singFun1 @(FSym3 (d :: a) (d :: b) (d :: c)))
             (((SF (sing @d)) (sing @d)) (sing @d))
+    instance (SingI d, SingI d) =>
+             SingI1 (FSym3 (d :: a) (d :: b) :: c -> (~>) d (Foo a b c d)) where
+      liftSing (s :: Sing (d :: c))
+        = (singFun1 @(FSym3 (d :: a) (d :: b) (d :: c)))
+            (((SF (sing @d)) (sing @d)) s)
+    instance SingI d =>
+             SingI2 (FSym3 (d :: a) :: b -> c -> (~>) d (Foo a b c d)) where
+      liftSing2 (s :: Sing (d :: b)) (s :: Sing (d :: c))
+        = (singFun1 @(FSym3 (d :: a) (d :: b) (d :: c)))
+            (((SF (sing @d)) s) s)

--- a/singletons-base/tests/compile-and-dump/Singletons/PatternMatching.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/PatternMatching.golden
@@ -175,11 +175,18 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
                       Show (SPair (z :: Pair a b))
     instance (SingI n, SingI n) => SingI (Pair (n :: a) (n :: b)) where
       sing = (SPair sing) sing
+    instance SingI n => SingI1 (Pair (n :: a)) where
+      liftSing = SPair sing
+    instance SingI2 Pair where
+      liftSing2 = SPair
     instance SingI (PairSym0 :: (~>) a ((~>) b (Pair a b))) where
       sing = (singFun2 @PairSym0) SPair
     instance SingI d =>
              SingI (PairSym1 (d :: a) :: (~>) b (Pair a b)) where
       sing = (singFun1 @(PairSym1 (d :: a))) (SPair (sing @d))
+    instance SingI1 (PairSym1 :: a -> (~>) b (Pair a b)) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(PairSym1 (d :: a))) (SPair s)
 Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     singletons
       [d| Pair sz lz = pr

--- a/singletons-base/tests/compile-and-dump/Singletons/Records.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Records.golden
@@ -77,8 +77,15 @@ Singletons/Records.hs:(0,0)-(0,0): Splicing declarations
     instance (SingI n, SingI n) =>
              SingI (MkRecord (n :: a) (n :: Bool)) where
       sing = (SMkRecord sing) sing
+    instance SingI n => SingI1 (MkRecord (n :: a)) where
+      liftSing = SMkRecord sing
+    instance SingI2 MkRecord where
+      liftSing2 = SMkRecord
     instance SingI (MkRecordSym0 :: (~>) a ((~>) Bool (Record a))) where
       sing = (singFun2 @MkRecordSym0) SMkRecord
     instance SingI d =>
              SingI (MkRecordSym1 (d :: a) :: (~>) Bool (Record a)) where
       sing = (singFun1 @(MkRecordSym1 (d :: a))) (SMkRecord (sing @d))
+    instance SingI1 (MkRecordSym1 :: a -> (~>) Bool (Record a)) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(MkRecordSym1 (d :: a))) (SMkRecord s)

--- a/singletons-base/tests/compile-and-dump/Singletons/ReturnFunc.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/ReturnFunc.golden
@@ -89,6 +89,9 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @IdFooSym0) sIdFoo
     instance SingI d => SingI (IdFooSym1 (d :: c) :: (~>) a a) where
       sing = (singFun1 @(IdFooSym1 (d :: c))) (sIdFoo (sing @d))
+    instance SingI1 (IdFooSym1 :: c -> (~>) a a) where
+      liftSing (s :: Sing (d :: c))
+        = (singFun1 @(IdFooSym1 (d :: c))) (sIdFoo s)
     instance SingI (IdSym0 :: (~>) a a) where
       sing = (singFun1 @IdSym0) sId
     instance SingI (ReturnFuncSym0 :: (~>) Nat ((~>) Nat Nat)) where
@@ -97,3 +100,6 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
              SingI (ReturnFuncSym1 (d :: Nat) :: (~>) Nat Nat) where
       sing
         = (singFun1 @(ReturnFuncSym1 (d :: Nat))) (sReturnFunc (sing @d))
+    instance SingI1 (ReturnFuncSym1 :: Nat -> (~>) Nat Nat) where
+      liftSing (s :: Sing (d :: Nat))
+        = (singFun1 @(ReturnFuncSym1 (d :: Nat))) (sReturnFunc s)

--- a/singletons-base/tests/compile-and-dump/Singletons/Sections.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Sections.golden
@@ -129,3 +129,6 @@ Singletons/Sections.hs:(0,0)-(0,0): Splicing declarations
     instance SingI d =>
              SingI ((+@#@$$) (d :: Nat) :: (~>) Nat Nat) where
       sing = (singFun1 @((+@#@$$) (d :: Nat))) ((%+) (sing @d))
+    instance SingI1 ((+@#@$$) :: Nat -> (~>) Nat Nat) where
+      liftSing (s :: Sing (d :: Nat))
+        = (singFun1 @((+@#@$$) (d :: Nat))) ((%+) s)

--- a/singletons-base/tests/compile-and-dump/Singletons/ShowDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/ShowDeriving.golden
@@ -538,40 +538,75 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance (SingI n, SingI n) =>
              SingI (MkFoo2a (n :: a) (n :: a)) where
       sing = (SMkFoo2a sing) sing
+    instance SingI n => SingI1 (MkFoo2a (n :: a)) where
+      liftSing = SMkFoo2a sing
+    instance SingI2 MkFoo2a where
+      liftSing2 = SMkFoo2a
     instance SingI (MkFoo2aSym0 :: (~>) a ((~>) a (Foo2 a))) where
       sing = (singFun2 @MkFoo2aSym0) SMkFoo2a
     instance SingI d =>
              SingI (MkFoo2aSym1 (d :: a) :: (~>) a (Foo2 a)) where
       sing = (singFun1 @(MkFoo2aSym1 (d :: a))) (SMkFoo2a (sing @d))
+    instance SingI1 (MkFoo2aSym1 :: a -> (~>) a (Foo2 a)) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(MkFoo2aSym1 (d :: a))) (SMkFoo2a s)
     instance (SingI n, SingI n) =>
              SingI (MkFoo2b (n :: a) (n :: a)) where
       sing = (SMkFoo2b sing) sing
+    instance SingI n => SingI1 (MkFoo2b (n :: a)) where
+      liftSing = SMkFoo2b sing
+    instance SingI2 MkFoo2b where
+      liftSing2 = SMkFoo2b
     instance SingI (MkFoo2bSym0 :: (~>) a ((~>) a (Foo2 a))) where
       sing = (singFun2 @MkFoo2bSym0) SMkFoo2b
     instance SingI d =>
              SingI (MkFoo2bSym1 (d :: a) :: (~>) a (Foo2 a)) where
       sing = (singFun1 @(MkFoo2bSym1 (d :: a))) (SMkFoo2b (sing @d))
+    instance SingI1 (MkFoo2bSym1 :: a -> (~>) a (Foo2 a)) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(MkFoo2bSym1 (d :: a))) (SMkFoo2b s)
     instance (SingI n, SingI n) =>
              SingI ((:*:) (n :: a) (n :: a)) where
       sing = ((:%*:) sing) sing
+    instance SingI n => SingI1 ((:*:) (n :: a)) where
+      liftSing = (:%*:) sing
+    instance SingI2 (:*:) where
+      liftSing2 = (:%*:)
     instance SingI ((:*:@#@$) :: (~>) a ((~>) a (Foo2 a))) where
       sing = (singFun2 @(:*:@#@$)) (:%*:)
     instance SingI d =>
              SingI ((:*:@#@$$) (d :: a) :: (~>) a (Foo2 a)) where
       sing = (singFun1 @((:*:@#@$$) (d :: a))) ((:%*:) (sing @d))
+    instance SingI1 ((:*:@#@$$) :: a -> (~>) a (Foo2 a)) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @((:*:@#@$$) (d :: a))) ((:%*:) s)
     instance (SingI n, SingI n) =>
              SingI ((:&:) (n :: a) (n :: a)) where
       sing = ((:%&:) sing) sing
+    instance SingI n => SingI1 ((:&:) (n :: a)) where
+      liftSing = (:%&:) sing
+    instance SingI2 (:&:) where
+      liftSing2 = (:%&:)
     instance SingI ((:&:@#@$) :: (~>) a ((~>) a (Foo2 a))) where
       sing = (singFun2 @(:&:@#@$)) (:%&:)
     instance SingI d =>
              SingI ((:&:@#@$$) (d :: a) :: (~>) a (Foo2 a)) where
       sing = (singFun1 @((:&:@#@$$) (d :: a))) ((:%&:) (sing @d))
+    instance SingI1 ((:&:@#@$$) :: a -> (~>) a (Foo2 a)) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @((:&:@#@$$) (d :: a))) ((:%&:) s)
     instance (SingI n, SingI n) =>
              SingI (MkFoo3 (n :: Bool) (n :: Bool)) where
       sing = (SMkFoo3 sing) sing
+    instance SingI n => SingI1 (MkFoo3 (n :: Bool)) where
+      liftSing = SMkFoo3 sing
+    instance SingI2 MkFoo3 where
+      liftSing2 = SMkFoo3
     instance SingI (MkFoo3Sym0 :: (~>) Bool ((~>) Bool Foo3)) where
       sing = (singFun2 @MkFoo3Sym0) SMkFoo3
     instance SingI d =>
              SingI (MkFoo3Sym1 (d :: Bool) :: (~>) Bool Foo3) where
       sing = (singFun1 @(MkFoo3Sym1 (d :: Bool))) (SMkFoo3 (sing @d))
+    instance SingI1 (MkFoo3Sym1 :: Bool -> (~>) Bool Foo3) where
+      liftSing (s :: Sing (d :: Bool))
+        = (singFun1 @(MkFoo3Sym1 (d :: Bool))) (SMkFoo3 s)

--- a/singletons-base/tests/compile-and-dump/Singletons/StandaloneDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/StandaloneDeriving.golden
@@ -537,11 +537,18 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance (SingI n, SingI n) =>
              SingI ((:*:) (n :: a) (n :: b)) where
       sing = ((:%*:) sing) sing
+    instance SingI n => SingI1 ((:*:) (n :: a)) where
+      liftSing = (:%*:) sing
+    instance SingI2 (:*:) where
+      liftSing2 = (:%*:)
     instance SingI ((:*:@#@$) :: (~>) a ((~>) b (T a b))) where
       sing = (singFun2 @(:*:@#@$)) (:%*:)
     instance SingI d =>
              SingI ((:*:@#@$$) (d :: a) :: (~>) b (T a b)) where
       sing = (singFun1 @((:*:@#@$$) (d :: a))) ((:%*:) (sing @d))
+    instance SingI1 ((:*:@#@$$) :: a -> (~>) b (T a b)) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @((:*:@#@$$) (d :: a))) ((:%*:) s)
     instance SingI S1 where
       sing = SS1
     instance SingI S2 where

--- a/singletons-base/tests/compile-and-dump/Singletons/Star.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Star.golden
@@ -484,13 +484,22 @@ Singletons/Star.hs:0:0:: Splicing declarations
       sing = SString
     instance SingI n => SingI (Maybe (n :: Type)) where
       sing = SMaybe sing
+    instance SingI1 Maybe where
+      liftSing = SMaybe
     instance SingI (MaybeSym0 :: (~>) Type Type) where
       sing = (singFun1 @MaybeSym0) SMaybe
     instance (SingI n, SingI n) =>
              SingI (Vec (n :: Type) (n :: Nat)) where
       sing = (SVec sing) sing
+    instance SingI n => SingI1 (Vec (n :: Type)) where
+      liftSing = SVec sing
+    instance SingI2 Vec where
+      liftSing2 = SVec
     instance SingI (VecSym0 :: (~>) Type ((~>) Nat Type)) where
       sing = (singFun2 @VecSym0) SVec
     instance SingI d =>
              SingI (VecSym1 (d :: Type) :: (~>) Nat Type) where
       sing = (singFun1 @(VecSym1 (d :: Type))) (SVec (sing @d))
+    instance SingI1 (VecSym1 :: Type -> (~>) Nat Type) where
+      liftSing (s :: Sing (d :: Type))
+        = (singFun1 @(VecSym1 (d :: Type))) (SVec s)

--- a/singletons-base/tests/compile-and-dump/Singletons/T145.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T145.golden
@@ -36,3 +36,6 @@ Singletons/T145.hs:(0,0)-(0,0): Splicing declarations
     instance (SColumn f, SingI d) =>
              SingI (ColSym1 (d :: f a) :: (~>) a Bool) where
       sing = (singFun1 @(ColSym1 (d :: f a))) (sCol (sing @d))
+    instance SColumn f => SingI1 (ColSym1 :: f a -> (~>) a Bool) where
+      liftSing (s :: Sing (d :: f a))
+        = (singFun1 @(ColSym1 (d :: f a))) (sCol s)

--- a/singletons-base/tests/compile-and-dump/Singletons/T150.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T150.golden
@@ -302,6 +302,10 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
       sing
         = (singFun1 @(TransitivitySym1 (d :: Equal a b)))
             (sTransitivity (sing @d))
+    instance SingI1 (TransitivitySym1 :: Equal a b
+                                         -> (~>) (Equal b c) (Equal a c)) where
+      liftSing (s :: Sing (d :: Equal a b))
+        = (singFun1 @(TransitivitySym1 (d :: Equal a b))) (sTransitivity s)
     instance SingI (SymmetrySym0 :: (~>) (Equal a b) (Equal b a)) where
       sing = (singFun1 @SymmetrySym0) sSymmetry
     instance SingI (MapVecSym0 :: (~>) ((~>) a b) ((~>) (Vec n a) (Vec n b))) where
@@ -309,11 +313,18 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
     instance SingI d =>
              SingI (MapVecSym1 (d :: (~>) a b) :: (~>) (Vec n a) (Vec n b)) where
       sing = (singFun1 @(MapVecSym1 (d :: (~>) a b))) (sMapVec (sing @d))
+    instance SingI1 (MapVecSym1 :: (~>) a b
+                                   -> (~>) (Vec n a) (Vec n b)) where
+      liftSing (s :: Sing (d :: (~>) a b))
+        = (singFun1 @(MapVecSym1 (d :: (~>) a b))) (sMapVec s)
     instance SingI ((!@#@$) :: (~>) (Vec n a) ((~>) (Fin n) a)) where
       sing = (singFun2 @(!@#@$)) (%!)
     instance SingI d =>
              SingI ((!@#@$$) (d :: Vec n a) :: (~>) (Fin n) a) where
       sing = (singFun1 @((!@#@$$) (d :: Vec n a))) ((%!) (sing @d))
+    instance SingI1 ((!@#@$$) :: Vec n a -> (~>) (Fin n) a) where
+      liftSing (s :: Sing (d :: Vec n a))
+        = (singFun1 @((!@#@$$) (d :: Vec n a))) ((%!) s)
     instance SingI (TailVecSym0 :: (~>) (Vec ('Succ n) a) (Vec n a)) where
       sing = (singFun1 @TailVecSym0) sTailVec
     instance SingI (HeadVecSym0 :: (~>) (Vec ('Succ n) a) a) where
@@ -351,6 +362,8 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
       sing = SFZ
     instance SingI n => SingI (FS (n :: Fin n)) where
       sing = SFS sing
+    instance SingI1 FS where
+      liftSing = SFS
     instance SingI (FSSym0 :: (~>) (Fin n) (Fin ('Succ n))) where
       sing = (singFun1 @FSSym0) SFS
     instance SingI MkFoo1 where
@@ -362,11 +375,19 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
     instance (SingI n, SingI n) =>
              SingI (VCons (n :: a) (n :: Vec n a)) where
       sing = (SVCons sing) sing
+    instance SingI n => SingI1 (VCons (n :: a)) where
+      liftSing = SVCons sing
+    instance SingI2 VCons where
+      liftSing2 = SVCons
     instance SingI (VConsSym0 :: (~>) a ((~>) (Vec n a) (Vec ('Succ n) a))) where
       sing = (singFun2 @VConsSym0) SVCons
     instance SingI d =>
              SingI (VConsSym1 (d :: a) :: (~>) (Vec n a) (Vec ('Succ n) a)) where
       sing = (singFun1 @(VConsSym1 (d :: a))) (SVCons (sing @d))
+    instance SingI1 (VConsSym1 :: a
+                                  -> (~>) (Vec n a) (Vec ('Succ n) a)) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(VConsSym1 (d :: a))) (SVCons s)
     instance SingI Reflexive where
       sing = SReflexive
     instance SingI HNil where
@@ -374,12 +395,22 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
     instance (SingI n, SingI n) =>
              SingI (HCons (n :: x) (n :: HList xs)) where
       sing = (SHCons sing) sing
+    instance SingI n => SingI1 (HCons (n :: x)) where
+      liftSing = SHCons sing
+    instance SingI2 HCons where
+      liftSing2 = SHCons
     instance SingI (HConsSym0 :: (~>) x ((~>) (HList xs) (HList ('(:) x xs)))) where
       sing = (singFun2 @HConsSym0) SHCons
     instance SingI d =>
              SingI (HConsSym1 (d :: x) :: (~>) (HList xs) (HList ('(:) x xs))) where
       sing = (singFun1 @(HConsSym1 (d :: x))) (SHCons (sing @d))
+    instance SingI1 (HConsSym1 :: x
+                                  -> (~>) (HList xs) (HList ('(:) x xs))) where
+      liftSing (s :: Sing (d :: x))
+        = (singFun1 @(HConsSym1 (d :: x))) (SHCons s)
     instance SingI n => SingI (Obj (n :: a)) where
       sing = SObj sing
+    instance SingI1 Obj where
+      liftSing = SObj
     instance SingI (ObjSym0 :: (~>) a Obj) where
       sing = (singFun1 @ObjSym0) SObj

--- a/singletons-base/tests/compile-and-dump/Singletons/T159.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T159.golden
@@ -134,18 +134,32 @@ Singletons/T159.hs:0:0:: Splicing declarations
     instance (SingI n, SingI n) =>
              SingI ('C1 (n :: T0) (n :: T1)) where
       sing = (SC1 sing) sing
+    instance SingI n => SingI1 ('C1 (n :: T0)) where
+      liftSing = SC1 sing
+    instance SingI2 'C1 where
+      liftSing2 = SC1
     instance SingI (C1Sym0 :: (~>) T0 ((~>) T1 T1)) where
       sing = (singFun2 @C1Sym0) SC1
     instance SingI d => SingI (C1Sym1 (d :: T0) :: (~>) T1 T1) where
       sing = (singFun1 @(C1Sym1 (d :: T0))) (SC1 (sing @d))
+    instance SingI1 (C1Sym1 :: T0 -> (~>) T1 T1) where
+      liftSing (s :: Sing (d :: T0))
+        = (singFun1 @(C1Sym1 (d :: T0))) (SC1 s)
     instance (SingI n, SingI n) =>
              SingI ('(:&&) (n :: T0) (n :: T1)) where
       sing = ((:%&&) sing) sing
+    instance SingI n => SingI1 ('(:&&) (n :: T0)) where
+      liftSing = (:%&&) sing
+    instance SingI2 '(:&&) where
+      liftSing2 = (:%&&)
     instance SingI ((:&&@#@$) :: (~>) T0 ((~>) T1 T1)) where
       sing = (singFun2 @(:&&@#@$)) (:%&&)
     instance SingI d =>
              SingI ((:&&@#@$$) (d :: T0) :: (~>) T1 T1) where
       sing = (singFun1 @((:&&@#@$$) (d :: T0))) ((:%&&) (sing @d))
+    instance SingI1 ((:&&@#@$$) :: T0 -> (~>) T1 T1) where
+      liftSing (s :: Sing (d :: T0))
+        = (singFun1 @((:&&@#@$$) (d :: T0))) ((:%&&) s)
 Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
     singletons
       [d| infixr 5 :||
@@ -233,15 +247,29 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
       sing = SN2
     instance (SingI n, SingI n) => SingI (C2 (n :: T0) (n :: T2)) where
       sing = (SC2 sing) sing
+    instance SingI n => SingI1 (C2 (n :: T0)) where
+      liftSing = SC2 sing
+    instance SingI2 C2 where
+      liftSing2 = SC2
     instance SingI (C2Sym0 :: (~>) T0 ((~>) T2 T2)) where
       sing = (singFun2 @C2Sym0) SC2
     instance SingI d => SingI (C2Sym1 (d :: T0) :: (~>) T2 T2) where
       sing = (singFun1 @(C2Sym1 (d :: T0))) (SC2 (sing @d))
+    instance SingI1 (C2Sym1 :: T0 -> (~>) T2 T2) where
+      liftSing (s :: Sing (d :: T0))
+        = (singFun1 @(C2Sym1 (d :: T0))) (SC2 s)
     instance (SingI n, SingI n) =>
              SingI ((:||) (n :: T0) (n :: T2)) where
       sing = ((:%||) sing) sing
+    instance SingI n => SingI1 ((:||) (n :: T0)) where
+      liftSing = (:%||) sing
+    instance SingI2 (:||) where
+      liftSing2 = (:%||)
     instance SingI ((:||@#@$) :: (~>) T0 ((~>) T2 T2)) where
       sing = (singFun2 @(:||@#@$)) (:%||)
     instance SingI d =>
              SingI ((:||@#@$$) (d :: T0) :: (~>) T2 T2) where
       sing = (singFun1 @((:||@#@$$) (d :: T0))) ((:%||) (sing @d))
+    instance SingI1 ((:||@#@$$) :: T0 -> (~>) T2 T2) where
+      liftSing (s :: Sing (d :: T0))
+        = (singFun1 @((:||@#@$$) (d :: T0))) ((:%||) s)

--- a/singletons-base/tests/compile-and-dump/Singletons/T163.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T163.golden
@@ -39,9 +39,13 @@ Singletons/T163.hs:0:0:: Splicing declarations
         = case toSing b :: SomeSing b of { SomeSing c -> SomeSing (SR c) }
     instance SingI n => SingI (L (n :: a)) where
       sing = SL sing
+    instance SingI1 L where
+      liftSing = SL
     instance SingI (LSym0 :: (~>) a ((+) a b)) where
       sing = (singFun1 @LSym0) SL
     instance SingI n => SingI (R (n :: b)) where
       sing = SR sing
+    instance SingI1 R where
+      liftSing = SR
     instance SingI (RSym0 :: (~>) b ((+) a b)) where
       sing = (singFun1 @RSym0) SR

--- a/singletons-base/tests/compile-and-dump/Singletons/T166.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T166.golden
@@ -113,11 +113,24 @@ Singletons/T166.hs:(0,0)-(0,0): Splicing declarations
     instance (SFoo a, SingI d) =>
              SingI (FoosPrecSym1 (d :: Nat) :: (~>) a ((~>) [Bool] [Bool])) where
       sing = (singFun2 @(FoosPrecSym1 (d :: Nat))) (sFoosPrec (sing @d))
+    instance SFoo a =>
+             SingI1 (FoosPrecSym1 :: Nat -> (~>) a ((~>) [Bool] [Bool])) where
+      liftSing (s :: Sing (d :: Nat))
+        = (singFun2 @(FoosPrecSym1 (d :: Nat))) (sFoosPrec s)
     instance (SFoo a, SingI d, SingI d) =>
              SingI (FoosPrecSym2 (d :: Nat) (d :: a) :: (~>) [Bool] [Bool]) where
       sing
         = (singFun1 @(FoosPrecSym2 (d :: Nat) (d :: a)))
             ((sFoosPrec (sing @d)) (sing @d))
+    instance (SFoo a, SingI d) =>
+             SingI1 (FoosPrecSym2 (d :: Nat) :: a -> (~>) [Bool] [Bool]) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(FoosPrecSym2 (d :: Nat) (d :: a)))
+            ((sFoosPrec (sing @d)) s)
+    instance SFoo a =>
+             SingI2 (FoosPrecSym2 :: Nat -> a -> (~>) [Bool] [Bool]) where
+      liftSing2 (s :: Sing (d :: Nat)) (s :: Sing (d :: a))
+        = (singFun1 @(FoosPrecSym2 (d :: Nat) (d :: a))) ((sFoosPrec s) s)
     instance SFoo a => SingI (FooSym0 :: (~>) a [Bool]) where
       sing = (singFun1 @FooSym0) sFoo
 

--- a/singletons-base/tests/compile-and-dump/Singletons/T167.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T167.golden
@@ -161,14 +161,31 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
     instance (SFoo a, SingI d) =>
              SingI (FoosPrecSym1 (d :: Nat) :: (~>) a ((~>) [Bool] [Bool])) where
       sing = (singFun2 @(FoosPrecSym1 (d :: Nat))) (sFoosPrec (sing @d))
+    instance SFoo a =>
+             SingI1 (FoosPrecSym1 :: Nat -> (~>) a ((~>) [Bool] [Bool])) where
+      liftSing (s :: Sing (d :: Nat))
+        = (singFun2 @(FoosPrecSym1 (d :: Nat))) (sFoosPrec s)
     instance (SFoo a, SingI d, SingI d) =>
              SingI (FoosPrecSym2 (d :: Nat) (d :: a) :: (~>) [Bool] [Bool]) where
       sing
         = (singFun1 @(FoosPrecSym2 (d :: Nat) (d :: a)))
             ((sFoosPrec (sing @d)) (sing @d))
+    instance (SFoo a, SingI d) =>
+             SingI1 (FoosPrecSym2 (d :: Nat) :: a -> (~>) [Bool] [Bool]) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(FoosPrecSym2 (d :: Nat) (d :: a)))
+            ((sFoosPrec (sing @d)) s)
+    instance SFoo a =>
+             SingI2 (FoosPrecSym2 :: Nat -> a -> (~>) [Bool] [Bool]) where
+      liftSing2 (s :: Sing (d :: Nat)) (s :: Sing (d :: a))
+        = (singFun1 @(FoosPrecSym2 (d :: Nat) (d :: a))) ((sFoosPrec s) s)
     instance SFoo a =>
              SingI (FooListSym0 :: (~>) a ((~>) [Bool] [Bool])) where
       sing = (singFun2 @FooListSym0) sFooList
     instance (SFoo a, SingI d) =>
              SingI (FooListSym1 (d :: a) :: (~>) [Bool] [Bool]) where
       sing = (singFun1 @(FooListSym1 (d :: a))) (sFooList (sing @d))
+    instance SFoo a =>
+             SingI1 (FooListSym1 :: a -> (~>) [Bool] [Bool]) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(FooListSym1 (d :: a))) (sFooList s)

--- a/singletons-base/tests/compile-and-dump/Singletons/T172.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T172.golden
@@ -39,3 +39,6 @@ Singletons/T172.hs:(0,0)-(0,0): Splicing declarations
     instance SingI d =>
              SingI (($>@#@$$) (d :: Nat) :: (~>) Nat Nat) where
       sing = (singFun1 @(($>@#@$$) (d :: Nat))) ((%$>) (sing @d))
+    instance SingI1 (($>@#@$$) :: Nat -> (~>) Nat Nat) where
+      liftSing (s :: Sing (d :: Nat))
+        = (singFun1 @(($>@#@$$) (d :: Nat))) ((%$>) s)

--- a/singletons-base/tests/compile-and-dump/Singletons/T176.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T176.golden
@@ -159,8 +159,15 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
     instance (SFoo1 a, SingI d) =>
              SingI (Bar1Sym1 (d :: a) :: (~>) ((~>) a b) b) where
       sing = (singFun1 @(Bar1Sym1 (d :: a))) (sBar1 (sing @d))
+    instance SFoo1 a =>
+             SingI1 (Bar1Sym1 :: a -> (~>) ((~>) a b) b) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(Bar1Sym1 (d :: a))) (sBar1 s)
     instance SFoo2 a => SingI (Bar2Sym0 :: (~>) a ((~>) b b)) where
       sing = (singFun2 @Bar2Sym0) sBar2
     instance (SFoo2 a, SingI d) =>
              SingI (Bar2Sym1 (d :: a) :: (~>) b b) where
       sing = (singFun1 @(Bar2Sym1 (d :: a))) (sBar2 (sing @d))
+    instance SFoo2 a => SingI1 (Bar2Sym1 :: a -> (~>) b b) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(Bar2Sym1 (d :: a))) (sBar2 s)

--- a/singletons-base/tests/compile-and-dump/Singletons/T183.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T183.golden
@@ -499,6 +499,9 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @Foo7Sym0) sFoo7
     instance SingI d => SingI (Foo7Sym1 (d :: a) :: (~>) b a) where
       sing = (singFun1 @(Foo7Sym1 (d :: a))) (sFoo7 (sing @d))
+    instance SingI1 (Foo7Sym1 :: a -> (~>) b a) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(Foo7Sym1 (d :: a))) (sFoo7 s)
     instance SingI (Foo6Sym0 :: (~>) (Maybe (Maybe a)) (Maybe (Maybe a))) where
       sing = (singFun1 @Foo6Sym0) sFoo6
     instance SingI (Foo5Sym0 :: (~>) (Maybe (Maybe a)) (Maybe (Maybe a))) where

--- a/singletons-base/tests/compile-and-dump/Singletons/T184.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T184.golden
@@ -433,13 +433,23 @@ Singletons/T184.hs:(0,0)-(0,0): Splicing declarations
     instance SingI d =>
              SingI (CartProdSym1 (d :: [a]) :: (~>) [b] [(a, b)]) where
       sing = (singFun1 @(CartProdSym1 (d :: [a]))) (sCartProd (sing @d))
+    instance SingI1 (CartProdSym1 :: [a] -> (~>) [b] [(a, b)]) where
+      liftSing (s :: Sing (d :: [a]))
+        = (singFun1 @(CartProdSym1 (d :: [a]))) (sCartProd s)
     instance SingI (Zip'Sym0 :: (~>) [a] ((~>) [b] [(a, b)])) where
       sing = (singFun2 @Zip'Sym0) sZip'
     instance SingI d =>
              SingI (Zip'Sym1 (d :: [a]) :: (~>) [b] [(a, b)]) where
       sing = (singFun1 @(Zip'Sym1 (d :: [a]))) (sZip' (sing @d))
+    instance SingI1 (Zip'Sym1 :: [a] -> (~>) [b] [(a, b)]) where
+      liftSing (s :: Sing (d :: [a]))
+        = (singFun1 @(Zip'Sym1 (d :: [a]))) (sZip' s)
     instance SingI (BoogieSym0 :: (~>) (Maybe a) ((~>) (Maybe Bool) (Maybe a))) where
       sing = (singFun2 @BoogieSym0) sBoogie
     instance SingI d =>
              SingI (BoogieSym1 (d :: Maybe a) :: (~>) (Maybe Bool) (Maybe a)) where
       sing = (singFun1 @(BoogieSym1 (d :: Maybe a))) (sBoogie (sing @d))
+    instance SingI1 (BoogieSym1 :: Maybe a
+                                   -> (~>) (Maybe Bool) (Maybe a)) where
+      liftSing (s :: Sing (d :: Maybe a))
+        = (singFun1 @(BoogieSym1 (d :: Maybe a))) (sBoogie s)

--- a/singletons-base/tests/compile-and-dump/Singletons/T197.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T197.golden
@@ -43,3 +43,6 @@ Singletons/T197.hs:(0,0)-(0,0): Splicing declarations
     instance SingI d =>
              SingI (($$:@#@$$) (d :: Bool) :: (~>) Bool Bool) where
       sing = (singFun1 @(($$:@#@$$) (d :: Bool))) ((%$$:) (sing @d))
+    instance SingI1 (($$:@#@$$) :: Bool -> (~>) Bool Bool) where
+      liftSing (s :: Sing (d :: Bool))
+        = (singFun1 @(($$:@#@$$) (d :: Bool))) ((%$$:) s)

--- a/singletons-base/tests/compile-and-dump/Singletons/T197b.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T197b.golden
@@ -76,16 +76,30 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
     instance (SingI n, SingI n) =>
              SingI ((:*:) (n :: a) (n :: b)) where
       sing = ((:%*:) sing) sing
+    instance SingI n => SingI1 ((:*:) (n :: a)) where
+      liftSing = (:%*:) sing
+    instance SingI2 (:*:) where
+      liftSing2 = (:%*:)
     instance SingI ((:*:@#@$) :: (~>) a ((~>) b ((:*:) a b))) where
       sing = (singFun2 @(:*:@#@$)) (:%*:)
     instance SingI d =>
              SingI ((:*:@#@$$) (d :: a) :: (~>) b ((:*:) a b)) where
       sing = (singFun1 @((:*:@#@$$) (d :: a))) ((:%*:) (sing @d))
+    instance SingI1 ((:*:@#@$$) :: a -> (~>) b ((:*:) a b)) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @((:*:@#@$$) (d :: a))) ((:%*:) s)
     instance (SingI n, SingI n) =>
              SingI (MkPair (n :: a) (n :: b)) where
       sing = (SMkPair sing) sing
+    instance SingI n => SingI1 (MkPair (n :: a)) where
+      liftSing = SMkPair sing
+    instance SingI2 MkPair where
+      liftSing2 = SMkPair
     instance SingI (MkPairSym0 :: (~>) a ((~>) b (Pair a b))) where
       sing = (singFun2 @MkPairSym0) SMkPair
     instance SingI d =>
              SingI (MkPairSym1 (d :: a) :: (~>) b (Pair a b)) where
       sing = (singFun1 @(MkPairSym1 (d :: a))) (SMkPair (sing @d))
+    instance SingI1 (MkPairSym1 :: a -> (~>) b (Pair a b)) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(MkPairSym1 (d :: a))) (SMkPair s)

--- a/singletons-base/tests/compile-and-dump/Singletons/T200.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T200.golden
@@ -129,12 +129,20 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
              SingI ((<>:@#@$$) (d :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage) where
       sing
         = (singFun1 @((<>:@#@$$) (d :: ErrorMessage))) ((%<>:) (sing @d))
+    instance SingI1 ((<>:@#@$$) :: ErrorMessage
+                                   -> (~>) ErrorMessage ErrorMessage) where
+      liftSing (s :: Sing (d :: ErrorMessage))
+        = (singFun1 @((<>:@#@$$) (d :: ErrorMessage))) ((%<>:) s)
     instance SingI (($$:@#@$) :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)) where
       sing = (singFun2 @($$:@#@$)) (%$$:)
     instance SingI d =>
              SingI (($$:@#@$$) (d :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage) where
       sing
         = (singFun1 @(($$:@#@$$) (d :: ErrorMessage))) ((%$$:) (sing @d))
+    instance SingI1 (($$:@#@$$) :: ErrorMessage
+                                   -> (~>) ErrorMessage ErrorMessage) where
+      liftSing (s :: Sing (d :: ErrorMessage))
+        = (singFun1 @(($$:@#@$$) (d :: ErrorMessage))) ((%$$:) s)
     data SErrorMessage :: ErrorMessage -> GHC.Types.Type
       where
         (:%$$:) :: forall (n :: ErrorMessage) (n :: ErrorMessage).
@@ -169,22 +177,40 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
     instance (SingI n, SingI n) =>
              SingI ((:$$:) (n :: ErrorMessage) (n :: ErrorMessage)) where
       sing = ((:%$$:) sing) sing
+    instance SingI n => SingI1 ((:$$:) (n :: ErrorMessage)) where
+      liftSing = (:%$$:) sing
+    instance SingI2 (:$$:) where
+      liftSing2 = (:%$$:)
     instance SingI ((:$$:@#@$) :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)) where
       sing = (singFun2 @(:$$:@#@$)) (:%$$:)
     instance SingI d =>
              SingI ((:$$:@#@$$) (d :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage) where
       sing
         = (singFun1 @((:$$:@#@$$) (d :: ErrorMessage))) ((:%$$:) (sing @d))
+    instance SingI1 ((:$$:@#@$$) :: ErrorMessage
+                                    -> (~>) ErrorMessage ErrorMessage) where
+      liftSing (s :: Sing (d :: ErrorMessage))
+        = (singFun1 @((:$$:@#@$$) (d :: ErrorMessage))) ((:%$$:) s)
     instance (SingI n, SingI n) =>
              SingI ((:<>:) (n :: ErrorMessage) (n :: ErrorMessage)) where
       sing = ((:%<>:) sing) sing
+    instance SingI n => SingI1 ((:<>:) (n :: ErrorMessage)) where
+      liftSing = (:%<>:) sing
+    instance SingI2 (:<>:) where
+      liftSing2 = (:%<>:)
     instance SingI ((:<>:@#@$) :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)) where
       sing = (singFun2 @(:<>:@#@$)) (:%<>:)
     instance SingI d =>
              SingI ((:<>:@#@$$) (d :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage) where
       sing
         = (singFun1 @((:<>:@#@$$) (d :: ErrorMessage))) ((:%<>:) (sing @d))
+    instance SingI1 ((:<>:@#@$$) :: ErrorMessage
+                                    -> (~>) ErrorMessage ErrorMessage) where
+      liftSing (s :: Sing (d :: ErrorMessage))
+        = (singFun1 @((:<>:@#@$$) (d :: ErrorMessage))) ((:%<>:) s)
     instance SingI n => SingI (EM (n :: [Bool])) where
       sing = SEM sing
+    instance SingI1 EM where
+      liftSing = SEM
     instance SingI (EMSym0 :: (~>) [Bool] ErrorMessage) where
       sing = (singFun1 @EMSym0) SEM

--- a/singletons-base/tests/compile-and-dump/Singletons/T204.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T204.golden
@@ -77,16 +77,30 @@ Singletons/T204.hs:(0,0)-(0,0): Splicing declarations
             (,) (SomeSing c) (SomeSing c) -> SomeSing (((:^%%) c) c) }
     instance (SingI n, SingI n) => SingI ((:%) (n :: a) (n :: a)) where
       sing = ((:^%) sing) sing
+    instance SingI n => SingI1 ((:%) (n :: a)) where
+      liftSing = (:^%) sing
+    instance SingI2 (:%) where
+      liftSing2 = (:^%)
     instance SingI ((:%@#@$) :: (~>) a ((~>) a (Ratio1 a))) where
       sing = (singFun2 @(:%@#@$)) (:^%)
     instance SingI d =>
              SingI ((:%@#@$$) (d :: a) :: (~>) a (Ratio1 a)) where
       sing = (singFun1 @((:%@#@$$) (d :: a))) ((:^%) (sing @d))
+    instance SingI1 ((:%@#@$$) :: a -> (~>) a (Ratio1 a)) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @((:%@#@$$) (d :: a))) ((:^%) s)
     instance (SingI n, SingI n) =>
              SingI ((:%%) (n :: a) (n :: a)) where
       sing = ((:^%%) sing) sing
+    instance SingI n => SingI1 ((:%%) (n :: a)) where
+      liftSing = (:^%%) sing
+    instance SingI2 (:%%) where
+      liftSing2 = (:^%%)
     instance SingI ((:%%@#@$) :: (~>) a ((~>) a (Ratio2 a))) where
       sing = (singFun2 @(:%%@#@$)) (:^%%)
     instance SingI d =>
              SingI ((:%%@#@$$) (d :: a) :: (~>) a (Ratio2 a)) where
       sing = (singFun1 @((:%%@#@$$) (d :: a))) ((:^%%) (sing @d))
+    instance SingI1 ((:%%@#@$$) :: a -> (~>) a (Ratio2 a)) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @((:%%@#@$$) (d :: a))) ((:^%%) s)

--- a/singletons-base/tests/compile-and-dump/Singletons/T209.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T209.golden
@@ -64,10 +64,19 @@ Singletons/T209.hs:(0,0)-(0,0): Splicing declarations
     instance SingI d =>
              SingI (MSym1 (d :: a) :: (~>) b ((~>) Bool Bool)) where
       sing = (singFun2 @(MSym1 (d :: a))) (sM (sing @d))
+    instance SingI1 (MSym1 :: a -> (~>) b ((~>) Bool Bool)) where
+      liftSing (s :: Sing (d :: a)) = (singFun2 @(MSym1 (d :: a))) (sM s)
     instance (SingI d, SingI d) =>
              SingI (MSym2 (d :: a) (d :: b) :: (~>) Bool Bool) where
       sing
         = (singFun1 @(MSym2 (d :: a) (d :: b))) ((sM (sing @d)) (sing @d))
+    instance SingI d =>
+             SingI1 (MSym2 (d :: a) :: b -> (~>) Bool Bool) where
+      liftSing (s :: Sing (d :: b))
+        = (singFun1 @(MSym2 (d :: a) (d :: b))) ((sM (sing @d)) s)
+    instance SingI2 (MSym2 :: a -> b -> (~>) Bool Bool) where
+      liftSing2 (s :: Sing (d :: a)) (s :: Sing (d :: b))
+        = (singFun1 @(MSym2 (d :: a) (d :: b))) ((sM s) s)
     data SHm :: Hm -> GHC.Types.Type where SHm :: SHm (Hm :: Hm)
     type instance Sing @Hm = SHm
     instance SingKind Hm where

--- a/singletons-base/tests/compile-and-dump/Singletons/T249.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T249.golden
@@ -75,13 +75,19 @@ Singletons/T249.hs:(0,0)-(0,0): Splicing declarations
             SomeSing c -> SomeSing (SMkFoo3 c) }
     instance SingI n => SingI (MkFoo1 (n :: a)) where
       sing = SMkFoo1 sing
+    instance SingI1 MkFoo1 where
+      liftSing = SMkFoo1
     instance SingI (MkFoo1Sym0 :: (~>) a (Foo1 a)) where
       sing = (singFun1 @MkFoo1Sym0) SMkFoo1
     instance SingI n => SingI (MkFoo2 (n :: x)) where
       sing = SMkFoo2 sing
+    instance SingI1 MkFoo2 where
+      liftSing = SMkFoo2
     instance SingI (MkFoo2Sym0 :: (~>) x (Foo2 x)) where
       sing = (singFun1 @MkFoo2Sym0) SMkFoo2
     instance SingI n => SingI (MkFoo3 (n :: x)) where
       sing = SMkFoo3 sing
+    instance SingI1 MkFoo3 where
+      liftSing = SMkFoo3
     instance SingI (MkFoo3Sym0 :: (~>) x (Foo3 x)) where
       sing = (singFun1 @MkFoo3Sym0) SMkFoo3

--- a/singletons-base/tests/compile-and-dump/Singletons/T271.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T271.golden
@@ -281,9 +281,13 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
         = Data.Singletons.Decide.decideCoercion
     instance SingI n => SingI (Constant (n :: a)) where
       sing = SConstant sing
+    instance SingI1 Constant where
+      liftSing = SConstant
     instance SingI (ConstantSym0 :: (~>) a (Constant (a :: Type) (b :: Type))) where
       sing = (singFun1 @ConstantSym0) SConstant
     instance SingI n => SingI (Identity (n :: a)) where
       sing = SIdentity sing
+    instance SingI1 Identity where
+      liftSing = SIdentity
     instance SingI (IdentitySym0 :: (~>) a (Identity a)) where
       sing = (singFun1 @IdentitySym0) SIdentity

--- a/singletons-base/tests/compile-and-dump/Singletons/T287.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T287.golden
@@ -109,3 +109,6 @@ Singletons/T287.hs:(0,0)-(0,0): Splicing declarations
     instance (SS a, SingI d) =>
              SingI ((<<>>@#@$$) (d :: a) :: (~>) a a) where
       sing = (singFun1 @((<<>>@#@$$) (d :: a))) ((%<<>>) (sing @d))
+    instance SS a => SingI1 ((<<>>@#@$$) :: a -> (~>) a a) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @((<<>>@#@$$) (d :: a))) ((%<<>>) s)

--- a/singletons-base/tests/compile-and-dump/Singletons/T312.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T312.golden
@@ -187,8 +187,14 @@ Singletons/T312.hs:(0,0)-(0,0): Splicing declarations
     instance (SFoo a, SingI d) =>
              SingI (BarSym1 (d :: a) :: (~>) b b) where
       sing = (singFun1 @(BarSym1 (d :: a))) (sBar (sing @d))
+    instance SFoo a => SingI1 (BarSym1 :: a -> (~>) b b) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(BarSym1 (d :: a))) (sBar s)
     instance SFoo a => SingI (BazSym0 :: (~>) a ((~>) b b)) where
       sing = (singFun2 @BazSym0) sBaz
     instance (SFoo a, SingI d) =>
              SingI (BazSym1 (d :: a) :: (~>) b b) where
       sing = (singFun1 @(BazSym1 (d :: a))) (sBaz (sing @d))
+    instance SFoo a => SingI1 (BazSym1 :: a -> (~>) b b) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(BazSym1 (d :: a))) (sBaz s)

--- a/singletons-base/tests/compile-and-dump/Singletons/T322.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T322.golden
@@ -48,3 +48,6 @@ Singletons/T322.hs:(0,0)-(0,0): Splicing declarations
     instance SingI d =>
              SingI ((!@#@$$) (d :: Bool) :: (~>) Bool Bool) where
       sing = (singFun1 @((!@#@$$) (d :: Bool))) ((%!) (sing @d))
+    instance SingI1 ((!@#@$$) :: Bool -> (~>) Bool Bool) where
+      liftSing (s :: Sing (d :: Bool))
+        = (singFun1 @((!@#@$$) (d :: Bool))) ((%!) s)

--- a/singletons-base/tests/compile-and-dump/Singletons/T326.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T326.golden
@@ -67,3 +67,6 @@ Singletons/T326.hs:0:0:: Splicing declarations
     instance (SC2 a, SingI d) =>
              SingI ((<%%>@#@$$) (d :: a) :: (~>) a a) where
       sing = (singFun1 @((<%%>@#@$$) (d :: a))) ((%<%%>) (sing @d))
+    instance SC2 a => SingI1 ((<%%>@#@$$) :: a -> (~>) a a) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @((<%%>@#@$$) (d :: a))) ((%<%%>) s)

--- a/singletons-base/tests/compile-and-dump/Singletons/T367.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T367.golden
@@ -35,3 +35,6 @@ Singletons/T367.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @Const'Sym0) sConst'
     instance SingI d => SingI (Const'Sym1 (d :: a) :: (~>) b a) where
       sing = (singFun1 @(Const'Sym1 (d :: a))) (sConst' (sing @d))
+    instance SingI1 (Const'Sym1 :: a -> (~>) b a) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(Const'Sym1 (d :: a))) (sConst' s)

--- a/singletons-base/tests/compile-and-dump/Singletons/T371.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T371.golden
@@ -227,11 +227,15 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
       sing = SX1
     instance SingI n => SingI (X2 (n :: Y a)) where
       sing = SX2 sing
+    instance SingI1 X2 where
+      liftSing = SX2
     instance SingI (X2Sym0 :: (~>) (Y a) (X (a :: Type))) where
       sing = (singFun1 @X2Sym0) SX2
     instance SingI Y1 where
       sing = SY1
     instance SingI n => SingI (Y2 (n :: X a)) where
       sing = SY2 sing
+    instance SingI1 Y2 where
+      liftSing = SY2
     instance SingI (Y2Sym0 :: (~>) (X a) (Y (a :: Type))) where
       sing = (singFun1 @Y2Sym0) SY2

--- a/singletons-base/tests/compile-and-dump/Singletons/T376.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T376.golden
@@ -39,3 +39,6 @@ Singletons/T376.hs:(0,0)-(0,0): Splicing declarations
     instance SingI d =>
              SingI (FSym1 (d :: (~>) () ()) :: (~>) () ()) where
       sing = (singFun1 @(FSym1 (d :: (~>) () ()))) (sF (sing @d))
+    instance SingI1 (FSym1 :: (~>) () () -> (~>) () ()) where
+      liftSing (s :: Sing (d :: (~>) () ()))
+        = (singFun1 @(FSym1 (d :: (~>) () ()))) (sF s)

--- a/singletons-base/tests/compile-and-dump/Singletons/T378a.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T378a.golden
@@ -60,6 +60,9 @@ Singletons/T378a.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun2 @ConstBASym0) sConstBA
     instance SingI d => SingI (ConstBASym1 (d :: a) :: (~>) b a) where
       sing = (singFun1 @(ConstBASym1 (d :: a))) (sConstBA (sing @d))
+    instance SingI1 (ConstBASym1 :: a -> (~>) b a) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(ConstBASym1 (d :: a))) (sConstBA s)
     data SProxy :: forall k (a :: k). Proxy a -> Type
       where
         SProxy1 :: forall a. SProxy (Proxy1 :: Proxy a)

--- a/singletons-base/tests/compile-and-dump/Singletons/T378b.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T378b.golden
@@ -109,10 +109,15 @@ Singletons/T378b.hs:(0,0)-(0,0): Splicing declarations
     instance SingI d =>
              SingI (NatMinusSym1 (d :: Nat) :: (~>) Nat Nat) where
       sing = (singFun1 @(NatMinusSym1 (d :: Nat))) (sNatMinus (sing @d))
+    instance SingI1 (NatMinusSym1 :: Nat -> (~>) Nat Nat) where
+      liftSing (s :: Sing (d :: Nat))
+        = (singFun1 @(NatMinusSym1 (d :: Nat))) (sNatMinus s)
     instance SingI (FSym0 :: (~>) a ((~>) b ())) where
       sing = (singFun2 @FSym0) sF
     instance SingI d => SingI (FSym1 (d :: a) :: (~>) b ()) where
       sing = (singFun1 @(FSym1 (d :: a))) (sF (sing @d))
+    instance SingI1 (FSym1 :: a -> (~>) b ()) where
+      liftSing (s :: Sing (d :: a)) = (singFun1 @(FSym1 (d :: a))) (sF s)
     type SD :: forall b a (x :: a) (y :: b). D x y -> Type
     data SD :: forall b a (x :: a) (y :: b). D x y -> Type
     type instance Sing @(D x y) = SD

--- a/singletons-base/tests/compile-and-dump/Singletons/T412.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T412.golden
@@ -178,16 +178,26 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
       infix 6 `sM1`
     instance (SingI n, SingI n) => SingI (MkD1 (n :: a) (n :: b)) where
       sing = (SMkD1 sing) sing
+    instance SingI n => SingI1 (MkD1 (n :: a)) where
+      liftSing = SMkD1 sing
+    instance SingI2 MkD1 where
+      liftSing2 = SMkD1
     instance SingI (MkD1Sym0 :: (~>) a ((~>) b (D1 a b))) where
       sing = (singFun2 @MkD1Sym0) SMkD1
     instance SingI d =>
              SingI (MkD1Sym1 (d :: a) :: (~>) b (D1 a b)) where
       sing = (singFun1 @(MkD1Sym1 (d :: a))) (SMkD1 (sing @d))
+    instance SingI1 (MkD1Sym1 :: a -> (~>) b (D1 a b)) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(MkD1Sym1 (d :: a))) (SMkD1 s)
     instance SC1 a b => SingI (M1Sym0 :: (~>) a ((~>) b Bool)) where
       sing = (singFun2 @M1Sym0) sM1
     instance (SC1 a b, SingI d) =>
              SingI (M1Sym1 (d :: a) :: (~>) b Bool) where
       sing = (singFun1 @(M1Sym1 (d :: a))) (sM1 (sing @d))
+    instance SC1 a b => SingI1 (M1Sym1 :: a -> (~>) b Bool) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(M1Sym1 (d :: a))) (sM1 s)
 Singletons/T412.hs:0:0:: Splicing declarations
     genSingletons [''C2, ''T2a, ''T2b, ''D2]
   ======>
@@ -230,6 +240,9 @@ Singletons/T412.hs:0:0:: Splicing declarations
     instance (SC2 a b, SingI d) =>
              SingI (M2Sym1 (d :: a) :: (~>) b Bool) where
       sing = (singFun1 @(M2Sym1 (d :: a))) (sM2 (sing @d))
+    instance SC2 a b => SingI1 (M2Sym1 :: a -> (~>) b Bool) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(M2Sym1 (d :: a))) (sM2 s)
     type T2aSym0 :: (~>) GHC.Types.Type ((~>) GHC.Types.Type GHC.Types.Type)
     data T2aSym0 :: (~>) GHC.Types.Type ((~>) GHC.Types.Type GHC.Types.Type)
       where
@@ -381,8 +394,16 @@ Singletons/T412.hs:0:0:: Splicing declarations
     instance (SingI n, SingI n) =>
              SingI ('MkD2 (n :: a) (n :: b)) where
       sing = (SMkD2 sing) sing
+    instance SingI n => SingI1 ('MkD2 (n :: a)) where
+      liftSing = SMkD2 sing
+    instance SingI2 'MkD2 where
+      liftSing2 = SMkD2
     instance SingI (MkD2Sym0 :: (~>) a ((~>) b (D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type)))) where
       sing = (singFun2 @MkD2Sym0) SMkD2
     instance SingI d =>
              SingI (MkD2Sym1 (d :: a) :: (~>) b (D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type))) where
       sing = (singFun1 @(MkD2Sym1 (d :: a))) (SMkD2 (sing @d))
+    instance SingI1 (MkD2Sym1 :: a
+                                 -> (~>) b (D2 (a :: GHC.Types.Type) (b :: GHC.Types.Type))) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @(MkD2Sym1 (d :: a))) (SMkD2 s)

--- a/singletons-base/tests/compile-and-dump/Singletons/T443.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T443.golden
@@ -103,6 +103,8 @@ Singletons/T443.hs:(0,0)-(0,0): Splicing declarations
       sing = SZ
     instance SingI n => SingI (S (n :: Nat)) where
       sing = SS sing
+    instance SingI1 S where
+      liftSing = SS
     instance SingI (SSym0 :: (~>) Nat Nat) where
       sing = (singFun1 @SSym0) SS
     instance SingI VNil where
@@ -110,8 +112,16 @@ Singletons/T443.hs:(0,0)-(0,0): Splicing declarations
     instance (SingI n, SingI n) =>
              SingI ((:>) (n :: a) (n :: Vec n a)) where
       sing = ((:%>) sing) sing
+    instance SingI n => SingI1 ((:>) (n :: a)) where
+      liftSing = (:%>) sing
+    instance SingI2 (:>) where
+      liftSing2 = (:%>)
     instance SingI ((:>@#@$) :: (~>) a ((~>) (Vec n a) (Vec (S n) a))) where
       sing = (singFun2 @(:>@#@$)) (:%>)
     instance SingI d =>
              SingI ((:>@#@$$) (d :: a) :: (~>) (Vec n a) (Vec (S n) a)) where
       sing = (singFun1 @((:>@#@$$) (d :: a))) ((:%>) (sing @d))
+    instance SingI1 ((:>@#@$$) :: a
+                                  -> (~>) (Vec n a) (Vec (S n) a)) where
+      liftSing (s :: Sing (d :: a))
+        = (singFun1 @((:>@#@$$) (d :: a))) ((:%>) s)

--- a/singletons-base/tests/compile-and-dump/Singletons/T450.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T450.golden
@@ -69,6 +69,8 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
             SomeSing c -> SomeSing (SMkAge c) }
     instance SingI n => SingI ('PMkAge (n :: Nat)) where
       sing = SMkAge sing
+    instance SingI1 'PMkAge where
+      liftSing = SMkAge
     instance SingI (PMkAgeSym0 :: (~>) Nat PAge) where
       sing = (singFun1 @PMkAgeSym0) SMkAge
     addAge :: Age -> Age -> Age
@@ -110,6 +112,9 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
     instance SingI d =>
              SingI (AddAgeSym1 (d :: PAge) :: (~>) PAge PAge) where
       sing = (singFun1 @(AddAgeSym1 (d :: PAge))) (sAddAge (sing @d))
+    instance SingI1 (AddAgeSym1 :: PAge -> (~>) PAge PAge) where
+      liftSing (s :: Sing (d :: PAge))
+        = (singFun1 @(AddAgeSym1 (d :: PAge))) (sAddAge s)
     type PMkMessageSym0 :: (~>) Symbol PMessage
     data PMkMessageSym0 :: (~>) Symbol PMessage
       where
@@ -135,6 +140,8 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
             SomeSing c -> SomeSing (SMkMessage c) }
     instance SingI n => SingI ('PMkMessage (n :: Symbol)) where
       sing = SMkMessage sing
+    instance SingI1 'PMkMessage where
+      liftSing = SMkMessage
     instance SingI (PMkMessageSym0 :: (~>) Symbol PMessage) where
       sing = (singFun1 @PMkMessageSym0) SMkMessage
     appendMessage :: Message -> Message -> Message
@@ -183,6 +190,11 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
       sing
         = (singFun1 @(AppendMessageSym1 (d :: PMessage)))
             (sAppendMessage (sing @d))
+    instance SingI1 (AppendMessageSym1 :: PMessage
+                                          -> (~>) PMessage PMessage) where
+      liftSing (s :: Sing (d :: PMessage))
+        = (singFun1 @(AppendMessageSym1 (d :: PMessage)))
+            (sAppendMessage s)
     type PMkFunctionSym0 :: forall (a :: GHC.Types.Type)
                                    (b :: GHC.Types.Type).
                             (~>) ((~>) a b) (PFunction (a :: GHC.Types.Type) (b :: GHC.Types.Type))
@@ -220,6 +232,8 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
             SomeSing c -> SomeSing (SMkFunction c) }
     instance SingI n => SingI ('PMkFunction (n :: (~>) a b)) where
       sing = SMkFunction sing
+    instance SingI1 'PMkFunction where
+      liftSing = SMkFunction
     instance SingI (PMkFunctionSym0 :: (~>) ((~>) a b) (PFunction (a :: GHC.Types.Type) (b :: GHC.Types.Type))) where
       sing = (singFun1 @PMkFunctionSym0) SMkFunction
     composeFunction :: Function b c -> Function a b -> Function a c
@@ -274,3 +288,8 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
       sing
         = (singFun1 @(ComposeFunctionSym1 (d :: PFunction b c)))
             (sComposeFunction (sing @d))
+    instance SingI1 (ComposeFunctionSym1 :: PFunction b c
+                                            -> (~>) (PFunction a b) (PFunction a c)) where
+      liftSing (s :: Sing (d :: PFunction b c))
+        = (singFun1 @(ComposeFunctionSym1 (d :: PFunction b c)))
+            (sComposeFunction s)

--- a/singletons-base/tests/compile-and-dump/Singletons/T470.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T470.golden
@@ -74,14 +74,20 @@ Singletons/T470.hs:(0,0)-(0,0): Splicing declarations
             SomeSing c -> SomeSing (SMkS c) }
     instance SingI n => SingI (MkT1 (n :: a)) where
       sing = SMkT1 sing
+    instance SingI1 MkT1 where
+      liftSing = SMkT1
     instance SingI (MkT1Sym0 :: (~>) a (T a)) where
       sing = (singFun1 @MkT1Sym0) SMkT1
     instance SingI n => SingI (MkT2 (n :: Void)) where
       sing = SMkT2 sing
+    instance SingI1 MkT2 where
+      liftSing = SMkT2
     instance SingI (MkT2Sym0 :: (~>) Void (T a)) where
       sing = (singFun1 @MkT2Sym0) SMkT2
     instance SingI n => SingI (MkS (n :: Bool)) where
       sing = SMkS sing
+    instance SingI1 MkS where
+      liftSing = SMkS
     instance SingI (MkSSym0 :: (~>) Bool S) where
       sing = (singFun1 @MkSSym0) SMkS
 

--- a/singletons-base/tests/compile-and-dump/Singletons/TopLevelPatterns.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/TopLevelPatterns.golden
@@ -63,11 +63,18 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
     instance (SingI n, SingI n) =>
              SingI (Bar (n :: Bool) (n :: Bool)) where
       sing = (SBar sing) sing
+    instance SingI n => SingI1 (Bar (n :: Bool)) where
+      liftSing = SBar sing
+    instance SingI2 Bar where
+      liftSing2 = SBar
     instance SingI (BarSym0 :: (~>) Bool ((~>) Bool Foo)) where
       sing = (singFun2 @BarSym0) SBar
     instance SingI d =>
              SingI (BarSym1 (d :: Bool) :: (~>) Bool Foo) where
       sing = (singFun1 @(BarSym1 (d :: Bool))) (SBar (sing @d))
+    instance SingI1 (BarSym1 :: Bool -> (~>) Bool Foo) where
+      liftSing (s :: Sing (d :: Bool))
+        = (singFun1 @(BarSym1 (d :: Bool))) (SBar s)
 Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
     singletons
       [d| otherwise :: Bool

--- a/singletons-th/CHANGES.md
+++ b/singletons-th/CHANGES.md
@@ -3,6 +3,8 @@ Changelog for the `singletons-th` project
 
 next [????.??.??]
 -----------------
+* Make the Template Haskell machinery generate `SingI1` and `SingI2` instances
+  when possible.
 * Make `genDefunSymbols` and related functions less likely to trigger
   [GHC#19743](https://gitlab.haskell.org/ghc/ghc/-/issues/19743).
 

--- a/singletons-th/singletons-th.cabal
+++ b/singletons-th/singletons-th.cabal
@@ -56,7 +56,7 @@ library
                       containers       >= 0.5,
                       mtl              >= 2.2.1,
                       ghc-boot-th,
-                      singletons       == 3.0.*,
+                      singletons       >= 3.0.1,
                       syb              >= 0.4,
                       template-haskell >= 2.17 && < 2.18,
                       th-desugar       >= 1.13 && < 1.14,

--- a/singletons-th/src/Data/Singletons/TH/Names.hs
+++ b/singletons-th/src/Data/Singletons/TH/Names.hs
@@ -62,7 +62,8 @@ boolName, andName, compareName, minBoundName,
   applyName, applyTyConName, applyTyConAux1Name,
   natName, symbolName, stringName,
   eqName, ordName, boundedName, orderingName,
-  singFamilyName, singIName, singMethName, demoteName, withSingIName,
+  singFamilyName, singIName, singI1Name, singI2Name,
+  singMethName, liftSingName, liftSing2Name, demoteName, withSingIName,
   singKindClassName, someSingTypeName, someSingDataName,
   sDecideClassName, sDecideMethName,
   testEqualityClassName, testEqualityMethName, decideEqualityName,
@@ -101,7 +102,11 @@ boundedName = ''Bounded
 orderingName = ''Ordering
 singFamilyName = ''Sing
 singIName = ''SingI
+singI1Name = ''SingI1
+singI2Name = ''SingI2
 singMethName = 'sing
+liftSingName = 'liftSing
+liftSing2Name = 'liftSing2
 toSingName = 'toSing
 fromSingName = 'fromSing
 demoteName = ''Demote
@@ -172,6 +177,18 @@ mkTyName tmName = do
 
 mkTyConName :: Int -> Name
 mkTyConName i = mkName $ "TyCon" ++ show i
+
+mkSingIName :: Int -> Name
+mkSingIName 0 = singIName
+mkSingIName 1 = singI1Name
+mkSingIName 2 = singI2Name
+mkSingIName n = error $ "SingI" ++ show n ++ " does not exist"
+
+mkSingMethName :: Int -> Name
+mkSingMethName 0 = singMethName
+mkSingMethName 1 = liftSingName
+mkSingMethName 2 = liftSing2Name
+mkSingMethName n = error $ "SingI" ++ show n ++ " does not exist"
 
 boolKi :: DKind
 boolKi = DConT boolName

--- a/singletons/CHANGES.md
+++ b/singletons/CHANGES.md
@@ -1,6 +1,17 @@
 Changelog for the `singletons` project
 ======================================
 
+3.0.1 [????.??.??]
+------------------
+* Add `SingI1` and `SingI2`, higher-order versions of `SingI`, to
+  `Data.Singletons`, along with various derived functions:
+
+  * `sing{1,2}`
+  * `singByProxy{1,2}` and `singByProxy{1,2}#`
+  * `usingSing{1,2}`
+  * `withSing{1,2}`
+  * `singThat{1,2}`
+
 3.0 [2021.03.12]
 ----------------
 * The `singletons` library has been split into three libraries:

--- a/singletons/singletons.cabal
+++ b/singletons/singletons.cabal
@@ -1,5 +1,5 @@
 name:           singletons
-version:        3.0
+version:        3.0.1
 cabal-version:  1.24
 synopsis:       Basic singleton types and definitions
 homepage:       http://www.github.com/goldfirere/singletons

--- a/singletons/tests/ByHand.hs
+++ b/singletons/tests/ByHand.hs
@@ -135,6 +135,8 @@ instance SingI Zero where
   sing = SZero
 instance SingI n => SingI (Succ n) where
   sing = SSucc sing
+instance SingI1 Succ where
+  liftSing = SSucc
 instance SingKind Nat where
   type Demote Nat = Nat
   fromSing SZero = Zero
@@ -221,6 +223,8 @@ instance SingI (Nothing :: Maybe k) where
   sing = SNothing
 instance SingI a => SingI (Just (a :: k)) where
   sing = SJust sing
+instance SingI1 Just where
+  liftSing = SJust
 instance SingKind k => SingKind (Maybe k) where
   type Demote (Maybe k) = Maybe (Demote k)
   fromSing SNothing = Nothing
@@ -289,6 +293,10 @@ instance SingI Nil where
 instance (SingI h, SingI t) =>
            SingI (Cons (h :: k) (t :: List k)) where
   sing = SCons sing sing
+instance SingI h => SingI1 (Cons (h :: k)) where
+  liftSing = SCons sing
+instance SingI2 Cons where
+  liftSing2 = SCons
 instance SingKind k => SingKind (List k) where
   type Demote (List k) = List (Demote k)
   fromSing SNil = Nil
@@ -311,8 +319,12 @@ type instance Sing = SEither
 
 instance (SingI a) => SingI (Left (a :: k)) where
   sing = SLeft sing
+instance SingI1 Left where
+  liftSing = SLeft
 instance (SingI b) => SingI (Right (b :: k)) where
   sing = SRight sing
+instance SingI1 Right where
+  liftSing = SRight
 instance (SingKind k1, SingKind k2) => SingKind (Either k1 k2) where
   type Demote (Either k1 k2) = Either (Demote k1) (Demote k2)
   fromSing (SLeft x) = Left (fromSing x)
@@ -353,6 +365,8 @@ type instance Sing = SComposite
 
 instance SingI a => SingI (MkComp (a :: Either (Maybe k1) k2)) where
   sing = SMkComp sing
+instance SingI1 MkComp where
+  liftSing = SMkComp
 instance (SingKind k1, SingKind k2) => SingKind (Composite k1 k2) where
   type Demote (Composite k1 k2) =
     Composite (Demote k1) (Demote k2)
@@ -412,8 +426,14 @@ instance SingI Nat where
   sing = SNat
 instance SingI a => SingI (Maybe a) where
   sing = SMaybe sing
+instance SingI1 Maybe where
+  liftSing = SMaybe
 instance (SingI a, SingI n) => SingI (Vec a n) where
   sing = SVec sing sing
+instance SingI a => SingI1 (Vec a) where
+  liftSing = SVec sing
+instance SingI2 Vec where
+  liftSing2 = SVec
 
 instance SingKind Type where
   type Demote Type = Rep


### PR DESCRIPTION
This adds `SingI{1,2}`, higher-order versions of the `SingI` class, to `Data.Singletons`. This has a couple of knock-on effects:

* `Data.Singletons` also sports a variety of derived functions which make it more convenient to use `SingI{1,2}`. See the `singletons` changelog for more details.
* `singletons-th` now generates `SingI{1,2}` instances whenever possible in addition to generating `SingI` instances. This required some mild refactoring to accomplish, but nothing too major.

Fixes #500.