### PR TITLE
Fix #536 with tactical uses of `promoteType`

### DIFF
--- a/singletons-base/CHANGES.md
+++ b/singletons-base/CHANGES.md
@@ -1,8 +1,8 @@
 Changelog for the `singletons-base` project
 ===========================================
 
-next [????.??.??]
------------------
+3.1.2 [????.??.??]
+------------------
 * Provide `TestEquality` and `TestCoercion` instances for `SNat, `SSymbol`, and
   `SChar`.
 

--- a/singletons-base/singletons-base.cabal
+++ b/singletons-base/singletons-base.cabal
@@ -1,5 +1,5 @@
 name:           singletons-base
-version:        3.1.1
+version:        3.1.2
 cabal-version:  1.24
 synopsis:       A promoted and singled version of the base library
 homepage:       http://www.github.com/goldfirere/singletons
@@ -55,7 +55,7 @@ source-repository this
   type:     git
   location: https://github.com/goldfirere/singletons.git
   subdir:   singletons-base
-  tag:      v3.1.1
+  tag:      v3.1.2
 
 source-repository head
   type:     git
@@ -75,7 +75,7 @@ library
   build-depends:      base             >= 4.17 && < 4.18,
                       pretty,
                       singletons       == 3.0.*,
-                      singletons-th    == 3.1.*,
+                      singletons-th    >= 3.1.2 && < 3.2,
                       template-haskell >= 2.19 && < 2.20,
                       text >= 1.2,
                       th-desugar       >= 1.14 && < 1.15

--- a/singletons-base/tests/SingletonsBaseTestSuite.hs
+++ b/singletons-base/tests/SingletonsBaseTestSuite.hs
@@ -144,6 +144,7 @@ tests =
     , compileAndDumpStdTest "T492"
     , compileAndDumpStdTest "Natural"
     , compileAndDumpStdTest "T511"
+    , compileAndDumpStdTest "T536"
     ],
     testCompileAndDumpGroup "Promote"
     [ compileAndDumpStdTest "Constructors"

--- a/singletons-base/tests/compile-and-dump/Singletons/T536.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T536.golden
@@ -1,0 +1,97 @@
+Singletons/T536.hs:(0,0)-(0,0): Splicing declarations
+    let
+      customPromote :: Name -> Name
+      customPromote n
+        | n == ''Message = ''PMessage
+        | n == 'MkMessage = 'PMkMessage
+        | n == ''Text = ''Symbol
+        | otherwise = promotedDataTypeOrConName defaultOptions n
+      customDefun :: Name -> Int -> Name
+      customDefun n sat
+        = defunctionalizedName defaultOptions (customPromote n) sat
+    in
+      withOptions
+        defaultOptions
+          {promotedDataTypeOrConName = customPromote,
+           defunctionalizedName = customDefun}
+        $ do decs1 <- genSingletons [''Message]
+             decs2 <- singletons
+                        [d| hello :: Message
+                            hello = MkMessage "hello" |]
+             decs3 <- singDecideInstances [''Message]
+             decs4 <- showSingInstances [''Message]
+             return $ decs1 ++ decs2 ++ decs3 ++ decs4
+  ======>
+    type PMkMessageSym0 :: (Data.Singletons.~>) Symbol PMessage
+    data PMkMessageSym0 :: (Data.Singletons.~>) Symbol PMessage
+      where
+        PMkMessageSym0KindInference :: Data.Singletons.SameKind (Data.Singletons.Apply PMkMessageSym0 arg) (PMkMessageSym1 arg) =>
+                                       PMkMessageSym0 a0123456789876543210
+    type instance Data.Singletons.Apply PMkMessageSym0 a0123456789876543210 = 'PMkMessage a0123456789876543210
+    instance Data.Singletons.TH.SuppressUnusedWarnings.SuppressUnusedWarnings PMkMessageSym0 where
+      Data.Singletons.TH.SuppressUnusedWarnings.suppressUnusedWarnings
+        = snd (((,) PMkMessageSym0KindInference) ())
+    type PMkMessageSym1 :: Symbol -> PMessage
+    type family PMkMessageSym1 (a0123456789876543210 :: Symbol) :: PMessage where
+      PMkMessageSym1 a0123456789876543210 = 'PMkMessage a0123456789876543210
+    type SMessage :: PMessage -> Type
+    data SMessage :: PMessage -> Type
+      where
+        SMkMessage :: forall (n :: Symbol).
+                      (Data.Singletons.Sing n) -> SMessage ('PMkMessage n :: PMessage)
+    type instance Data.Singletons.Sing @PMessage = SMessage
+    instance Data.Singletons.SingKind PMessage where
+      type Data.Singletons.Demote PMessage = Message
+      Data.Singletons.fromSing (SMkMessage b)
+        = MkMessage (Data.Singletons.fromSing b)
+      Data.Singletons.toSing
+        (MkMessage (b :: Data.Singletons.Demote Symbol))
+        = case  Data.Singletons.toSing b :: Data.Singletons.SomeSing Symbol
+          of
+            Data.Singletons.SomeSing c
+              -> Data.Singletons.SomeSing (SMkMessage c)
+    instance Data.Singletons.SingI n =>
+             Data.Singletons.SingI ('PMkMessage (n :: Symbol)) where
+      Data.Singletons.sing = SMkMessage Data.Singletons.sing
+    instance Data.Singletons.SingI1 'PMkMessage where
+      Data.Singletons.liftSing = SMkMessage
+    instance Data.Singletons.SingI (PMkMessageSym0 :: (Data.Singletons.~>) Symbol PMessage) where
+      Data.Singletons.sing
+        = (Data.Singletons.singFun1 @PMkMessageSym0) SMkMessage
+    hello :: Message
+    hello = MkMessage "hello"
+    type HelloSym0 :: PMessage
+    type family HelloSym0 :: PMessage where
+      HelloSym0 = Hello
+    type Hello :: PMessage
+    type family Hello :: PMessage where
+      Hello = Data.Singletons.Apply PMkMessageSym0 (FromString "hello")
+    sHello :: Data.Singletons.Sing (HelloSym0 :: PMessage)
+    sHello
+      = (Data.Singletons.applySing
+           ((Data.Singletons.singFun1 @PMkMessageSym0) SMkMessage))
+          (sFromString
+             (Data.Singletons.sing :: Data.Singletons.Sing "hello"))
+    instance Data.Singletons.Decide.SDecide Text =>
+             Data.Singletons.Decide.SDecide PMessage where
+      (Data.Singletons.Decide.%~) (SMkMessage a) (SMkMessage b)
+        = case ((Data.Singletons.Decide.%~) a) b of
+            Data.Singletons.Decide.Proved Data.Type.Equality.Refl
+              -> Data.Singletons.Decide.Proved Data.Type.Equality.Refl
+            Data.Singletons.Decide.Disproved contra
+              -> Data.Singletons.Decide.Disproved
+                   (\ refl
+                      -> case refl of
+                           Data.Type.Equality.Refl -> contra Data.Type.Equality.Refl)
+    instance Data.Singletons.Decide.SDecide Text =>
+             Data.Type.Equality.TestEquality (SMessage :: PMessage
+                                                          -> Type) where
+      Data.Type.Equality.testEquality
+        = Data.Singletons.Decide.decideEquality
+    instance Data.Singletons.Decide.SDecide Text =>
+             Data.Type.Coercion.TestCoercion (SMessage :: PMessage
+                                                          -> Type) where
+      Data.Type.Coercion.testCoercion
+        = Data.Singletons.Decide.decideCoercion
+    deriving instance Data.Singletons.ShowSing.ShowSing Text =>
+                      Show (SMessage (z :: PMessage))

--- a/singletons-base/tests/compile-and-dump/Singletons/T536.hs
+++ b/singletons-base/tests/compile-and-dump/Singletons/T536.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE OverloadedStrings #-}
+module T536 where
+
+import           Data.Singletons.TH         (genSingletons, showSingInstances,
+                                             singDecideInstances, singletons)
+import           Data.Singletons.TH.Options (defaultOptions,
+                                             defunctionalizedName,
+                                             promotedDataTypeOrConName,
+                                             withOptions)
+import           Data.String                (fromString)
+import           Data.String.Singletons     (FromString, sFromString)
+import           Data.Text                  (Text)
+import           GHC.TypeLits.Singletons    (Symbol)
+import           Language.Haskell.TH        (Name)
+
+-- Term-level
+newtype Message = MkMessage Text
+-- Type-level
+newtype PMessage = PMkMessage Symbol
+
+$(let customPromote :: Name -> Name
+      customPromote n
+        | n == ''Message  = ''PMessage
+        | n == 'MkMessage = 'PMkMessage
+        | n == ''Text     = ''Symbol
+        | otherwise       = promotedDataTypeOrConName defaultOptions n
+
+      customDefun :: Name -> Int -> Name
+      customDefun n sat = defunctionalizedName defaultOptions (customPromote n) sat in
+
+  withOptions defaultOptions{ promotedDataTypeOrConName = customPromote
+                            , defunctionalizedName      = customDefun
+                            } $ do
+    decs1 <- genSingletons [''Message]
+    decs2 <- singletons [d|
+               hello :: Message
+               hello = MkMessage "hello"
+               |]
+    decs3 <- singDecideInstances [''Message]
+    decs4 <- showSingInstances [''Message]
+    return $ decs1 ++ decs2 ++ decs3 ++ decs4)

--- a/singletons-th/CHANGES.md
+++ b/singletons-th/CHANGES.md
@@ -1,6 +1,12 @@
 Changelog for the `singletons-th` project
 =========================================
 
+3.1.2 [????.??.??]
+------------------
+* Fix a bug in which the `singDecideInstances` and `showSingInstances`, as well
+  as `deriving Show` declarations, would not respect custom
+  `promotedDataTypeOrConName` options.
+
 3.1.1 [2022.08.23]
 ------------------
 * Require building with GHC 9.4.

--- a/singletons-th/singletons-th.cabal
+++ b/singletons-th/singletons-th.cabal
@@ -1,5 +1,5 @@
 name:           singletons-th
-version:        3.1.1
+version:        3.1.2
 cabal-version:  1.24
 synopsis:       A framework for generating singleton types
 homepage:       http://www.github.com/goldfirere/singletons
@@ -42,7 +42,7 @@ source-repository this
   type:     git
   location: https://github.com/goldfirere/singletons.git
   subdir:   singletons-th
-  tag:      v3.1.1
+  tag:      v3.1.2
 
 source-repository head
   type:     git


### PR DESCRIPTION
The code paths for generating `SDecide` and `ShowSing` instances are somewhat
different from the code paths for other derived instances, and while the latter
code paths remembered to call `promoteType` on types that are meant to appear
as kinds, the `SDecide` and `ShowSing` code paths did not remember to do this.
Easily fixed.