### PR TITLE
Define `Eq` and `Ord` instances for singleton types

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,12 +270,45 @@ the advantage that your program can take action when two types do _not_ equal,
 while propositional equality has the advantage that GHC can use the equality
 of types during type inference.
 
-Instances of `SEq`, `SDecide`, `TestEquality`, and `TestCoercion` are generated
-when `singletons` is called on a datatype that has `deriving Eq`. You can also
-generate these instances directly through functions exported from
-`Data.Singletons.TH` (from `singletons-th`) and
-`Data.Singletons.Base.TH` (from `singletons-base`).
+Instances of `SEq`, `SDecide`, `Eq`, `TestEquality`, and `TestCoercion` are
+generated when `singletons-th` is used to single a data type that has a
+`deriving Eq` clause.  The structure of the `SEq` and `SDecide` instances will
+match that of the derived `Eq` instance, while the other instances will be
+boilerplate code:
 
+```hs
+instance Eq (SExample a) where
+  _ == _ = True
+
+-- See Data.Singletons.Decide for how decideEquality and decideCoercion are
+-- implemented
+
+instance TestEquality (SExample a) where
+  testEquality = decideEquality
+
+instance TestCoercion (SExample a) where
+  testEquality = decideCoercion
+```
+
+You can also generate these instances directly through functions exported from
+`Data.Singletons.TH` (from `singletons-th`) and `Data.Singletons.Base.TH` (from
+`singletons-base`).
+
+`Ord` classes
+-------------
+
+Promoted and singled versions of the `Ord` class (`POrd` and `SOrd`,
+respectively) are provided in the `Data.Ord.Singletons` module from
+`singletons-base`.
+
+Just like how singling a data type with a `deriving Eq` clause will generate a
+boilerplate `Eq` instance, singling a data type with a `deriving Ord` clause
+will generate a boilerplate `Ord` instance:
+
+```hs
+instance Ord (SExample a) where
+  compare _ _ = EQ
+```
 
 `Show` classes
 --------------

--- a/singletons-base/CHANGES.md
+++ b/singletons-base/CHANGES.md
@@ -1,6 +1,22 @@
 Changelog for the `singletons-base` project
 ===========================================
 
+next [????.??.??]
+-----------------
+* All singleton types with `SEq` or `SOrd` instances now have `Eq` or `Ord`
+  instances of the form:
+
+  ```hs
+  instance Eq (SExample a) where
+    _ == _ = True
+
+  instance Ord (SExample a) where
+    compare _ _ = EQ
+  ```
+* Define `{P,S}Eq` and `{P,S}Ord` instances for `Sum`, `Product`, and `Compose`.
+* Define `TestEquality` and `TestOrdering` instances for `SSum`, `SProduct`, and
+  `SCompose`.
+
 3.2 [2023.03.12]
 ----------------
 * Require building with GHC 9.6.

--- a/singletons-base/src/Data/Functor/Compose/Singletons.hs
+++ b/singletons-base/src/Data/Functor/Compose/Singletons.hs
@@ -28,11 +28,15 @@ module Data.Functor.Compose.Singletons (
 
 import Control.Applicative
 import Control.Applicative.Singletons
+import Data.Eq.Singletons
 import Data.Foldable.Singletons
 import Data.Functor.Compose
 import Data.Functor.Singletons
+import Data.Ord.Singletons
 import Data.Kind
+import Data.Semigroup.Singletons
 import Data.Singletons
+import Data.Singletons.Base.Instances (SList(..), (:@#@$), NilSym0)
 import Data.Singletons.TH
 import Data.Traversable.Singletons
 
@@ -69,6 +73,9 @@ type family ComposeSym1 x where
 $(singletonsOnly [d|
   getCompose :: Compose f g a -> f (g a)
   getCompose (Compose x) = x
+
+  deriving instance Eq (f (g a)) => Eq (Compose f g a)
+  deriving instance Ord (f (g a)) => Ord (Compose f g a)
 
   instance (Functor f, Functor g) => Functor (Compose f g) where
       fmap f (Compose x) = Compose (fmap (fmap f) x)

--- a/singletons-base/src/Data/Functor/Product/Singletons.hs
+++ b/singletons-base/src/Data/Functor/Product/Singletons.hs
@@ -31,11 +31,16 @@ import Control.Monad
 import Control.Monad.Singletons
 import Control.Monad.Zip
 import Control.Monad.Zip.Singletons
+import Data.Bool.Singletons
+import Data.Eq.Singletons
 import Data.Foldable.Singletons hiding (Product)
 import Data.Function.Singletons
 import Data.Functor.Product
 import Data.Kind
 import Data.Monoid.Singletons hiding (SProduct(..))
+import Data.Semigroup.Singletons hiding (SProduct(..))
+import Data.Singletons.Base.Instances (SList(..), (:@#@$), NilSym0)
+import Data.Ord.Singletons
 import Data.Singletons
 import Data.Singletons.TH
 import Data.Traversable.Singletons
@@ -78,6 +83,9 @@ type family PairSym2 x y where
   PairSym2 x y = 'Pair x y
 
 $(singletonsOnly [d|
+  deriving instance (Eq (f a), Eq (g a)) => Eq (Product f g a)
+  deriving instance (Ord (f a), Ord (g a)) => Ord (Product f g a)
+
   instance (Functor f, Functor g) => Functor (Product f g) where
       fmap f (Pair x y) = Pair (fmap f x) (fmap f y)
       a <$ (Pair x y) = Pair (a <$ x) (a <$ y)

--- a/singletons-base/src/Data/Functor/Sum/Singletons.hs
+++ b/singletons-base/src/Data/Functor/Sum/Singletons.hs
@@ -26,11 +26,16 @@ module Data.Functor.Sum.Singletons (
   InRSym0, InRSym1,
   ) where
 
+import Data.Bool.Singletons
+import Data.Eq.Singletons
 import Data.Foldable.Singletons hiding (Sum)
 import Data.Functor.Singletons
 import Data.Functor.Sum
 import Data.Kind
+import Data.Ord.Singletons
+import Data.Semigroup.Singletons hiding (SSum(..))
 import Data.Singletons
+import Data.Singletons.Base.Instances (SList(..), (:@#@$), NilSym0)
 import Data.Singletons.TH
 import Data.Traversable.Singletons
 
@@ -78,6 +83,9 @@ type family InRSym1 x where
   InRSym1 y = 'InR y
 
 $(singletonsOnly [d|
+  deriving instance (Eq (f a), Eq (g a)) => Eq (Sum f g a)
+  deriving instance (Ord (f a), Ord (g a)) => Ord (Sum f g a)
+
   instance (Functor f, Functor g) => Functor (Sum f g) where
       fmap f (InL x) = InL (fmap f x)
       fmap f (InR y) = InR (fmap f y)

--- a/singletons-base/src/Data/Proxy/Singletons.hs
+++ b/singletons-base/src/Data/Proxy/Singletons.hs
@@ -71,6 +71,9 @@ type ProxySym0 :: Proxy t
 type family ProxySym0 where
   ProxySym0 = 'Proxy
 
+instance Eq (SProxy z) where
+  _ == _ = True
+
 instance SDecide (Proxy t) where
   SProxy %~ SProxy = Proved Refl
 
@@ -79,6 +82,9 @@ instance TestEquality SProxy where
 
 instance TestCoercion SProxy where
   testCoercion = decideCoercion
+
+instance Ord (SProxy z) where
+  compare _ _ = EQ
 
 instance Show (SProxy z) where
   showsPrec _ _ = showString "SProxy"

--- a/singletons-base/src/Data/Semigroup/Singletons.hs
+++ b/singletons-base/src/Data/Semigroup/Singletons.hs
@@ -79,6 +79,12 @@ $(genSingletons [''Arg])
 $(showSingInstances semigroupBasicTypes)
 $(singShowInstances semigroupBasicTypes)
 
+instance Eq (SArg z) where
+  _ == _ = True
+
+instance Ord (SArg z) where
+  compare _ _ = EQ
+
 $(singletonsOnly [d|
   instance Applicative Semi.Min where
     pure = Semi.Min

--- a/singletons-base/tests/compile-and-dump/GradingClient/Database.golden
+++ b/singletons-base/tests/compile-and-dump/GradingClient/Database.golden
@@ -143,6 +143,8 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
             Proved Refl -> Proved Refl
             Disproved contra
               -> Disproved (\ refl -> case refl of Refl -> contra Refl)
+    instance Eq (SNat (z :: Nat)) where
+      (==) _ _ = True
     instance SDecide Nat =>
              Data.Type.Equality.TestEquality (SNat :: Nat -> Type) where
       Data.Type.Equality.testEquality
@@ -151,6 +153,8 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
              Data.Type.Coercion.TestCoercion (SNat :: Nat -> Type) where
       Data.Type.Coercion.testCoercion
         = Data.Singletons.Decide.decideCoercion
+    instance Ord (SNat (z :: Nat)) where
+      compare _ _ = EQ
     instance SingI Zero where
       sing = SZero
     instance SingI n => SingI (Succ (n :: Nat)) where
@@ -2687,6 +2691,8 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
               -> Disproved (\ refl -> case refl of Refl -> contra Refl)
             (,) _ (Disproved contra)
               -> Disproved (\ refl -> case refl of Refl -> contra Refl)
+    instance Eq (SU (z :: U)) where
+      (==) _ _ = True
     instance (SDecide U, SDecide Nat) =>
              Data.Type.Equality.TestEquality (SU :: U -> Type) where
       Data.Type.Equality.testEquality
@@ -3372,6 +3378,8 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       (%~) SCZ SCX = Disproved (\ x -> case x of {})
       (%~) SCZ SCY = Disproved (\ x -> case x of {})
       (%~) SCZ SCZ = Proved Refl
+    instance Eq (SAChar (z :: AChar)) where
+      (==) _ _ = True
     instance Data.Type.Equality.TestEquality (SAChar :: AChar
                                                         -> Type) where
       Data.Type.Equality.testEquality

--- a/singletons-base/tests/compile-and-dump/Singletons/Maybe.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Maybe.golden
@@ -166,6 +166,8 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
             Proved Refl -> Proved Refl
             Disproved contra
               -> Disproved (\ refl -> case refl of Refl -> contra Refl)
+    instance Eq (SMaybe (z :: Maybe a)) where
+      (==) _ _ = True
     instance SDecide a =>
              Data.Type.Equality.TestEquality (SMaybe :: Maybe a -> Type) where
       Data.Type.Equality.testEquality

--- a/singletons-base/tests/compile-and-dump/Singletons/Nat.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Nat.golden
@@ -301,6 +301,8 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
             Proved Refl -> Proved Refl
             Disproved contra
               -> Disproved (\ refl -> case refl of Refl -> contra Refl)
+    instance Eq (SNat (z :: Nat)) where
+      (==) _ _ = True
     instance SDecide Nat =>
              Data.Type.Equality.TestEquality (SNat :: Nat -> Type) where
       Data.Type.Equality.testEquality
@@ -309,6 +311,8 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
              Data.Type.Coercion.TestCoercion (SNat :: Nat -> Type) where
       Data.Type.Coercion.testCoercion
         = Data.Singletons.Decide.decideCoercion
+    instance Ord (SNat (z :: Nat)) where
+      compare _ _ = EQ
     deriving instance Data.Singletons.ShowSing.ShowSing Nat =>
                       Show (SNat (z :: Nat))
     instance SingI Zero where

--- a/singletons-base/tests/compile-and-dump/Singletons/OrdDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/OrdDeriving.golden
@@ -1116,6 +1116,8 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
             Proved Refl -> Proved Refl
             Disproved contra
               -> Disproved (\ refl -> case refl of Refl -> contra Refl)
+    instance Eq (SNat (z :: Nat)) where
+      (==) _ _ = True
     instance SDecide Nat =>
              Data.Type.Equality.TestEquality (SNat :: Nat -> Type) where
       Data.Type.Equality.testEquality
@@ -1228,6 +1230,8 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
               -> Disproved (\ refl -> case refl of Refl -> contra Refl)
             (,,,) _ _ _ (Disproved contra)
               -> Disproved (\ refl -> case refl of Refl -> contra Refl)
+    instance Eq (SFoo (z :: Foo a b c d)) where
+      (==) _ _ = True
     instance (SDecide a, SDecide b, SDecide c, SDecide d) =>
              Data.Type.Equality.TestEquality (SFoo :: Foo a b c d -> Type) where
       Data.Type.Equality.testEquality
@@ -1236,6 +1240,10 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
              Data.Type.Coercion.TestCoercion (SFoo :: Foo a b c d -> Type) where
       Data.Type.Coercion.testCoercion
         = Data.Singletons.Decide.decideCoercion
+    instance Ord (SNat (z :: Nat)) where
+      compare _ _ = EQ
+    instance Ord (SFoo (z :: Foo a b c d)) where
+      compare _ _ = EQ
     instance SingI Zero where
       sing = SZero
     instance SingI n => SingI (Succ (n :: Nat)) where

--- a/singletons-base/tests/compile-and-dump/Singletons/StandaloneDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/StandaloneDeriving.golden
@@ -510,6 +510,8 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
               -> Disproved (\ refl -> case refl of Refl -> contra Refl)
             (,) _ (Disproved contra)
               -> Disproved (\ refl -> case refl of Refl -> contra Refl)
+    instance Eq (ST (z :: T a ())) where
+      (==) _ _ = True
     instance SDecide a =>
              Data.Type.Equality.TestEquality (ST :: T a () -> Type) where
       Data.Type.Equality.testEquality
@@ -523,12 +525,18 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
       (%~) SS1 SS2 = Disproved (\ x -> case x of {})
       (%~) SS2 SS1 = Disproved (\ x -> case x of {})
       (%~) SS2 SS2 = Proved Refl
+    instance Eq (SS (z :: S)) where
+      (==) _ _ = True
     instance Data.Type.Equality.TestEquality (SS :: S -> Type) where
       Data.Type.Equality.testEquality
         = Data.Singletons.Decide.decideEquality
     instance Data.Type.Coercion.TestCoercion (SS :: S -> Type) where
       Data.Type.Coercion.testCoercion
         = Data.Singletons.Decide.decideCoercion
+    instance Ord (ST (z :: T a ())) where
+      compare _ _ = EQ
+    instance Ord (SS (z :: S)) where
+      compare _ _ = EQ
     deriving instance Data.Singletons.ShowSing.ShowSing a =>
                       Show (ST (z :: T a ()))
     deriving instance Show (SS (z :: S))

--- a/singletons-base/tests/compile-and-dump/Singletons/Star.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Star.golden
@@ -254,6 +254,8 @@ Singletons/Star.hs:0:0:: Splicing declarations
               -> Disproved (\ refl -> case refl of Refl -> contra Refl)
             (,) _ (Disproved contra)
               -> Disproved (\ refl -> case refl of Refl -> contra Refl)
+    instance Eq (SRep (z :: Type)) where
+      (==) _ _ = True
     instance (SDecide Type, SDecide Nat) =>
              Data.Type.Equality.TestEquality (SRep :: Type -> Type) where
       Data.Type.Equality.testEquality = decideEquality

--- a/singletons-base/tests/compile-and-dump/Singletons/T178.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T178.golden
@@ -242,6 +242,8 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
       (%~) SMany SStr = Disproved (\ x -> case x of {})
       (%~) SMany SOpt = Disproved (\ x -> case x of {})
       (%~) SMany SMany = Proved Refl
+    instance Eq (SOcc (z :: Occ)) where
+      (==) _ _ = True
     instance Data.Type.Equality.TestEquality (SOcc :: Occ
                                                       -> Type) where
       Data.Type.Equality.testEquality
@@ -250,6 +252,8 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
                                                       -> Type) where
       Data.Type.Coercion.testCoercion
         = Data.Singletons.Decide.decideCoercion
+    instance Ord (SOcc (z :: Occ)) where
+      compare _ _ = EQ
     deriving instance Show (SOcc (z :: Occ))
     instance SingI Str where
       sing = SStr

--- a/singletons-base/tests/compile-and-dump/Singletons/T187.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T187.golden
@@ -83,6 +83,8 @@ Singletons/T187.hs:(0,0)-(0,0): Splicing declarations
       sCompare _ _ = SEQ
     instance SDecide Empty where
       (%~) x _ = Proved (case x of {})
+    instance Eq (SEmpty (z :: Empty)) where
+      (==) _ _ = True
     instance Data.Type.Equality.TestEquality (SEmpty :: Empty
                                                         -> Type) where
       Data.Type.Equality.testEquality
@@ -91,3 +93,5 @@ Singletons/T187.hs:(0,0)-(0,0): Splicing declarations
                                                         -> Type) where
       Data.Type.Coercion.testCoercion
         = Data.Singletons.Decide.decideCoercion
+    instance Ord (SEmpty (z :: Empty)) where
+      compare _ _ = EQ

--- a/singletons-base/tests/compile-and-dump/Singletons/T190.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T190.golden
@@ -222,12 +222,16 @@ Singletons/T190.hs:0:0:: Splicing declarations
             sA_0123456789876543210
     instance SDecide T where
       (%~) ST ST = Proved Refl
+    instance Eq (ST (z :: T)) where
+      (==) _ _ = True
     instance Data.Type.Equality.TestEquality (ST :: T -> Type) where
       Data.Type.Equality.testEquality
         = Data.Singletons.Decide.decideEquality
     instance Data.Type.Coercion.TestCoercion (ST :: T -> Type) where
       Data.Type.Coercion.testCoercion
         = Data.Singletons.Decide.decideCoercion
+    instance Ord (ST (z :: T)) where
+      compare _ _ = EQ
     deriving instance Show (ST (z :: T))
     instance SingI T where
       sing = ST

--- a/singletons-base/tests/compile-and-dump/Singletons/T271.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T271.golden
@@ -247,6 +247,8 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
             Proved Refl -> Proved Refl
             Disproved contra
               -> Disproved (\ refl -> case refl of Refl -> contra Refl)
+    instance Eq (SConstant (z :: Constant a b)) where
+      (==) _ _ = True
     instance SDecide a =>
              Data.Type.Equality.TestEquality (SConstant :: Constant a b
                                                            -> Type) where
@@ -263,6 +265,8 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
             Proved Refl -> Proved Refl
             Disproved contra
               -> Disproved (\ refl -> case refl of Refl -> contra Refl)
+    instance Eq (SIdentity (z :: Identity a)) where
+      (==) _ _ = True
     instance SDecide a =>
              Data.Type.Equality.TestEquality (SIdentity :: Identity a
                                                            -> Type) where
@@ -273,6 +277,10 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
                                                            -> Type) where
       Data.Type.Coercion.testCoercion
         = Data.Singletons.Decide.decideCoercion
+    instance Ord (SConstant (z :: Constant a b)) where
+      compare _ _ = EQ
+    instance Ord (SIdentity (z :: Identity a)) where
+      compare _ _ = EQ
     instance SingI n => SingI (Constant (n :: a)) where
       sing = SConstant sing
     instance SingI1 Constant where

--- a/singletons-base/tests/compile-and-dump/Singletons/T536.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T536.golden
@@ -83,6 +83,8 @@ Singletons/T536.hs:(0,0)-(0,0): Splicing declarations
                    (\ refl
                       -> case refl of
                            Data.Type.Equality.Refl -> contra Data.Type.Equality.Refl)
+    instance Eq (SMessage (z :: PMessage)) where
+      (==) _ _ = True
     instance Data.Singletons.Decide.SDecide Text =>
              Data.Type.Equality.TestEquality (SMessage :: PMessage
                                                           -> Type) where

--- a/singletons-base/tests/compile-and-dump/Singletons/T555.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T555.golden
@@ -188,6 +188,8 @@ Singletons/T555.hs:(0,0)-(0,0): Splicing declarations
       (%~) SLocation SQuaternion = Disproved (\ x -> case x of {})
       (%~) SQuaternion SLocation = Disproved (\ x -> case x of {})
       (%~) SQuaternion SQuaternion = Proved Refl
+    instance Eq (SMyPropKind (z :: MyPropKind)) where
+      (==) _ _ = True
     instance Data.Type.Equality.TestEquality (SMyPropKind :: MyPropKind
                                                              -> Type) where
       Data.Type.Equality.testEquality
@@ -196,6 +198,8 @@ Singletons/T555.hs:(0,0)-(0,0): Splicing declarations
                                                              -> Type) where
       Data.Type.Coercion.testCoercion
         = Data.Singletons.Decide.decideCoercion
+    instance Ord (SMyPropKind (z :: MyPropKind)) where
+      compare _ _ = EQ
     deriving instance Show (SMyPropKind (z :: MyPropKind))
     instance SingI Location where
       sing = SLocation

--- a/singletons-th/CHANGES.md
+++ b/singletons-th/CHANGES.md
@@ -1,6 +1,19 @@
 Changelog for the `singletons-th` project
 =========================================
 
+next [????.??.??]
+-----------------
+* Singled data types with derived `Eq` or `Ord` instances now generate `Eq` or
+  `Ord` instances for the singleton type itself, e.g.,
+
+  ```hs
+  instance Eq (SExample a) where
+    _ == _ = True
+
+  instance Ord (SExample a) where
+    compare _ _ = EQ
+  ```
+
 3.2 [2023.03.12]
 ----------------
 * Require building with GHC 9.6.

--- a/singletons-th/singletons-th.cabal
+++ b/singletons-th/singletons-th.cabal
@@ -91,6 +91,7 @@ library
                       Data.Singletons.TH.Single.Defun
                       Data.Singletons.TH.Single.Fixity
                       Data.Singletons.TH.Single.Monad
+                      Data.Singletons.TH.Single.Ord
                       Data.Singletons.TH.Single.Type
                       Data.Singletons.TH.Syntax
                       Data.Singletons.TH.Util

--- a/singletons-th/src/Data/Singletons/TH/Single/Decide.hs
+++ b/singletons-th/src/Data/Singletons/TH/Single/Decide.hs
@@ -35,6 +35,28 @@ mkDecideInstance mb_ctxt data_ty ctors sctors = do
                      (DAppT (DConT sDecideClassName) data_ki)
                      [DLetDec $ DFunD sDecideMethName methClauses]
 
+-- Make a boilerplate Eq instance for a singleton type, e.g.,
+--
+-- @
+-- instance Eq (SExample (z :: Example a)) where
+--   _ == _ = True
+-- @
+mkEqInstanceForSingleton :: OptionsMonad q
+                         => DType
+                         -> Name
+                         -- ^ The name of the data type
+                         -> q DDec
+mkEqInstanceForSingleton data_ty data_name = do
+  opts <- getOptions
+  z <- qNewName "z"
+  data_ki <- promoteType data_ty
+  let sdata_name = singledDataTypeName opts data_name
+  pure $ DInstanceD Nothing Nothing []
+           (DAppT (DConT eqName) (DConT sdata_name `DAppT` DSigT (DVarT z) data_ki))
+           [DLetDec $
+            DFunD equalsName
+                  [DClause [DWildP, DWildP] (DConE trueName)]]
+
 data TestInstance = TestEquality
                   | TestCoercion
 

--- a/singletons-th/src/Data/Singletons/TH/Single/Ord.hs
+++ b/singletons-th/src/Data/Singletons/TH/Single/Ord.hs
@@ -1,0 +1,43 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Singletons.TH.Single.Ord
+-- Copyright   :  (C) 2023 Ryan Scott
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Ryan Scott
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Defines a function to generate boilerplate Ord instances for singleton
+-- types.
+--
+-----------------------------------------------------------------------------
+
+module Data.Singletons.TH.Single.Ord (mkOrdInstanceForSingleton) where
+
+import Language.Haskell.TH.Syntax
+import Language.Haskell.TH.Desugar
+import Data.Singletons.TH.Names
+import Data.Singletons.TH.Options
+import Data.Singletons.TH.Promote.Type
+
+-- Make a boilerplate Ord instance for a singleton type, e.g.,
+--
+-- @
+-- instance Ord (SExample (z :: Example a)) where
+--   compare _ _ = EQ
+-- @
+mkOrdInstanceForSingleton :: OptionsMonad q
+                          => DType
+                          -> Name
+                          -- ^ The name of the data type
+                          -> q DDec
+mkOrdInstanceForSingleton data_ty data_name = do
+  opts <- getOptions
+  z <- qNewName "z"
+  data_ki <- promoteType data_ty
+  let sdata_name = singledDataTypeName opts data_name
+  pure $ DInstanceD Nothing Nothing []
+           (DAppT (DConT ordName) (DConT sdata_name `DAppT` DSigT (DVarT z) data_ki))
+           [DLetDec $
+            DFunD compareName
+                  [DClause [DWildP, DWildP] (DConE cmpEQName)]]

--- a/singletons-th/src/Data/Singletons/TH/Syntax.hs
+++ b/singletons-th/src/Data/Singletons/TH/Syntax.hs
@@ -192,6 +192,7 @@ data DerivedDecl (cls :: Type -> Constraint) = DerivedDecl
   }
 
 type DerivedEqDecl   = DerivedDecl Eq
+type DerivedOrdDecl  = DerivedDecl Ord
 type DerivedShowDecl = DerivedDecl Show
 
 {- Note [DerivedDecl]
@@ -212,13 +213,14 @@ encode just enough information to recreate the derived instance:
 Why are these instances handled outside of partitionDecs?
 
 * Deriving Eq in singletons-th not only derives PEq/SEq instances, but it also
-  derives SDecide, TestEquality, and TestCoercion instances.
-  Data.Singletons.TH.Single (depending on the task at hand).
+  derives SDecide, Eq, TestEquality, and TestCoercion instances.
+* Deriving Ord in singletons-th not only derives POrd/SOrd instances, but it also
+  derives Ord instances for the singleton types themselves.
 * Deriving Show in singletons-th not only derives PShow/SShow instances, but it
-  also derives Show instances for singletons-th types.
+  also derives Show instances for the singleton types themselves.
 
 To make this work, we let partitionDecs handle the P{Eq,Show} and S{Eq,Show}
 instances, but we also stick the relevant info into a DerivedDecl value for
 later use in Data.Singletons.TH.Single, where we additionally generate
-SDecide, TestEquality, TestCoercion and Show instances for singleton types.
+SDecide, Eq, TestEquality, TestCoercion and Show instances for singleton types.
 -}


### PR DESCRIPTION
* `singletons-th` now generates `Eq` or `Ord` instances for data types that derive `Eq` or `Ord` instances, respectively.
* `singletons-base` now defines `Eq` and `Ord` instances by hand for types that do not derive their `Eq` instances (e.g., `SProxy`). It also adds derived `Eq` instances for `Sum`, `Product`, and `Compose` (which were lacking them before) to generate `Eq` and `Ord` instances for the corresponding singleton types.

Fixes #561.