### PR TITLE
`promoteLetDecName`: Fix visibility-related bug

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -264,7 +264,7 @@ jobs:
           source-repository-package
             type:     git
             location: https://github.com/goldfirere/th-desugar
-            tag:      a910bb140d6f9d0c69077c32f70ff08286825dff
+            tag:      5aa3585028b05b90e78ead54e4f5fda6ace13ac2
           EOF
           if $HEADHACKAGE; then
           echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project

--- a/cabal.project
+++ b/cabal.project
@@ -5,4 +5,4 @@ packages: ./singletons
 source-repository-package
   type: git
   location: https://github.com/goldfirere/th-desugar
-  tag: a910bb140d6f9d0c69077c32f70ff08286825dff
+  tag: 5aa3585028b05b90e78ead54e4f5fda6ace13ac2

--- a/singletons-base/tests/SingletonsBaseTestSuite.hs
+++ b/singletons-base/tests/SingletonsBaseTestSuite.hs
@@ -152,6 +152,7 @@ tests =
     , compileAndDumpStdTest "T563"
     , compileAndDumpStdTest "T567"
     , compileAndDumpStdTest "T571"
+    , compileAndDumpStdTest "T585"
     , compileAndDumpStdTest "TypeAbstractions"
     ],
     testCompileAndDumpGroup "Promote"

--- a/singletons-base/tests/compile-and-dump/Singletons/T585.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T585.golden
@@ -1,0 +1,40 @@
+Singletons/T585.hs:(0,0)-(0,0): Splicing declarations
+    singletons
+      [d| konst :: forall a {b}. a -> b -> a
+          konst x _ = x |]
+  ======>
+    konst :: forall a {b}. a -> b -> a
+    konst x _ = x
+    type KonstSym0 :: forall a {b}. (~>) a ((~>) b a)
+    data KonstSym0 :: (~>) a ((~>) b a)
+      where
+        KonstSym0KindInference :: SameKind (Apply KonstSym0 arg) (KonstSym1 arg) =>
+                                  KonstSym0 a0123456789876543210
+    type instance Apply KonstSym0 a0123456789876543210 = KonstSym1 a0123456789876543210
+    instance SuppressUnusedWarnings KonstSym0 where
+      suppressUnusedWarnings = snd ((,) KonstSym0KindInference ())
+    type KonstSym1 :: forall a {b}. a -> (~>) b a
+    data KonstSym1 (a0123456789876543210 :: a) :: (~>) b a
+      where
+        KonstSym1KindInference :: SameKind (Apply (KonstSym1 a0123456789876543210) arg) (KonstSym2 a0123456789876543210 arg) =>
+                                  KonstSym1 a0123456789876543210 a0123456789876543210
+    type instance Apply (KonstSym1 a0123456789876543210) a0123456789876543210 = Konst a0123456789876543210 a0123456789876543210
+    instance SuppressUnusedWarnings (KonstSym1 a0123456789876543210) where
+      suppressUnusedWarnings = snd ((,) KonstSym1KindInference ())
+    type KonstSym2 :: forall a {b}. a -> b -> a
+    type family KonstSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: a where
+      KonstSym2 a0123456789876543210 a0123456789876543210 = Konst a0123456789876543210 a0123456789876543210
+    type Konst :: forall a {b}. a -> b -> a
+    type family Konst (a :: a) (a :: b) :: a where
+      Konst @a (x :: a) (_ :: b) = x
+    sKonst ::
+      forall a {b} (t :: a) (t :: b). Sing t
+                                      -> Sing t -> Sing (Apply (Apply KonstSym0 t) t :: a)
+    sKonst (sX :: Sing x) _ = sX
+    instance SingI (KonstSym0 :: (~>) a ((~>) b a)) where
+      sing = singFun2 @KonstSym0 sKonst
+    instance SingI d => SingI (KonstSym1 (d :: a) :: (~>) b a) where
+      sing = singFun1 @(KonstSym1 (d :: a)) (sKonst (sing @d))
+    instance SingI1 (KonstSym1 :: a -> (~>) b a) where
+      liftSing (s :: Sing (d :: a))
+        = singFun1 @(KonstSym1 (d :: a)) (sKonst s)

--- a/singletons-base/tests/compile-and-dump/Singletons/T585.hs
+++ b/singletons-base/tests/compile-and-dump/Singletons/T585.hs
@@ -1,0 +1,8 @@
+module T585 where
+
+import Data.Singletons.TH
+
+$(singletons [d|
+  konst :: forall a {b}. a -> b -> a
+  konst x _ = x
+  |])

--- a/singletons-th/CHANGES.md
+++ b/singletons-th/CHANGES.md
@@ -1,6 +1,11 @@
 Changelog for the `singletons-th` project
 =========================================
 
+next [????.??.??]
+-----------------
+* Fix a bug causing definitions with type signatures using inferred type
+  variable binders (e.g., `forall a {b}. a -> b -> a`) to fail to promote.
+
 3.3 [2023.10.13]
 ----------------
 * Require building with GHC 9.8.


### PR DESCRIPTION
Previously, `promoteLetDecName` would convert every `DTyVarBndrSpec` in an outermost `forall` to an invisible argument in a promoted type family equation. This is not quite right, however, as https://github.com/goldfirere/singletons/issues/585 reveals: we do not want to convert _inferred_ type variable binders to invisible arguments.

To do this properly, we introduce a new `tvbSpecsToBndrVis` function, which converts a list of `DTyVarBndrSpec`s to a list of `DTyVarBndrVis`es, dropping any `DTyVarBndrSpec`s with an `InferredSpec` in the process. We then use `tvbSpecsToBndrVis` in `promoteLetDecName`, which neatly fixes https://github.com/goldfirere/singletons/issues/585.