### PR TITLE
`singletons-th`: Support type applications in data constructor patterns 

### DIFF
--- a/singletons-base/tests/SingletonsBaseTestSuite.hs
+++ b/singletons-base/tests/SingletonsBaseTestSuite.hs
@@ -138,6 +138,7 @@ tests =
     , compileAndDumpStdTest "T453"
     , compileAndDumpStdTest "NegativeLiterals"
     , compileAndDumpStdTest "T470"
+    , compileAndDumpStdTest "T480"
     , compileAndDumpStdTest "T487"
     , compileAndDumpStdTest "T492"
     , compileAndDumpStdTest "Natural"

--- a/singletons-base/tests/SingletonsBaseTestSuite.hs
+++ b/singletons-base/tests/SingletonsBaseTestSuite.hs
@@ -140,6 +140,7 @@ tests =
     , compileAndDumpStdTest "T470"
     , compileAndDumpStdTest "T480"
     , compileAndDumpStdTest "T487"
+    , compileAndDumpStdTest "T489"
     , compileAndDumpStdTest "T492"
     , compileAndDumpStdTest "Natural"
     ],

--- a/singletons-base/tests/compile-and-dump/Singletons/T480.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T480.golden
@@ -6,6 +6,7 @@ Singletons/T480.hs:0:0: error: Q monad failure
 
 Singletons/T480.hs:0:0: error:
     `singletons-th` does not support wildcard types
+	unless they appear in visible type patterns of data constructors
 	In the type: _
 
   |

--- a/singletons-base/tests/compile-and-dump/Singletons/T480.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T480.golden
@@ -1,0 +1,13 @@
+
+Singletons/T480.hs:0:0: error: Q monad failure
+  |
+5 | $(singletons
+  |  ^^^^^^^^^^^...
+
+Singletons/T480.hs:0:0: error:
+    `singletons-th` does not support wildcard types
+	In the type: _
+
+  |
+5 | $(singletons
+  |  ^^^^^^^^^^^...

--- a/singletons-base/tests/compile-and-dump/Singletons/T480.hs
+++ b/singletons-base/tests/compile-and-dump/Singletons/T480.hs
@@ -1,0 +1,8 @@
+module T480 where
+
+import Data.Singletons.TH
+
+$(singletons
+  [d| f :: _ -> _
+      f x = x
+  |])

--- a/singletons-base/tests/compile-and-dump/Singletons/T489.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T489.golden
@@ -1,0 +1,60 @@
+Singletons/T489.hs:(0,0)-(0,0): Splicing declarations
+    singletons
+      [d| blah :: Maybe a -> [a]
+          blah (Just @a x) = [x :: a]
+          blah (Nothing @a) = [] :: [a]
+          flurmp :: Maybe () -> ()
+          flurmp (Nothing @_) = ()
+          flurmp (Just ()) = () |]
+  ======>
+    blah :: Maybe a -> [a]
+    blah (Just @a x) = [x :: a]
+    blah (Nothing @a) = [] :: [a]
+    flurmp :: Maybe () -> ()
+    flurmp (Nothing @_) = ()
+    flurmp (Just ()) = ()
+    type FlurmpSym0 :: (~>) (Maybe ()) ()
+    data FlurmpSym0 :: (~>) (Maybe ()) ()
+      where
+        FlurmpSym0KindInference :: SameKind (Apply FlurmpSym0 arg) (FlurmpSym1 arg) =>
+                                   FlurmpSym0 a0123456789876543210
+    type instance Apply FlurmpSym0 a0123456789876543210 = Flurmp a0123456789876543210
+    instance SuppressUnusedWarnings FlurmpSym0 where
+      suppressUnusedWarnings = snd (((,) FlurmpSym0KindInference) ())
+    type FlurmpSym1 :: Maybe () -> ()
+    type family FlurmpSym1 (a0123456789876543210 :: Maybe ()) :: () where
+      FlurmpSym1 a0123456789876543210 = Flurmp a0123456789876543210
+    type BlahSym0 :: (~>) (Maybe a) [a]
+    data BlahSym0 :: (~>) (Maybe a) [a]
+      where
+        BlahSym0KindInference :: SameKind (Apply BlahSym0 arg) (BlahSym1 arg) =>
+                                 BlahSym0 a0123456789876543210
+    type instance Apply BlahSym0 a0123456789876543210 = Blah a0123456789876543210
+    instance SuppressUnusedWarnings BlahSym0 where
+      suppressUnusedWarnings = snd (((,) BlahSym0KindInference) ())
+    type BlahSym1 :: Maybe a -> [a]
+    type family BlahSym1 (a0123456789876543210 :: Maybe a) :: [a] where
+      BlahSym1 a0123456789876543210 = Blah a0123456789876543210
+    type Flurmp :: Maybe () -> ()
+    type family Flurmp (a :: Maybe ()) :: () where
+      Flurmp ('Nothing @_) = Tuple0Sym0
+      Flurmp ('Just '()) = Tuple0Sym0
+    type Blah :: Maybe a -> [a]
+    type family Blah (a :: Maybe a) :: [a] where
+      Blah ('Just @a x) = Apply (Apply (:@#@$) (x :: a)) NilSym0
+      Blah ('Nothing @a) = NilSym0 :: [a]
+    sFlurmp ::
+      forall (t :: Maybe ()). Sing t -> Sing (Apply FlurmpSym0 t :: ())
+    sBlah ::
+      forall a (t :: Maybe a). Sing t -> Sing (Apply BlahSym0 t :: [a])
+    sFlurmp (SNothing @_) = STuple0
+    sFlurmp (SJust STuple0) = STuple0
+    sBlah (SJust @a (sX :: Sing x))
+      = (applySing
+           ((applySing ((singFun2 @(:@#@$)) SCons)) (sX :: Sing (x :: a))))
+          SNil
+    sBlah (SNothing @a) = SNil :: Sing (NilSym0 :: [a])
+    instance SingI (FlurmpSym0 :: (~>) (Maybe ()) ()) where
+      sing = (singFun1 @FlurmpSym0) sFlurmp
+    instance SingI (BlahSym0 :: (~>) (Maybe a) [a]) where
+      sing = (singFun1 @BlahSym0) sBlah

--- a/singletons-base/tests/compile-and-dump/Singletons/T489.hs
+++ b/singletons-base/tests/compile-and-dump/Singletons/T489.hs
@@ -1,0 +1,14 @@
+module T489 where
+
+import Data.Singletons.Base.TH
+import Prelude.Singletons
+
+$(singletons [d|
+  blah :: Maybe a -> [a]
+  blah (Just @a x)  = [x :: a]
+  blah (Nothing @a) = [] :: [a]
+
+  flurmp :: Maybe () -> ()
+  flurmp (Nothing @_) = ()
+  flurmp (Just ())    = ()
+  |])

--- a/singletons-th/CHANGES.md
+++ b/singletons-th/CHANGES.md
@@ -4,6 +4,7 @@ Changelog for the `singletons-th` project
 next [????.??.??]
 -----------------
 * Require building with GHC 9.2.
+* Allow promoting and singling type applications in data constructor patterns.
 * Make the Template Haskell machinery generate `SingI1` and `SingI2` instances
   when possible.
 * Make `genDefunSymbols` and related functions less likely to trigger

--- a/singletons-th/src/Data/Singletons/TH/Promote/Type.hs
+++ b/singletons-th/src/Data/Singletons/TH/Promote/Type.hs
@@ -15,6 +15,7 @@ module Data.Singletons.TH.Promote.Type
   ) where
 
 import Control.Monad (when)
+import Language.Haskell.TH (pprint)
 import Language.Haskell.TH.Desugar
 import Data.Singletons.TH.Names
 import Data.Singletons.TH.Options
@@ -91,7 +92,10 @@ promoteType_options pto typ = do
     go args     ty@DArrowT = illegal args ty
     go []       ty@DLitT{} = pure ty
     go args     ty@DLitT{} = illegal args ty
-    go args     ty@DWildCardT{} = illegal args ty
+    go _args    DWildCardT{} = fail $ unlines
+      [ "`singletons-th` does not support wildcard types"
+      , "\tIn the type: " ++ pprint (sweeten typ)
+      ]
 
     illegal :: [DTypeArg] -> DType -> m a
     illegal args hd = fail $ unlines

--- a/singletons-th/src/Data/Singletons/TH/Single.hs
+++ b/singletons-th/src/Data/Singletons/TH/Single.hs
@@ -790,9 +790,9 @@ singPat var_proms = go
                   Just tyname -> return tyname
       pure $ DVarP (singledValueName opts name)
                `DSigP` (singFamily `DAppT` DVarT tyname)
-    go (ADConP name pats) = do
+    go (ADConP name tys pats) = do
       opts <- getOptions
-      DConP (singledDataConName opts name) [] <$> mapM go pats
+      DConP (singledDataConName opts name) tys <$> mapM go pats
     go (ADTildeP pat) = do
       qReportWarning
         "Lazy pattern converted into regular pattern during singleton generation."

--- a/singletons-th/src/Data/Singletons/TH/Syntax.hs
+++ b/singletons-th/src/Data/Singletons/TH/Syntax.hs
@@ -114,7 +114,7 @@ data ADExp = ADVarE Name
 -- A DPat with a pattern-signature node annotated with its type-level equivalent
 data ADPat = ADLitP Lit
            | ADVarP Name
-           | ADConP Name [ADPat]
+           | ADConP Name [DType] [ADPat]
            | ADTildeP ADPat
            | ADBangP ADPat
            | ADSigP DType -- The promoted pattern. Will not contain any wildcards,


### PR DESCRIPTION
While supporting visible type applications in their full generality is challenging, type applications in data constructor patterns are a very well behaved subset, which makes it quite feasible to support in `singletons-th`. This patch accomplishes just that.

We also make an effort to distinguish between wildcard types found in type applications in data constructor, which we can support, and other wildcard types, which we cannot yet support due to GHC restrictions about using wildcard types in kind-level contexts. I have added a section to the `README` to explain this distinction.

Fixes #489.

While I was in town, I also improved the error message that `singletons-th` produces when it tries to promote a wildcard type that it cannot currently support, thus fixing #480.