### PR TITLE
Support `type data` out of the box

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -259,7 +259,7 @@ jobs:
           source-repository-package
             type:     git
             location: https://github.com/goldfirere/th-desugar
-            tag:      c33d1dfae5e064be1c143929fd65ce9a10412468
+            tag:      a4d188c7f00fcbc2a345514833f193fa4b6bd1c8
           EOF
           if $HEADHACKAGE; then
           echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project

--- a/README.md
+++ b/README.md
@@ -800,6 +800,7 @@ The following constructs are fully supported:
 * class and instance declarations
 * signatures (e.g., `(x :: Maybe a)`) in expressions
 * `InstanceSigs`
+* `TypeData`
 
 ## Partial support
 

--- a/cabal.project
+++ b/cabal.project
@@ -5,4 +5,4 @@ packages: ./singletons
 source-repository-package
   type: git
   location: https://github.com/goldfirere/th-desugar
-  tag: c33d1dfae5e064be1c143929fd65ce9a10412468
+  tag: a4d188c7f00fcbc2a345514833f193fa4b6bd1c8

--- a/singletons-base/tests/SingletonsBaseTestSuite.hs
+++ b/singletons-base/tests/SingletonsBaseTestSuite.hs
@@ -147,6 +147,7 @@ tests =
     , compileAndDumpStdTest "T511"
     , compileAndDumpStdTest "T536"
     , compileAndDumpStdTest "T555"
+    , compileAndDumpStdTest "T559"
     ],
     testCompileAndDumpGroup "Promote"
     [ compileAndDumpStdTest "Constructors"

--- a/singletons-base/tests/compile-and-dump/Singletons/T559.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T559.golden
@@ -1,0 +1,11 @@
+Singletons/T559.hs:0:0:: Splicing declarations
+    singletons [d| type data T = MkT |]
+  ======>
+    type data T = MkT
+    type MkTSym0 :: T
+    type family MkTSym0 :: T where
+      MkTSym0 = MkT
+    data ST :: T -> Type where SMkT :: ST (MkT :: T)
+    type instance Sing @T = ST
+    instance SingI MkT where
+      sing = SMkT

--- a/singletons-base/tests/compile-and-dump/Singletons/T559.hs
+++ b/singletons-base/tests/compile-and-dump/Singletons/T559.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE TypeData #-}
+module T559 where
+
+import Data.Singletons.TH
+
+$(singletons [d| type data T = MkT |])

--- a/singletons-th/src/Data/Singletons/TH/CustomStar.hs
+++ b/singletons-th/src/Data/Singletons/TH/CustomStar.hs
@@ -81,7 +81,7 @@ singletonStar names = do
   let repDecl = DDataD Data [] repName [] (Just (DConT typeKindName)) ctors
                          [DDerivClause Nothing (map DConT [''Eq, ''Ord, ''Read, ''Show])]
   fakeCtors <- zipWithM (mkCtor False) names kinds
-  let dataDecl = DataDecl repName [] fakeCtors
+  let dataDecl = DataDecl Data repName [] fakeCtors
   -- Why do we need withLocalDeclarations here? It's because we end up
   -- expanding type synonyms when deriving instances for Rep, which requires
   -- reifying Rep itself. Since Rep hasn't been spliced in yet, we must put it

--- a/singletons-th/src/Data/Singletons/TH/Deriving/Bounded.hs
+++ b/singletons-th/src/Data/Singletons/TH/Deriving/Bounded.hs
@@ -25,7 +25,7 @@ import Control.Monad
 -- monadic only for failure and parallelism with other functions
 -- that make instances
 mkBoundedInstance :: DsMonad q => DerivDesc q
-mkBoundedInstance mb_ctxt ty (DataDecl _ _ cons) = do
+mkBoundedInstance mb_ctxt ty (DataDecl _ _ _ cons) = do
   -- We can derive instance of Bounded if datatype is an enumeration (all
   -- constructors must be nullary) or has only one constructor. See Section 11
   -- of Haskell 2010 Language Report.

--- a/singletons-th/src/Data/Singletons/TH/Deriving/Enum.hs
+++ b/singletons-th/src/Data/Singletons/TH/Deriving/Enum.hs
@@ -25,7 +25,7 @@ import Data.Maybe
 
 -- monadic for failure only
 mkEnumInstance :: DsMonad q => DerivDesc q
-mkEnumInstance mb_ctxt ty (DataDecl _ _ cons) = do
+mkEnumInstance mb_ctxt ty (DataDecl _ _ _ cons) = do
   -- GHC only allows deriving Enum instances for enumeration types (i.e., those
   -- data types whose constructors all lack fields). We perform the same
   -- validity check here.

--- a/singletons-th/src/Data/Singletons/TH/Deriving/Eq.hs
+++ b/singletons-th/src/Data/Singletons/TH/Deriving/Eq.hs
@@ -22,7 +22,7 @@ import Language.Haskell.TH.Desugar
 import Language.Haskell.TH.Syntax
 
 mkEqInstance :: DsMonad q => DerivDesc q
-mkEqInstance mb_ctxt ty (DataDecl _ _ cons) = do
+mkEqInstance mb_ctxt ty (DataDecl _ _ _ cons) = do
   let con_pairs = [ (c1, c2) | c1 <- cons, c2 <- cons ]
   constraints <- inferConstraintsDef mb_ctxt (DConT eqName) ty cons
   clauses <- if null cons

--- a/singletons-th/src/Data/Singletons/TH/Deriving/Foldable.hs
+++ b/singletons-th/src/Data/Singletons/TH/Deriving/Foldable.hs
@@ -20,7 +20,7 @@ import Data.Singletons.TH.Syntax
 import Language.Haskell.TH.Desugar
 
 mkFoldableInstance :: forall q. DsMonad q => DerivDesc q
-mkFoldableInstance mb_ctxt ty dd@(DataDecl _ _ cons) = do
+mkFoldableInstance mb_ctxt ty dd@(DataDecl _ _ _ cons) = do
   functorLikeValidityChecks False dd
   f <- newUniqueName "_f"
   z <- newUniqueName "_z"

--- a/singletons-th/src/Data/Singletons/TH/Deriving/Functor.hs
+++ b/singletons-th/src/Data/Singletons/TH/Deriving/Functor.hs
@@ -21,7 +21,7 @@ import Data.Singletons.TH.Util
 import Language.Haskell.TH.Desugar
 
 mkFunctorInstance :: forall q. DsMonad q => DerivDesc q
-mkFunctorInstance mb_ctxt ty dd@(DataDecl _ _ cons) = do
+mkFunctorInstance mb_ctxt ty dd@(DataDecl _ _ _ cons) = do
   functorLikeValidityChecks False dd
   f <- newUniqueName "_f"
   z <- newUniqueName "_z"

--- a/singletons-th/src/Data/Singletons/TH/Deriving/Ord.hs
+++ b/singletons-th/src/Data/Singletons/TH/Deriving/Ord.hs
@@ -23,7 +23,7 @@ import Data.Singletons.TH.Util
 
 -- | Make a *non-singleton* Ord instance
 mkOrdInstance :: DsMonad q => DerivDesc q
-mkOrdInstance mb_ctxt ty (DataDecl _ _ cons) = do
+mkOrdInstance mb_ctxt ty (DataDecl _ _ _ cons) = do
   constraints <- inferConstraintsDef mb_ctxt (DConT ordName) ty cons
   compare_eq_clauses <- mapM mk_equal_clause cons
   let compare_noneq_clauses = map (uncurry mk_nonequal_clause)

--- a/singletons-th/src/Data/Singletons/TH/Deriving/Show.hs
+++ b/singletons-th/src/Data/Singletons/TH/Deriving/Show.hs
@@ -29,7 +29,7 @@ import GHC.Lexeme (startsConSym, startsVarSym)
 import GHC.Show (appPrec, appPrec1)
 
 mkShowInstance :: OptionsMonad q => DerivDesc q
-mkShowInstance mb_ctxt ty (DataDecl _ _ cons) = do
+mkShowInstance mb_ctxt ty (DataDecl _ _ _ cons) = do
   clauses <- mk_showsPrec cons
   constraints <- inferConstraintsDef mb_ctxt (DConT showName) ty cons
   return $ InstDecl { id_cxt = constraints

--- a/singletons-th/src/Data/Singletons/TH/Deriving/Traversable.hs
+++ b/singletons-th/src/Data/Singletons/TH/Deriving/Traversable.hs
@@ -20,7 +20,7 @@ import Data.Singletons.TH.Syntax
 import Language.Haskell.TH.Desugar
 
 mkTraversableInstance :: forall q. DsMonad q => DerivDesc q
-mkTraversableInstance mb_ctxt ty dd@(DataDecl _ _ cons) = do
+mkTraversableInstance mb_ctxt ty dd@(DataDecl _ _ _ cons) = do
   functorLikeValidityChecks False dd
   f <- newUniqueName "_f"
   let ft_trav :: FFoldType (q DExp)

--- a/singletons-th/src/Data/Singletons/TH/Deriving/Util.hs
+++ b/singletons-th/src/Data/Singletons/TH/Deriving/Util.hs
@@ -174,7 +174,7 @@ isInTypeFamilyApp name tyFun tyArgs =
 -- deal with a more complex error message when the generate code fails to
 -- typecheck.
 functorLikeValidityChecks :: forall q. DsMonad q => Bool -> DataDecl -> q ()
-functorLikeValidityChecks allowConstrainedLastTyVar (DataDecl n data_tvbs cons)
+functorLikeValidityChecks allowConstrainedLastTyVar (DataDecl _df n data_tvbs cons)
   | null data_tvbs -- (1)
   = fail $ "Data type " ++ nameBase n ++ " must have some type parameters"
   | otherwise

--- a/singletons-th/src/Data/Singletons/TH/Partition.hs
+++ b/singletons-th/src/Data/Singletons/TH/Partition.hs
@@ -69,9 +69,9 @@ partitionDec :: OptionsMonad m => DDec -> m PartitionedDecs
 partitionDec (DLetDec (DPragmaD {})) = return mempty
 partitionDec (DLetDec letdec) = return $ mempty { pd_let_decs = [letdec] }
 
-partitionDec (DDataD _nd _cxt name tvbs mk cons derivings) = do
+partitionDec (DDataD df _cxt name tvbs mk cons derivings) = do
   all_tvbs <- buildDataDTvbs tvbs mk
-  let data_decl   = DataDecl name all_tvbs cons
+  let data_decl   = DataDecl df name all_tvbs cons
       derived_dec = mempty { pd_data_decs = [data_decl] }
   derived_decs
     <- mapM (\(strat, deriv_pred) ->
@@ -143,9 +143,9 @@ partitionDec (DStandaloneDerivD mb_strat _ ctxt ty) =
       -> do let cls_pred = foldType cls_pred_ty cls_arg_tys
             dinfo <- dsReify data_tycon
             case dinfo of
-              Just (DTyConI (DDataD _ _ dn dtvbs dk dcons _) _) -> do
+              Just (DTyConI (DDataD df _ dn dtvbs dk dcons _) _) -> do
                 all_tvbs <- buildDataDTvbs dtvbs dk
-                let data_decl = DataDecl dn all_tvbs dcons
+                let data_decl = DataDecl df dn all_tvbs dcons
                 partitionDeriving mb_strat cls_pred (Just ctxt) data_ty data_decl
               Just _ ->
                 fail $ "Standalone derived instance for something other than a datatype: "

--- a/singletons-th/src/Data/Singletons/TH/Promote.hs
+++ b/singletons-th/src/Data/Singletons/TH/Promote.hs
@@ -156,12 +156,12 @@ promoteShowInstance = promoteInstance mkShowInstance "Show"
 
 promoteInstance :: OptionsMonad q => DerivDesc q -> String -> Name -> q [Dec]
 promoteInstance mk_inst class_name name = do
-  (tvbs, cons) <- getDataD ("I cannot make an instance of " ++ class_name
-                            ++ " for it.") name
+  (df, tvbs, cons) <- getDataD ("I cannot make an instance of " ++ class_name
+                                ++ " for it.") name
   tvbs' <- mapM dsTvbUnit tvbs
   let data_ty   = foldTypeTvbs (DConT name) tvbs'
   cons' <- concatMapM (dsCon tvbs' data_ty) cons
-  let data_decl = DataDecl name tvbs' cons'
+  let data_decl = DataDecl df name tvbs' cons'
   raw_inst <- mk_inst Nothing data_ty data_decl
   decs <- promoteM_ [] $ void $
           promoteInstanceDec OMap.empty Map.empty raw_inst
@@ -236,7 +236,7 @@ promoteDataDecs = concatMapM promoteDataDec
 --    be promoted in a single location.
 --    See Note [singletons-th and record selectors] in D.S.TH.Single.Data.
 promoteDataDec :: DataDecl -> PrM [DLetDec]
-promoteDataDec (DataDecl _ _ ctors) = do
+promoteDataDec (DataDecl _ _ _ ctors) = do
   let rec_sel_names = nub $ concatMap extractRecSelNames ctors
                       -- Note the use of nub: the same record selector name can
                       -- be used in multiple constructors!

--- a/singletons-th/src/Data/Singletons/TH/Syntax.hs
+++ b/singletons-th/src/Data/Singletons/TH/Syntax.hs
@@ -28,7 +28,7 @@ type VarPromotions = [(Name, Name)] -- from term-level name to type-level name
 type SingDSigPaInfos = [(DExp, DType)]
 
 -- The parts of data declarations that are relevant to singletons-th.
-data DataDecl = DataDecl Name [DTyVarBndrUnit] [DCon]
+data DataDecl = DataDecl DataFlavor Name [DTyVarBndrUnit] [DCon]
 
 -- The parts of type synonyms that are relevant to singletons-th.
 data TySynDecl = TySynDecl Name [DTyVarBndrUnit] DType


### PR DESCRIPTION
`type data` declarations cannot reasonably be given `SingKind` instances, as these only make sense for things that exist at the term level. Whenever we pass a `type data` declaration to the `singletons-th` machinery, we now always omit generation of a `SingKind` instance.

This requires bumping the `th-desugar` commit to bring in the changes from goldfirere/th-desugar#181, which are necessary for determining whether a locally reified data type is actually a `type data` declaration or not.

Fixes #559.