### PR TITLE
Greatly simplify how implicitly quantified type signatures are singled

### DIFF
--- a/singletons-base/tests/compile-and-dump/GradingClient/Database.golden
+++ b/singletons-base/tests/compile-and-dump/GradingClient/Database.golden
@@ -1416,21 +1416,25 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     instance PEq AChar where
       type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
     sLookup ::
-      forall (t :: [AChar]) (t :: Schema). Sing t
-                                           -> Sing t -> Sing (Apply (Apply LookupSym0 t) t :: U)
+      forall (t :: [AChar]) (t :: Schema).
+      Sing t
+      -> Sing t -> Sing (Apply (Apply LookupSym0 t) t :: U) :: Type
     sOccurs ::
-      forall (t :: [AChar]) (t :: Schema). Sing t
-                                           -> Sing t -> Sing (Apply (Apply OccursSym0 t) t :: Bool)
+      forall (t :: [AChar]) (t :: Schema).
+      Sing t
+      -> Sing t -> Sing (Apply (Apply OccursSym0 t) t :: Bool) :: Type
     sDisjoint ::
-      forall (t :: Schema) (t :: Schema). Sing t
-                                          -> Sing t -> Sing (Apply (Apply DisjointSym0 t) t :: Bool)
+      forall (t :: Schema) (t :: Schema).
+      Sing t
+      -> Sing t -> Sing (Apply (Apply DisjointSym0 t) t :: Bool) :: Type
     sAttrNotIn ::
-      forall (t :: Attribute) (t :: Schema). Sing t
-                                             -> Sing t
-                                                -> Sing (Apply (Apply AttrNotInSym0 t) t :: Bool)
+      forall (t :: Attribute) (t :: Schema).
+      Sing t
+      -> Sing t -> Sing (Apply (Apply AttrNotInSym0 t) t :: Bool) :: Type
     sAppend ::
-      forall (t :: Schema) (t :: Schema). Sing t
-                                          -> Sing t -> Sing (Apply (Apply AppendSym0 t) t :: Schema)
+      forall (t :: Schema) (t :: Schema).
+      Sing t
+      -> Sing t -> Sing (Apply (Apply AppendSym0 t) t :: Schema) :: Type
     sLookup _ (SSch SNil) = sUndefined
     sLookup
       (sName :: Sing name)

--- a/singletons-base/tests/compile-and-dump/GradingClient/Main.golden
+++ b/singletons-base/tests/compile-and-dump/GradingClient/Main.golden
@@ -73,13 +73,13 @@ GradingClient/Main.hs:(0,0)-(0,0): Splicing declarations
     type LastName :: [AChar]
     type family LastName :: [AChar] where
       LastName = Apply (Apply (:@#@$) CLSym0) (Apply (Apply (:@#@$) CASym0) (Apply (Apply (:@#@$) CSSym0) (Apply (Apply (:@#@$) CTSym0) NilSym0)))
-    sNames :: Sing (NamesSym0 :: Schema)
-    sGradingSchema :: Sing (GradingSchemaSym0 :: Schema)
-    sMajorName :: Sing (MajorNameSym0 :: [AChar])
-    sGradeName :: Sing (GradeNameSym0 :: [AChar])
-    sYearName :: Sing (YearNameSym0 :: [AChar])
-    sFirstName :: Sing (FirstNameSym0 :: [AChar])
-    sLastName :: Sing (LastNameSym0 :: [AChar])
+    sNames :: Sing (NamesSym0 :: Schema) :: Type
+    sGradingSchema :: Sing (GradingSchemaSym0 :: Schema) :: Type
+    sMajorName :: Sing (MajorNameSym0 :: [AChar]) :: Type
+    sGradeName :: Sing (GradeNameSym0 :: [AChar]) :: Type
+    sYearName :: Sing (YearNameSym0 :: [AChar]) :: Type
+    sFirstName :: Sing (FirstNameSym0 :: [AChar]) :: Type
+    sLastName :: Sing (LastNameSym0 :: [AChar]) :: Type
     sNames
       = (applySing ((singFun1 @SchSym0) SSch))
           ((applySing

--- a/singletons-base/tests/compile-and-dump/InsertionSort/InsertionSortImp.golden
+++ b/singletons-base/tests/compile-and-dump/InsertionSort/InsertionSortImp.golden
@@ -165,14 +165,16 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
       Leq ('Succ _) 'Zero = FalseSym0
       Leq ('Succ a) ('Succ b) = Apply (Apply LeqSym0 a) b
     sInsertionSort ::
-      forall (t :: [Nat]). Sing t
-                           -> Sing (Apply InsertionSortSym0 t :: [Nat])
+      forall (t :: [Nat]).
+      Sing t -> Sing (Apply InsertionSortSym0 t :: [Nat]) :: Type
     sInsert ::
-      forall (t :: Nat) (t :: [Nat]). Sing t
-                                      -> Sing t -> Sing (Apply (Apply InsertSym0 t) t :: [Nat])
+      forall (t :: Nat) (t :: [Nat]).
+      Sing t
+      -> Sing t -> Sing (Apply (Apply InsertSym0 t) t :: [Nat]) :: Type
     sLeq ::
-      forall (t :: Nat) (t :: Nat). Sing t
-                                    -> Sing t -> Sing (Apply (Apply LeqSym0 t) t :: Bool)
+      forall (t :: Nat) (t :: Nat).
+      Sing t
+      -> Sing t -> Sing (Apply (Apply LeqSym0 t) t :: Bool) :: Type
     sInsertionSort SNil = SNil
     sInsertionSort (SCons (sH :: Sing h) (sT :: Sing t))
       = (applySing ((applySing ((singFun2 @InsertSym0) sInsert)) sH))

--- a/singletons-base/tests/compile-and-dump/Singletons/AsPattern.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/AsPattern.golden
@@ -251,19 +251,20 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
       MaybePlus ('Just n) = Apply JustSym0 (Apply (Apply PlusSym0 (Apply SuccSym0 ZeroSym0)) n)
       MaybePlus 'Nothing = Let0123456789876543210PSym0
     sFoo ::
-      forall (t :: [Nat]). Sing t -> Sing (Apply FooSym0 t :: [Nat])
+      forall (t :: [Nat]).
+      Sing t -> Sing (Apply FooSym0 t :: [Nat]) :: Type
     sTup ::
-      forall (t :: (Nat, Nat)). Sing t
-                                -> Sing (Apply TupSym0 t :: (Nat, Nat))
+      forall (t :: (Nat, Nat)).
+      Sing t -> Sing (Apply TupSym0 t :: (Nat, Nat)) :: Type
     sBaz_ ::
-      forall (t :: Maybe Baz). Sing t
-                               -> Sing (Apply Baz_Sym0 t :: Maybe Baz)
+      forall (t :: Maybe Baz).
+      Sing t -> Sing (Apply Baz_Sym0 t :: Maybe Baz) :: Type
     sBar ::
-      forall (t :: Maybe Nat). Sing t
-                               -> Sing (Apply BarSym0 t :: Maybe Nat)
+      forall (t :: Maybe Nat).
+      Sing t -> Sing (Apply BarSym0 t :: Maybe Nat) :: Type
     sMaybePlus ::
-      forall (t :: Maybe Nat). Sing t
-                               -> Sing (Apply MaybePlusSym0 t :: Maybe Nat)
+      forall (t :: Maybe Nat).
+      Sing t -> Sing (Apply MaybePlusSym0 t :: Maybe Nat) :: Type
     sFoo SNil
       = let
           sP :: Sing @_ Let0123456789876543210PSym0

--- a/singletons-base/tests/compile-and-dump/Singletons/BoxUnBox.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/BoxUnBox.golden
@@ -34,7 +34,8 @@ Singletons/BoxUnBox.hs:(0,0)-(0,0): Splicing declarations
     type family UnBox (a :: Box a) :: a where
       UnBox (FBox a) = a
     sUnBox ::
-      forall a (t :: Box a). Sing t -> Sing (Apply UnBoxSym0 t :: a)
+      forall (t :: Box a).
+      Sing t -> Sing (Apply UnBoxSym0 t :: a) :: Type
     sUnBox (SFBox (sA :: Sing a)) = sA
     instance SingI (UnBoxSym0 :: (~>) (Box a) a) where
       sing = (singFun1 @UnBoxSym0) sUnBox

--- a/singletons-base/tests/compile-and-dump/Singletons/CaseExpressions.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/CaseExpressions.golden
@@ -233,17 +233,18 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
     type Foo1 :: a -> Maybe a -> a
     type family Foo1 (a :: a) (a :: Maybe a) :: a where
       Foo1 d x = Case_0123456789876543210 d x x
-    sFoo5 :: forall a (t :: a). Sing t -> Sing (Apply Foo5Sym0 t :: a)
+    sFoo5 ::
+      forall (t :: a). Sing t -> Sing (Apply Foo5Sym0 t :: a) :: Type
     sFoo4 :: forall a (t :: a). Sing t -> Sing (Apply Foo4Sym0 t :: a)
     sFoo3 ::
-      forall a b (t :: a) (t :: b). Sing t
-                                    -> Sing t -> Sing (Apply (Apply Foo3Sym0 t) t :: a)
+      forall (t :: a) (t :: b).
+      Sing t -> Sing t -> Sing (Apply (Apply Foo3Sym0 t) t :: a) :: Type
     sFoo2 ::
-      forall a (t :: a) (t :: Maybe a). Sing t
-                                        -> Sing t -> Sing (Apply (Apply Foo2Sym0 t) t :: a)
+      forall (t :: a) (t :: Maybe a).
+      Sing t -> Sing t -> Sing (Apply (Apply Foo2Sym0 t) t :: a) :: Type
     sFoo1 ::
-      forall a (t :: a) (t :: Maybe a). Sing t
-                                        -> Sing t -> Sing (Apply (Apply Foo1Sym0 t) t :: a)
+      forall (t :: a) (t :: Maybe a).
+      Sing t -> Sing t -> Sing (Apply (Apply Foo1Sym0 t) t :: a) :: Type
     sFoo5 (sX :: Sing x)
       = (id @(Sing (Case_0123456789876543210 x x)))
           (case sX of
@@ -262,7 +263,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
           (case sX of
              (sY :: Sing y)
                -> let
-                    sZ :: Sing (Let0123456789876543210ZSym2 y x :: a)
+                    sZ :: Sing (Let0123456789876543210ZSym2 y x :: a) :: Type
                     sZ = sY
                   in sZ)
     sFoo3 (sA :: Sing a) (sB :: Sing b)

--- a/singletons-base/tests/compile-and-dump/Singletons/Classes.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Classes.golden
@@ -298,11 +298,13 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     instance PEq Foo2 where
       type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
     sFooCompare ::
-      forall (t :: Foo) (t :: Foo). Sing t
-                                    -> Sing t -> Sing (Apply (Apply FooCompareSym0 t) t :: Ordering)
+      forall (t :: Foo) (t :: Foo).
+      Sing t
+      -> Sing t
+         -> Sing (Apply (Apply FooCompareSym0 t) t :: Ordering) :: Type
     sConst ::
-      forall a b (t :: a) (t :: b). Sing t
-                                    -> Sing t -> Sing (Apply (Apply ConstSym0 t) t :: a)
+      forall (t :: a) (t :: b).
+      Sing t -> Sing t -> Sing (Apply (Apply ConstSym0 t) t :: a) :: Type
     sFooCompare SA SA = SEQ
     sFooCompare SA SB = SLT
     sFooCompare SB SB = SGT
@@ -348,17 +350,21 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       toSing G = SomeSing SG
     class SMyOrd a where
       sMycompare ::
-        forall (t :: a) (t :: a). Sing t
-                                  -> Sing t -> Sing (Apply (Apply MycompareSym0 t) t :: Ordering)
+        forall (t :: a) (t :: a).
+        Sing t
+        -> Sing t
+           -> Sing (Apply (Apply MycompareSym0 t) t :: Ordering) :: Type
       (%<=>) ::
-        forall (t :: a) (t :: a). Sing t
-                                  -> Sing t -> Sing (Apply (Apply (<=>@#@$) t) t :: Ordering)
+        forall (t :: a) (t :: a).
+        Sing t
+        -> Sing t -> Sing (Apply (Apply (<=>@#@$) t) t :: Ordering) :: Type
       infix 4 %<=>
       default (%<=>) ::
-                forall (t :: a)
-                       (t :: a). ((Apply (Apply (<=>@#@$) t) t :: Ordering)
-                                  ~ Apply (Apply TFHelper_0123456789876543210Sym0 t) t) =>
-                                 Sing t -> Sing t -> Sing (Apply (Apply (<=>@#@$) t) t :: Ordering)
+                forall (t :: a) (t :: a).
+                ((Apply (Apply (<=>@#@$) t) t :: Ordering)
+                 ~ Apply (Apply TFHelper_0123456789876543210Sym0 t) t) =>
+                Sing t
+                -> Sing t -> Sing (Apply (Apply (<=>@#@$) t) t :: Ordering) :: Type
       (%<=>)
         (sA_0123456789876543210 :: Sing a_0123456789876543210)
         (sA_0123456789876543210 :: Sing a_0123456789876543210)
@@ -368,9 +374,10 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
             sA_0123456789876543210
     instance SMyOrd Nat where
       sMycompare ::
-        forall (t :: Nat) (t :: Nat). Sing t
-                                      -> Sing t
-                                         -> Sing (Apply (Apply MycompareSym0 t) t :: Ordering)
+        forall (t :: Nat) (t :: Nat).
+        Sing t
+        -> Sing t
+           -> Sing (Apply (Apply MycompareSym0 t) t :: Ordering) :: Type
       sMycompare SZero SZero = SEQ
       sMycompare SZero (SSucc _) = SLT
       sMycompare (SSucc _) SZero = SGT
@@ -380,16 +387,19 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
             sN
     instance SMyOrd () where
       sMycompare ::
-        forall (t :: ()) (t :: ()). Sing t
-                                    -> Sing t -> Sing (Apply (Apply MycompareSym0 t) t :: Ordering)
+        forall (t :: ()) (t :: ()).
+        Sing t
+        -> Sing t
+           -> Sing (Apply (Apply MycompareSym0 t) t :: Ordering) :: Type
       sMycompare _ (sA_0123456789876543210 :: Sing a_0123456789876543210)
         = (applySing ((applySing ((singFun2 @ConstSym0) sConst)) SEQ))
             sA_0123456789876543210
     instance SMyOrd Foo where
       sMycompare ::
-        forall (t :: Foo) (t :: Foo). Sing t
-                                      -> Sing t
-                                         -> Sing (Apply (Apply MycompareSym0 t) t :: Ordering)
+        forall (t :: Foo) (t :: Foo).
+        Sing t
+        -> Sing t
+           -> Sing (Apply (Apply MycompareSym0 t) t :: Ordering) :: Type
       sMycompare
         (sA_0123456789876543210 :: Sing a_0123456789876543210)
         (sA_0123456789876543210 :: Sing a_0123456789876543210)

--- a/singletons-base/tests/compile-and-dump/Singletons/Contains.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Contains.golden
@@ -31,9 +31,10 @@ Singletons/Contains.hs:(0,0)-(0,0): Splicing declarations
       Contains _ '[] = FalseSym0
       Contains elt ('(:) h t) = Apply (Apply (||@#@$) (Apply (Apply (==@#@$) elt) h)) (Apply (Apply ContainsSym0 elt) t)
     sContains ::
-      forall a (t :: a) (t :: [a]). SEq a =>
-                                    Sing t
-                                    -> Sing t -> Sing (Apply (Apply ContainsSym0 t) t :: Bool)
+      forall (t :: a) (t :: [a]).
+      SEq a =>
+      Sing t
+      -> Sing t -> Sing (Apply (Apply ContainsSym0 t) t :: Bool) :: Type
     sContains _ SNil = SFalse
     sContains (sElt :: Sing elt) (SCons (sH :: Sing h) (sT :: Sing t))
       = (applySing

--- a/singletons-base/tests/compile-and-dump/Singletons/Error.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Error.golden
@@ -23,7 +23,7 @@ Singletons/Error.hs:(0,0)-(0,0): Splicing declarations
       Head ('(:) a _) = a
       Head '[] = Apply ErrorSym0 "head: empty list"
     sHead ::
-      forall a (t :: [a]). Sing t -> Sing (Apply HeadSym0 t :: a)
+      forall (t :: [a]). Sing t -> Sing (Apply HeadSym0 t :: a) :: Type
     sHead (SCons (sA :: Sing a) _) = sA
     sHead SNil = sError (sing :: Sing "head: empty list")
     instance SingI (HeadSym0 :: (~>) [a] a) where

--- a/singletons-base/tests/compile-and-dump/Singletons/Fixity.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Fixity.golden
@@ -66,8 +66,9 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
       type family (<=>) (arg :: a) (arg :: a) :: Ordering
     infix 4 %====
     (%====) ::
-      forall a (t :: a) (t :: a). Sing t
-                                  -> Sing t -> Sing (Apply (Apply (====@#@$) t) t :: a)
+      forall (t :: a) (t :: a).
+      Sing t
+      -> Sing t -> Sing (Apply (Apply (====@#@$) t) t :: a) :: Type
     (%====) (sA :: Sing a) _ = sA
     instance SingI ((====@#@$) :: (~>) a ((~>) a a)) where
       sing = (singFun2 @(====@#@$)) (%====)
@@ -78,8 +79,9 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
         = (singFun1 @((====@#@$$) (d :: a))) ((%====) s)
     class SMyOrd a where
       (%<=>) ::
-        forall (t :: a) (t :: a). Sing t
-                                  -> Sing t -> Sing (Apply (Apply (<=>@#@$) t) t :: Ordering)
+        forall (t :: a) (t :: a).
+        Sing t
+        -> Sing t -> Sing (Apply (Apply (<=>@#@$) t) t :: Ordering) :: Type
       infix 4 %<=>
     instance SMyOrd a =>
              SingI ((<=>@#@$) :: (~>) a ((~>) a Ordering)) where

--- a/singletons-base/tests/compile-and-dump/Singletons/FunDeps.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/FunDeps.golden
@@ -85,13 +85,17 @@ Singletons/FunDeps.hs:(0,0)-(0,0): Splicing declarations
     sT1 :: Sing @_ T1Sym0
     sT1 = (applySing ((singFun1 @MethSym0) sMeth)) STrue
     class SFD a b | a -> b where
-      sMeth :: forall (t :: a). Sing t -> Sing (Apply MethSym0 t :: a)
-      sL2r :: forall (t :: a). Sing t -> Sing (Apply L2rSym0 t :: b)
+      sMeth ::
+        forall (t :: a). Sing t -> Sing (Apply MethSym0 t :: a) :: Type
+      sL2r ::
+        forall (t :: a). Sing t -> Sing (Apply L2rSym0 t :: b) :: Type
     instance SFD Bool Natural where
       sMeth ::
-        forall (t :: Bool). Sing t -> Sing (Apply MethSym0 t :: Bool)
+        forall (t :: Bool).
+        Sing t -> Sing (Apply MethSym0 t :: Bool) :: Type
       sL2r ::
-        forall (t :: Bool). Sing t -> Sing (Apply L2rSym0 t :: Natural)
+        forall (t :: Bool).
+        Sing t -> Sing (Apply L2rSym0 t :: Natural) :: Type
       sMeth (sA_0123456789876543210 :: Sing a_0123456789876543210)
         = (applySing ((singFun1 @NotSym0) sNot)) sA_0123456789876543210
       sL2r SFalse = sFromInteger (sing :: Sing 0)

--- a/singletons-base/tests/compile-and-dump/Singletons/HigherOrder.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/HigherOrder.golden
@@ -295,31 +295,33 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
       Map _ '[] = NilSym0
       Map f ('(:) h t) = Apply (Apply (:@#@$) (Apply f h)) (Apply (Apply MapSym0 f) t)
     sEtad ::
-      forall (t :: [Nat]) (t :: [Bool]). Sing t
-                                         -> Sing t -> Sing (Apply (Apply EtadSym0 t) t :: [Nat])
+      forall (t :: [Nat]) (t :: [Bool]).
+      Sing t
+      -> Sing t -> Sing (Apply (Apply EtadSym0 t) t :: [Nat]) :: Type
     sSplunge ::
-      forall (t :: [Nat]) (t :: [Bool]). Sing t
-                                         -> Sing t -> Sing (Apply (Apply SplungeSym0 t) t :: [Nat])
+      forall (t :: [Nat]) (t :: [Bool]).
+      Sing t
+      -> Sing t -> Sing (Apply (Apply SplungeSym0 t) t :: [Nat]) :: Type
     sFoo ::
-      forall a
-             b
-             (t :: (~>) ((~>) a b) ((~>) a b))
-             (t :: (~>) a b)
-             (t :: a). Sing t
-                       -> Sing t
-                          -> Sing t -> Sing (Apply (Apply (Apply FooSym0 t) t) t :: b)
+      forall (t :: (~>) ((~>) a b) ((~>) a b)) (t :: (~>) a b) (t :: a).
+      Sing t
+      -> Sing t
+         -> Sing t
+            -> Sing (Apply (Apply (Apply FooSym0 t) t) t :: b) :: Type
     sZipWith ::
-      forall a b c (t :: (~>) a ((~>) b c)) (t :: [a]) (t :: [b]). Sing t
-                                                                   -> Sing t
-                                                                      -> Sing t
-                                                                         -> Sing (Apply (Apply (Apply ZipWithSym0 t) t) t :: [c])
+      forall (t :: (~>) a ((~>) b c)) (t :: [a]) (t :: [b]).
+      Sing t
+      -> Sing t
+         -> Sing t
+            -> Sing (Apply (Apply (Apply ZipWithSym0 t) t) t :: [c]) :: Type
     sLiftMaybe ::
-      forall a b (t :: (~>) a b) (t :: Maybe a). Sing t
-                                                 -> Sing t
-                                                    -> Sing (Apply (Apply LiftMaybeSym0 t) t :: Maybe b)
+      forall (t :: (~>) a b) (t :: Maybe a).
+      Sing t
+      -> Sing t
+         -> Sing (Apply (Apply LiftMaybeSym0 t) t :: Maybe b) :: Type
     sMap ::
-      forall a b (t :: (~>) a b) (t :: [a]). Sing t
-                                             -> Sing t -> Sing (Apply (Apply MapSym0 t) t :: [b])
+      forall (t :: (~>) a b) (t :: [a]).
+      Sing t -> Sing t -> Sing (Apply (Apply MapSym0 t) t :: [b]) :: Type
     sEtad
       (sA_0123456789876543210 :: Sing a_0123456789876543210)
       (sA_0123456789876543210 :: Sing a_0123456789876543210)

--- a/singletons-base/tests/compile-and-dump/Singletons/LambdaCase.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/LambdaCase.golden
@@ -180,14 +180,14 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
     type family Foo1 (a :: a) (a :: Maybe a) :: a where
       Foo1 d x = Apply (Apply (Apply Lambda_0123456789876543210Sym0 d) x) x
     sFoo3 ::
-      forall a b (t :: a) (t :: b). Sing t
-                                    -> Sing t -> Sing (Apply (Apply Foo3Sym0 t) t :: a)
+      forall (t :: a) (t :: b).
+      Sing t -> Sing t -> Sing (Apply (Apply Foo3Sym0 t) t :: a) :: Type
     sFoo2 ::
-      forall a (t :: a) (t :: Maybe a). Sing t
-                                        -> Sing t -> Sing (Apply (Apply Foo2Sym0 t) t :: a)
+      forall (t :: a) (t :: Maybe a).
+      Sing t -> Sing t -> Sing (Apply (Apply Foo2Sym0 t) t :: a) :: Type
     sFoo1 ::
-      forall a (t :: a) (t :: Maybe a). Sing t
-                                        -> Sing t -> Sing (Apply (Apply Foo1Sym0 t) t :: a)
+      forall (t :: a) (t :: Maybe a).
+      Sing t -> Sing t -> Sing (Apply (Apply Foo1Sym0 t) t :: a) :: Type
     sFoo3 (sA :: Sing a) (sB :: Sing b)
       = (applySing
            ((singFun1 @(Apply (Apply Lambda_0123456789876543210Sym0 a) b))

--- a/singletons-base/tests/compile-and-dump/Singletons/Lambdas.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Lambdas.golden
@@ -559,31 +559,34 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     type family Foo0 (a :: a) (a :: b) :: a where
       Foo0 a_0123456789876543210 a_0123456789876543210 = Apply (Apply (Apply (Apply Lambda_0123456789876543210Sym0 a_0123456789876543210) a_0123456789876543210) a_0123456789876543210) a_0123456789876543210
     sFoo8 ::
-      forall a b (t :: Foo a b). Sing t -> Sing (Apply Foo8Sym0 t :: a)
+      forall (t :: Foo a b).
+      Sing t -> Sing (Apply Foo8Sym0 t :: a) :: Type
     sFoo7 ::
-      forall a b (t :: a) (t :: b). Sing t
-                                    -> Sing t -> Sing (Apply (Apply Foo7Sym0 t) t :: b)
+      forall (t :: a) (t :: b).
+      Sing t -> Sing t -> Sing (Apply (Apply Foo7Sym0 t) t :: b) :: Type
     sFoo6 ::
-      forall a b (t :: a) (t :: b). Sing t
-                                    -> Sing t -> Sing (Apply (Apply Foo6Sym0 t) t :: a)
+      forall (t :: a) (t :: b).
+      Sing t -> Sing t -> Sing (Apply (Apply Foo6Sym0 t) t :: a) :: Type
     sFoo5 ::
-      forall a b (t :: a) (t :: b). Sing t
-                                    -> Sing t -> Sing (Apply (Apply Foo5Sym0 t) t :: b)
+      forall (t :: a) (t :: b).
+      Sing t -> Sing t -> Sing (Apply (Apply Foo5Sym0 t) t :: b) :: Type
     sFoo4 ::
-      forall a b c (t :: a) (t :: b) (t :: c). Sing t
-                                               -> Sing t
-                                                  -> Sing t
-                                                     -> Sing (Apply (Apply (Apply Foo4Sym0 t) t) t :: a)
-    sFoo3 :: forall a (t :: a). Sing t -> Sing (Apply Foo3Sym0 t :: a)
+      forall (t :: a) (t :: b) (t :: c).
+      Sing t
+      -> Sing t
+         -> Sing t
+            -> Sing (Apply (Apply (Apply Foo4Sym0 t) t) t :: a) :: Type
+    sFoo3 ::
+      forall (t :: a). Sing t -> Sing (Apply Foo3Sym0 t :: a) :: Type
     sFoo2 ::
-      forall a b (t :: a) (t :: b). Sing t
-                                    -> Sing t -> Sing (Apply (Apply Foo2Sym0 t) t :: a)
+      forall (t :: a) (t :: b).
+      Sing t -> Sing t -> Sing (Apply (Apply Foo2Sym0 t) t :: a) :: Type
     sFoo1 ::
-      forall a b (t :: a) (t :: b). Sing t
-                                    -> Sing t -> Sing (Apply (Apply Foo1Sym0 t) t :: a)
+      forall (t :: a) (t :: b).
+      Sing t -> Sing t -> Sing (Apply (Apply Foo1Sym0 t) t :: a) :: Type
     sFoo0 ::
-      forall a b (t :: a) (t :: b). Sing t
-                                    -> Sing t -> Sing (Apply (Apply Foo0Sym0 t) t :: a)
+      forall (t :: a) (t :: b).
+      Sing t -> Sing t -> Sing (Apply (Apply Foo0Sym0 t) t :: a) :: Type
     sFoo8 (sX :: Sing x)
       = (applySing
            ((singFun1 @(Apply Lambda_0123456789876543210Sym0 x))

--- a/singletons-base/tests/compile-and-dump/Singletons/LambdasComprehensive.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/LambdasComprehensive.golden
@@ -36,8 +36,8 @@ Singletons/LambdasComprehensive.hs:(0,0)-(0,0): Splicing declarations
     type Foo :: [Nat]
     type family Foo :: [Nat] where
       Foo = Apply (Apply MapSym0 Lambda_0123456789876543210Sym0) (Apply (Apply (:@#@$) (Apply LeftSym0 ZeroSym0)) (Apply (Apply (:@#@$) (Apply RightSym0 (Apply SuccSym0 ZeroSym0))) NilSym0))
-    sBar :: Sing (BarSym0 :: [Nat])
-    sFoo :: Sing (FooSym0 :: [Nat])
+    sBar :: Sing (BarSym0 :: [Nat]) :: Type
+    sFoo :: Sing (FooSym0 :: [Nat]) :: Type
     sBar
       = (applySing
            ((applySing ((singFun2 @MapSym0) sMap))

--- a/singletons-base/tests/compile-and-dump/Singletons/LetStatements.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/LetStatements.golden
@@ -764,34 +764,38 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type family Foo1 (a :: Nat) :: Nat where
       Foo1 x = Let0123456789876543210YSym1 x
     sFoo14 ::
-      forall (t :: Nat). Sing t -> Sing (Apply Foo14Sym0 t :: (Nat, Nat))
+      forall (t :: Nat).
+      Sing t -> Sing (Apply Foo14Sym0 t :: (Nat, Nat)) :: Type
     sFoo13_ ::
-      forall a (t :: a). Sing t -> Sing (Apply Foo13_Sym0 t :: a)
+      forall (t :: a). Sing t -> Sing (Apply Foo13_Sym0 t :: a) :: Type
     sFoo13 ::
       forall a (t :: a). Sing t -> Sing (Apply Foo13Sym0 t :: a)
     sFoo12 ::
-      forall (t :: Nat). Sing t -> Sing (Apply Foo12Sym0 t :: Nat)
+      forall (t :: Nat).
+      Sing t -> Sing (Apply Foo12Sym0 t :: Nat) :: Type
     sFoo11 ::
-      forall (t :: Nat). Sing t -> Sing (Apply Foo11Sym0 t :: Nat)
+      forall (t :: Nat).
+      Sing t -> Sing (Apply Foo11Sym0 t :: Nat) :: Type
     sFoo10 ::
-      forall (t :: Nat). Sing t -> Sing (Apply Foo10Sym0 t :: Nat)
+      forall (t :: Nat).
+      Sing t -> Sing (Apply Foo10Sym0 t :: Nat) :: Type
     sFoo9 ::
-      forall (t :: Nat). Sing t -> Sing (Apply Foo9Sym0 t :: Nat)
+      forall (t :: Nat). Sing t -> Sing (Apply Foo9Sym0 t :: Nat) :: Type
     sFoo8 ::
-      forall (t :: Nat). Sing t -> Sing (Apply Foo8Sym0 t :: Nat)
+      forall (t :: Nat). Sing t -> Sing (Apply Foo8Sym0 t :: Nat) :: Type
     sFoo7 ::
-      forall (t :: Nat). Sing t -> Sing (Apply Foo7Sym0 t :: Nat)
+      forall (t :: Nat). Sing t -> Sing (Apply Foo7Sym0 t :: Nat) :: Type
     sFoo6 ::
-      forall (t :: Nat). Sing t -> Sing (Apply Foo6Sym0 t :: Nat)
+      forall (t :: Nat). Sing t -> Sing (Apply Foo6Sym0 t :: Nat) :: Type
     sFoo5 ::
-      forall (t :: Nat). Sing t -> Sing (Apply Foo5Sym0 t :: Nat)
+      forall (t :: Nat). Sing t -> Sing (Apply Foo5Sym0 t :: Nat) :: Type
     sFoo4 ::
-      forall (t :: Nat). Sing t -> Sing (Apply Foo4Sym0 t :: Nat)
+      forall (t :: Nat). Sing t -> Sing (Apply Foo4Sym0 t :: Nat) :: Type
     sFoo3 ::
-      forall (t :: Nat). Sing t -> Sing (Apply Foo3Sym0 t :: Nat)
-    sFoo2 :: Sing (Foo2Sym0 :: Nat)
+      forall (t :: Nat). Sing t -> Sing (Apply Foo3Sym0 t :: Nat) :: Type
+    sFoo2 :: Sing (Foo2Sym0 :: Nat) :: Type
     sFoo1 ::
-      forall (t :: Nat). Sing t -> Sing (Apply Foo1Sym0 t :: Nat)
+      forall (t :: Nat). Sing t -> Sing (Apply Foo1Sym0 t :: Nat) :: Type
     sFoo14 (sX :: Sing x)
       = let
           sZ :: Sing @_ (Let0123456789876543210ZSym1 x)
@@ -819,15 +823,16 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     sFoo13_ (sY :: Sing y) = sY
     sFoo13 (sX :: Sing x)
       = let
-          sBar :: Sing (Let0123456789876543210BarSym1 x :: a)
+          sBar :: Sing (Let0123456789876543210BarSym1 x :: a) :: Type
           sBar = sX
         in (applySing ((singFun1 @Foo13_Sym0) sFoo13_)) sBar
     sFoo12 (sX :: Sing x)
       = let
           (%+) ::
-            forall (t :: Nat) (t :: Nat). Sing t
-                                          -> Sing t
-                                             -> Sing (Apply (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x) t) t :: Nat)
+            forall (t :: Nat) (t :: Nat).
+            Sing t
+            -> Sing t
+               -> Sing (Apply (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x) t) t :: Nat) :: Type
           (%+) SZero (sM :: Sing m) = sM
           (%+) (SSucc (sN :: Sing n)) (sM :: Sing m)
             = (applySing ((singFun1 @SuccSym0) SSucc))
@@ -843,11 +848,12 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
                ((applySing ((singFun1 @SuccSym0) SSucc)) SZero))
     sFoo11 (sX :: Sing x)
       = let
-          sZ :: Sing (Let0123456789876543210ZSym1 x :: Nat)
+          sZ :: Sing (Let0123456789876543210ZSym1 x :: Nat) :: Type
           (%+) ::
-            forall (t :: Nat) (t :: Nat). Sing t
-                                          -> Sing t
-                                             -> Sing (Apply (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x) t) t :: Nat)
+            forall (t :: Nat) (t :: Nat).
+            Sing t
+            -> Sing t
+               -> Sing (Apply (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x) t) t :: Nat) :: Type
           sZ = sX
           (%+) SZero (sM :: Sing m) = sM
           (%+) (SSucc (sN :: Sing n)) (sM :: Sing m)
@@ -864,9 +870,10 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     sFoo10 (sX :: Sing x)
       = let
           (%+) ::
-            forall (t :: Nat) (t :: Nat). Sing t
-                                          -> Sing t
-                                             -> Sing (Apply (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x) t) t :: Nat)
+            forall (t :: Nat) (t :: Nat).
+            Sing t
+            -> Sing t
+               -> Sing (Apply (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x) t) t :: Nat) :: Type
           (%+) SZero (sM :: Sing m) = sM
           (%+) (SSucc (sN :: Sing n)) (sM :: Sing m)
             = (applySing ((singFun1 @SuccSym0) SSucc))
@@ -882,8 +889,9 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     sFoo9 (sX :: Sing x)
       = let
           sZ ::
-            forall (t :: Nat). Sing t
-                               -> Sing (Apply (Let0123456789876543210ZSym1 x) t :: Nat)
+            forall (t :: Nat).
+            Sing t
+            -> Sing (Apply (Let0123456789876543210ZSym1 x) t :: Nat) :: Type
           sZ (sA_0123456789876543210 :: Sing a_0123456789876543210)
             = (applySing
                  ((singFun1
@@ -893,7 +901,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         in (applySing ((singFun1 @(Let0123456789876543210ZSym1 x)) sZ)) sX
     sFoo8 (sX :: Sing x)
       = let
-          sZ :: Sing (Let0123456789876543210ZSym1 x :: Nat)
+          sZ :: Sing (Let0123456789876543210ZSym1 x :: Nat) :: Type
           sZ
             = (applySing
                  ((singFun1 @(Apply Lambda_0123456789876543210Sym0 x))
@@ -902,41 +910,44 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         in sZ
     sFoo7 (sX :: Sing x)
       = let
-          sX :: Sing (Let0123456789876543210XSym1 x :: Nat)
+          sX :: Sing (Let0123456789876543210XSym1 x :: Nat) :: Type
           sX = SZero
         in sX
     sFoo6 (sX :: Sing x)
       = let
           sF ::
-            forall (t :: Nat). Sing t
-                               -> Sing (Apply (Let0123456789876543210FSym1 x) t :: Nat)
+            forall (t :: Nat).
+            Sing t
+            -> Sing (Apply (Let0123456789876543210FSym1 x) t :: Nat) :: Type
           sF (sY :: Sing y) = (applySing ((singFun1 @SuccSym0) SSucc)) sY in
         let
-          sZ :: Sing (Let0123456789876543210ZSym1 x :: Nat)
+          sZ :: Sing (Let0123456789876543210ZSym1 x :: Nat) :: Type
           sZ
             = (applySing ((singFun1 @(Let0123456789876543210FSym1 x)) sF)) sX
         in sZ
     sFoo5 (sX :: Sing x)
       = let
           sF ::
-            forall (t :: Nat). Sing t
-                               -> Sing (Apply (Let0123456789876543210FSym1 x) t :: Nat)
+            forall (t :: Nat).
+            Sing t
+            -> Sing (Apply (Let0123456789876543210FSym1 x) t :: Nat) :: Type
           sF (sY :: Sing y)
             = let
-                sZ :: Sing (Let0123456789876543210ZSym2 y x :: Nat)
+                sZ :: Sing (Let0123456789876543210ZSym2 y x :: Nat) :: Type
                 sZ = (applySing ((singFun1 @SuccSym0) SSucc)) sY
               in (applySing ((singFun1 @SuccSym0) SSucc)) sZ
         in (applySing ((singFun1 @(Let0123456789876543210FSym1 x)) sF)) sX
     sFoo4 (sX :: Sing x)
       = let
           sF ::
-            forall (t :: Nat). Sing t
-                               -> Sing (Apply (Let0123456789876543210FSym1 x) t :: Nat)
+            forall (t :: Nat).
+            Sing t
+            -> Sing (Apply (Let0123456789876543210FSym1 x) t :: Nat) :: Type
           sF (sY :: Sing y) = (applySing ((singFun1 @SuccSym0) SSucc)) sY
         in (applySing ((singFun1 @(Let0123456789876543210FSym1 x)) sF)) sX
     sFoo3 (sX :: Sing x)
       = let
-          sY :: Sing (Let0123456789876543210YSym1 x :: Nat)
+          sY :: Sing (Let0123456789876543210YSym1 x :: Nat) :: Type
           sY = (applySing ((singFun1 @SuccSym0) SSucc)) sX
         in sY
     sFoo2
@@ -948,7 +959,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         in sZ
     sFoo1 (sX :: Sing x)
       = let
-          sY :: Sing (Let0123456789876543210YSym1 x :: Nat)
+          sY :: Sing (Let0123456789876543210YSym1 x :: Nat) :: Type
           sY = (applySing ((singFun1 @SuccSym0) SSucc)) SZero
         in sY
     instance SingI (Foo14Sym0 :: (~>) Nat (Nat, Nat)) where

--- a/singletons-base/tests/compile-and-dump/Singletons/Nat.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Nat.golden
@@ -175,10 +175,11 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
     instance POrd Nat where
       type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
     sPred ::
-      forall (t :: Nat). Sing t -> Sing (Apply PredSym0 t :: Nat)
+      forall (t :: Nat). Sing t -> Sing (Apply PredSym0 t :: Nat) :: Type
     sPlus ::
-      forall (t :: Nat) (t :: Nat). Sing t
-                                    -> Sing t -> Sing (Apply (Apply PlusSym0 t) t :: Nat)
+      forall (t :: Nat) (t :: Nat).
+      Sing t
+      -> Sing t -> Sing (Apply (Apply PlusSym0 t) t :: Nat) :: Type
     sPred SZero = SZero
     sPred (SSucc (sN :: Sing n)) = sN
     sPlus SZero (sM :: Sing m) = sM

--- a/singletons-base/tests/compile-and-dump/Singletons/Natural.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Natural.golden
@@ -44,8 +44,9 @@ Singletons/Natural.hs:(0,0)-(0,0): Splicing declarations
     type family AddAge (a :: Age) (a :: Age) :: Age where
       AddAge (MkAge (x :: Natural)) (MkAge (y :: Natural)) = Apply MkAgeSym0 (Apply (Apply (+@#@$) x) y :: Natural)
     sAddAge ::
-      forall (t :: Age) (t :: Age). Sing t
-                                    -> Sing t -> Sing (Apply (Apply AddAgeSym0 t) t :: Age)
+      forall (t :: Age) (t :: Age).
+      Sing t
+      -> Sing t -> Sing (Apply (Apply AddAgeSym0 t) t :: Age) :: Type
     sAddAge (SMkAge (sX :: Sing x)) (SMkAge (sY :: Sing y))
       = case ((,) (sX :: Sing x)) (sY :: Sing y) of
           (,) (_ :: Sing (x :: Natural)) (_ :: Sing (y :: Natural))

--- a/singletons-base/tests/compile-and-dump/Singletons/NegativeLiterals.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/NegativeLiterals.golden
@@ -11,7 +11,7 @@ Singletons/NegativeLiterals.hs:(0,0)-(0,0): Splicing declarations
     type F :: Natural
     type family F :: Natural where
       F = Negate (FromInteger 1)
-    sF :: Sing (FSym0 :: Natural)
+    sF :: Sing (FSym0 :: Natural) :: Type
     sF = sNegate (sFromInteger (sing :: Sing 1))
 
 Singletons/NegativeLiterals.hs:0:0: warning: [-Woverflowed-literals]

--- a/singletons-base/tests/compile-and-dump/Singletons/Operators.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Operators.golden
@@ -83,10 +83,11 @@ Singletons/Operators.hs:(0,0)-(0,0): Splicing declarations
       Child FLeaf = FLeafSym0
       Child ((:+:) a _) = a
     (%+) ::
-      forall (t :: Nat) (t :: Nat). Sing t
-                                    -> Sing t -> Sing (Apply (Apply (+@#@$) t) t :: Nat)
+      forall (t :: Nat) (t :: Nat).
+      Sing t -> Sing t -> Sing (Apply (Apply (+@#@$) t) t :: Nat) :: Type
     sChild ::
-      forall (t :: Foo). Sing t -> Sing (Apply ChildSym0 t :: Foo)
+      forall (t :: Foo).
+      Sing t -> Sing (Apply ChildSym0 t :: Foo) :: Type
     (%+) SZero (sM :: Sing m) = sM
     (%+) (SSucc (sN :: Sing n)) (sM :: Sing m)
       = (applySing ((singFun1 @SuccSym0) SSucc))

--- a/singletons-base/tests/compile-and-dump/Singletons/OverloadedStrings.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/OverloadedStrings.golden
@@ -29,9 +29,10 @@ Singletons/OverloadedStrings.hs:(0,0)-(0,0): Splicing declarations
     type SymId :: Symbol -> Symbol
     type family SymId (a :: Symbol) :: Symbol where
       SymId x = x
-    sFoo :: Sing (FooSym0 :: Symbol)
+    sFoo :: Sing (FooSym0 :: Symbol) :: Type
     sSymId ::
-      forall (t :: Symbol). Sing t -> Sing (Apply SymIdSym0 t :: Symbol)
+      forall (t :: Symbol).
+      Sing t -> Sing (Apply SymIdSym0 t :: Symbol) :: Type
     sFoo
       = (applySing ((singFun1 @SymIdSym0) sSymId))
           (sFromString (sing :: Sing "foo"))

--- a/singletons-base/tests/compile-and-dump/Singletons/PatternMatching.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/PatternMatching.golden
@@ -451,19 +451,21 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     type family X_0123456789876543210 where
       X_0123456789876543210 = PrSym0
     sSilly ::
-      forall a (t :: a). Sing t -> Sing (Apply SillySym0 t :: ())
+      forall (t :: a). Sing t -> Sing (Apply SillySym0 t :: ()) :: Type
     sFoo2 ::
-      forall a b (t :: (a, b)). Sing t -> Sing (Apply Foo2Sym0 t :: a)
+      forall (t :: (a, b)).
+      Sing t -> Sing (Apply Foo2Sym0 t :: a) :: Type
     sFoo1 ::
-      forall a b (t :: (a, b)). Sing t -> Sing (Apply Foo1Sym0 t :: a)
+      forall (t :: (a, b)).
+      Sing t -> Sing (Apply Foo1Sym0 t :: a) :: Type
     sBlimy :: Sing @_ BlimySym0
-    sLsz :: Sing (LszSym0 :: Nat)
+    sLsz :: Sing (LszSym0 :: Nat) :: Type
     sX_0123456789876543210 :: Sing @_ X_0123456789876543210Sym0
     sTt :: Sing @_ TtSym0
     sTjz :: Sing @_ TjzSym0
     sTf :: Sing @_ TfSym0
     sX_0123456789876543210 :: Sing @_ X_0123456789876543210Sym0
-    sFls :: Sing (FlsSym0 :: Bool)
+    sFls :: Sing (FlsSym0 :: Bool) :: Type
     sZz :: Sing @_ ZzSym0
     sJz :: Sing @_ JzSym0
     sX_0123456789876543210 :: Sing @_ X_0123456789876543210Sym0

--- a/singletons-base/tests/compile-and-dump/Singletons/PolyKinds.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/PolyKinds.golden
@@ -20,8 +20,8 @@ Singletons/PolyKinds.hs:(0,0)-(0,0): Splicing declarations
       type family Fff (arg :: Proxy (a :: k)) :: ()
     class SCls (a :: k) where
       sFff ::
-        forall (t :: Proxy (a :: k)). Sing t
-                                      -> Sing (Apply FffSym0 t :: ())
+        forall (t :: Proxy (a :: k)).
+        Sing t -> Sing (Apply FffSym0 t :: ()) :: Type
     instance SCls a =>
              SingI (FffSym0 :: (~>) (Proxy (a :: k)) ()) where
       sing = (singFun1 @FffSym0) sFff

--- a/singletons-base/tests/compile-and-dump/Singletons/PolyKindsApp.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/PolyKindsApp.golden
@@ -12,5 +12,4 @@ Singletons/PolyKindsApp.hs:(0,0)-(0,0): Splicing declarations
     class PCls (a :: k -> Type) where
       type family Fff :: (a :: k -> Type) (b :: k)
     class SCls (a :: k -> Type) where
-      sFff ::
-        forall (b :: k). Sing (FffSym0 :: (a :: k -> Type) (b :: k))
+      sFff :: Sing (FffSym0 :: (a :: k -> Type) (b :: k)) :: Type

--- a/singletons-base/tests/compile-and-dump/Singletons/ReturnFunc.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/ReturnFunc.golden
@@ -72,12 +72,14 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
     type family ReturnFunc (a :: Nat) (a :: Nat) :: Nat where
       ReturnFunc _ a_0123456789876543210 = Apply SuccSym0 a_0123456789876543210
     sIdFoo ::
-      forall c a (t :: c) (t :: a). Sing t
-                                    -> Sing t -> Sing (Apply (Apply IdFooSym0 t) t :: a)
-    sId :: forall a (t :: a). Sing t -> Sing (Apply IdSym0 t :: a)
+      forall (t :: c) (t :: a).
+      Sing t -> Sing t -> Sing (Apply (Apply IdFooSym0 t) t :: a) :: Type
+    sId ::
+      forall (t :: a). Sing t -> Sing (Apply IdSym0 t :: a) :: Type
     sReturnFunc ::
-      forall (t :: Nat) (t :: Nat). Sing t
-                                    -> Sing t -> Sing (Apply (Apply ReturnFuncSym0 t) t :: Nat)
+      forall (t :: Nat) (t :: Nat).
+      Sing t
+      -> Sing t -> Sing (Apply (Apply ReturnFuncSym0 t) t :: Nat) :: Type
     sIdFoo _ (sA_0123456789876543210 :: Sing a_0123456789876543210)
       = (applySing ((singFun1 @IdSym0) sId)) sA_0123456789876543210
     sId (sX :: Sing x) = sX

--- a/singletons-base/tests/compile-and-dump/Singletons/Sections.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Sections.golden
@@ -72,12 +72,12 @@ Singletons/Sections.hs:(0,0)-(0,0): Splicing declarations
     type family (+) (a :: Nat) (a :: Nat) :: Nat where
       (+) 'Zero m = m
       (+) ('Succ n) m = Apply SuccSym0 (Apply (Apply (+@#@$) n) m)
-    sFoo3 :: Sing (Foo3Sym0 :: [Nat])
-    sFoo2 :: Sing (Foo2Sym0 :: [Nat])
-    sFoo1 :: Sing (Foo1Sym0 :: [Nat])
+    sFoo3 :: Sing (Foo3Sym0 :: [Nat]) :: Type
+    sFoo2 :: Sing (Foo2Sym0 :: [Nat]) :: Type
+    sFoo1 :: Sing (Foo1Sym0 :: [Nat]) :: Type
     (%+) ::
-      forall (t :: Nat) (t :: Nat). Sing t
-                                    -> Sing t -> Sing (Apply (Apply (+@#@$) t) t :: Nat)
+      forall (t :: Nat) (t :: Nat).
+      Sing t -> Sing t -> Sing (Apply (Apply (+@#@$) t) t :: Nat) :: Type
     sFoo3
       = (applySing
            ((applySing

--- a/singletons-base/tests/compile-and-dump/Singletons/ShowDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/ShowDeriving.golden
@@ -283,9 +283,11 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     infixl 5 :%*:
     infixl 5 `SMkFoo2b`
     (%***) ::
-      forall (t :: Foo3). Sing t -> Sing (Apply (***@#@$) t :: Bool)
+      forall (t :: Foo3).
+      Sing t -> Sing (Apply (***@#@$) t :: Bool) :: Type
     sGetFoo3a ::
-      forall (t :: Foo3). Sing t -> Sing (Apply GetFoo3aSym0 t :: Bool)
+      forall (t :: Foo3).
+      Sing t -> Sing (Apply GetFoo3aSym0 t :: Bool) :: Type
     (%***) (SMkFoo3 _ (sField :: Sing field)) = sField
     sGetFoo3a (SMkFoo3 (sField :: Sing field) _) = sField
     instance SingI ((***@#@$) :: (~>) Foo3 Bool) where

--- a/singletons-base/tests/compile-and-dump/Singletons/T124.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T124.golden
@@ -22,7 +22,8 @@ Singletons/T124.hs:(0,0)-(0,0): Splicing declarations
     type family Foo (a :: Bool) :: () where
       Foo 'True = Tuple0Sym0
       Foo 'False = Tuple0Sym0
-    sFoo :: forall (t :: Bool). Sing t -> Sing (Apply FooSym0 t :: ())
+    sFoo ::
+      forall (t :: Bool). Sing t -> Sing (Apply FooSym0 t :: ()) :: Type
     sFoo STrue = STuple0
     sFoo SFalse = STuple0
     instance SingI (FooSym0 :: (~>) Bool ()) where

--- a/singletons-base/tests/compile-and-dump/Singletons/T136b.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T136b.golden
@@ -19,7 +19,8 @@ Singletons/T136b.hs:(0,0)-(0,0): Splicing declarations
     class PC a where
       type family Meth (arg :: a) :: a
     class SC a where
-      sMeth :: forall (t :: a). Sing t -> Sing (Apply MethSym0 t :: a)
+      sMeth ::
+        forall (t :: a). Sing t -> Sing (Apply MethSym0 t :: a) :: Type
     instance SC a => SingI (MethSym0 :: (~>) a a) where
       sing = (singFun1 @MethSym0) sMeth
 Singletons/T136b.hs:(0,0)-(0,0): Splicing declarations

--- a/singletons-base/tests/compile-and-dump/Singletons/T145.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T145.golden
@@ -28,8 +28,9 @@ Singletons/T145.hs:(0,0)-(0,0): Splicing declarations
       type family Col (arg :: f a) (arg :: a) :: Bool
     class SColumn (f :: Type -> Type) where
       sCol ::
-        forall a (t :: f a) (t :: a). Sing t
-                                      -> Sing t -> Sing (Apply (Apply ColSym0 t) t :: Bool)
+        forall (t :: f a) (t :: a).
+        Sing t
+        -> Sing t -> Sing (Apply (Apply ColSym0 t) t :: Bool) :: Type
     instance SColumn f =>
              SingI (ColSym0 :: (~>) (f a) ((~>) a Bool)) where
       sing = (singFun2 @ColSym0) sCol

--- a/singletons-base/tests/compile-and-dump/Singletons/T150.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T150.golden
@@ -263,25 +263,26 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
     type family HeadVec (a :: Vec ('Succ n) a) :: a where
       HeadVec (VCons x _) = x
     sTransitivity ::
-      forall a b c (t :: Equal a b) (t :: Equal b c). Sing t
-                                                      -> Sing t
-                                                         -> Sing (Apply (Apply TransitivitySym0 t) t :: Equal a c)
+      forall (t :: Equal a b) (t :: Equal b c).
+      Sing t
+      -> Sing t
+         -> Sing (Apply (Apply TransitivitySym0 t) t :: Equal a c) :: Type
     sSymmetry ::
-      forall a b (t :: Equal a b). Sing t
-                                   -> Sing (Apply SymmetrySym0 t :: Equal b a)
+      forall (t :: Equal a b).
+      Sing t -> Sing (Apply SymmetrySym0 t :: Equal b a) :: Type
     sMapVec ::
-      forall a b n (t :: (~>) a b) (t :: Vec n a). Sing t
-                                                   -> Sing t
-                                                      -> Sing (Apply (Apply MapVecSym0 t) t :: Vec n b)
+      forall (t :: (~>) a b) (t :: Vec n a).
+      Sing t
+      -> Sing t -> Sing (Apply (Apply MapVecSym0 t) t :: Vec n b) :: Type
     (%!) ::
-      forall n a (t :: Vec n a) (t :: Fin n). Sing t
-                                              -> Sing t -> Sing (Apply (Apply (!@#@$) t) t :: a)
+      forall (t :: Vec n a) (t :: Fin n).
+      Sing t -> Sing t -> Sing (Apply (Apply (!@#@$) t) t :: a) :: Type
     sTailVec ::
-      forall n a (t :: Vec ('Succ n) a). Sing t
-                                         -> Sing (Apply TailVecSym0 t :: Vec n a)
+      forall (t :: Vec ('Succ n) a).
+      Sing t -> Sing (Apply TailVecSym0 t :: Vec n a) :: Type
     sHeadVec ::
-      forall n a (t :: Vec ('Succ n) a). Sing t
-                                         -> Sing (Apply HeadVecSym0 t :: a)
+      forall (t :: Vec ('Succ n) a).
+      Sing t -> Sing (Apply HeadVecSym0 t :: a) :: Type
     sTransitivity SReflexive SReflexive = SReflexive
     sSymmetry SReflexive = SReflexive
     sMapVec _ SVNil = SVNil

--- a/singletons-base/tests/compile-and-dump/Singletons/T160.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T160.golden
@@ -38,8 +38,8 @@ Singletons/T160.hs:(0,0)-(0,0): Splicing declarations
     type family Foo (a :: a) :: a where
       Foo x = Case_0123456789876543210 x (Let0123456789876543210Scrutinee_0123456789876543210Sym1 x)
     sFoo ::
-      forall a (t :: a). (SNum a, SEq a) =>
-                         Sing t -> Sing (Apply FooSym0 t :: a)
+      forall (t :: a).
+      (SNum a, SEq a) => Sing t -> Sing (Apply FooSym0 t :: a) :: Type
     sFoo (sX :: Sing x)
       = let
           sScrutinee_0123456789876543210 ::

--- a/singletons-base/tests/compile-and-dump/Singletons/T166.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T166.golden
@@ -85,15 +85,18 @@ Singletons/T166.hs:(0,0)-(0,0): Splicing declarations
       type Foo a = Apply Foo_0123456789876543210Sym0 a
     class SFoo a where
       sFoosPrec ::
-        forall (t :: Natural) (t :: a) (t :: [Bool]). Sing t
-                                                      -> Sing t
-                                                         -> Sing t
-                                                            -> Sing (Apply (Apply (Apply FoosPrecSym0 t) t) t :: [Bool])
-      sFoo :: forall (t :: a). Sing t -> Sing (Apply FooSym0 t :: [Bool])
+        forall (t :: Natural) (t :: a) (t :: [Bool]).
+        Sing t
+        -> Sing t
+           -> Sing t
+              -> Sing (Apply (Apply (Apply FoosPrecSym0 t) t) t :: [Bool]) :: Type
+      sFoo ::
+        forall (t :: a). Sing t -> Sing (Apply FooSym0 t :: [Bool]) :: Type
       default sFoo ::
-                forall (t :: a). ((Apply FooSym0 t :: [Bool])
-                                  ~ Apply Foo_0123456789876543210Sym0 t) =>
-                                 Sing t -> Sing (Apply FooSym0 t :: [Bool])
+                forall (t :: a).
+                ((Apply FooSym0 t :: [Bool])
+                 ~ Apply Foo_0123456789876543210Sym0 t) =>
+                Sing t -> Sing (Apply FooSym0 t :: [Bool]) :: Type
       sFoo (sX :: Sing x)
         = (singFun1 @(Apply Lambda_0123456789876543210Sym0 x))
             (\ sS

--- a/singletons-base/tests/compile-and-dump/Singletons/T167.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T167.golden
@@ -124,29 +124,32 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
       type FoosPrec a a a = Apply (Apply (Apply FoosPrec_0123456789876543210Sym0 a) a) a
     class SFoo a where
       sFoosPrec ::
-        forall (t :: Natural) (t :: a) (t :: [Bool]). Sing t
-                                                      -> Sing t
-                                                         -> Sing t
-                                                            -> Sing (Apply (Apply (Apply FoosPrecSym0 t) t) t :: [Bool])
+        forall (t :: Natural) (t :: a) (t :: [Bool]).
+        Sing t
+        -> Sing t
+           -> Sing t
+              -> Sing (Apply (Apply (Apply FoosPrecSym0 t) t) t :: [Bool]) :: Type
       sFooList ::
-        forall (t :: a) (t :: [Bool]). Sing t
-                                       -> Sing t -> Sing (Apply (Apply FooListSym0 t) t :: [Bool])
+        forall (t :: a) (t :: [Bool]).
+        Sing t
+        -> Sing t -> Sing (Apply (Apply FooListSym0 t) t :: [Bool]) :: Type
       default sFooList ::
-                forall (t :: a)
-                       (t :: [Bool]). ((Apply (Apply FooListSym0 t) t :: [Bool])
-                                       ~ Apply (Apply FooList_0123456789876543210Sym0 t) t) =>
-                                      Sing t
-                                      -> Sing t -> Sing (Apply (Apply FooListSym0 t) t :: [Bool])
+                forall (t :: a) (t :: [Bool]).
+                ((Apply (Apply FooListSym0 t) t :: [Bool])
+                 ~ Apply (Apply FooList_0123456789876543210Sym0 t) t) =>
+                Sing t
+                -> Sing t -> Sing (Apply (Apply FooListSym0 t) t :: [Bool]) :: Type
       sFooList
         (sA_0123456789876543210 :: Sing a_0123456789876543210)
         (sA_0123456789876543210 :: Sing a_0123456789876543210)
         = (sUndefined sA_0123456789876543210) sA_0123456789876543210
     instance SFoo a => SFoo [a] where
       sFoosPrec ::
-        forall (t :: Natural) (t :: [a]) (t :: [Bool]). Sing t
-                                                        -> Sing t
-                                                           -> Sing t
-                                                              -> Sing (Apply (Apply (Apply FoosPrecSym0 t) t) t :: [Bool])
+        forall (t :: Natural) (t :: [a]) (t :: [Bool]).
+        Sing t
+        -> Sing t
+           -> Sing t
+              -> Sing (Apply (Apply (Apply FoosPrecSym0 t) t) t :: [Bool]) :: Type
       sFoosPrec
         _
         (sA_0123456789876543210 :: Sing a_0123456789876543210)

--- a/singletons-base/tests/compile-and-dump/Singletons/T172.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T172.golden
@@ -26,9 +26,9 @@ Singletons/T172.hs:(0,0)-(0,0): Splicing declarations
     type family ($>) (a :: Natural) (a :: Natural) :: Natural where
       ($>) a_0123456789876543210 a_0123456789876543210 = Apply (Apply (+@#@$) a_0123456789876543210) a_0123456789876543210
     (%$>) ::
-      forall (t :: Natural) (t :: Natural). Sing t
-                                            -> Sing t
-                                               -> Sing (Apply (Apply ($>@#@$) t) t :: Natural)
+      forall (t :: Natural) (t :: Natural).
+      Sing t
+      -> Sing t -> Sing (Apply (Apply ($>@#@$) t) t :: Natural) :: Type
     (%$>)
       (sA_0123456789876543210 :: Sing a_0123456789876543210)
       (sA_0123456789876543210 :: Sing a_0123456789876543210)

--- a/singletons-base/tests/compile-and-dump/Singletons/T175.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T175.golden
@@ -42,14 +42,14 @@ Singletons/T175.hs:(0,0)-(0,0): Splicing declarations
       type family Quux1 :: a
       type Quux1 = Quux1_0123456789876543210Sym0
     class PBar2 a
-    sQuux2 :: forall a. SBar2 a => Sing (Quux2Sym0 :: a)
+    sQuux2 :: SBar2 a => Sing (Quux2Sym0 :: a) :: Type
     sQuux2 = sBaz
     class SFoo a where
-      sBaz :: Sing (BazSym0 :: a)
+      sBaz :: Sing (BazSym0 :: a) :: Type
     class SFoo a => SBar1 a where
-      sQuux1 :: Sing (Quux1Sym0 :: a)
+      sQuux1 :: Sing (Quux1Sym0 :: a) :: Type
       default sQuux1 ::
                 ((Quux1Sym0 :: a) ~ Quux1_0123456789876543210Sym0) =>
-                Sing (Quux1Sym0 :: a)
+                Sing (Quux1Sym0 :: a) :: Type
       sQuux1 = sBaz
     class SFoo a => SBar2 a

--- a/singletons-base/tests/compile-and-dump/Singletons/T176.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T176.golden
@@ -123,11 +123,11 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
       type family Bar2 (arg :: a) (arg :: b) :: b
       type family Baz2 :: a
     sQuux2 ::
-      forall a (t :: a). SFoo2 a =>
-                         Sing t -> Sing (Apply Quux2Sym0 t :: a)
+      forall (t :: a).
+      SFoo2 a => Sing t -> Sing (Apply Quux2Sym0 t :: a) :: Type
     sQuux1 ::
-      forall a (t :: a). SFoo1 a =>
-                         Sing t -> Sing (Apply Quux1Sym0 t :: a)
+      forall (t :: a).
+      SFoo1 a => Sing t -> Sing (Apply Quux1Sym0 t :: a) :: Type
     sQuux2 (sX :: Sing x)
       = (applySing ((applySing ((singFun2 @Bar2Sym0) sBar2)) sX)) sBaz2
     sQuux1 (sX :: Sing x)
@@ -145,14 +145,14 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
       sing = (singFun1 @Quux1Sym0) sQuux1
     class SFoo1 a where
       sBar1 ::
-        forall b (t :: a) (t :: (~>) a b). Sing t
-                                           -> Sing t -> Sing (Apply (Apply Bar1Sym0 t) t :: b)
-      sBaz1 :: Sing (Baz1Sym0 :: a)
+        forall (t :: a) (t :: (~>) a b).
+        Sing t -> Sing t -> Sing (Apply (Apply Bar1Sym0 t) t :: b) :: Type
+      sBaz1 :: Sing (Baz1Sym0 :: a) :: Type
     class SFoo2 a where
       sBar2 ::
-        forall b (t :: a) (t :: b). Sing t
-                                    -> Sing t -> Sing (Apply (Apply Bar2Sym0 t) t :: b)
-      sBaz2 :: Sing (Baz2Sym0 :: a)
+        forall (t :: a) (t :: b).
+        Sing t -> Sing t -> Sing (Apply (Apply Bar2Sym0 t) t :: b) :: Type
+      sBaz2 :: Sing (Baz2Sym0 :: a) :: Type
     instance SFoo1 a =>
              SingI (Bar1Sym0 :: (~>) a ((~>) ((~>) a b) b)) where
       sing = (singFun2 @Bar1Sym0) sBar1

--- a/singletons-base/tests/compile-and-dump/Singletons/T178.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T178.golden
@@ -140,7 +140,7 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
       ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow Occ where
       type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
-    sEmpty :: Sing (EmptySym0 :: [(Symbol, Occ)])
+    sEmpty :: Sing (EmptySym0 :: [(Symbol, Occ)]) :: Type
     sEmpty = SNil
     data SOcc :: Occ -> Type
       where

--- a/singletons-base/tests/compile-and-dump/Singletons/T183.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T183.golden
@@ -340,28 +340,30 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
       F2 (x :: Maybe a) = x :: Maybe a
     type family F1 a where
       F1 (x :: Maybe Bool) = x :: Maybe Bool
-    sFoo9 :: forall a (t :: a). Sing t -> Sing (Apply Foo9Sym0 t :: a)
+    sFoo9 ::
+      forall (t :: a). Sing t -> Sing (Apply Foo9Sym0 t :: a) :: Type
     sFoo8 ::
       forall a (t :: Maybe a). Sing t
                                -> Sing (Apply Foo8Sym0 t :: Maybe a)
     sFoo7 ::
-      forall a b (t :: a) (t :: b). Sing t
-                                    -> Sing t -> Sing (Apply (Apply Foo7Sym0 t) t :: a)
+      forall (t :: a) (t :: b).
+      Sing t -> Sing t -> Sing (Apply (Apply Foo7Sym0 t) t :: a) :: Type
     sFoo6 ::
-      forall a (t :: Maybe (Maybe a)). Sing t
-                                       -> Sing (Apply Foo6Sym0 t :: Maybe (Maybe a))
+      forall (t :: Maybe (Maybe a)).
+      Sing t -> Sing (Apply Foo6Sym0 t :: Maybe (Maybe a)) :: Type
     sFoo5 ::
-      forall a (t :: Maybe (Maybe a)). Sing t
-                                       -> Sing (Apply Foo5Sym0 t :: Maybe (Maybe a))
+      forall (t :: Maybe (Maybe a)).
+      Sing t -> Sing (Apply Foo5Sym0 t :: Maybe (Maybe a)) :: Type
     sFoo4 ::
-      forall a b (t :: (a, b)). Sing t
-                                -> Sing (Apply Foo4Sym0 t :: (b, a))
+      forall (t :: (a, b)).
+      Sing t -> Sing (Apply Foo4Sym0 t :: (b, a)) :: Type
     sFoo3 ::
       forall a (t :: Maybe a). Sing t -> Sing (Apply Foo3Sym0 t :: a)
     sFoo2 ::
       forall a (t :: Maybe a). Sing t -> Sing (Apply Foo2Sym0 t :: a)
     sFoo1 ::
-      forall a (t :: Maybe a). Sing t -> Sing (Apply Foo1Sym0 t :: a)
+      forall (t :: Maybe a).
+      Sing t -> Sing (Apply Foo1Sym0 t :: a) :: Type
     sG :: forall arg. Sing arg -> Sing (Apply GSym0 arg)
     sF3 :: forall arg. Sing arg -> Sing (Apply F3Sym0 arg)
     sF2 :: forall arg. Sing arg -> Sing (Apply F2Sym0 arg)
@@ -371,9 +373,10 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
           (_ :: Sing (x :: a))
             -> let
                  sG ::
-                   forall b (t :: a) (t :: b). Sing t
-                                               -> Sing t
-                                                  -> Sing (Apply (Apply (Let0123456789876543210GSym1 x) t) t :: a)
+                   forall (t :: a) (t :: b).
+                   Sing t
+                   -> Sing t
+                      -> Sing (Apply (Apply (Let0123456789876543210GSym1 x) t) t :: a) :: Type
                  sG (sY :: Sing y) _ = sY
                in
                  (applySing

--- a/singletons-base/tests/compile-and-dump/Singletons/T184.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T184.golden
@@ -344,18 +344,21 @@ Singletons/T184.hs:(0,0)-(0,0): Splicing declarations
     type family Boogie (a :: Maybe a) (a :: Maybe Bool) :: Maybe a where
       Boogie ma mb = Apply (Apply (>>=@#@$) ma) (Apply (Apply Lambda_0123456789876543210Sym0 ma) mb)
     sTrues ::
-      forall (t :: [Bool]). Sing t -> Sing (Apply TruesSym0 t :: [Bool])
+      forall (t :: [Bool]).
+      Sing t -> Sing (Apply TruesSym0 t :: [Bool]) :: Type
     sCartProd ::
-      forall a b (t :: [a]) (t :: [b]). Sing t
-                                        -> Sing t
-                                           -> Sing (Apply (Apply CartProdSym0 t) t :: [(a, b)])
+      forall (t :: [a]) (t :: [b]).
+      Sing t
+      -> Sing t
+         -> Sing (Apply (Apply CartProdSym0 t) t :: [(a, b)]) :: Type
     sZip' ::
-      forall a b (t :: [a]) (t :: [b]). Sing t
-                                        -> Sing t -> Sing (Apply (Apply Zip'Sym0 t) t :: [(a, b)])
+      forall (t :: [a]) (t :: [b]).
+      Sing t
+      -> Sing t -> Sing (Apply (Apply Zip'Sym0 t) t :: [(a, b)]) :: Type
     sBoogie ::
-      forall a (t :: Maybe a) (t :: Maybe Bool). Sing t
-                                                 -> Sing t
-                                                    -> Sing (Apply (Apply BoogieSym0 t) t :: Maybe a)
+      forall (t :: Maybe a) (t :: Maybe Bool).
+      Sing t
+      -> Sing t -> Sing (Apply (Apply BoogieSym0 t) t :: Maybe a) :: Type
     sTrues (sXs :: Sing xs)
       = (applySing ((applySing ((singFun2 @(>>=@#@$)) (%>>=))) sXs))
           ((singFun1 @(Apply Lambda_0123456789876543210Sym0 xs))

--- a/singletons-base/tests/compile-and-dump/Singletons/T197.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T197.golden
@@ -35,8 +35,9 @@ Singletons/T197.hs:(0,0)-(0,0): Splicing declarations
       ($$:) _ _ = FalseSym0
     infixl 5 %$$:
     (%$$:) ::
-      forall (t :: Bool) (t :: Bool). Sing t
-                                      -> Sing t -> Sing (Apply (Apply ($$:@#@$) t) t :: Bool)
+      forall (t :: Bool) (t :: Bool).
+      Sing t
+      -> Sing t -> Sing (Apply (Apply ($$:@#@$) t) t :: Bool) :: Type
     (%$$:) _ _ = SFalse
     instance SingI (($$:@#@$) :: (~>) Bool ((~>) Bool Bool)) where
       sing = (singFun2 @($$:@#@$)) (%$$:)

--- a/singletons-base/tests/compile-and-dump/Singletons/T200.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T200.golden
@@ -112,13 +112,15 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
     type family ($$:) (a :: ErrorMessage) (a :: ErrorMessage) :: ErrorMessage where
       ($$:) x y = Apply (Apply (:$$:@#@$) x) y
     (%<>:) ::
-      forall (t :: ErrorMessage) (t :: ErrorMessage). Sing t
-                                                      -> Sing t
-                                                         -> Sing (Apply (Apply (<>:@#@$) t) t :: ErrorMessage)
+      forall (t :: ErrorMessage) (t :: ErrorMessage).
+      Sing t
+      -> Sing t
+         -> Sing (Apply (Apply (<>:@#@$) t) t :: ErrorMessage) :: Type
     (%$$:) ::
-      forall (t :: ErrorMessage) (t :: ErrorMessage). Sing t
-                                                      -> Sing t
-                                                         -> Sing (Apply (Apply ($$:@#@$) t) t :: ErrorMessage)
+      forall (t :: ErrorMessage) (t :: ErrorMessage).
+      Sing t
+      -> Sing t
+         -> Sing (Apply (Apply ($$:@#@$) t) t :: ErrorMessage) :: Type
     (%<>:) (sX :: Sing x) (sY :: Sing y)
       = (applySing ((applySing ((singFun2 @(:<>:@#@$)) (:%<>:))) sX)) sY
     (%$$:) (sX :: Sing x) (sY :: Sing y)

--- a/singletons-base/tests/compile-and-dump/Singletons/T209.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T209.golden
@@ -54,10 +54,11 @@ Singletons/T209.hs:(0,0)-(0,0): Splicing declarations
     instance PC Bool Hm
     instance PC a (Maybe a)
     sM ::
-      forall a b (t :: a) (t :: b) (t :: Bool). Sing t
-                                                -> Sing t
-                                                   -> Sing t
-                                                      -> Sing (Apply (Apply (Apply MSym0 t) t) t :: Bool)
+      forall (t :: a) (t :: b) (t :: Bool).
+      Sing t
+      -> Sing t
+         -> Sing t
+            -> Sing (Apply (Apply (Apply MSym0 t) t) t :: Bool) :: Type
     sM _ _ (sX :: Sing x) = sX
     instance SingI (MSym0 :: (~>) a ((~>) b ((~>) Bool Bool))) where
       sing = (singFun3 @MSym0) sM

--- a/singletons-base/tests/compile-and-dump/Singletons/T229.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T229.golden
@@ -20,7 +20,8 @@ Singletons/T229.hs:(0,0)-(0,0): Splicing declarations
     type family US___foo (a :: Bool) :: Bool where
       US___foo _ = TrueSym0
     ___sfoo ::
-      forall (t :: Bool). Sing t -> Sing (Apply US___fooSym0 t :: Bool)
+      forall (t :: Bool).
+      Sing t -> Sing (Apply US___fooSym0 t :: Bool) :: Type
     ___sfoo _ = STrue
     instance SingI (US___fooSym0 :: (~>) Bool Bool) where
       sing = (singFun1 @US___fooSym0) ___sfoo

--- a/singletons-base/tests/compile-and-dump/Singletons/T287.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T287.golden
@@ -90,13 +90,15 @@ Singletons/T287.hs:(0,0)-(0,0): Splicing declarations
       type (<<>>) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
     class SS a where
       (%<<>>) ::
-        forall (t :: a) (t :: a). Sing t
-                                  -> Sing t -> Sing (Apply (Apply (<<>>@#@$) t) t :: a)
+        forall (t :: a) (t :: a).
+        Sing t
+        -> Sing t -> Sing (Apply (Apply (<<>>@#@$) t) t :: a) :: Type
     instance SS b => SS ((~>) a b) where
       (%<<>>) ::
-        forall (t :: (~>) a b) (t :: (~>) a b). Sing t
-                                                -> Sing t
-                                                   -> Sing (Apply (Apply (<<>>@#@$) t) t :: (~>) a b)
+        forall (t :: (~>) a b) (t :: (~>) a b).
+        Sing t
+        -> Sing t
+           -> Sing (Apply (Apply (<<>>@#@$) t) t :: (~>) a b) :: Type
       (%<<>>) (sF :: Sing f) (sG :: Sing g)
         = (singFun1 @(Apply (Apply Lambda_0123456789876543210Sym0 f) g))
             (\ sX

--- a/singletons-base/tests/compile-and-dump/Singletons/T29.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T29.golden
@@ -74,13 +74,17 @@ Singletons/T29.hs:(0,0)-(0,0): Splicing declarations
     type family Foo (a :: Bool) :: Bool where
       Foo x = Apply (Apply ($@#@$) NotSym0) x
     sBan ::
-      forall (t :: Bool). Sing t -> Sing (Apply BanSym0 t :: Bool)
+      forall (t :: Bool).
+      Sing t -> Sing (Apply BanSym0 t :: Bool) :: Type
     sBaz ::
-      forall (t :: Bool). Sing t -> Sing (Apply BazSym0 t :: Bool)
+      forall (t :: Bool).
+      Sing t -> Sing (Apply BazSym0 t :: Bool) :: Type
     sBar ::
-      forall (t :: Bool). Sing t -> Sing (Apply BarSym0 t :: Bool)
+      forall (t :: Bool).
+      Sing t -> Sing (Apply BarSym0 t :: Bool) :: Type
     sFoo ::
-      forall (t :: Bool). Sing t -> Sing (Apply FooSym0 t :: Bool)
+      forall (t :: Bool).
+      Sing t -> Sing (Apply FooSym0 t :: Bool) :: Type
     sBan (sX :: Sing x)
       = (applySing
            ((applySing ((singFun2 @($!@#@$)) (%$!)))

--- a/singletons-base/tests/compile-and-dump/Singletons/T296.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T296.golden
@@ -55,7 +55,7 @@ Singletons/T296.hs:(0,0)-(0,0): Splicing declarations
           sX :: Sing @_ Let0123456789876543210XSym0
           sX
             = let
-                sZ :: Sing (Let0123456789876543210ZSym0 :: MyProxy a)
+                sZ :: Sing (Let0123456789876543210ZSym0 :: MyProxy a) :: Type
                 sZ = SMyProxy
               in sZ
         in sX

--- a/singletons-base/tests/compile-and-dump/Singletons/T297.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T297.golden
@@ -48,7 +48,7 @@ Singletons/T297.hs:(0,0)-(0,0): Splicing declarations
           sX :: Sing @_ Let0123456789876543210XSym0
           sX
             = let
-                sZ :: forall a. Sing (Let0123456789876543210ZSym0 :: MyProxy a)
+                sZ :: Sing (Let0123456789876543210ZSym0 :: MyProxy a) :: Type
                 sZ = SMyProxy
               in sZ
         in sX

--- a/singletons-base/tests/compile-and-dump/Singletons/T312.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T312.golden
@@ -148,16 +148,16 @@ Singletons/T312.hs:(0,0)-(0,0): Splicing declarations
       type Baz a a = Apply (Apply Baz_0123456789876543210Sym0 a) a
     class SFoo a where
       sBar ::
-        forall b (t :: a) (t :: b). Sing t
-                                    -> Sing t -> Sing (Apply (Apply BarSym0 t) t :: b)
+        forall (t :: a) (t :: b).
+        Sing t -> Sing t -> Sing (Apply (Apply BarSym0 t) t :: b) :: Type
       sBaz ::
         forall b (t :: a) (t :: b). Sing t
                                     -> Sing t -> Sing (Apply (Apply BazSym0 t) t :: b)
       default sBar ::
-                forall b (t :: a) (t :: b). ((Apply (Apply BarSym0 t) t :: b)
-                                             ~ Apply (Apply Bar_0123456789876543210Sym0 t) t) =>
-                                            Sing t
-                                            -> Sing t -> Sing (Apply (Apply BarSym0 t) t :: b)
+                forall (t :: a) (t :: b).
+                ((Apply (Apply BarSym0 t) t :: b)
+                 ~ Apply (Apply Bar_0123456789876543210Sym0 t) t) =>
+                Sing t -> Sing t -> Sing (Apply (Apply BarSym0 t) t :: b) :: Type
       default sBaz ::
                 forall b (t :: a) (t :: b). ((Apply (Apply BazSym0 t) t :: b)
                                              ~ Apply (Apply Baz_0123456789876543210Sym0 t) t) =>

--- a/singletons-base/tests/compile-and-dump/Singletons/T322.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T322.golden
@@ -35,8 +35,9 @@ Singletons/T322.hs:(0,0)-(0,0): Splicing declarations
       (!) a_0123456789876543210 a_0123456789876543210 = Apply (Apply (||@#@$) a_0123456789876543210) a_0123456789876543210
     infixr 2 %!
     (%!) ::
-      forall (t :: Bool) (t :: Bool). Sing t
-                                      -> Sing t -> Sing (Apply (Apply (!@#@$) t) t :: Bool)
+      forall (t :: Bool) (t :: Bool).
+      Sing t
+      -> Sing t -> Sing (Apply (Apply (!@#@$) t) t :: Bool) :: Type
     (%!)
       (sA_0123456789876543210 :: Sing a_0123456789876543210)
       (sA_0123456789876543210 :: Sing a_0123456789876543210)

--- a/singletons-base/tests/compile-and-dump/Singletons/T326.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T326.golden
@@ -58,8 +58,9 @@ Singletons/T326.hs:0:0:: Splicing declarations
     infixl 9 <%%>
     class SC2 (a :: Type) where
       (%<%%>) ::
-        forall (t :: a) (t :: a). Sing t
-                                  -> Sing t -> Sing (Apply (Apply (<%%>@#@$) t) t :: a)
+        forall (t :: a) (t :: a).
+        Sing t
+        -> Sing t -> Sing (Apply (Apply (<%%>@#@$) t) t :: a) :: Type
     type SC2 :: Type -> Constraint
     infixl 9 %<%%>
     instance SC2 a => SingI ((<%%>@#@$) :: (~>) a ((~>) a a)) where

--- a/singletons-base/tests/compile-and-dump/Singletons/T33.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T33.golden
@@ -21,7 +21,8 @@ Singletons/T33.hs:(0,0)-(0,0): Splicing declarations
     type family Foo (a :: (Bool, Bool)) :: () where
       Foo '(_, _) = Tuple0Sym0
     sFoo ::
-      forall (t :: (Bool, Bool)). Sing t -> Sing (Apply FooSym0 t :: ())
+      forall (t :: (Bool, Bool)).
+      Sing t -> Sing (Apply FooSym0 t :: ()) :: Type
     sFoo (STuple2 _ _) = STuple0
     instance SingI (FooSym0 :: (~>) (Bool, Bool) ()) where
       sing = (singFun1 @FooSym0) sFoo

--- a/singletons-base/tests/compile-and-dump/Singletons/T332.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T332.golden
@@ -52,7 +52,8 @@ Singletons/T332.hs:(0,0)-(0,0): Splicing declarations
     type B :: Bar -> ()
     type family B (a :: Bar) :: () where
       B MkBar = Tuple0Sym0
-    sB :: forall (t :: Bar). Sing t -> Sing (Apply BSym0 t :: ())
+    sB ::
+      forall (t :: Bar). Sing t -> Sing (Apply BSym0 t :: ()) :: Type
     sB SMkBar = STuple0
     instance SingI (BSym0 :: (~>) Bar ()) where
       sing = (singFun1 @BSym0) sB

--- a/singletons-base/tests/compile-and-dump/Singletons/T358.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T358.golden
@@ -97,14 +97,14 @@ Singletons/T358.hs:(0,0)-(0,0): Splicing declarations
       type Method2a a = Apply Method2a_0123456789876543210Sym0 a
       type Method2b a = Apply Method2b_0123456789876543210Sym0 a
     class SC1 (f :: k -> Type) where
-      sMethod1 :: forall a. Sing (Method1Sym0 :: f a)
+      sMethod1 :: Sing (Method1Sym0 :: f a) :: Type
     class SC2 a where
       sMethod2a ::
         forall b (t :: b). Sing t -> Sing (Apply Method2aSym0 t :: a)
       sMethod2b ::
         forall b (t :: b). Sing t -> Sing (Apply Method2bSym0 t :: a)
     instance SC1 [] where
-      sMethod1 :: forall a. Sing (Method1Sym0 :: [a])
+      sMethod1 :: Sing (Method1Sym0 :: [a]) :: Type
       sMethod1 = SNil
     instance SC2 [a] where
       sMethod2a ::

--- a/singletons-base/tests/compile-and-dump/Singletons/T367.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T367.golden
@@ -28,8 +28,9 @@ Singletons/T367.hs:(0,0)-(0,0): Splicing declarations
     type family Const' (a :: a) (a :: b) :: a where
       Const' x _ = x
     sConst' ::
-      forall a b (t :: a) (t :: b). Sing t
-                                    -> Sing t -> Sing (Apply (Apply Const'Sym0 t) t :: a)
+      forall (t :: a) (t :: b).
+      Sing t
+      -> Sing t -> Sing (Apply (Apply Const'Sym0 t) t :: a) :: Type
     sConst' (sX :: Sing x) _ = sX
     instance SingI (Const'Sym0 :: (~>) a ((~>) b a)) where
       sing = (singFun2 @Const'Sym0) sConst'

--- a/singletons-base/tests/compile-and-dump/Singletons/T376.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T376.golden
@@ -28,8 +28,8 @@ Singletons/T376.hs:(0,0)-(0,0): Splicing declarations
     type family F (a :: (~>) () ()) (a :: ()) :: () where
       F g a_0123456789876543210 = Apply (g :: (~>) () ()) a_0123456789876543210
     sF ::
-      forall (t :: (~>) () ()) (t :: ()). Sing t
-                                          -> Sing t -> Sing (Apply (Apply FSym0 t) t :: ())
+      forall (t :: (~>) () ()) (t :: ()).
+      Sing t -> Sing t -> Sing (Apply (Apply FSym0 t) t :: ()) :: Type
     sF
       (sG :: Sing g)
       (sA_0123456789876543210 :: Sing a_0123456789876543210)

--- a/singletons-base/tests/compile-and-dump/Singletons/T378b.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T378b.golden
@@ -84,8 +84,9 @@ Singletons/T378b.hs:(0,0)-(0,0): Splicing declarations
     type PC :: forall b a. a -> b -> Constraint
     class PC x y
     sNatMinus ::
-      forall (t :: Nat) (t :: Nat). Sing t
-                                    -> Sing t -> Sing (Apply (Apply NatMinusSym0 t) t :: Nat)
+      forall (t :: Nat) (t :: Nat).
+      Sing t
+      -> Sing t -> Sing (Apply (Apply NatMinusSym0 t) t :: Nat) :: Type
     sF ::
       forall b a (t :: a) (t :: b). Sing t
                                     -> Sing t -> Sing (Apply (Apply FSym0 t) t :: ())

--- a/singletons-base/tests/compile-and-dump/Singletons/T412.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T412.golden
@@ -173,8 +173,8 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
             (,) (SomeSing c) (SomeSing c) -> SomeSing ((SMkD1 c) c)
     class SC1 a b where
       sM1 ::
-        forall (t :: a) (t :: b). Sing t
-                                  -> Sing t -> Sing (Apply (Apply M1Sym0 t) t :: Bool)
+        forall (t :: a) (t :: b).
+        Sing t -> Sing t -> Sing (Apply (Apply M1Sym0 t) t :: Bool) :: Type
       infix 6 `sM1`
     instance (SingI n, SingI n) => SingI (MkD1 (n :: a) (n :: b)) where
       sing = (SMkD1 sing) sing
@@ -230,8 +230,8 @@ Singletons/T412.hs:0:0:: Splicing declarations
     infix 6 `M2`
     class SC2 (a :: Type) (b :: Type) where
       sM2 ::
-        forall (t :: a) (t :: b). Sing t
-                                  -> Sing t -> Sing (Apply (Apply M2Sym0 t) t :: Bool)
+        forall (t :: a) (t :: b).
+        Sing t -> Sing t -> Sing (Apply (Apply M2Sym0 t) t :: Bool) :: Type
     type SC2 :: Type -> Type -> Constraint
     infix 5 `SC2`
     infix 6 `sM2`

--- a/singletons-base/tests/compile-and-dump/Singletons/T443.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T443.golden
@@ -77,11 +77,11 @@ Singletons/T443.hs:(0,0)-(0,0): Splicing declarations
     type family Head (a :: Vec (S n) a) :: a where
       Head ((:>) field _) = field
     sTail ::
-      forall n a (t :: Vec (S n) a). Sing t
-                                     -> Sing (Apply TailSym0 t :: Vec n a)
+      forall (t :: Vec (S n) a).
+      Sing t -> Sing (Apply TailSym0 t :: Vec n a) :: Type
     sHead ::
-      forall n a (t :: Vec (S n) a). Sing t
-                                     -> Sing (Apply HeadSym0 t :: a)
+      forall (t :: Vec (S n) a).
+      Sing t -> Sing (Apply HeadSym0 t :: a) :: Type
     sTail ((:%>) _ (sField :: Sing field)) = sField
     sHead ((:%>) (sField :: Sing field) _) = sField
     instance SingI (TailSym0 :: (~>) (Vec (S n) a) (Vec n a)) where

--- a/singletons-base/tests/compile-and-dump/Singletons/T450.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T450.golden
@@ -93,9 +93,10 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
     type family AppendMessage (a :: PMessage) (a :: PMessage) :: PMessage where
       AppendMessage ('PMkMessage (x :: Symbol)) ('PMkMessage (y :: Symbol)) = Apply PMkMessageSym0 (Apply (Apply (<>@#@$) x) y :: Symbol)
     sAppendMessage ::
-      forall (t :: PMessage) (t :: PMessage). Sing t
-                                              -> Sing t
-                                                 -> Sing (Apply (Apply AppendMessageSym0 t) t :: PMessage)
+      forall (t :: PMessage) (t :: PMessage).
+      Sing t
+      -> Sing t
+         -> Sing (Apply (Apply AppendMessageSym0 t) t :: PMessage) :: Type
     sAppendMessage
       (SMkMessage (sX :: Sing x))
       (SMkMessage (sY :: Sing y))
@@ -184,9 +185,10 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
     type family ComposeFunction (a :: PFunction b c) (a :: PFunction a b) :: PFunction a c where
       ComposeFunction ('PMkFunction (f :: (~>) b c)) ('PMkFunction (g :: (~>) a b)) = Apply PMkFunctionSym0 (Apply (Apply (.@#@$) f) g :: (~>) a c)
     sComposeFunction ::
-      forall b c a (t :: PFunction b c) (t :: PFunction a b). Sing t
-                                                              -> Sing t
-                                                                 -> Sing (Apply (Apply ComposeFunctionSym0 t) t :: PFunction a c)
+      forall (t :: PFunction b c) (t :: PFunction a b).
+      Sing t
+      -> Sing t
+         -> Sing (Apply (Apply ComposeFunctionSym0 t) t :: PFunction a c) :: Type
     sComposeFunction
       (SMkFunction (sF :: Sing f))
       (SMkFunction (sG :: Sing g))

--- a/singletons-base/tests/compile-and-dump/Singletons/T487.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T487.golden
@@ -49,12 +49,13 @@ Singletons/T487.hs:(0,0)-(0,0): Splicing declarations
     type ExprEx :: Char
     type family ExprEx :: Char where
       ExprEx = 'a'
-    sCharToNatEx :: Sing (CharToNatExSym0 :: Natural)
-    sNatToCharEx :: Sing (NatToCharExSym0 :: Char)
-    sUnconsEx :: Sing (UnconsExSym0 :: Maybe (Char, Symbol))
+    sCharToNatEx :: Sing (CharToNatExSym0 :: Natural) :: Type
+    sNatToCharEx :: Sing (NatToCharExSym0 :: Char) :: Type
+    sUnconsEx :: Sing (UnconsExSym0 :: Maybe (Char, Symbol)) :: Type
     sConsEx ::
-      forall (t :: Char). Sing t -> Sing (Apply ConsExSym0 t :: Symbol)
-    sExprEx :: Sing (ExprExSym0 :: Char)
+      forall (t :: Char).
+      Sing t -> Sing (Apply ConsExSym0 t :: Symbol) :: Type
+    sExprEx :: Sing (ExprExSym0 :: Char) :: Type
     sCharToNatEx
       = (applySing ((singFun1 @CharToNatSym0) sCharToNat))
           (sing :: Sing 'a')

--- a/singletons-base/tests/compile-and-dump/Singletons/T489.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T489.golden
@@ -44,9 +44,11 @@ Singletons/T489.hs:(0,0)-(0,0): Splicing declarations
       Blah ('Just @a x) = Apply (Apply (:@#@$) (x :: a)) NilSym0
       Blah ('Nothing @a) = NilSym0 :: [a]
     sFlurmp ::
-      forall (t :: Maybe ()). Sing t -> Sing (Apply FlurmpSym0 t :: ())
+      forall (t :: Maybe ()).
+      Sing t -> Sing (Apply FlurmpSym0 t :: ()) :: Type
     sBlah ::
-      forall a (t :: Maybe a). Sing t -> Sing (Apply BlahSym0 t :: [a])
+      forall (t :: Maybe a).
+      Sing t -> Sing (Apply BlahSym0 t :: [a]) :: Type
     sFlurmp (SNothing @_) = STuple0
     sFlurmp (SJust STuple0) = STuple0
     sBlah (SJust @a (sX :: Sing x))

--- a/singletons-base/tests/compile-and-dump/Singletons/T536.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T536.golden
@@ -66,7 +66,7 @@ Singletons/T536.hs:(0,0)-(0,0): Splicing declarations
     type Hello :: PMessage
     type family Hello :: PMessage where
       Hello = Data.Singletons.Apply PMkMessageSym0 (FromString "hello")
-    sHello :: Data.Singletons.Sing (HelloSym0 :: PMessage)
+    sHello :: Data.Singletons.Sing (HelloSym0 :: PMessage) :: Type
     sHello
       = (Data.Singletons.applySing
            ((Data.Singletons.singFun1 @PMkMessageSym0) SMkMessage))

--- a/singletons-base/tests/compile-and-dump/Singletons/T54.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T54.golden
@@ -36,7 +36,8 @@ Singletons/T54.hs:(0,0)-(0,0): Splicing declarations
     type G :: Bool -> Bool
     type family G (a :: Bool) :: Bool where
       G e = Apply (Case_0123456789876543210 e (Let0123456789876543210Scrutinee_0123456789876543210Sym1 e)) e
-    sG :: forall (t :: Bool). Sing t -> Sing (Apply GSym0 t :: Bool)
+    sG ::
+      forall (t :: Bool). Sing t -> Sing (Apply GSym0 t :: Bool) :: Type
     sG (sE :: Sing e)
       = (applySing
            (let

--- a/singletons-base/tests/compile-and-dump/Singletons/T78.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T78.golden
@@ -26,7 +26,8 @@ Singletons/T78.hs:(0,0)-(0,0): Splicing declarations
       Foo ('Just 'True) = TrueSym0
       Foo 'Nothing = FalseSym0
     sFoo ::
-      forall (t :: Maybe Bool). Sing t -> Sing (Apply FooSym0 t :: Bool)
+      forall (t :: Maybe Bool).
+      Sing t -> Sing (Apply FooSym0 t :: Bool) :: Type
     sFoo (SJust SFalse) = SFalse
     sFoo (SJust STrue) = STrue
     sFoo SNothing = SFalse

--- a/singletons-base/tests/compile-and-dump/Singletons/TopLevelPatterns.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/TopLevelPatterns.golden
@@ -277,23 +277,29 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
     type Otherwise :: Bool
     type family Otherwise :: Bool where
       Otherwise = TrueSym0
-    sM :: Sing (MSym0 :: Bool)
-    sL :: Sing (LSym0 :: Bool)
+    sM :: Sing (MSym0 :: Bool) :: Type
+    sL :: Sing (LSym0 :: Bool) :: Type
     sX_0123456789876543210 :: Sing @_ X_0123456789876543210Sym0
-    sK :: Sing (KSym0 :: Bool)
-    sJ :: Sing (JSym0 :: Bool)
+    sK :: Sing (KSym0 :: Bool) :: Type
+    sJ :: Sing (JSym0 :: Bool) :: Type
     sX_0123456789876543210 :: Sing @_ X_0123456789876543210Sym0
-    sI :: forall (t :: Bool). Sing t -> Sing (Apply ISym0 t :: Bool)
-    sH :: forall (t :: Bool). Sing t -> Sing (Apply HSym0 t :: Bool)
+    sI ::
+      forall (t :: Bool). Sing t -> Sing (Apply ISym0 t :: Bool) :: Type
+    sH ::
+      forall (t :: Bool). Sing t -> Sing (Apply HSym0 t :: Bool) :: Type
     sX_0123456789876543210 :: Sing @_ X_0123456789876543210Sym0
-    sG :: forall (t :: Bool). Sing t -> Sing (Apply GSym0 t :: Bool)
-    sF :: forall (t :: Bool). Sing t -> Sing (Apply FSym0 t :: Bool)
+    sG ::
+      forall (t :: Bool). Sing t -> Sing (Apply GSym0 t :: Bool) :: Type
+    sF ::
+      forall (t :: Bool). Sing t -> Sing (Apply FSym0 t :: Bool) :: Type
     sX_0123456789876543210 :: Sing @_ X_0123456789876543210Sym0
     sFalse_ :: Sing @_ False_Sym0
     sNot ::
-      forall (t :: Bool). Sing t -> Sing (Apply NotSym0 t :: Bool)
-    sId :: forall a (t :: a). Sing t -> Sing (Apply IdSym0 t :: a)
-    sOtherwise :: Sing (OtherwiseSym0 :: Bool)
+      forall (t :: Bool).
+      Sing t -> Sing (Apply NotSym0 t :: Bool) :: Type
+    sId ::
+      forall (t :: a). Sing t -> Sing (Apply IdSym0 t :: a) :: Type
+    sOtherwise :: Sing (OtherwiseSym0 :: Bool) :: Type
     sM
       = (GHC.Base.id
            @(Sing (Case_0123456789876543210 X_0123456789876543210Sym0)))

--- a/singletons-base/tests/compile-and-dump/Singletons/Undef.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Undef.golden
@@ -38,9 +38,11 @@ Singletons/Undef.hs:(0,0)-(0,0): Splicing declarations
     type family Foo (a :: Bool) :: Bool where
       Foo a_0123456789876543210 = Apply UndefinedSym0 a_0123456789876543210
     sBar ::
-      forall (t :: Bool). Sing t -> Sing (Apply BarSym0 t :: Bool)
+      forall (t :: Bool).
+      Sing t -> Sing (Apply BarSym0 t :: Bool) :: Type
     sFoo ::
-      forall (t :: Bool). Sing t -> Sing (Apply FooSym0 t :: Bool)
+      forall (t :: Bool).
+      Sing t -> Sing (Apply FooSym0 t :: Bool) :: Type
     sBar (sA_0123456789876543210 :: Sing a_0123456789876543210)
       = (sError (sing :: Sing "urk")) sA_0123456789876543210
     sFoo (sA_0123456789876543210 :: Sing a_0123456789876543210)


### PR DESCRIPTION
This patch rips out essentially all of the implicit-type-variable-tracking machinery described in the former `Note [Explicitly binding kind variables]` in favor of a much simpler approach that relies on GHC to perform implicit quantification. See the newly revamped `Note [Preserve the order of type variables during singling]` (Wrinkle 1: Dealing with the presence (and absence) of `forall`) in `D.S.TH.Single.Type` for the full details.

Fixes #550.