### PR TITLE
`singletons-{th,base}`: Require building with GHC 9.8 

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.16.6
+# version: 0.17.20231010
 #
-# REGENDATA ("0.16.6",["github","cabal.project"])
+# REGENDATA ("0.17.20231010",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -32,6 +32,11 @@ jobs:
             compilerKind: ghcjs
             compilerVersion: "8.4"
             setup-method: hvr-ppa
+            allow-failure: false
+          - compiler: ghc-9.8.1
+            compilerKind: ghc
+            compilerVersion: 9.8.1
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.6.2
             compilerKind: ghc
@@ -104,7 +109,7 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
@@ -116,7 +121,7 @@ jobs:
             apt-get update
             if [ $((GHCJSARITH)) -ne 0 ] ; then apt-get install -y "$HCNAME" ghc-8.4.4 nodejs ; else apt-get install -y "$HCNAME" ; fi
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
@@ -133,10 +138,12 @@ jobs:
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCDIR=/opt/$HCKIND/$HCVER
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
+            HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+            HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+            HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
             echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
+            echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
             echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
@@ -150,7 +157,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((! GHCJSARITH && HCNUMVER >= 90800)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -178,6 +185,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -210,8 +229,8 @@ jobs:
         run: |
           touch cabal.project
           echo "packages: $GITHUB_WORKSPACE/source/./singletons" >> cabal.project
-          if [ $((! GHCJSARITH && HCNUMVER >= 90600)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/./singletons-th" >> cabal.project ; fi
-          if [ $((! GHCJSARITH && HCNUMVER >= 90600)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/./singletons-base" >> cabal.project ; fi
+          if [ $((! GHCJSARITH && HCNUMVER >= 90800)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/./singletons-th" >> cabal.project ; fi
+          if [ $((! GHCJSARITH && HCNUMVER >= 90800)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/./singletons-base" >> cabal.project ; fi
           cat cabal.project
       - name: sdist
         run: |
@@ -233,20 +252,23 @@ jobs:
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_singletons}" >> cabal.project
-          if [ $((! GHCJSARITH && HCNUMVER >= 90600)) -ne 0 ] ; then echo "packages: ${PKGDIR_singletons_th}" >> cabal.project ; fi
-          if [ $((! GHCJSARITH && HCNUMVER >= 90600)) -ne 0 ] ; then echo "packages: ${PKGDIR_singletons_base}" >> cabal.project ; fi
+          if [ $((! GHCJSARITH && HCNUMVER >= 90800)) -ne 0 ] ; then echo "packages: ${PKGDIR_singletons_th}" >> cabal.project ; fi
+          if [ $((! GHCJSARITH && HCNUMVER >= 90800)) -ne 0 ] ; then echo "packages: ${PKGDIR_singletons_base}" >> cabal.project ; fi
           if [ $((GHCJSARITH || ! GHCJSARITH && HCNUMVER >= 80200)) -ne 0 ] ; then echo "package singletons" >> cabal.project ; fi
           if [ $((GHCJSARITH || ! GHCJSARITH && HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
-          if [ $((! GHCJSARITH && HCNUMVER >= 90600)) -ne 0 ] ; then echo "package singletons-th" >> cabal.project ; fi
-          if [ $((! GHCJSARITH && HCNUMVER >= 90600)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
-          if [ $((! GHCJSARITH && HCNUMVER >= 90600)) -ne 0 ] ; then echo "package singletons-base" >> cabal.project ; fi
-          if [ $((! GHCJSARITH && HCNUMVER >= 90600)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          if [ $((! GHCJSARITH && HCNUMVER >= 90800)) -ne 0 ] ; then echo "package singletons-th" >> cabal.project ; fi
+          if [ $((! GHCJSARITH && HCNUMVER >= 90800)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          if [ $((! GHCJSARITH && HCNUMVER >= 90800)) -ne 0 ] ; then echo "package singletons-base" >> cabal.project ; fi
+          if [ $((! GHCJSARITH && HCNUMVER >= 90800)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           source-repository-package
             type:     git
             location: https://github.com/goldfirere/th-desugar
             tag:      47f6221088ac6185566066b4d45909b0cc704855
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(singletons|singletons-base|singletons-th)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
@@ -274,10 +296,10 @@ jobs:
         run: |
           cd ${PKGDIR_singletons} || false
           ${CABAL} -vnormal check
-          if [ $((! GHCJSARITH && HCNUMVER >= 90600)) -ne 0 ] ; then cd ${PKGDIR_singletons_th} || false ; fi
-          if [ $((! GHCJSARITH && HCNUMVER >= 90600)) -ne 0 ] ; then ${CABAL} -vnormal check ; fi
-          if [ $((! GHCJSARITH && HCNUMVER >= 90600)) -ne 0 ] ; then cd ${PKGDIR_singletons_base} || false ; fi
-          if [ $((! GHCJSARITH && HCNUMVER >= 90600)) -ne 0 ] ; then ${CABAL} -vnormal check ; fi
+          if [ $((! GHCJSARITH && HCNUMVER >= 90800)) -ne 0 ] ; then cd ${PKGDIR_singletons_th} || false ; fi
+          if [ $((! GHCJSARITH && HCNUMVER >= 90800)) -ne 0 ] ; then ${CABAL} -vnormal check ; fi
+          if [ $((! GHCJSARITH && HCNUMVER >= 90800)) -ne 0 ] ; then cd ${PKGDIR_singletons_base} || false ; fi
+          if [ $((! GHCJSARITH && HCNUMVER >= 90800)) -ne 0 ] ; then ${CABAL} -vnormal check ; fi
       - name: haddock
         run: |
           if [ $((! GHCJSARITH)) -ne 0 ] ; then $CABAL v2-haddock --disable-documentation $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all ; fi

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ windows for requirements on the compiler version needed to build each library:
   GHC language extensions, even more so than `singletons` itself. As such, it
   is difficult to maintain support for multiple GHC versions in any given
   release of either library, so they only support the latest major GHC version
-  (currently GHC 9.6).
+  (currently GHC 9.8).
 
 Any code that uses the singleton-generation functionality from `singletons-th`
 or `singletons-base` needs to enable a long list of GHC extensions. This list

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ includes, but is not necessarily limited to, the following:
 * `StandaloneDeriving`
 * `StandaloneKindSignatures`
 * `TemplateHaskell`
+* `TypeAbstractions`
 * `TypeApplications`
 * `TypeFamilies`
 * `TypeOperators`
@@ -834,6 +835,7 @@ The following constructs are fully supported:
 * signatures (e.g., `(x :: Maybe a)`) in expressions
 * `InstanceSigs`
 * `TypeData`
+* `TypeAbstractions`
 
 ## Partial support
 

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -4,3 +4,5 @@ unconstrained:          False
 jobs-selection:         any
 -- Needed to avoid https://github.com/haskell/cabal/issues/5423
 haddock-components:     libs
+-- Temporarily use head.hackage for GHC 9.8 until the ecosystem catches up
+head-hackage:           >= 9.8

--- a/singletons-base/CHANGES.md
+++ b/singletons-base/CHANGES.md
@@ -3,6 +3,7 @@ Changelog for the `singletons-base` project
 
 next [????.??.??]
 -----------------
+* Require building with GHC 9.8.
 * All singleton types with `SEq` or `SOrd` instances now have `Eq` or `Ord`
   instances of the form:
 

--- a/singletons-base/README.md
+++ b/singletons-base/README.md
@@ -18,7 +18,7 @@ that code with `singletons-base`.
 
 `singletons-base` uses code that relies on bleeding-edge GHC language
 extensions. As such, `singletons-base` only supports the latest major version
-of GHC (currently GHC 9.6). For more information,
+of GHC (currently GHC 9.8). For more information,
 consult the `singletons`
 [`README`](https://github.com/goldfirere/singletons/blob/master/README.md).
 

--- a/singletons-base/singletons-base.cabal
+++ b/singletons-base/singletons-base.cabal
@@ -8,7 +8,7 @@ author:         Richard Eisenberg <rae@cs.brynmawr.edu>, Jan Stolarek <jan.stola
 maintainer:     Ryan Scott <ryan.gl.scott@gmail.com>
 bug-reports:    https://github.com/goldfirere/singletons/issues
 stability:      experimental
-tested-with:    GHC == 9.6.2
+tested-with:    GHC == 9.8.1
 extra-source-files: README.md, CHANGES.md, tests/README.md,
                     tests/compile-and-dump/GradingClient/*.hs,
                     tests/compile-and-dump/InsertionSort/*.hs,
@@ -38,7 +38,7 @@ description:
     .
     @singletons-base@ uses code that relies on bleeding-edge GHC language
     extensions. As such, @singletons-base@ only supports the latest major version
-    of GHC (currently GHC 9.6). For more information,
+    of GHC (currently GHC 9.8). For more information,
     consult the @singletons@
     @<https://github.com/goldfirere/singletons/blob/master/README.md README>@.
     .

--- a/singletons-base/singletons-base.cabal
+++ b/singletons-base/singletons-base.cabal
@@ -65,18 +65,18 @@ source-repository head
 
 custom-setup
   setup-depends:
-    base      >= 4.18 && < 4.19,
-    Cabal     >= 3.0 && < 3.11,
+    base      >= 4.19 && < 4.20,
+    Cabal     >= 3.0 && < 3.13,
     directory >= 1,
     filepath  >= 1.3
 
 library
   hs-source-dirs:     src
-  build-depends:      base             >= 4.18 && < 4.19,
+  build-depends:      base             >= 4.19 && < 4.20,
                       pretty,
                       singletons       == 3.0.*,
                       singletons-th    >= 3.2  && < 3.3,
-                      template-haskell >= 2.20 && < 2.21,
+                      template-haskell >= 2.21 && < 2.22,
                       text >= 1.2,
                       th-desugar       >= 1.16 && < 1.17
   default-language:   GHC2021
@@ -155,7 +155,7 @@ test-suite singletons-base-test-suite
   main-is:            SingletonsBaseTestSuite.hs
   other-modules:      SingletonsBaseTestSuiteUtils
 
-  build-depends:      base >= 4.18 && < 4.19,
+  build-depends:      base >= 4.19 && < 4.20,
                       bytestring >= 0.10.9,
                       deepseq >= 1.4.4,
                       filepath >= 1.3,

--- a/singletons-base/tests/SingletonsBaseTestSuite.hs
+++ b/singletons-base/tests/SingletonsBaseTestSuite.hs
@@ -151,6 +151,7 @@ tests =
     , compileAndDumpStdTest "T559"
     , compileAndDumpStdTest "T567"
     , compileAndDumpStdTest "T571"
+    , compileAndDumpStdTest "TypeAbstractions"
     ],
     testCompileAndDumpGroup "Promote"
     [ compileAndDumpStdTest "Constructors"

--- a/singletons-base/tests/SingletonsBaseTestSuiteUtils.hs
+++ b/singletons-base/tests/SingletonsBaseTestSuiteUtils.hs
@@ -59,6 +59,7 @@ ghcOpts = ghcFlags ++ [
   , "-XCPP"
   , "-XNoStarIsType"
   , "-XNoNamedWildCards"
+  , "-XTypeAbstractions"
   ]
 
 -- Compile a test using specified GHC options. Save output to file, normalize

--- a/singletons-base/tests/compile-and-dump/GradingClient/Database.hs
+++ b/singletons-base/tests/compile-and-dump/GradingClient/Database.hs
@@ -215,12 +215,12 @@ readRow id (SSch (SCons (SAttr _ u) at)) (sh:st) = do
   (rowTail, strTail) <- readRow id (SSch at) st
   case elUReadInstance u of
     ElUReadInstance ->
-      let results = readsPrec 0 sh in
-      if null results
-        then throwError $ "No parse of " ++ sh ++ " as a " ++
-                          (show (fromSing u))
-        else
-          let item = fst $ head results in
+      case readsPrec 0 sh of
+        [] ->
+          throwError $ "No parse of " ++ sh ++ " as a " ++
+                       (show (fromSing u))
+        result:_ ->
+          let item = fst result in
           case elUShowInstance u of
             ElUShowInstance -> return (ConsRow item rowTail, strTail)
 

--- a/singletons-base/tests/compile-and-dump/Singletons/T342.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T342.golden
@@ -1,7 +1,7 @@
 Singletons/T342.hs:(0,0)-(0,0): Splicing declarations
     do synName <- newName "MyId"
        a <- newName "a"
-       let dsyn = DTySynD synName [DPlainTV a ()] (DVarT a)
+       let dsyn = DTySynD synName [DPlainTV a BndrReq] (DVarT a)
            syn = decToTH dsyn
        defuns <- withLocalDeclarations [syn] $ genDefunSymbols [synName]
        pure $ syn : defuns

--- a/singletons-base/tests/compile-and-dump/Singletons/T342.hs
+++ b/singletons-base/tests/compile-and-dump/Singletons/T342.hs
@@ -6,7 +6,7 @@ import Language.Haskell.TH.Desugar
 
 $(do synName <- newName "MyId"
      a       <- newName "a"
-     let dsyn = DTySynD synName [DPlainTV a ()] (DVarT a)
+     let dsyn = DTySynD synName [DPlainTV a BndrReq] (DVarT a)
          syn  = decToTH dsyn
      defuns <- withLocalDeclarations [syn] $
                genDefunSymbols [synName]

--- a/singletons-base/tests/compile-and-dump/Singletons/TypeAbstractions.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/TypeAbstractions.golden
@@ -1,0 +1,336 @@
+Singletons/TypeAbstractions.hs:(0,0)-(0,0): Splicing declarations
+    withOptions defaultOptions {genSingKindInsts = False}
+      $ singletons
+          [d| type D1 :: forall j k. j -> k -> Type
+              type D2 :: forall j k. j -> k -> Type
+              type D3 :: forall j. j -> forall k. k -> Type
+              type D4 :: forall (a :: Type). Type
+              type C1 :: forall j k. j -> k -> Constraint
+              type C2 :: forall j k. j -> k -> Constraint
+              type C3 :: forall j. j -> forall k. k -> Constraint
+              type C4 :: forall (a :: Type). Constraint
+              type TF :: forall j. j -> forall k. k -> Type
+              type TS :: forall j. j -> forall k. k -> Type
+              
+              data D1 @j @k (a :: j) (b :: k) = MkD1 (Proxy a) (Proxy b)
+              data D2 @x @y (a :: x) (b :: y) = MkD2 (Proxy a) (Proxy b)
+              data D3 @j (a :: j) @k (b :: k) = MkD3 (Proxy a) (Proxy b)
+              data D4 @a = MkD4 a
+              class C1 @j @k (a :: j) (b :: k) where
+                meth1 :: Proxy a -> Proxy b
+              class C2 @x @y (a :: x) (b :: y) where
+                meth2 :: Proxy a -> Proxy b
+              class C3 @j (a :: j) @k (b :: k) where
+                meth3 :: Proxy a -> Proxy b
+              class C4 @a where
+                meth4 :: a
+              type family TF @j (a :: j) @k (b :: k) where
+                TF @j _ @k _ = (j, k)
+              type TS @j (a :: j) @k (b :: k) = (j, k) |]
+  ======>
+    type D1 :: forall j k. j -> k -> Type
+    data D1 @j @k (a :: j) (b :: k) = MkD1 (Proxy a) (Proxy b)
+    type D2 :: forall j k. j -> k -> Type
+    data D2 @x @y (a :: x) (b :: y) = MkD2 (Proxy a) (Proxy b)
+    type D3 :: forall j. j -> forall k. k -> Type
+    data D3 @j (a :: j) @k (b :: k) = MkD3 (Proxy a) (Proxy b)
+    type D4 :: forall (a :: Type). Type
+    data D4 @a = MkD4 a
+    type C1 :: forall j k. j -> k -> Constraint
+    class C1 @j @k (a :: j) (b :: k) where
+      meth1 :: Proxy a -> Proxy b
+    type C2 :: forall j k. j -> k -> Constraint
+    class C2 @x @y (a :: x) (b :: y) where
+      meth2 :: Proxy a -> Proxy b
+    type C3 :: forall j. j -> forall k. k -> Constraint
+    class C3 @j (a :: j) @k (b :: k) where
+      meth3 :: Proxy a -> Proxy b
+    type C4 :: forall (a :: Type). Constraint
+    class C4 @a where
+      meth4 :: a
+    type TF :: forall j. j -> forall k. k -> Type
+    type family TF @j (a :: j) @k (b :: k) where
+      TF @j _ @k _ = (j, k)
+    type TS :: forall j. j -> forall k. k -> Type
+    type TS @j (a :: j) @k (b :: k) = (j, k)
+    data TSSym0 :: (~>) j0123456789876543210 ((~>) k0123456789876543210 Type)
+      where
+        TSSym0KindInference :: SameKind (Apply TSSym0 arg) (TSSym1 arg) =>
+                               TSSym0 e0123456789876543210
+    type instance Apply TSSym0 e0123456789876543210 = TSSym1 e0123456789876543210
+    instance SuppressUnusedWarnings TSSym0 where
+      suppressUnusedWarnings = snd ((,) TSSym0KindInference ())
+    data TSSym1 (e0123456789876543210 :: j0123456789876543210) :: (~>) k0123456789876543210 Type
+      where
+        TSSym1KindInference :: SameKind (Apply (TSSym1 e0123456789876543210) arg) (TSSym2 e0123456789876543210 arg) =>
+                               TSSym1 e0123456789876543210 e0123456789876543210
+    type instance Apply (TSSym1 e0123456789876543210) e0123456789876543210 = TS e0123456789876543210 e0123456789876543210
+    instance SuppressUnusedWarnings (TSSym1 e0123456789876543210) where
+      suppressUnusedWarnings = snd ((,) TSSym1KindInference ())
+    type family TSSym2 (e0123456789876543210 :: j0123456789876543210) (e0123456789876543210 :: k0123456789876543210) :: Type where
+      TSSym2 e0123456789876543210 e0123456789876543210 = TS e0123456789876543210 e0123456789876543210
+    data TFSym0 :: (~>) j0123456789876543210 ((~>) k0123456789876543210 Type)
+      where
+        TFSym0KindInference :: SameKind (Apply TFSym0 arg) (TFSym1 arg) =>
+                               TFSym0 e0123456789876543210
+    type instance Apply TFSym0 e0123456789876543210 = TFSym1 e0123456789876543210
+    instance SuppressUnusedWarnings TFSym0 where
+      suppressUnusedWarnings = snd ((,) TFSym0KindInference ())
+    data TFSym1 (e0123456789876543210 :: j0123456789876543210) :: (~>) k0123456789876543210 Type
+      where
+        TFSym1KindInference :: SameKind (Apply (TFSym1 e0123456789876543210) arg) (TFSym2 e0123456789876543210 arg) =>
+                               TFSym1 e0123456789876543210 e0123456789876543210
+    type instance Apply (TFSym1 e0123456789876543210) e0123456789876543210 = TF e0123456789876543210 e0123456789876543210
+    instance SuppressUnusedWarnings (TFSym1 e0123456789876543210) where
+      suppressUnusedWarnings = snd ((,) TFSym1KindInference ())
+    type family TFSym2 (e0123456789876543210 :: j0123456789876543210) (e0123456789876543210 :: k0123456789876543210) :: Type where
+      TFSym2 e0123456789876543210 e0123456789876543210 = TF e0123456789876543210 e0123456789876543210
+    type MkD1Sym0 :: forall j
+                            k
+                            (a :: j)
+                            (b :: k). (~>) (Proxy a) ((~>) (Proxy b) (D1 @j @k a b))
+    data MkD1Sym0 :: (~>) (Proxy a) ((~>) (Proxy b) (D1 @j @k a b))
+      where
+        MkD1Sym0KindInference :: SameKind (Apply MkD1Sym0 arg) (MkD1Sym1 arg) =>
+                                 MkD1Sym0 a0123456789876543210
+    type instance Apply MkD1Sym0 a0123456789876543210 = MkD1Sym1 a0123456789876543210
+    instance SuppressUnusedWarnings MkD1Sym0 where
+      suppressUnusedWarnings = snd ((,) MkD1Sym0KindInference ())
+    type MkD1Sym1 :: forall j k (a :: j) (b :: k). Proxy a
+                                                   -> (~>) (Proxy b) (D1 @j @k a b)
+    data MkD1Sym1 (a0123456789876543210 :: Proxy a) :: (~>) (Proxy b) (D1 @j @k a b)
+      where
+        MkD1Sym1KindInference :: SameKind (Apply (MkD1Sym1 a0123456789876543210) arg) (MkD1Sym2 a0123456789876543210 arg) =>
+                                 MkD1Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (MkD1Sym1 a0123456789876543210) a0123456789876543210 = MkD1 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (MkD1Sym1 a0123456789876543210) where
+      suppressUnusedWarnings = snd ((,) MkD1Sym1KindInference ())
+    type MkD1Sym2 :: forall j k (a :: j) (b :: k). Proxy a
+                                                   -> Proxy b -> D1 @j @k a b
+    type family MkD1Sym2 (a0123456789876543210 :: Proxy a) (a0123456789876543210 :: Proxy b) :: D1 @j @k a b where
+      MkD1Sym2 a0123456789876543210 a0123456789876543210 = MkD1 a0123456789876543210 a0123456789876543210
+    type MkD2Sym0 :: forall x
+                            y
+                            (a :: x)
+                            (b :: y). (~>) (Proxy a) ((~>) (Proxy b) (D2 @x @y a b))
+    data MkD2Sym0 :: (~>) (Proxy a) ((~>) (Proxy b) (D2 @x @y a b))
+      where
+        MkD2Sym0KindInference :: SameKind (Apply MkD2Sym0 arg) (MkD2Sym1 arg) =>
+                                 MkD2Sym0 a0123456789876543210
+    type instance Apply MkD2Sym0 a0123456789876543210 = MkD2Sym1 a0123456789876543210
+    instance SuppressUnusedWarnings MkD2Sym0 where
+      suppressUnusedWarnings = snd ((,) MkD2Sym0KindInference ())
+    type MkD2Sym1 :: forall x y (a :: x) (b :: y). Proxy a
+                                                   -> (~>) (Proxy b) (D2 @x @y a b)
+    data MkD2Sym1 (a0123456789876543210 :: Proxy a) :: (~>) (Proxy b) (D2 @x @y a b)
+      where
+        MkD2Sym1KindInference :: SameKind (Apply (MkD2Sym1 a0123456789876543210) arg) (MkD2Sym2 a0123456789876543210 arg) =>
+                                 MkD2Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (MkD2Sym1 a0123456789876543210) a0123456789876543210 = MkD2 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (MkD2Sym1 a0123456789876543210) where
+      suppressUnusedWarnings = snd ((,) MkD2Sym1KindInference ())
+    type MkD2Sym2 :: forall x y (a :: x) (b :: y). Proxy a
+                                                   -> Proxy b -> D2 @x @y a b
+    type family MkD2Sym2 (a0123456789876543210 :: Proxy a) (a0123456789876543210 :: Proxy b) :: D2 @x @y a b where
+      MkD2Sym2 a0123456789876543210 a0123456789876543210 = MkD2 a0123456789876543210 a0123456789876543210
+    type MkD3Sym0 :: forall j
+                            (a :: j)
+                            k
+                            (b :: k). (~>) (Proxy a) ((~>) (Proxy b) (D3 @j a @k b))
+    data MkD3Sym0 :: (~>) (Proxy a) ((~>) (Proxy b) (D3 @j a @k b))
+      where
+        MkD3Sym0KindInference :: SameKind (Apply MkD3Sym0 arg) (MkD3Sym1 arg) =>
+                                 MkD3Sym0 a0123456789876543210
+    type instance Apply MkD3Sym0 a0123456789876543210 = MkD3Sym1 a0123456789876543210
+    instance SuppressUnusedWarnings MkD3Sym0 where
+      suppressUnusedWarnings = snd ((,) MkD3Sym0KindInference ())
+    type MkD3Sym1 :: forall j (a :: j) k (b :: k). Proxy a
+                                                   -> (~>) (Proxy b) (D3 @j a @k b)
+    data MkD3Sym1 (a0123456789876543210 :: Proxy a) :: (~>) (Proxy b) (D3 @j a @k b)
+      where
+        MkD3Sym1KindInference :: SameKind (Apply (MkD3Sym1 a0123456789876543210) arg) (MkD3Sym2 a0123456789876543210 arg) =>
+                                 MkD3Sym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (MkD3Sym1 a0123456789876543210) a0123456789876543210 = MkD3 a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (MkD3Sym1 a0123456789876543210) where
+      suppressUnusedWarnings = snd ((,) MkD3Sym1KindInference ())
+    type MkD3Sym2 :: forall j (a :: j) k (b :: k). Proxy a
+                                                   -> Proxy b -> D3 @j a @k b
+    type family MkD3Sym2 (a0123456789876543210 :: Proxy a) (a0123456789876543210 :: Proxy b) :: D3 @j a @k b where
+      MkD3Sym2 a0123456789876543210 a0123456789876543210 = MkD3 a0123456789876543210 a0123456789876543210
+    type MkD4Sym0 :: forall a. (~>) a (D4 @a)
+    data MkD4Sym0 :: (~>) a (D4 @a)
+      where
+        MkD4Sym0KindInference :: SameKind (Apply MkD4Sym0 arg) (MkD4Sym1 arg) =>
+                                 MkD4Sym0 a0123456789876543210
+    type instance Apply MkD4Sym0 a0123456789876543210 = MkD4 a0123456789876543210
+    instance SuppressUnusedWarnings MkD4Sym0 where
+      suppressUnusedWarnings = snd ((,) MkD4Sym0KindInference ())
+    type MkD4Sym1 :: forall a. a -> D4 @a
+    type family MkD4Sym1 (a0123456789876543210 :: a) :: D4 @a where
+      MkD4Sym1 a0123456789876543210 = MkD4 a0123456789876543210
+    type Meth1Sym0 :: forall a b. (~>) (Proxy a) (Proxy b)
+    data Meth1Sym0 :: (~>) (Proxy a) (Proxy b)
+      where
+        Meth1Sym0KindInference :: SameKind (Apply Meth1Sym0 arg) (Meth1Sym1 arg) =>
+                                  Meth1Sym0 a0123456789876543210
+    type instance Apply Meth1Sym0 a0123456789876543210 = Meth1 a0123456789876543210
+    instance SuppressUnusedWarnings Meth1Sym0 where
+      suppressUnusedWarnings = snd ((,) Meth1Sym0KindInference ())
+    type Meth1Sym1 :: forall a b. Proxy a -> Proxy b
+    type family Meth1Sym1 (a0123456789876543210 :: Proxy a) :: Proxy b where
+      Meth1Sym1 a0123456789876543210 = Meth1 a0123456789876543210
+    type PC1 :: forall j k. j -> k -> Constraint
+    class PC1 @j @k (a :: j) (b :: k) where
+      type family Meth1 (arg :: Proxy a) :: Proxy b
+    type Meth2Sym0 :: forall a b. (~>) (Proxy a) (Proxy b)
+    data Meth2Sym0 :: (~>) (Proxy a) (Proxy b)
+      where
+        Meth2Sym0KindInference :: SameKind (Apply Meth2Sym0 arg) (Meth2Sym1 arg) =>
+                                  Meth2Sym0 a0123456789876543210
+    type instance Apply Meth2Sym0 a0123456789876543210 = Meth2 a0123456789876543210
+    instance SuppressUnusedWarnings Meth2Sym0 where
+      suppressUnusedWarnings = snd ((,) Meth2Sym0KindInference ())
+    type Meth2Sym1 :: forall a b. Proxy a -> Proxy b
+    type family Meth2Sym1 (a0123456789876543210 :: Proxy a) :: Proxy b where
+      Meth2Sym1 a0123456789876543210 = Meth2 a0123456789876543210
+    type PC2 :: forall j k. j -> k -> Constraint
+    class PC2 @x @y (a :: x) (b :: y) where
+      type family Meth2 (arg :: Proxy a) :: Proxy b
+    type Meth3Sym0 :: forall a b. (~>) (Proxy a) (Proxy b)
+    data Meth3Sym0 :: (~>) (Proxy a) (Proxy b)
+      where
+        Meth3Sym0KindInference :: SameKind (Apply Meth3Sym0 arg) (Meth3Sym1 arg) =>
+                                  Meth3Sym0 a0123456789876543210
+    type instance Apply Meth3Sym0 a0123456789876543210 = Meth3 a0123456789876543210
+    instance SuppressUnusedWarnings Meth3Sym0 where
+      suppressUnusedWarnings = snd ((,) Meth3Sym0KindInference ())
+    type Meth3Sym1 :: forall a b. Proxy a -> Proxy b
+    type family Meth3Sym1 (a0123456789876543210 :: Proxy a) :: Proxy b where
+      Meth3Sym1 a0123456789876543210 = Meth3 a0123456789876543210
+    type PC3 :: forall j. j -> forall k. k -> Constraint
+    class PC3 @j (a :: j) @k (b :: k) where
+      type family Meth3 (arg :: Proxy a) :: Proxy b
+    type Meth4Sym0 :: forall a. a
+    type family Meth4Sym0 :: a where
+      Meth4Sym0 = Meth4
+    type PC4 :: forall (a :: Type). Constraint
+    class PC4 @a where
+      type family Meth4 :: a
+    type SD1 :: forall j k (a :: j) (b :: k). D1 @j @k a b -> Type
+    data SD1 :: forall j k (a :: j) (b :: k). D1 @j @k a b -> Type
+      where
+        SMkD1 :: forall j
+                        k
+                        (a :: j)
+                        (b :: k)
+                        (n :: Proxy a)
+                        (n :: Proxy b).
+                 (Sing n) -> (Sing n) -> SD1 (MkD1 n n :: D1 @j @k a b)
+    type instance Sing @(D1 @j @k a b) = SD1
+    type SD2 :: forall x y (a :: x) (b :: y). D2 @x @y a b -> Type
+    data SD2 :: forall x y (a :: x) (b :: y). D2 @x @y a b -> Type
+      where
+        SMkD2 :: forall x
+                        y
+                        (a :: x)
+                        (b :: y)
+                        (n :: Proxy a)
+                        (n :: Proxy b).
+                 (Sing n) -> (Sing n) -> SD2 (MkD2 n n :: D2 @x @y a b)
+    type instance Sing @(D2 @x @y a b) = SD2
+    type SD3 :: forall j (a :: j) k (b :: k). D3 @j a @k b -> Type
+    data SD3 :: forall j (a :: j) k (b :: k). D3 @j a @k b -> Type
+      where
+        SMkD3 :: forall j
+                        (a :: j)
+                        k
+                        (b :: k)
+                        (n :: Proxy a)
+                        (n :: Proxy b).
+                 (Sing n) -> (Sing n) -> SD3 (MkD3 n n :: D3 @j a @k b)
+    type instance Sing @(D3 @j a @k b) = SD3
+    type SD4 :: forall (a :: Type). D4 @a -> Type
+    data SD4 :: forall (a :: Type). D4 @a -> Type
+      where SMkD4 :: forall a (n :: a). (Sing n) -> SD4 (MkD4 n :: D4 @a)
+    type instance Sing @(D4 @a) = SD4
+    class SC1 @j @k (a :: j) (b :: k) where
+      sMeth1 ::
+        (forall (t :: Proxy a).
+         Sing t -> Sing (Apply Meth1Sym0 t :: Proxy b) :: Type)
+    class SC2 @x @y (a :: x) (b :: y) where
+      sMeth2 ::
+        (forall (t :: Proxy a).
+         Sing t -> Sing (Apply Meth2Sym0 t :: Proxy b) :: Type)
+    class SC3 @j (a :: j) @k (b :: k) where
+      sMeth3 ::
+        (forall (t :: Proxy a).
+         Sing t -> Sing (Apply Meth3Sym0 t :: Proxy b) :: Type)
+    class SC4 @a where
+      sMeth4 :: (Sing (Meth4Sym0 :: a) :: Type)
+    instance (SingI n, SingI n) =>
+             SingI (MkD1 (n :: Proxy a) (n :: Proxy b)) where
+      sing = SMkD1 sing sing
+    instance SingI n => SingI1 (MkD1 (n :: Proxy a)) where
+      liftSing = SMkD1 sing
+    instance SingI2 MkD1 where
+      liftSing2 = SMkD1
+    instance SingI (MkD1Sym0 :: (~>) (Proxy a) ((~>) (Proxy b) (D1 @j @k a b))) where
+      sing = singFun2 @MkD1Sym0 SMkD1
+    instance SingI d =>
+             SingI (MkD1Sym1 (d :: Proxy a) :: (~>) (Proxy b) (D1 @j @k a b)) where
+      sing = singFun1 @(MkD1Sym1 (d :: Proxy a)) (SMkD1 (sing @d))
+    instance SingI1 (MkD1Sym1 :: Proxy a
+                                 -> (~>) (Proxy b) (D1 @j @k a b)) where
+      liftSing (s :: Sing (d :: Proxy a))
+        = singFun1 @(MkD1Sym1 (d :: Proxy a)) (SMkD1 s)
+    instance (SingI n, SingI n) =>
+             SingI (MkD2 (n :: Proxy a) (n :: Proxy b)) where
+      sing = SMkD2 sing sing
+    instance SingI n => SingI1 (MkD2 (n :: Proxy a)) where
+      liftSing = SMkD2 sing
+    instance SingI2 MkD2 where
+      liftSing2 = SMkD2
+    instance SingI (MkD2Sym0 :: (~>) (Proxy a) ((~>) (Proxy b) (D2 @x @y a b))) where
+      sing = singFun2 @MkD2Sym0 SMkD2
+    instance SingI d =>
+             SingI (MkD2Sym1 (d :: Proxy a) :: (~>) (Proxy b) (D2 @x @y a b)) where
+      sing = singFun1 @(MkD2Sym1 (d :: Proxy a)) (SMkD2 (sing @d))
+    instance SingI1 (MkD2Sym1 :: Proxy a
+                                 -> (~>) (Proxy b) (D2 @x @y a b)) where
+      liftSing (s :: Sing (d :: Proxy a))
+        = singFun1 @(MkD2Sym1 (d :: Proxy a)) (SMkD2 s)
+    instance (SingI n, SingI n) =>
+             SingI (MkD3 (n :: Proxy a) (n :: Proxy b)) where
+      sing = SMkD3 sing sing
+    instance SingI n => SingI1 (MkD3 (n :: Proxy a)) where
+      liftSing = SMkD3 sing
+    instance SingI2 MkD3 where
+      liftSing2 = SMkD3
+    instance SingI (MkD3Sym0 :: (~>) (Proxy a) ((~>) (Proxy b) (D3 @j a @k b))) where
+      sing = singFun2 @MkD3Sym0 SMkD3
+    instance SingI d =>
+             SingI (MkD3Sym1 (d :: Proxy a) :: (~>) (Proxy b) (D3 @j a @k b)) where
+      sing = singFun1 @(MkD3Sym1 (d :: Proxy a)) (SMkD3 (sing @d))
+    instance SingI1 (MkD3Sym1 :: Proxy a
+                                 -> (~>) (Proxy b) (D3 @j a @k b)) where
+      liftSing (s :: Sing (d :: Proxy a))
+        = singFun1 @(MkD3Sym1 (d :: Proxy a)) (SMkD3 s)
+    instance SingI n => SingI (MkD4 (n :: a)) where
+      sing = SMkD4 sing
+    instance SingI1 MkD4 where
+      liftSing = SMkD4
+    instance SingI (MkD4Sym0 :: (~>) a (D4 @a)) where
+      sing = singFun1 @MkD4Sym0 SMkD4
+    type SC1 :: forall j k. j -> k -> Constraint
+    instance SC1 @j @k a b =>
+             SingI (Meth1Sym0 :: (~>) (Proxy a) (Proxy b)) where
+      sing = singFun1 @Meth1Sym0 sMeth1
+    type SC2 :: forall j k. j -> k -> Constraint
+    instance SC2 @x @y a b =>
+             SingI (Meth2Sym0 :: (~>) (Proxy a) (Proxy b)) where
+      sing = singFun1 @Meth2Sym0 sMeth2
+    type SC3 :: forall j. j -> forall k. k -> Constraint
+    instance SC3 @j a @k b =>
+             SingI (Meth3Sym0 :: (~>) (Proxy a) (Proxy b)) where
+      sing = singFun1 @Meth3Sym0 sMeth3
+    type SC4 :: forall (a :: Type). Constraint

--- a/singletons-base/tests/compile-and-dump/Singletons/TypeAbstractions.hs
+++ b/singletons-base/tests/compile-and-dump/Singletons/TypeAbstractions.hs
@@ -1,0 +1,46 @@
+module TypeAbstractions where
+
+import Data.Kind
+import Data.Proxy
+import Data.Proxy.Singletons
+import Data.Singletons.Base.TH
+import Data.Singletons.TH.Options
+import Prelude.Singletons
+
+$(withOptions defaultOptions{genSingKindInsts = False} $
+  singletons [d|
+  type D1 :: forall j k. j -> k -> Type
+  data D1 @j @k (a :: j) (b :: k) = MkD1 (Proxy a) (Proxy b)
+
+  type D2 :: forall j k. j -> k -> Type
+  data D2 @x @y (a :: x) (b :: y) = MkD2 (Proxy a) (Proxy b)
+
+  type D3 :: forall j. j -> forall k. k -> Type
+  data D3 @j (a :: j) @k (b :: k) = MkD3 (Proxy a) (Proxy b)
+
+  type D4 :: forall (a :: Type). Type
+  data D4 @a = MkD4 a
+
+  type C1 :: forall j k. j -> k -> Constraint
+  class C1 @j @k (a :: j) (b :: k) where
+    meth1 :: Proxy a -> Proxy b
+
+  type C2 :: forall j k. j -> k -> Constraint
+  class C2 @x @y (a :: x) (b :: y) where
+    meth2 :: Proxy a -> Proxy b
+
+  type C3 :: forall j. j -> forall k. k -> Constraint
+  class C3 @j (a :: j) @k (b :: k) where
+    meth3 :: Proxy a -> Proxy b
+
+  type C4 :: forall (a :: Type). Constraint
+  class C4 @a where
+    meth4 :: a
+
+  type TF :: forall j. j -> forall k. k -> Type
+  type family TF @j (a :: j) @k (b :: k) where
+    TF @j _ @k _ = (j, k)
+
+  type TS :: forall j. j -> forall k. k -> Type
+  type TS @j (a :: j) @k (b :: k) = (j, k)
+  |])

--- a/singletons-th/CHANGES.md
+++ b/singletons-th/CHANGES.md
@@ -17,6 +17,8 @@ next [????.??.??]
 * `singletons-th` now makes an effort to promote definitions that use scoped
   type variables. See the "Scoped type variables" section of the `README` for
   more information about what `singletons-th` can (and can't) do.
+* `singletons-th` now supports singling type-level definitions that use
+  `TypeAbstractions`.
 * Fix a bug in which data types using visible dependent quantification would
   generate ill-scoped code when singled.
 * Fix a bug in which singling a local variable that shadows a top-level

--- a/singletons-th/CHANGES.md
+++ b/singletons-th/CHANGES.md
@@ -3,6 +3,7 @@ Changelog for the `singletons-th` project
 
 next [????.??.??]
 -----------------
+* Require building with GHC 9.8.
 * Singled data types with derived `Eq` or `Ord` instances now generate `Eq` or
   `Ord` instances for the singleton type itself, e.g.,
 

--- a/singletons-th/README.md
+++ b/singletons-th/README.md
@@ -14,7 +14,7 @@ which describes how promotion works in greater detail.
 
 `singletons-th` generates code that relies on bleeding-edge GHC language
 extensions. As such, `singletons-th` only supports the latest major version
-of GHC (currently GHC 9.6). For more information,
+of GHC (currently GHC 9.8). For more information,
 consult the `singletons`
 [`README`](https://github.com/goldfirere/singletons/blob/master/README.md).
 

--- a/singletons-th/singletons-th.cabal
+++ b/singletons-th/singletons-th.cabal
@@ -8,7 +8,7 @@ author:         Richard Eisenberg <rae@cs.brynmawr.edu>, Jan Stolarek <jan.stola
 maintainer:     Ryan Scott <ryan.gl.scott@gmail.com>
 bug-reports:    https://github.com/goldfirere/singletons/issues
 stability:      experimental
-tested-with:    GHC == 9.6.2
+tested-with:    GHC == 9.8.1
 extra-source-files: README.md, CHANGES.md
 license:        BSD3
 license-file:   LICENSE
@@ -26,7 +26,7 @@ description:
     .
     @singletons-th@ generates code that relies on bleeding-edge GHC language
     extensions. As such, @singletons-th@ only supports the latest major version
-    of GHC (currently GHC 9.6). For more information,
+    of GHC (currently GHC 9.8). For more information,
     consult the @singletons@
     @<https://github.com/goldfirere/singletons/blob/master/README.md README>@.
     .

--- a/singletons-th/singletons-th.cabal
+++ b/singletons-th/singletons-th.cabal
@@ -52,13 +52,13 @@ source-repository head
 
 library
   hs-source-dirs:     src
-  build-depends:      base             >= 4.18 && < 4.19,
+  build-depends:      base             >= 4.19 && < 4.20,
                       containers       >= 0.5,
                       mtl              >= 2.2.1 && < 2.4,
                       ghc-boot-th,
                       singletons       == 3.0.*,
                       syb              >= 0.4,
-                      template-haskell >= 2.20 && < 2.21,
+                      template-haskell >= 2.21 && < 2.22,
                       th-desugar       >= 1.16 && < 1.17,
                       th-orphans       >= 0.13.11 && < 0.14,
                       transformers     >= 0.5.2

--- a/singletons-th/src/Data/Singletons/TH/Names.hs
+++ b/singletons-th/src/Data/Singletons/TH/Names.hs
@@ -175,7 +175,7 @@ liftA2Name = 'liftA2
 mkTyName :: Quasi q => Name -> q Name
 mkTyName tmName = do
   let nameStr  = nameBase tmName
-      symbolic = not (isHsLetter (head nameStr))
+      symbolic = not (isHsLetter (headNameStr nameStr))
   qNewName (if symbolic then "ty" else nameStr)
 
 mkTyConName :: Int -> Name

--- a/singletons-th/src/Data/Singletons/TH/Options.hs
+++ b/singletons-th/src/Data/Singletons/TH/Options.hs
@@ -248,7 +248,7 @@ promoteTySym name sat
     default_case :: Name -> Name
     default_case name' =
       let capped = toUpcaseStr noPrefix name' in
-      if isHsLetter (head capped)
+      if isHsLetter (headNameStr capped)
       then mkName (capped ++ "Sym" ++ (show sat))
       else mkName (capped ++ "@#@" -- See Note [Defunctionalization symbol suffixes]
                           ++ (replicate (sat + 1) '$'))

--- a/singletons-th/src/Data/Singletons/TH/Promote.hs
+++ b/singletons-th/src/Data/Singletons/TH/Promote.hs
@@ -614,10 +614,11 @@ promoteInfixDecl mb_let_uniq name fixity = do
   mb_ns <- reifyNameSpace name
   case mb_ns of
     -- If we can't find the Name for some odd reason, fall back to promote_val
-    Nothing        -> promote_val
-    Just VarName   -> promote_val
-    Just DataName  -> never_mind
-    Just TcClsName -> do
+    Nothing          -> promote_val
+    Just VarName     -> promote_val
+    Just (FldName _) -> promote_val
+    Just DataName    -> never_mind
+    Just TcClsName   -> do
       mb_info <- dsReify name
       case mb_info of
         Just (DTyConI DClassD{} _)

--- a/singletons-th/src/Data/Singletons/TH/Promote.hs
+++ b/singletons-th/src/Data/Singletons/TH/Promote.hs
@@ -159,7 +159,7 @@ promoteInstance :: OptionsMonad q => DerivDesc q -> String -> Name -> q [Dec]
 promoteInstance mk_inst class_name name = do
   (df, tvbs, cons) <- getDataD ("I cannot make an instance of " ++ class_name
                                 ++ " for it.") name
-  tvbs' <- mapM dsTvbUnit tvbs
+  tvbs' <- mapM dsTvbVis tvbs
   let data_ty   = foldTypeTvbs (DConT name) tvbs'
   cons' <- concatMapM (dsCon tvbs' data_ty) cons
   let data_decl = DataDecl df name tvbs' cons'
@@ -290,7 +290,7 @@ promoteClassDec decl@(ClassDecl { cd_name = cls_name
       -- /don't/ use the type variable binders from the method's type...
       (_, argKs, resK) <- promoteUnraveled ty
       args <- mapM (const $ qNewName "arg") argKs
-      let proTvbs = zipWith (`DKindedTV` ()) args argKs
+      let proTvbs = zipWith (`DKindedTV` BndrReq) args argKs
       -- ...instead, compute the type variable binders in a left-to-right order,
       -- since that is the same order that the promoted method's kind will use.
       -- See Note [Promoted class methods and kind variable ordering]
@@ -353,7 +353,7 @@ decided not to use this hack unless someone specifically requests it.
 -- returns (unpromoted method name, ALetDecRHS) pairs
 promoteInstanceDec :: OMap Name DType
                       -- Class method type signatures
-                   -> Map Name [DTyVarBndrUnit]
+                   -> Map Name [DTyVarBndrVis]
                       -- Class header type variable (e.g., if `class C a b` is
                       -- quoted, then this will have an entry for {C |-> [a, b]})
                    -> UInstDecl -> PrM AInstDecl
@@ -375,7 +375,7 @@ promoteInstanceDec orig_meth_sigs cls_tvbs_map
                                             inst_kis) meths']
   return (decl { id_meths = zip (map fst meths) ann_rhss })
   where
-    lookup_cls_tvbs :: PrM [DTyVarBndrUnit]
+    lookup_cls_tvbs :: PrM [DTyVarBndrVis]
     lookup_cls_tvbs =
       -- First, try consulting the map of class names to their type variables.
       -- It is important to do this first to ensure that we consider locally
@@ -387,7 +387,7 @@ promoteInstanceDec orig_meth_sigs cls_tvbs_map
           -- If the class isn't present in this map, we try reifying the class
           -- as a last resort.
 
-    reify_cls_tvbs :: PrM [DTyVarBndrUnit]
+    reify_cls_tvbs :: PrM [DTyVarBndrVis]
     reify_cls_tvbs = do
       opts <- getOptions
       let pClsName = promotedClassName opts cls_name
@@ -399,7 +399,7 @@ promoteInstanceDec orig_meth_sigs cls_tvbs_map
         Just tvbs -> pure tvbs
         Nothing -> fail $ "Cannot find class declaration annotation for " ++ show cls_name
 
-    extract_tvbs :: PrM (Maybe DInfo) -> MaybeT PrM [DTyVarBndrUnit]
+    extract_tvbs :: PrM (Maybe DInfo) -> MaybeT PrM [DTyVarBndrVis]
     extract_tvbs reify_info = do
       mb_info <- lift reify_info
       case mb_info of
@@ -737,10 +737,10 @@ promoteLetDecRHS rhs_sort type_env fix_env mb_let_uniq name let_dec_rhs = do
       opts <- getOptions
       tyvarNames <- replicateM ty_num_args (qNewName "a")
       let proName    = promotedValueName opts name mb_let_uniq
-          local_tvbs = map (`DPlainTV` ()) all_locals
+          local_tvbs = map (`DPlainTV` BndrReq) all_locals
           m_fixity   = OMap.lookup name fix_env
 
-          mk_tf_head :: [DTyVarBndrUnit] -> DFamilyResultSig -> DTypeFamilyHead
+          mk_tf_head :: [DTyVarBndrVis] -> DFamilyResultSig -> DTypeFamilyHead
           mk_tf_head arg_tvbs res_sig =
             dTypeFamilyHead_with_locals proName all_locals arg_tvbs res_sig
 
@@ -749,7 +749,7 @@ promoteLetDecRHS rhs_sort type_env fix_env mb_let_uniq name let_dec_rhs = do
             case m_ldrki of
               -- 1. We have no kind information whatsoever.
               Nothing ->
-                let arg_tvbs = map (`DPlainTV` ()) tyvarNames in
+                let arg_tvbs = map (`DPlainTV` BndrReq) tyvarNames in
                 ( OSet.empty
                 , Nothing
                 , DefunNoSAK (local_tvbs ++ arg_tvbs) Nothing
@@ -757,7 +757,7 @@ promoteLetDecRHS rhs_sort type_env fix_env mb_let_uniq name let_dec_rhs = do
                 )
               -- 2. We have some kind information in the form of a LetDecRHSKindInfo.
               Just (LDRKI m_sak tvbs argKs resK) ->
-                let arg_tvbs = zipWith (`DKindedTV` ()) tyvarNames argKs
+                let arg_tvbs = zipWith (`DKindedTV` BndrReq) tyvarNames argKs
                     lde_kvs_to_bind' = OSet.fromList (map extractTvbName tvbs) in
                 case m_sak of
                   -- 2(a). We do not have a standalone kind signature.
@@ -1050,9 +1050,9 @@ promoteExp (DLamE names exp) = do
   let var_proms = zip names tyNames
   (rhs, ann_exp) <- lambdaBind var_proms $ promoteExp exp
   all_locals <- allLocals
-  let tvbs     = map (`DPlainTV` ()) tyNames
+  let tvbs     = map (`DPlainTV` BndrReq) tyNames
       all_args = all_locals ++ tyNames
-      all_tvbs = map (`DPlainTV` ()) all_args
+      all_tvbs = map (`DPlainTV` BndrReq) all_args
       tfh      = dTypeFamilyHead_with_locals lambdaName all_locals tvbs DNoSig
   emitDecs [DClosedTypeFamilyD
               tfh
@@ -1070,7 +1070,7 @@ promoteExp (DCaseE exp matches) = do
   (exp', ann_exp)     <- promoteExp exp
   (eqns, ann_matches) <- mapAndUnzipM (promoteMatch prom_case) matches
   tyvarName  <- qNewName "t"
-  let tvbs = [DPlainTV tyvarName ()]
+  let tvbs = [DPlainTV tyvarName BndrReq]
       tfh  = dTypeFamilyHead_with_locals caseTFName all_locals tvbs DNoSig
   emitDecs [DClosedTypeFamilyD tfh eqns]
     -- See Note [Annotate case return type] in Single
@@ -1161,7 +1161,7 @@ dTypeFamilyHead_with_locals ::
   -- ^ Name of type family
   -> [Name]
   -- ^ Local variables
-  -> [DTyVarBndrUnit]
+  -> [DTyVarBndrVis]
   -- ^ Variables for type family arguments
   -> DFamilyResultSig
   -- ^ Type family result
@@ -1169,7 +1169,7 @@ dTypeFamilyHead_with_locals ::
 dTypeFamilyHead_with_locals tf_nm local_nms arg_tvbs res_sig =
   DTypeFamilyHead
     tf_nm
-    (map (`DPlainTV` ()) local_nms' ++ arg_tvbs')
+    (map (`DPlainTV` BndrReq) local_nms' ++ arg_tvbs')
     res_sig'
     Nothing
   where

--- a/singletons-th/src/Data/Singletons/TH/Single.hs
+++ b/singletons-th/src/Data/Singletons/TH/Single.hs
@@ -147,7 +147,7 @@ singDecideInstances = concatMapM singDecideInstance
 singDecideInstance :: OptionsMonad q => Name -> q [Dec]
 singDecideInstance name = do
   (_df, tvbs, cons) <- getDataD ("I cannot make an instance of SDecide for it.") name
-  dtvbs <- mapM dsTvbUnit tvbs
+  dtvbs <- mapM dsTvbVis tvbs
   let data_ty = foldTypeTvbs (DConT name) dtvbs
   dcons <- concatMapM (dsCon dtvbs data_ty) cons
   (scons, _) <- singM [] $ mapM (singCtor name) dcons
@@ -199,7 +199,7 @@ singShowInstances = concatMapM singShowInstance
 showSingInstance :: OptionsMonad q => Name -> q [Dec]
 showSingInstance name = do
   (df, tvbs, cons) <- getDataD ("I cannot make an instance of Show for it.") name
-  dtvbs <- mapM dsTvbUnit tvbs
+  dtvbs <- mapM dsTvbVis tvbs
   let data_ty = foldTypeTvbs (DConT name) dtvbs
   dcons <- concatMapM (dsCon dtvbs data_ty) cons
   let tyvars    = map (DVarT . extractTvbName) dtvbs
@@ -271,7 +271,7 @@ singInstance :: OptionsMonad q => DerivDesc q -> String -> Name -> q [Dec]
 singInstance mk_inst inst_name name = do
   (df, tvbs, cons) <- getDataD ("I cannot make an instance of " ++ inst_name
                                 ++ " for it.") name
-  dtvbs <- mapM dsTvbUnit tvbs
+  dtvbs <- mapM dsTvbVis tvbs
   let data_ty = foldTypeTvbs (DConT name) dtvbs
   dcons <- concatMapM (dsCon dtvbs data_ty) cons
   let data_decl = DataDecl df name dtvbs dcons

--- a/singletons-th/src/Data/Singletons/TH/Single/Fixity.hs
+++ b/singletons-th/src/Data/Singletons/TH/Single/Fixity.hs
@@ -15,10 +15,11 @@ singInfixDecl name fixity = do
   case mb_ns of
     -- If we can't find the Name for some odd reason,
     -- fall back to singValName
-    Nothing        -> finish $ singledValueName   opts name
-    Just VarName   -> finish $ singledValueName   opts name
-    Just DataName  -> finish $ singledDataConName opts name
-    Just TcClsName -> do
+    Nothing          -> finish $ singledValueName   opts name
+    Just VarName     -> finish $ singledValueName   opts name
+    Just (FldName _) -> finish $ singledValueName   opts name
+    Just DataName    -> finish $ singledDataConName opts name
+    Just TcClsName   -> do
       mb_info <- dsReify name
       case mb_info of
         Just (DTyConI DClassD{} _)

--- a/singletons-th/src/Data/Singletons/TH/Syntax.hs
+++ b/singletons-th/src/Data/Singletons/TH/Syntax.hs
@@ -45,10 +45,10 @@ instance Monoid PromDPatInfos where
 type SingDSigPaInfos = [(DExp, DType)]
 
 -- The parts of data declarations that are relevant to singletons-th.
-data DataDecl = DataDecl DataFlavor Name [DTyVarBndrUnit] [DCon]
+data DataDecl = DataDecl DataFlavor Name [DTyVarBndrVis] [DCon]
 
 -- The parts of type synonyms that are relevant to singletons-th.
-data TySynDecl = TySynDecl Name [DTyVarBndrUnit] DType
+data TySynDecl = TySynDecl Name [DTyVarBndrVis] DType
 
 -- The parts of open type families that are relevant to singletons-th.
 type OpenTypeFamilyDecl = TypeFamilyDecl 'Open
@@ -65,7 +65,7 @@ data FamilyInfo = Open | Closed
 data ClassDecl ann
   = ClassDecl { cd_cxt  :: DCxt
               , cd_name :: Name
-              , cd_tvbs :: [DTyVarBndrUnit]
+              , cd_tvbs :: [DTyVarBndrVis]
               , cd_fds  :: [FunDep]
               , cd_lde  :: LetDecEnv ann
               , cd_atfs :: [OpenTypeFamilyDecl]

--- a/singletons-th/src/Data/Singletons/TH/Util.hs
+++ b/singletons-th/src/Data/Singletons/TH/Util.hs
@@ -86,7 +86,7 @@ isInfixDataCon _       = False
 -- | Is an identifier a legal data constructor name in Haskell? That is, is its
 -- first character an uppercase letter (prefix) or a colon (infix)?
 isDataConName :: Name -> Bool
-isDataConName n = let first = head (nameBase n) in isUpper first || first == ':'
+isDataConName n = let first = headNameStr (nameBase n) in isUpper first || first == ':'
 
 -- | Is an identifier uppercase?
 --
@@ -95,7 +95,7 @@ isDataConName n = let first = head (nameBase n) in isUpper first || first == ':'
 -- If you want to check if a name is legal as a data constructor, use the
 -- 'isDataConName' function.
 isUpcase :: Name -> Bool
-isUpcase n = let first = head (nameBase n) in isUpper first
+isUpcase n = let first = headNameStr (nameBase n) in isUpper first
 
 -- Make an identifier uppercase. If the identifier is infix, this acts as the
 -- identity function.
@@ -114,9 +114,9 @@ toUpcaseStr (alpha, symb) n
 
   where
     str   = nameBase n
-    first = head str
+    first = headNameStr str
 
-    upcase_alpha = alpha ++ (toUpper first) : tail str
+    upcase_alpha = alpha ++ (toUpper first) : tailNameStr str
     upcase_symb = symb ++ str
 
 noPrefix :: (String, String)
@@ -138,7 +138,7 @@ prefixConName pre tyPre n = case (nameBase n) of
 prefixName :: String -> String -> Name -> Name
 prefixName pre tyPre n =
   let str = nameBase n
-      first = head str in
+      first = headNameStr str in
     if isHsLetter first
      then mkName (pre ++ str)
      else mkName (tyPre ++ str)
@@ -148,10 +148,26 @@ prefixName pre tyPre n =
 suffixName :: String -> String -> Name -> Name
 suffixName ident symb n =
   let str = nameBase n
-      first = head str in
+      first = headNameStr str in
   if isHsLetter first
   then mkName (str ++ ident)
   else mkName (str ++ symb)
+
+-- Return the first character in a Name's string (i.e., nameBase).
+-- Precondition: the string is non-empty.
+headNameStr :: String -> Char
+headNameStr str =
+  case str of
+    (c:_) -> c
+    [] -> error "headNameStr: Expected non-empty string"
+
+-- Drop the first character in a Name's string (i.e., nameBase).
+-- Precondition: the string is non-empty.
+tailNameStr :: String -> String
+tailNameStr str =
+  case str of
+    (_:cs) -> cs
+    [] -> error "tailNameStr: Expected non-empty string"
 
 -- convert a number into both alphanumeric and symoblic forms
 uniquePrefixes :: String   -- alphanumeric prefix

--- a/singletons/singletons.cabal
+++ b/singletons/singletons.cabal
@@ -18,6 +18,7 @@ tested-with:    GHC == 8.0.2
               , GHC == 9.2.7
               , GHC == 9.4.5
               , GHC == 9.6.2
+              , GHC == 9.8.1
               , GHCJS==8.4
 extra-source-files: README.md, CHANGES.md
 license:        BSD3

--- a/singletons/singletons.cabal
+++ b/singletons/singletons.cabal
@@ -59,7 +59,7 @@ source-repository head
 
 library
   hs-source-dirs:     src
-  build-depends:      base >= 4.9 && < 4.19
+  build-depends:      base >= 4.9 && < 4.20
   default-language:   Haskell2010
   exposed-modules:    Data.Singletons
                       Data.Singletons.Decide
@@ -76,5 +76,5 @@ test-suite singletons-test-suite
   other-modules:      ByHand
                       ByHand2
 
-  build-depends:      base >= 4.9 && < 4.19,
+  build-depends:      base >= 4.9 && < 4.20,
                       singletons

--- a/singletons/tests/ByHand2.hs
+++ b/singletons/tests/ByHand2.hs
@@ -2,7 +2,7 @@
              DefaultSignatures, ScopedTypeVariables, InstanceSigs,
              MultiParamTypeClasses, FunctionalDependencies,
              UndecidableInstances, CPP #-}
-{-# OPTIONS_GHC -Wno-missing-signatures #-}
+{-# OPTIONS_GHC -Wno-missing-signatures -Wno-orphans #-}
 
 #if __GLASGOW_HASKELL__ < 806
 {-# LANGUAGE TypeInType #-}


### PR DESCRIPTION
This:

* Supports invisible binders in type-level declarations.
* Supports the `FldName` namespace introduced in GHC 9.8.
* Tweaks some code to avoid `-Wx-partial` warnings introduced in GHC 9.8.

See also #564.