### PR TITLE
`singletons-th`: Remove unused `unSingFun*` machinery

### DIFF
--- a/singletons-th/src/Data/Singletons/TH/Single/Monad.hs
+++ b/singletons-th/src/Data/Singletons/TH/Single/Monad.hs
@@ -12,7 +12,7 @@ The SgM monad allows reading from a SgEnv environment and is wrapped around a Q.
 
 module Data.Singletons.TH.Single.Monad (
   SgM, bindLets, bindContext, askContext, lookupVarE, lookupConE,
-  wrapSingFun, wrapUnSingFun,
+  wrapSingFun,
   singM, singDecsM,
   emitDecs, emitDecsM
   ) where
@@ -120,21 +120,6 @@ wrapSingFun n ty =
                            _ -> error "No support for functions of arity > 7."
   in
   (wrap_fun `DAppTypeE` ty `DAppE`)
-
-wrapUnSingFun :: Int -> DType -> DExp -> DExp
-wrapUnSingFun 0 _  = id
-wrapUnSingFun n ty =
-  let unwrap_fun = DVarE $ case n of
-                             1 -> 'unSingFun1
-                             2 -> 'unSingFun2
-                             3 -> 'unSingFun3
-                             4 -> 'unSingFun4
-                             5 -> 'unSingFun5
-                             6 -> 'unSingFun6
-                             7 -> 'unSingFun7
-                             _ -> error "No support for functions of arity > 7."
-  in
-  (unwrap_fun `DAppTypeE` ty `DAppE`)
 
 singM :: OptionsMonad q => [Dec] -> SgM a -> q (a, [DDec])
 singM locals (SgM rdr) = do

--- a/singletons-th/src/Data/Singletons/TH/Syntax.hs
+++ b/singletons-th/src/Data/Singletons/TH/Syntax.hs
@@ -138,12 +138,18 @@ type family IfAnn (ann :: AnnotationFlag) (yes :: k) (no :: k) :: k where
 
 data family LetDecRHS :: AnnotationFlag -> Type
 data instance LetDecRHS Annotated
-  = AFunction DType  -- promote function (unapplied)
-    Int    -- number of arrows in type
-    [ADClause]
-  | AValue DType -- promoted exp
-    Int   -- number of arrows in type
-    ADExp
+  = -- A function definition. Invariant: each ADClause contains at least one
+    -- pattern.
+    AFunction
+      Int -- The number of arrows in the type. As a consequence of the invariant
+          -- above, this is always a positive number.
+      [ADClause]
+
+  | -- A value whose definition is given by the DExp. Invariant: the value is
+    -- not a function (i.e., there are no occurrences of (->) in the value's
+    -- type).
+    AValue
+      ADExp
 data instance LetDecRHS Unannotated = UFunction [DClause]
                                     | UValue DExp
 


### PR DESCRIPTION
Previous versions of `singletons` generated uses of `unSingFun*` as a way to accomplish eta expansion. In the current version of the library, however, eta expansion is instead accomplished by giving function clauses more patterns, which removes the need for `unSingFun*` entirely. There were still some vestigial remains of the old `unSingFun*` machinery lying around, however, so this patch removes them.

While I was in the neighborhood, I took the opportunity to document some of the invariants that the current eta expansion machinery relies on.

Fixes #545.