### PR TITLE
Prefer user-written binder names in singled data type SAKS

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -245,7 +245,7 @@ jobs:
           source-repository-package
             type:     git
             location: https://github.com/goldfirere/th-desugar
-            tag:      94ad694765f70f2f0f296c2fc6c5e0e4ace42afb
+            tag:      f7db712e95a125e710cefc7cd819c6480f7e52e3
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(singletons|singletons-base|singletons-th)$/; }' >> cabal.project.local
           cat cabal.project

--- a/cabal.project
+++ b/cabal.project
@@ -5,4 +5,4 @@ packages: ./singletons
 source-repository-package
   type: git
   location: https://github.com/goldfirere/th-desugar
-  tag: 94ad694765f70f2f0f296c2fc6c5e0e4ace42afb
+  tag: f7db712e95a125e710cefc7cd819c6480f7e52e3

--- a/singletons-base/tests/SingletonsBaseTestSuite.hs
+++ b/singletons-base/tests/SingletonsBaseTestSuite.hs
@@ -148,6 +148,7 @@ tests =
     , compileAndDumpStdTest "T536"
     , compileAndDumpStdTest "T555"
     , compileAndDumpStdTest "T559"
+    , compileAndDumpStdTest "T567"
     ],
     testCompileAndDumpGroup "Promote"
     [ compileAndDumpStdTest "Constructors"

--- a/singletons-base/tests/compile-and-dump/Singletons/T567.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T567.golden
@@ -1,0 +1,62 @@
+Singletons/T567.hs:(0,0)-(0,0): Splicing declarations
+    withOptions defaultOptions {genSingKindInsts = False}
+      $ singletons
+          [d| type D1 :: forall k. forall (a :: k) -> Proxy a -> Type
+              type D2 :: forall k. forall (a :: k) -> Proxy a -> Type
+              type D3 :: forall k. forall (a :: k) -> Proxy a -> Type
+              type D4 :: forall k. forall (a :: k) -> Proxy a -> Type
+              
+              data D1 x p = MkD1
+              data D2 (x :: j) p = MkD2
+              data D3 x (p :: Proxy x) = MkD3
+              data D4 (x :: j) (p :: Proxy x) = MkD4 |]
+  ======>
+    type D1 :: forall k. forall (a :: k) -> Proxy a -> Type
+    data D1 x p = MkD1
+    type D2 :: forall k. forall (a :: k) -> Proxy a -> Type
+    data D2 (x :: j) p = MkD2
+    type D3 :: forall k. forall (a :: k) -> Proxy a -> Type
+    data D3 x (p :: Proxy x) = MkD3
+    type D4 :: forall k. forall (a :: k) -> Proxy a -> Type
+    data D4 (x :: j) (p :: Proxy x) = MkD4
+    type MkD1Sym0 :: forall x p. D1 x p
+    type family MkD1Sym0 :: D1 x p where
+      MkD1Sym0 = MkD1
+    type MkD2Sym0 :: forall j (x :: j) p. D2 (x :: j) p
+    type family MkD2Sym0 :: D2 (x :: j) p where
+      MkD2Sym0 = MkD2
+    type MkD3Sym0 :: forall x (p :: Proxy x). D3 x (p :: Proxy x)
+    type family MkD3Sym0 :: D3 x (p :: Proxy x) where
+      MkD3Sym0 = MkD3
+    type MkD4Sym0 :: forall j
+                            (x :: j)
+                            (p :: Proxy x). D4 (x :: j) (p :: Proxy x)
+    type family MkD4Sym0 :: D4 (x :: j) (p :: Proxy x) where
+      MkD4Sym0 = MkD4
+    type SD1 :: forall k (x :: k) (p :: Proxy x). D1 x p -> Type
+    data SD1 :: forall k (x :: k) (p :: Proxy x). D1 x p -> Type
+      where SMkD1 :: forall x p. SD1 (MkD1 :: D1 x p)
+    type instance Sing @(D1 x p) = SD1
+    type SD2 :: forall j (x :: j) (p :: Proxy x). D2 x p -> Type
+    data SD2 :: forall j (x :: j) (p :: Proxy x). D2 x p -> Type
+      where SMkD2 :: forall j (x :: j) p. SD2 (MkD2 :: D2 (x :: j) p)
+    type instance Sing @(D2 x p) = SD2
+    type SD3 :: forall k (x :: k) (p :: Proxy x). D3 x p -> Type
+    data SD3 :: forall k (x :: k) (p :: Proxy x). D3 x p -> Type
+      where
+        SMkD3 :: forall x (p :: Proxy x). SD3 (MkD3 :: D3 x (p :: Proxy x))
+    type instance Sing @(D3 x p) = SD3
+    type SD4 :: forall j (x :: j) (p :: Proxy x). D4 x p -> Type
+    data SD4 :: forall j (x :: j) (p :: Proxy x). D4 x p -> Type
+      where
+        SMkD4 :: forall j (x :: j) (p :: Proxy x).
+                 SD4 (MkD4 :: D4 (x :: j) (p :: Proxy x))
+    type instance Sing @(D4 x p) = SD4
+    instance SingI MkD1 where
+      sing = SMkD1
+    instance SingI MkD2 where
+      sing = SMkD2
+    instance SingI MkD3 where
+      sing = SMkD3
+    instance SingI MkD4 where
+      sing = SMkD4

--- a/singletons-base/tests/compile-and-dump/Singletons/T567.hs
+++ b/singletons-base/tests/compile-and-dump/Singletons/T567.hs
@@ -1,0 +1,21 @@
+module T567 where
+
+import Data.Kind (Type)
+import Data.Proxy (Proxy)
+import Data.Singletons.TH.Options
+import Data.Singletons.Base.TH
+
+$(withOptions defaultOptions{genSingKindInsts = False} $
+  singletons [d|
+  type D1 :: forall k. forall (a :: k) -> Proxy a -> Type
+  data D1 x p = MkD1
+
+  type D2 :: forall k. forall (a :: k) -> Proxy a -> Type
+  data D2 (x :: j) p = MkD2
+
+  type D3 :: forall k. forall (a :: k) -> Proxy a -> Type
+  data D3 x (p :: Proxy x) = MkD3
+
+  type D4 :: forall k. forall (a :: k) -> Proxy a -> Type
+  data D4 (x :: j) (p :: Proxy x) = MkD4
+  |])

--- a/singletons-th/CHANGES.md
+++ b/singletons-th/CHANGES.md
@@ -13,6 +13,8 @@ next [????.??.??]
   instance Ord (SExample a) where
     compare _ _ = EQ
   ```
+* Fix a bug in which data types using visible dependent quantification would
+  generate ill-scoped code when singled.
 
 3.2 [2023.03.12]
 ----------------


### PR DESCRIPTION
Previously, the algorithm for computing a standalone kind signature for a singled data type's standalone kind signature was poorly implemented, and it would combine type variables from the original data type's standalone kind signature alongside type variables from the user-written binders in the data type declaration. The result was that it was possible for `singletons-th` to single a data type and produce a standalone kind signature that was completely ill-scoped, as seen in https://github.com/goldfirere/singletons/issues/567.

This patch implements a new algorithm that is closely based on GHC's `matchUpSigWithDecl` function, which GHC uses to match up type variables from data type SAKS with their user-written binders. While more verbose, the new algorithm is (in my opinion) easier to understand and maintain. The new algorithm will also make it much easier to add support for invisible binders in data types declarations, which will arrive in GHC 9.8.

This bumps the `th-desugar` source-repository-package to bring in the changes from https://github.com/goldfirere/th-desugar/pull/189, which are required to make the `T567` test case's scoping work out correctly.

Fixes https://github.com/goldfirere/singletons/issues/567.