### PR TITLE
Clean up local variable tracking in `SgM`

### DIFF
--- a/singletons-base/tests/SingletonsBaseTestSuite.hs
+++ b/singletons-base/tests/SingletonsBaseTestSuite.hs
@@ -149,6 +149,7 @@ tests =
     , compileAndDumpStdTest "T555"
     , compileAndDumpStdTest "T559"
     , compileAndDumpStdTest "T567"
+    , compileAndDumpStdTest "T571"
     ],
     testCompileAndDumpGroup "Promote"
     [ compileAndDumpStdTest "Constructors"

--- a/singletons-base/tests/compile-and-dump/Singletons/T571.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T571.golden
@@ -1,0 +1,66 @@
+Singletons/T571.hs:(0,0)-(0,0): Splicing declarations
+    singletons
+      [d| f :: a -> a
+          f x = x |]
+  ======>
+    f :: a -> a
+    f x = x
+    type FSym0 :: (~>) a a
+    data FSym0 :: (~>) a a
+      where
+        FSym0KindInference :: SameKind (Apply FSym0 arg) (FSym1 arg) =>
+                              FSym0 a0123456789876543210
+    type instance Apply FSym0 a0123456789876543210 = F a0123456789876543210
+    instance SuppressUnusedWarnings FSym0 where
+      suppressUnusedWarnings = snd ((,) FSym0KindInference ())
+    type FSym1 :: a -> a
+    type family FSym1 (a0123456789876543210 :: a) :: a where
+      FSym1 a0123456789876543210 = F a0123456789876543210
+    type F :: a -> a
+    type family F (a :: a) :: a where
+      F x = x
+    sF ::
+      (forall (t :: a). Sing t -> Sing (Apply FSym0 t :: a) :: Type)
+    sF (sX :: Sing x) = sX
+    instance SingI (FSym0 :: (~>) a a) where
+      sing = singFun1 @FSym0 sF
+Singletons/T571.hs:(0,0)-(0,0): Splicing declarations
+    singletons
+      [d| g :: (a -> a) -> a -> a
+          g f x = f x |]
+  ======>
+    g :: (a -> a) -> a -> a
+    g f x = f x
+    type GSym0 :: (~>) ((~>) a a) ((~>) a a)
+    data GSym0 :: (~>) ((~>) a a) ((~>) a a)
+      where
+        GSym0KindInference :: SameKind (Apply GSym0 arg) (GSym1 arg) =>
+                              GSym0 a0123456789876543210
+    type instance Apply GSym0 a0123456789876543210 = GSym1 a0123456789876543210
+    instance SuppressUnusedWarnings GSym0 where
+      suppressUnusedWarnings = snd ((,) GSym0KindInference ())
+    type GSym1 :: (~>) a a -> (~>) a a
+    data GSym1 (a0123456789876543210 :: (~>) a a) :: (~>) a a
+      where
+        GSym1KindInference :: SameKind (Apply (GSym1 a0123456789876543210) arg) (GSym2 a0123456789876543210 arg) =>
+                              GSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (GSym1 a0123456789876543210) a0123456789876543210 = G a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (GSym1 a0123456789876543210) where
+      suppressUnusedWarnings = snd ((,) GSym1KindInference ())
+    type GSym2 :: (~>) a a -> a -> a
+    type family GSym2 (a0123456789876543210 :: (~>) a a) (a0123456789876543210 :: a) :: a where
+      GSym2 a0123456789876543210 a0123456789876543210 = G a0123456789876543210 a0123456789876543210
+    type G :: (~>) a a -> a -> a
+    type family G (a :: (~>) a a) (a :: a) :: a where
+      G f x = Apply f x
+    sG ::
+      (forall (t :: (~>) a a) (t :: a).
+       Sing t -> Sing t -> Sing (Apply (Apply GSym0 t) t :: a) :: Type)
+    sG (sF :: Sing f) (sX :: Sing x) = applySing sF sX
+    instance SingI (GSym0 :: (~>) ((~>) a a) ((~>) a a)) where
+      sing = singFun2 @GSym0 sG
+    instance SingI d => SingI (GSym1 (d :: (~>) a a) :: (~>) a a) where
+      sing = singFun1 @(GSym1 (d :: (~>) a a)) (sG (sing @d))
+    instance SingI1 (GSym1 :: (~>) a a -> (~>) a a) where
+      liftSing (s :: Sing (d :: (~>) a a))
+        = singFun1 @(GSym1 (d :: (~>) a a)) (sG s)

--- a/singletons-base/tests/compile-and-dump/Singletons/T571.hs
+++ b/singletons-base/tests/compile-and-dump/Singletons/T571.hs
@@ -1,0 +1,13 @@
+module T571 where
+
+import Data.Singletons.TH
+
+$(singletons [d|
+  f :: a -> a
+  f x = x
+  |])
+
+$(singletons [d|
+  g :: (a -> a) -> a -> a
+  g f x = f x
+  |])

--- a/singletons-th/CHANGES.md
+++ b/singletons-th/CHANGES.md
@@ -15,6 +15,8 @@ next [????.??.??]
   ```
 * Fix a bug in which data types using visible dependent quantification would
   generate ill-scoped code when singled.
+* Fix a bug in which singling a local variable that shadows a top-level
+  definition would fail to typecheck in some circumstances.
 
 3.2 [2023.03.12]
 ----------------

--- a/singletons-th/src/Data/Singletons/TH/Names.hs
+++ b/singletons-th/src/Data/Singletons/TH/Names.hs
@@ -167,6 +167,11 @@ pureName = 'pure
 apName = '(<*>)
 liftA2Name = 'liftA2
 
+-- | Return a fresh alphanumeric 'Name'. In particular, if the supplied 'Name'
+-- is symbolic (e.g., (%%)), then return a fresh 'Name' with the 'OccName' @ty@.
+-- Otherwise, return a fresh 'Name' with the same 'OccName' as the supplied
+-- 'Name'. See @Note [Tracking local variables]@ in
+-- "Data.Singletons.TH.Promote.Monad" for why we do this.
 mkTyName :: Quasi q => Name -> q Name
 mkTyName tmName = do
   let nameStr  = nameBase tmName

--- a/singletons-th/src/Data/Singletons/TH/Promote/Monad.hs
+++ b/singletons-th/src/Data/Singletons/TH/Promote/Monad.hs
@@ -24,21 +24,24 @@ import Language.Haskell.TH.Desugar.OMap.Strict (OMap)
 import Data.Singletons.TH.Options
 import Data.Singletons.TH.Syntax
 
-type LetExpansions = OMap Name DType  -- from **term-level** name
-
 -- environment during promotion
 data PrEnv =
-  PrEnv { pr_options      :: Options
-        , pr_lambda_bound :: OMap Name Name
-        , pr_let_bound    :: LetExpansions
-        , pr_local_decls  :: [Dec]
+  PrEnv { pr_options     :: Options
+        , pr_lambda_vars :: OMap Name Name
+          -- ^ Map from term-level 'Name's of variables bound in lambdas and
+          -- function clauses to their type-level counterparts.
+          -- See @Note [Tracking local variables]@.
+        , pr_local_vars  :: OMap Name DType
+          -- ^ Map from term-level 'Name's of local variables to their
+          -- type-level counterparts. See @Note [Tracking local variables]@.
+        , pr_local_decls :: [Dec]
         }
 
 emptyPrEnv :: PrEnv
-emptyPrEnv = PrEnv { pr_options      = defaultOptions
-                   , pr_lambda_bound = OMap.empty
-                   , pr_let_bound    = OMap.empty
-                   , pr_local_decls  = [] }
+emptyPrEnv = PrEnv { pr_options     = defaultOptions
+                   , pr_lambda_vars = OMap.empty
+                   , pr_local_vars  = OMap.empty
+                   , pr_local_decls = [] }
 
 -- the promotion monad
 newtype PrM a = PrM (ReaderT PrEnv (WriterT [DDec] Q) a)
@@ -55,14 +58,8 @@ instance OptionsMonad PrM where
 -- return *type-level* names
 allLocals :: MonadReader PrEnv m => m [Name]
 allLocals = do
-  lambdas <- asks (OMap.assocs . pr_lambda_bound)
-  lets    <- asks pr_let_bound
-    -- filter out shadowed variables!
-  return [ typeName
-         | (termName, typeName) <- lambdas
-         , case OMap.lookup termName lets of
-             Just (DVarT typeName') | typeName' == typeName -> True
-             _                                              -> False ]
+  lambdas <- asks (OMap.assocs . pr_lambda_vars)
+  return $ map snd lambdas
 
 emitDecs :: MonadWriter [DDec] m => [DDec] -> m ()
 emitDecs = tell
@@ -72,27 +69,38 @@ emitDecsM action = do
   decs <- action
   emitDecs decs
 
--- when lambda-binding variables, we still need to add the variables
--- to the let-expansion, because of shadowing. ugh.
+-- ^ Bring a list of 'VarPromotions' into scope for the duration the supplied
+-- computation. See @Note [Tracking local variables]@.
 lambdaBind :: VarPromotions -> PrM a -> PrM a
 lambdaBind binds = local add_binds
-  where add_binds env@(PrEnv { pr_lambda_bound = lambdas
-                             , pr_let_bound    = lets }) =
-          let new_lets = OMap.fromList [ (tmN, DVarT tyN) | (tmN, tyN) <- binds ] in
-          env { pr_lambda_bound = OMap.fromList binds `OMap.union` lambdas
-              , pr_let_bound    = new_lets            `OMap.union` lets }
+  where add_binds env@(PrEnv { pr_lambda_vars = lambdas
+                             , pr_local_vars  = locals }) =
+          -- Per Note [Tracking local variables], these will be added to both
+          -- `pr_lambda_vars` and `pr_local_vars`.
+          let new_locals = OMap.fromList [ (tmN, DVarT tyN) | (tmN, tyN) <- binds ] in
+          env { pr_lambda_vars = OMap.fromList binds `OMap.union` lambdas
+              , pr_local_vars  = new_locals          `OMap.union` locals }
 
+-- ^ A pair consisting of a term-level 'Name' of a variable, bound in a @let@
+-- binding or @where@ clause, and its type-level counterpart.
+-- See @Note [Tracking local variables]@.
 type LetBind = (Name, DType)
+
+-- ^ Bring a list of 'LetBind's into scope for the duration the supplied
+-- computation. See @Note [Tracking local variables]@.
 letBind :: [LetBind] -> PrM a -> PrM a
 letBind binds = local add_binds
-  where add_binds env@(PrEnv { pr_let_bound = lets }) =
-          env { pr_let_bound = OMap.fromList binds `OMap.union` lets }
+  where add_binds env@(PrEnv { pr_local_vars = locals }) =
+          env { pr_local_vars = OMap.fromList binds `OMap.union` locals }
 
+-- | Map a term-level 'Name' to its type-level counterpart. This function is
+-- aware of any local variables that are currently in scope.
+-- See @Note [Tracking local variables]@.
 lookupVarE :: Name -> PrM DType
 lookupVarE n = do
   opts <- getOptions
-  lets <- asks pr_let_bound
-  case OMap.lookup n lets of
+  locals <- asks pr_local_vars
+  case OMap.lookup n locals of
     Just ty -> return ty
     Nothing -> return $ DConT $ defunctionalizedName0 opts n
 
@@ -115,3 +123,123 @@ promoteMDecs :: OptionsMonad q => [Dec] -> PrM [DDec] -> q [DDec]
 promoteMDecs locals thing = do
   (decs1, decs2) <- promoteM locals thing
   return $ decs1 ++ decs2
+
+{-
+Note [Tracking local variables]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Handling local variables in singletons-th requires some care. There are two
+sorts of local variables that singletons-th tracks:
+
+1. Lambda-bound variables, e.g.,
+
+     f = \x -> x
+     g x = x
+
+   In both `f` and `g`, the variable `x` is considered lambda-bound.
+
+2. Let-bound variables, e.g.,
+
+     h =
+       let x = 42 in
+       x + x
+
+     i = x + x
+       where
+         x = 42
+
+   In both `h` and `i`, the variable `x` is considered let-bound.
+
+Why does singletons-th need to track local variables? It's because they must
+be promoted differently depending on whether they are local or not. Consider:
+
+  j = ... x ...
+
+When promoting the `j` function to a type family `J`, there are three possible
+ways of promoting `x`:
+
+* If `x` is a lambda-bound variable, then `x` must be promoted to a type
+  variable. In general, we cannot promote `x` to the same name. Consider this
+  example:
+
+    j (%%) x y = x %% y
+
+  Here, `(%%)`, `x`, and `y` are lambda-bound variables. But we cannot promote
+  `j` to this type family:
+
+    type family J (%%) x y where
+      J (%%) x y = x %% y
+
+  This is because type variable names cannot be symbolic like `(%%)` is. As a
+  result, we create a fresh name `ty` and promote each occurrence of `(%%)` to
+  `ty`:
+
+    type family J ty x y where
+      J ty x y = x `ty` y
+
+  See `mkTyName` in Data.Singletons.TH.Names. In fact, `mkTyName` will also
+  freshen alphanumeric names, so it would be more accurate to say that `j` will
+  be promoted to this:
+
+    type family J ty x_123 y_456 where
+      J ty x_123 y_456 = x_123 `ty` y_456
+
+  Where `x_123` and `y_456` are fresh names that are distinct from `x` and `y`.
+  Freshening alphanumeric names like `x` and `y` is probably not strictly
+  necessary, but `mkTyName` does it anyway (1) for consistency with symbolic
+  names and (2) to make the type-level names easier to tell apart from the
+  original term-level names.
+
+* If `x` is a let-bound variable, then `x` must be promoted to something like
+  `LetX`, where `LetX` is the lambda-lifted version of `x`. For instance, we
+  would promote this:
+
+    j = x
+      where
+        x = True
+
+  To this:
+
+    type family J where
+      J = LetX
+    type family LetX where
+      LetX = True
+
+* If `x` is not a local variable at all, then `x` must be promoted to something
+  like `X`, which is assumed to be a top-level function. For instance, we would
+  promote this:
+
+    x = 42
+    j = x
+
+  To this:
+
+    type family X where
+      X = 42
+    type family J where
+      J = X
+
+Being able to distinguish between all these sorts of variables requires
+recording whether they are lambda-/let-bound at their binding sites during
+promotion and singling. During promotion, the `pr_local_vars` field of `PrEnv`
+is responsible for this. In singling, the `sg_local_vars` field of `SgEnv` is
+responsible for this. Each of these fields are Maps from the original,
+term-level Names to the promoted or singled versions of the Names. The
+`lookupVarE` functions (which can be found in both
+Data.Singletons.TH.Promote.Monad and Data.Singletons.TH.Single.Monad) are
+responsible for determining what a term-level Name should be mapped to.
+
+In addition to `pr_local_vars` and `sg_local_vars`, which include both lambda-
+and let-bound variables, `PrEnv` also includes a separate `pr_lambda_vars`
+field, which only tracks lambda-bound variables. We must do this because
+lambda-bound variables are treated differently during lambda lifting.
+Lambda-lifted functions must close over any lambda-bound variables in scope,
+but /not/ any let-bound variables in scope, since the latter are lambda-lifted
+separately. (Because singling does not do anything akin to lambda lifting,
+`SgEnv` does not have anything like `sg_lambda_vars`.)
+
+A consequence of this is that when we lambda-bind a variable during promotion
+(see `lambdaBind`), we add the variable to both `pr_lambda_vars` and
+`pr_local_vars`.  When we let-bind a variable during promotion (see `letBind`),
+we only add the variable to `pr_local_vars`. This means that `pr_lambda_vars`
+will always be a subset of `pr_local_vars`.
+-}


### PR DESCRIPTION
Previously, `SgEnv` (the reader environment for `SgM`, the singling monad) was only tracking let-bound variables.  But as #571 reveals, it must track _lambda_-bound variables as well, lest the `lookupVarE` function accidentally look up a top-level function name instead of a local name that shadows it.

It turns out that `PrEnv` (the reader environment for `PrM`, the promotion monad) was already doing this, so this patch mostly copies the existing `PrM` treatment for lambda-bound variables over to `SgM`. While I was in town, I took the liberty to clean up the naming conventions a bit and document how all of this works in the new `Note [Tracking local variables]` in `Data.Singletons.TH.Promote.Monad`.

Fixes #571.