### PR TITLE
Support type-level `Char`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,13 +305,6 @@ generate these instances directly through functions exported from
 `Data.Singletons.TH` (from `singletons-th`) and
 `Data.Singletons.Base.TH` (from `singletons-base`).
 
-A promoted and singled `Show` instance is provided for `Symbol`, but it is only
-a crude approximation of the value-level `Show` instance for `String`. On the
-value level, showing `String`s escapes special characters (such as double
-quotes), but implementing this requires pattern-matching on character literals,
-something which is currently impossible at the type level. As a consequence, the
-type-level `Show` instance for `Symbol`s does not do any character escaping.
-
 Errors
 ------
 
@@ -795,7 +788,8 @@ The following constructs are fully supported:
 * undefined
 * error
 * class constraints (though these sometimes fail with `let`, `lambda`, and `case`)
-* literals (for `Natural` and `Symbol`), including overloaded number literals
+* literal expressions (for `Natural`, `Symbol`, and `Char`), including
+  overloaded number literals
 * datatypes that store `Natural`
 * unboxed tuples (which are treated as normal tuples)
 * pattern guards
@@ -1083,7 +1077,7 @@ instance C [] where
 
 ### Literal patterns
 
-Patterns which match on numeric or string literals cannot be
+Patterns which match on numeric, string, or character literals cannot be
 singled. Using this code as an example:
 
 ```hs

--- a/singletons-base/CHANGES.md
+++ b/singletons-base/CHANGES.md
@@ -4,6 +4,21 @@ Changelog for the `singletons-base` project
 next [????.??.??]
 -----------------
 * Require building with GHC 9.2.
+* `singletons-base` now supports type-level `Char`s, a feature added in
+  GHC 9.2. In particular:
+
+  * Promoting and singling character literal expressions (e.g., `f = 'a'`) is
+    now supported. Promoting (but not singling) character patterns
+    (e.g., `g 'a' = ()`) is also supported.
+  * `GHC.TypeLits.Singletons` now offers singled versions of the `ConsSymbol`,
+    `UnconsSymbol`, `CharToNat`, and `NatToChar` type families that were
+    introduced to `GHC.TypeLits` in GHC 9.2.
+  * `Text.Show.Singletons` now makes use of type-level `Char`s, a feature added
+    in GHC 9.2. As a result, there is no longer any need for the `SChar` type
+    synonym, so it has been removed.
+  * The `PShow` and `SShow` instances for `Symbol` now display escape characters
+    properly rather than returning the input `Symbol` unchanged.
+
 * In GHC 9.2, `Nat` is now a synonym for `Natural`. As a result, the bogus
   `Num`, `Eq`, `Ord`, `Enum`, and `Show` instances for `Nat` in
   `GHC.TypeLits.Singletons` have been removed, as they have replaced by the

--- a/singletons-base/src/Data/Eq/Singletons.hs
+++ b/singletons-base/src/Data/Eq/Singletons.hs
@@ -87,7 +87,7 @@ $(singletonsOnly [d|
 -- @
 --
 -- 'DefaultEq' is most suited for data types that are not inductively defined.
--- Three concrete examples of this are 'Natural', 'Lit.Symbol', and
+-- Four concrete examples of this are 'Natural', 'Lit.Symbol', 'Lit.Char', and
 -- 'Kind.Type'. One cannot implement boolean equality for these types by
 -- pattern matching alone, so 'DefaultEq' is a good fit instead.
 --

--- a/singletons-base/src/Data/Singletons/Base/Enum.hs
+++ b/singletons-base/src/Data/Singletons/Base/Enum.hs
@@ -52,6 +52,10 @@ import GHC.TypeLits.Singletons
 $(singletonsOnly [d|
   class Bounded a where
     minBound, maxBound :: a
+
+  instance  Bounded Char  where
+      minBound =  '\0'
+      maxBound =  '\x10FFFF'
   |])
 
 $(singBoundedInstances boundedBasicTypes)
@@ -138,6 +142,10 @@ $(singletonsOnly [d|
 
       enumFromTo = eftNat
       enumFromThenTo = efdtNat
+
+  instance  Enum Char  where
+      toEnum   = natToChar
+      fromEnum = charToNat
   |])
 
 $(singEnumInstances enumBasicTypes)

--- a/singletons-base/tests/SingletonsBaseTestSuite.hs
+++ b/singletons-base/tests/SingletonsBaseTestSuite.hs
@@ -138,6 +138,7 @@ tests =
     , compileAndDumpStdTest "T453"
     , compileAndDumpStdTest "NegativeLiterals"
     , compileAndDumpStdTest "T470"
+    , compileAndDumpStdTest "T487"
     , compileAndDumpStdTest "T492"
     , compileAndDumpStdTest "Natural"
     ],

--- a/singletons-base/tests/compile-and-dump/Singletons/ShowDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/ShowDeriving.golden
@@ -243,7 +243,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     type ShowsPrec_0123456789876543210 :: GHC.Num.Natural.Natural
                                           -> Foo3 -> Symbol -> Symbol
     type family ShowsPrec_0123456789876543210 (a :: GHC.Num.Natural.Natural) (a :: Foo3) (a :: Symbol) :: Symbol where
-      ShowsPrec_0123456789876543210 p_0123456789876543210 (MkFoo3 arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "MkFoo3 ")) (Apply (Apply (.@#@$) (Apply ShowCharSym0 "{")) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "getFoo3a = ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 0)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowCommaSpaceSym0) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "(***) = ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 0)) arg_0123456789876543210)) (Apply ShowCharSym0 "}"))))))))) a_0123456789876543210
+      ShowsPrec_0123456789876543210 p_0123456789876543210 (MkFoo3 arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "MkFoo3 ")) (Apply (Apply (.@#@$) (Apply ShowCharSym0 '{')) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "getFoo3a = ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 0)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowCommaSpaceSym0) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "(***) = ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 0)) arg_0123456789876543210)) (Apply ShowCharSym0 '}'))))))))) a_0123456789876543210
     type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) Foo3 ((~>) Symbol Symbol))
     data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) Foo3 ((~>) Symbol Symbol))
       where
@@ -504,7 +504,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                    ((applySing
                        ((applySing ((singFun3 @(.@#@$)) (%.)))
                           ((applySing ((singFun2 @ShowCharSym0) sShowChar))
-                             (sing :: Sing "{"))))
+                             (sing :: Sing '{'))))
                       ((applySing
                           ((applySing ((singFun3 @(.@#@$)) (%.)))
                              ((applySing ((singFun2 @ShowStringSym0) sShowString))
@@ -529,7 +529,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                                                 (sFromInteger (sing :: Sing 0))))
                                             sArg_0123456789876543210)))
                                      ((applySing ((singFun2 @ShowCharSym0) sShowChar))
-                                        (sing :: Sing "}")))))))))))
+                                        (sing :: Sing '}')))))))))))
             sA_0123456789876543210
     deriving instance Show (SFoo1 (z :: Foo1))
     deriving instance Data.Singletons.ShowSing.ShowSing a =>

--- a/singletons-base/tests/compile-and-dump/Singletons/T487.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T487.golden
@@ -1,0 +1,73 @@
+Singletons/T487.hs:(0,0)-(0,0): Splicing declarations
+    singletonsOnly
+      [d| exprEx :: Char
+          exprEx = 'a'
+          consEx :: Char -> Symbol
+          consEx x = consSymbol x "bc"
+          unconsEx :: Maybe (Char, Symbol)
+          unconsEx = unconsSymbol "abc"
+          natToCharEx :: Char
+          natToCharEx = natToChar 97
+          charToNatEx :: Natural
+          charToNatEx = charToNat 'a' |]
+  ======>
+    type CharToNatExSym0 :: Natural
+    type family CharToNatExSym0 :: Natural where
+      CharToNatExSym0 = CharToNatEx
+    type NatToCharExSym0 :: Char
+    type family NatToCharExSym0 :: Char where
+      NatToCharExSym0 = NatToCharEx
+    type UnconsExSym0 :: Maybe (Char, Symbol)
+    type family UnconsExSym0 :: Maybe (Char, Symbol) where
+      UnconsExSym0 = UnconsEx
+    type ConsExSym0 :: (~>) Char Symbol
+    data ConsExSym0 :: (~>) Char Symbol
+      where
+        ConsExSym0KindInference :: SameKind (Apply ConsExSym0 arg) (ConsExSym1 arg) =>
+                                   ConsExSym0 a0123456789876543210
+    type instance Apply ConsExSym0 a0123456789876543210 = ConsEx a0123456789876543210
+    instance SuppressUnusedWarnings ConsExSym0 where
+      suppressUnusedWarnings = snd (((,) ConsExSym0KindInference) ())
+    type ConsExSym1 :: Char -> Symbol
+    type family ConsExSym1 (a0123456789876543210 :: Char) :: Symbol where
+      ConsExSym1 a0123456789876543210 = ConsEx a0123456789876543210
+    type ExprExSym0 :: Char
+    type family ExprExSym0 :: Char where
+      ExprExSym0 = ExprEx
+    type CharToNatEx :: Natural
+    type family CharToNatEx :: Natural where
+      CharToNatEx = Apply CharToNatSym0 'a'
+    type NatToCharEx :: Char
+    type family NatToCharEx :: Char where
+      NatToCharEx = Apply NatToCharSym0 (FromInteger 97)
+    type UnconsEx :: Maybe (Char, Symbol)
+    type family UnconsEx :: Maybe (Char, Symbol) where
+      UnconsEx = Apply UnconsSymbolSym0 "abc"
+    type ConsEx :: Char -> Symbol
+    type family ConsEx (a :: Char) :: Symbol where
+      ConsEx x = Apply (Apply ConsSymbolSym0 x) "bc"
+    type ExprEx :: Char
+    type family ExprEx :: Char where
+      ExprEx = 'a'
+    sCharToNatEx :: Sing (CharToNatExSym0 :: Natural)
+    sNatToCharEx :: Sing (NatToCharExSym0 :: Char)
+    sUnconsEx :: Sing (UnconsExSym0 :: Maybe (Char, Symbol))
+    sConsEx ::
+      forall (t :: Char). Sing t -> Sing (Apply ConsExSym0 t :: Symbol)
+    sExprEx :: Sing (ExprExSym0 :: Char)
+    sCharToNatEx
+      = (applySing ((singFun1 @CharToNatSym0) sCharToNat))
+          (sing :: Sing 'a')
+    sNatToCharEx
+      = (applySing ((singFun1 @NatToCharSym0) sNatToChar))
+          (sFromInteger (sing :: Sing 97))
+    sUnconsEx
+      = (applySing ((singFun1 @UnconsSymbolSym0) sUnconsSymbol))
+          (sing :: Sing "abc")
+    sConsEx (sX :: Sing x)
+      = (applySing
+           ((applySing ((singFun2 @ConsSymbolSym0) sConsSymbol)) sX))
+          (sing :: Sing "bc")
+    sExprEx = sing :: Sing 'a'
+    instance SingI (ConsExSym0 :: (~>) Char Symbol) where
+      sing = (singFun1 @ConsExSym0) sConsEx

--- a/singletons-base/tests/compile-and-dump/Singletons/T487.hs
+++ b/singletons-base/tests/compile-and-dump/Singletons/T487.hs
@@ -1,0 +1,40 @@
+module T487 where
+
+import Data.Singletons.Base.TH
+import GHC.TypeLits.Singletons
+import Text.Show.Singletons
+
+$(singletonsOnly [d|
+  exprEx :: Char
+  exprEx = 'a'
+
+  consEx :: Char -> Symbol
+  consEx x = consSymbol x "bc"
+
+  unconsEx :: Maybe (Char, Symbol)
+  unconsEx = unconsSymbol "abc"
+
+  natToCharEx :: Char
+  natToCharEx = natToChar 97
+
+  charToNatEx :: Natural
+  charToNatEx = charToNat 'a'
+  |])
+
+showCharTest :: Show_ ExprEx :~: "'a'"
+showCharTest = Refl
+
+showSymbolTest :: Show_ "Hello, World!" :~: "\"Hello, World!\""
+showSymbolTest = Refl
+
+consSymbolTest :: ConsEx 'a' :~: "abc"
+consSymbolTest = Refl
+
+unconsSymbolTest :: UnconsEx :~: Just '( 'a', "bc" )
+unconsSymbolTest = Refl
+
+natToCharTest :: NatToCharEx :~: 'a'
+natToCharTest = Refl
+
+charToNatTest :: CharToNatEx :~: 97
+charToNatTest = Refl

--- a/singletons-th/src/Data/Singletons/TH/Deriving/Show.hs
+++ b/singletons-th/src/Data/Singletons/TH/Deriving/Show.hs
@@ -140,8 +140,7 @@ showsPrecE :: Int -> Name -> DExp
 showsPrecE prec n = DVarE showsPrecName `DAppE` dIntegerE prec `DAppE` DVarE n
 
 dCharE :: Char -> DExp
-dCharE c = DLitE $ StringL [c] -- There aren't type-level characters yet,
-                               -- so fake it with a string
+dCharE = DLitE . CharL
 
 dStringE :: String -> DExp
 dStringE = DLitE . StringL

--- a/singletons-th/src/Data/Singletons/TH/Promote.hs
+++ b/singletons-th/src/Data/Singletons/TH/Promote.hs
@@ -1151,8 +1151,9 @@ promoteLitExp (StringL str) = do
   pure $ if os_enabled
          then DConT (promotedValueName opts fromStringName Nothing) `DAppT` prom_str_lit
          else prom_str_lit
+promoteLitExp (CharL c) = return $ DLitT (CharTyLit c)
 promoteLitExp lit =
-  fail ("Only string and natural number literals can be promoted: " ++ show lit)
+  fail ("Only string, natural number, and character literals can be promoted: " ++ show lit)
 
 promoteLitPat :: MonadFail m => Lit -> m DType
 promoteLitPat (IntegerL n)
@@ -1161,5 +1162,6 @@ promoteLitPat (IntegerL n)
     fail $ "Negative literal patterns are not allowed,\n" ++
            "because literal patterns are promoted to natural numbers."
 promoteLitPat (StringL str) = return $ DLitT (StrTyLit str)
+promoteLitPat (CharL c) = return $ DLitT (CharTyLit c)
 promoteLitPat lit =
-  fail ("Only string and natural number literals can be promoted: " ++ show lit)
+  fail ("Only string, natural number, and character literals can be promoted: " ++ show lit)

--- a/singletons-th/src/Data/Singletons/TH/Single.hs
+++ b/singletons-th/src/Data/Singletons/TH/Single.hs
@@ -1065,8 +1065,10 @@ singLit (StringL str) = do
   pure $ if os_enabled
          then DVarE (singledValueName opts fromStringName) `DAppE` sing_str_lit
          else sing_str_lit
+singLit (CharL c) =
+  return $ DVarE singMethName `DSigE` (singFamily `DAppT` DLitT (CharTyLit c))
 singLit lit =
-  fail ("Only string and natural number literals can be singled: " ++ show lit)
+  fail ("Only string, natural number, and character literals can be singled: " ++ show lit)
 
 {-
 Note [The id hack; or, how singletons-th learned to stop worrying and avoid kind generalization]


### PR DESCRIPTION
GHC 9.2 now supports type-level characters, which means that `singletons-th` is now able to promote and single character literals in certain circumstances. It also means that we can remove two terrible hacks in `Text.Show.Singletons`:

* We no longer need `SChar`, which fakes type-level characters with `Symbol`s of length one.
* The `PShow` and `SShow` instances for `Symbol` can now display escape characters properly rather than returning the input `Symbol` unchanged.

Fixes #487.