### PR TITLE
Adapt to `(~)` becoming a type operator

### DIFF
--- a/singletons/src/Data/Singletons/ShowSing.hs
+++ b/singletons/src/Data/Singletons/ShowSing.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 


### PR DESCRIPTION
`(~)` now requires `TypeOperators` in GHC 9.4 (see [the 9.4 Migration Guide](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.4?version_id=503a517b7238e8bac3dd588f32e234bf74b17097#-is-now-a-type-operator)) to build without warnings.