### PR TITLE
`singletons-th`: Remove unneeded kind annotation when singling `case` expressions

### DIFF
--- a/singletons-base/tests/compile-and-dump/GradingClient/Database.golden
+++ b/singletons-base/tests/compile-and-dump/GradingClient/Database.golden
@@ -1444,7 +1444,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
                 sName'
         in
           (GHC.Base.id
-             @(Sing (Case_0123456789876543210 name name' u attrs (Let0123456789876543210Scrutinee_0123456789876543210Sym4 name name' u attrs) :: U)))
+             @(Sing (Case_0123456789876543210 name name' u attrs (Let0123456789876543210Scrutinee_0123456789876543210Sym4 name name' u attrs))))
             (case sScrutinee_0123456789876543210 of
                STrue -> sU
                SFalse

--- a/singletons-base/tests/compile-and-dump/InsertionSort/InsertionSortImp.golden
+++ b/singletons-base/tests/compile-and-dump/InsertionSort/InsertionSortImp.golden
@@ -187,7 +187,7 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
             = (applySing ((applySing ((singFun2 @LeqSym0) sLeq)) sN)) sH
         in
           (id
-             @(Sing (Case_0123456789876543210 n h t (Let0123456789876543210Scrutinee_0123456789876543210Sym3 n h t) :: [Nat])))
+             @(Sing (Case_0123456789876543210 n h t (Let0123456789876543210Scrutinee_0123456789876543210Sym3 n h t))))
             (case sScrutinee_0123456789876543210 of
                STrue
                  -> (applySing ((applySing ((singFun2 @(:@#@$)) SCons)) sN))

--- a/singletons-base/tests/compile-and-dump/Singletons/CaseExpressions.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/CaseExpressions.golden
@@ -245,7 +245,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
       forall a (t :: a) (t :: Maybe a). Sing t
                                         -> Sing t -> Sing (Apply (Apply Foo1Sym0 t) t :: a)
     sFoo5 (sX :: Sing x)
-      = (id @(Sing (Case_0123456789876543210 x x :: a)))
+      = (id @(Sing (Case_0123456789876543210 x x)))
           (case sX of
              (sY :: Sing y)
                -> (applySing
@@ -258,7 +258,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
                                        (case sArg_0123456789876543210 of _ -> sX))))
                     sY)
     sFoo4 (sX :: Sing x)
-      = (id @(Sing (Case_0123456789876543210 x x :: a)))
+      = (id @(Sing (Case_0123456789876543210 x x)))
           (case sX of
              (sY :: Sing y)
                -> let
@@ -273,7 +273,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
             = (applySing ((applySing ((singFun2 @Tuple2Sym0) STuple2)) sA)) sB
         in
           (id
-             @(Sing (Case_0123456789876543210 a b (Let0123456789876543210Scrutinee_0123456789876543210Sym2 a b) :: a)))
+             @(Sing (Case_0123456789876543210 a b (Let0123456789876543210Scrutinee_0123456789876543210Sym2 a b))))
             (case sScrutinee_0123456789876543210 of
                STuple2 (sP :: Sing p) _ -> sP)
     sFoo2 (sD :: Sing d) _
@@ -284,10 +284,10 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
             = (applySing ((singFun1 @JustSym0) SJust)) sD
         in
           (id
-             @(Sing (Case_0123456789876543210 d (Let0123456789876543210Scrutinee_0123456789876543210Sym1 d) :: a)))
+             @(Sing (Case_0123456789876543210 d (Let0123456789876543210Scrutinee_0123456789876543210Sym1 d))))
             (case sScrutinee_0123456789876543210 of SJust (sY :: Sing y) -> sY)
     sFoo1 (sD :: Sing d) (sX :: Sing x)
-      = (id @(Sing (Case_0123456789876543210 d x x :: a)))
+      = (id @(Sing (Case_0123456789876543210 d x x)))
           (case sX of
              SJust (sY :: Sing y) -> sY
              SNothing -> sD)

--- a/singletons-base/tests/compile-and-dump/Singletons/PatternMatching.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/PatternMatching.golden
@@ -471,7 +471,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     sSz :: Sing @_ SzSym0
     sX_0123456789876543210 :: Sing @_ X_0123456789876543210Sym0
     sSilly (sX :: Sing x)
-      = (id @(Sing (Case_0123456789876543210 x x :: ())))
+      = (id @(Sing (Case_0123456789876543210 x x)))
           (case sX of _ -> STuple0)
     sFoo2 (STuple2 (sX :: Sing x) (sY :: Sing y))
       = let
@@ -480,7 +480,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
             = (applySing ((applySing ((singFun2 @Tuple2Sym0) STuple2)) sX)) sY
         in
           (id
-             @(Sing (Case_0123456789876543210 x y (Let0123456789876543210TSym2 x y) :: a)))
+             @(Sing (Case_0123456789876543210 x y (Let0123456789876543210TSym2 x y))))
             (case sT of
                STuple2 (sA :: Sing a) (sB :: Sing b)
                  -> (applySing
@@ -512,8 +512,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
                                  SNil))
                -> sY_0123456789876543210)
     sLsz
-      = (id
-           @(Sing (Case_0123456789876543210 X_0123456789876543210Sym0 :: Nat)))
+      = (id @(Sing (Case_0123456789876543210 X_0123456789876543210Sym0)))
           (case sX_0123456789876543210 of
              SCons _
                    (SCons (sY_0123456789876543210 :: Sing y_0123456789876543210)
@@ -537,8 +536,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
                -> sY_0123456789876543210)
     sX_0123456789876543210 = sTuple
     sFls
-      = (id
-           @(Sing (Case_0123456789876543210 X_0123456789876543210Sym0 :: Bool)))
+      = (id @(Sing (Case_0123456789876543210 X_0123456789876543210Sym0)))
           (case sX_0123456789876543210 of
              SPair (SPair _ _)
                    (sY_0123456789876543210 :: Sing y_0123456789876543210)

--- a/singletons-base/tests/compile-and-dump/Singletons/T150.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T150.golden
@@ -293,7 +293,7 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
     (%!) (SVCons _ (sXs :: Sing xs)) (SFS (sN :: Sing n))
       = (applySing ((applySing ((singFun2 @(!@#@$)) (%!))) sXs)) sN
     (%!) SVNil (sN :: Sing n)
-      = (id @(Sing (Case_0123456789876543210 n n :: a))) (case sN of {})
+      = (id @(Sing (Case_0123456789876543210 n n))) (case sN of {})
     sTailVec (SVCons _ (sXs :: Sing xs)) = sXs
     sHeadVec (SVCons (sX :: Sing x) _) = sX
     instance SingI (TransitivitySym0 :: (~>) (Equal a b) ((~>) (Equal b c) (Equal a c))) where

--- a/singletons-base/tests/compile-and-dump/Singletons/T160.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T160.golden
@@ -49,7 +49,7 @@ Singletons/T160.hs:(0,0)-(0,0): Splicing declarations
                 (sFromInteger (sing :: Sing 0))
         in
           (id
-             @(Sing (Case_0123456789876543210 x (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x) :: a)))
+             @(Sing (Case_0123456789876543210 x (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x))))
             (case sScrutinee_0123456789876543210 of
                STrue -> sFromInteger (sing :: Sing 1)
                SFalse

--- a/singletons-base/tests/compile-and-dump/Singletons/T183.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T183.golden
@@ -423,7 +423,7 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
                  sScrutinee_0123456789876543210 = sX :: Sing (x :: Maybe a)
                in
                  (id
-                    @(Sing (Case_0123456789876543210 x (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x) :: Maybe (Maybe a))))
+                    @(Sing (Case_0123456789876543210 x (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x))))
                    (case sScrutinee_0123456789876543210 of
                       SJust (sY :: Sing y)
                         -> case ((,) (sY :: Sing y)) (SJust (sY :: Sing y)) of

--- a/singletons-base/tests/compile-and-dump/Singletons/TopLevelPatterns.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/TopLevelPatterns.golden
@@ -296,14 +296,14 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
     sOtherwise :: Sing (OtherwiseSym0 :: Bool)
     sM
       = (GHC.Base.id
-           @(Sing (Case_0123456789876543210 X_0123456789876543210Sym0 :: Bool)))
+           @(Sing (Case_0123456789876543210 X_0123456789876543210Sym0)))
           (case sX_0123456789876543210 of
              SCons _
                    (SCons (sY_0123456789876543210 :: Sing y_0123456789876543210) SNil)
                -> sY_0123456789876543210)
     sL
       = (GHC.Base.id
-           @(Sing (Case_0123456789876543210 X_0123456789876543210Sym0 :: Bool)))
+           @(Sing (Case_0123456789876543210 X_0123456789876543210Sym0)))
           (case sX_0123456789876543210 of
              SCons (sY_0123456789876543210 :: Sing y_0123456789876543210)
                    (SCons _ SNil)
@@ -318,13 +318,13 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
              SNil)
     sK
       = (GHC.Base.id
-           @(Sing (Case_0123456789876543210 X_0123456789876543210Sym0 :: Bool)))
+           @(Sing (Case_0123456789876543210 X_0123456789876543210Sym0)))
           (case sX_0123456789876543210 of
              SBar _ (sY_0123456789876543210 :: Sing y_0123456789876543210)
                -> sY_0123456789876543210)
     sJ
       = (GHC.Base.id
-           @(Sing (Case_0123456789876543210 X_0123456789876543210Sym0 :: Bool)))
+           @(Sing (Case_0123456789876543210 X_0123456789876543210Sym0)))
           (case sX_0123456789876543210 of
              SBar (sY_0123456789876543210 :: Sing y_0123456789876543210) _
                -> sY_0123456789876543210)


### PR DESCRIPTION
Explicit kind annotations aren't necessary in modern `singletons-th` due to the approach that it uses for singling `case` expressions. This allows us to delete a modest amount of code.

Fixes #547.