### PR TITLE
Don't defunctionalize helpers for class defaults or instance methods

### DIFF
--- a/singletons-base/tests/compile-and-dump/GradingClient/Database.golden
+++ b/singletons-base/tests/compile-and-dump/GradingClient/Database.golden
@@ -27,58 +27,16 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       TFHelper_0123456789876543210 Zero (Succ _) = FalseSym0
       TFHelper_0123456789876543210 (Succ _) Zero = FalseSym0
       TFHelper_0123456789876543210 (Succ a_0123456789876543210) (Succ b_0123456789876543210) = Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210
-    type TFHelper_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Bool)
-    data TFHelper_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Bool)
-      where
-        TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Nat @((~>) Nat Bool) TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym0KindInference ())
-    type TFHelper_0123456789876543210Sym1 :: Nat -> (~>) Nat Bool
-    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Nat) :: (~>) Nat Bool
-      where
-        TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @Bool (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym1KindInference ())
-    type TFHelper_0123456789876543210Sym2 :: Nat -> Nat -> Bool
-    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Bool where
-      TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq Nat where
-      type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
+      type (==) a a = TFHelper_0123456789876543210 a a
     type Compare_0123456789876543210 :: Nat -> Nat -> Ordering
     type family Compare_0123456789876543210 (a :: Nat) (a :: Nat) :: Ordering where
       Compare_0123456789876543210 Zero Zero = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
       Compare_0123456789876543210 (Succ a_0123456789876543210) (Succ b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0)
       Compare_0123456789876543210 Zero (Succ _) = LTSym0
       Compare_0123456789876543210 (Succ _) Zero = GTSym0
-    type Compare_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Ordering)
-    data Compare_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Ordering)
-      where
-        Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Nat @((~>) Nat Ordering) Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym0KindInference ())
-    type Compare_0123456789876543210Sym1 :: Nat -> (~>) Nat Ordering
-    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Nat) :: (~>) Nat Ordering
-      where
-        Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @Ordering (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym1KindInference ())
-    type Compare_0123456789876543210Sym2 :: Nat -> Nat -> Ordering
-    type family Compare_0123456789876543210Sym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Ordering where
-      Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd Nat where
-      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
+      type Compare a a = Compare_0123456789876543210 a a
     data SNat :: Nat -> Type
       where
         SZero :: SNat (Zero :: Nat)
@@ -534,29 +492,8 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       TFHelper_0123456789876543210 (VEC _ _) STRING = FalseSym0
       TFHelper_0123456789876543210 (VEC _ _) NAT = FalseSym0
       TFHelper_0123456789876543210 (VEC a_0123456789876543210 a_0123456789876543210) (VEC b_0123456789876543210 b_0123456789876543210) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)
-    type TFHelper_0123456789876543210Sym0 :: (~>) U ((~>) U Bool)
-    data TFHelper_0123456789876543210Sym0 :: (~>) U ((~>) U Bool)
-      where
-        TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @U @((~>) U Bool) TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym0KindInference ())
-    type TFHelper_0123456789876543210Sym1 :: U -> (~>) U Bool
-    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: U) :: (~>) U Bool
-      where
-        TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @U @Bool (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym1KindInference ())
-    type TFHelper_0123456789876543210Sym2 :: U -> U -> Bool
-    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: U) (a0123456789876543210 :: U) :: Bool where
-      TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq U where
-      type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
+      type (==) a a = TFHelper_0123456789876543210 a a
     type ShowsPrec_0123456789876543210 :: GHC.Num.Natural.Natural
                                           -> U -> Symbol -> Symbol
     type family ShowsPrec_0123456789876543210 (a :: GHC.Num.Natural.Natural) (a :: U) (a :: Symbol) :: Symbol where
@@ -564,41 +501,8 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       ShowsPrec_0123456789876543210 _ STRING a_0123456789876543210 = Apply (Apply ShowStringSym0 "STRING") a_0123456789876543210
       ShowsPrec_0123456789876543210 _ NAT a_0123456789876543210 = Apply (Apply ShowStringSym0 "NAT") a_0123456789876543210
       ShowsPrec_0123456789876543210 p_0123456789876543210 (VEC arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "VEC ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) U ((~>) Symbol Symbol))
-    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) U ((~>) Symbol Symbol))
-      where
-        ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @GHC.Num.Natural.Natural @((~>) U ((~>) Symbol Symbol)) ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym0KindInference ())
-    type ShowsPrec_0123456789876543210Sym1 :: GHC.Num.Natural.Natural
-                                              -> (~>) U ((~>) Symbol Symbol)
-    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Num.Natural.Natural) :: (~>) U ((~>) Symbol Symbol)
-      where
-        ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @U @((~>) Symbol Symbol) (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym1KindInference ())
-    type ShowsPrec_0123456789876543210Sym2 :: GHC.Num.Natural.Natural
-                                              -> U -> (~>) Symbol Symbol
-    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: U) :: (~>) Symbol Symbol
-      where
-        ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @Symbol @Symbol (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym2KindInference ())
-    type ShowsPrec_0123456789876543210Sym3 :: GHC.Num.Natural.Natural
-                                              -> U -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: U) (a0123456789876543210 :: Symbol) :: Symbol where
-      ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow U where
-      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
     type ShowsPrec_0123456789876543210 :: GHC.Num.Natural.Natural
                                           -> AChar -> Symbol -> Symbol
     type family ShowsPrec_0123456789876543210 (a :: GHC.Num.Natural.Natural) (a :: AChar) (a :: Symbol) :: Symbol where
@@ -628,41 +532,8 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       ShowsPrec_0123456789876543210 _ CX a_0123456789876543210 = Apply (Apply ShowStringSym0 "CX") a_0123456789876543210
       ShowsPrec_0123456789876543210 _ CY a_0123456789876543210 = Apply (Apply ShowStringSym0 "CY") a_0123456789876543210
       ShowsPrec_0123456789876543210 _ CZ a_0123456789876543210 = Apply (Apply ShowStringSym0 "CZ") a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) AChar ((~>) Symbol Symbol))
-    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) AChar ((~>) Symbol Symbol))
-      where
-        ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @GHC.Num.Natural.Natural @((~>) AChar ((~>) Symbol Symbol)) ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym0KindInference ())
-    type ShowsPrec_0123456789876543210Sym1 :: GHC.Num.Natural.Natural
-                                              -> (~>) AChar ((~>) Symbol Symbol)
-    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Num.Natural.Natural) :: (~>) AChar ((~>) Symbol Symbol)
-      where
-        ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @AChar @((~>) Symbol Symbol) (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym1KindInference ())
-    type ShowsPrec_0123456789876543210Sym2 :: GHC.Num.Natural.Natural
-                                              -> AChar -> (~>) Symbol Symbol
-    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: AChar) :: (~>) Symbol Symbol
-      where
-        ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @Symbol @Symbol (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym2KindInference ())
-    type ShowsPrec_0123456789876543210Sym3 :: GHC.Num.Natural.Natural
-                                              -> AChar -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: AChar) (a0123456789876543210 :: Symbol) :: Symbol where
-      ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow AChar where
-      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
     type TFHelper_0123456789876543210 :: AChar -> AChar -> Bool
     type family TFHelper_0123456789876543210 (a :: AChar) (a :: AChar) :: Bool where
       TFHelper_0123456789876543210 CA CA = TrueSym0
@@ -1341,29 +1212,8 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       TFHelper_0123456789876543210 CZ CX = FalseSym0
       TFHelper_0123456789876543210 CZ CY = FalseSym0
       TFHelper_0123456789876543210 CZ CZ = TrueSym0
-    type TFHelper_0123456789876543210Sym0 :: (~>) AChar ((~>) AChar Bool)
-    data TFHelper_0123456789876543210Sym0 :: (~>) AChar ((~>) AChar Bool)
-      where
-        TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @AChar @((~>) AChar Bool) TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym0KindInference ())
-    type TFHelper_0123456789876543210Sym1 :: AChar -> (~>) AChar Bool
-    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: AChar) :: (~>) AChar Bool
-      where
-        TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @AChar @Bool (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym1KindInference ())
-    type TFHelper_0123456789876543210Sym2 :: AChar -> AChar -> Bool
-    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: AChar) (a0123456789876543210 :: AChar) :: Bool where
-      TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq AChar where
-      type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
+      type (==) a a = TFHelper_0123456789876543210 a a
     sLookup ::
       (forall (t :: [AChar]) (t :: Schema).
        Sing t

--- a/singletons-base/tests/compile-and-dump/GradingClient/Database.golden
+++ b/singletons-base/tests/compile-and-dump/GradingClient/Database.golden
@@ -1216,25 +1216,19 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       type (==) a a = TFHelper_0123456789876543210 a a
     sLookup ::
       (forall (t :: [AChar]) (t :: Schema).
-       Sing t
-       -> Sing t -> Sing (Apply (Apply LookupSym0 t) t :: U) :: Type)
+       Sing t -> Sing t -> Sing (Lookup t t :: U) :: Type)
     sOccurs ::
       (forall (t :: [AChar]) (t :: Schema).
-       Sing t
-       -> Sing t -> Sing (Apply (Apply OccursSym0 t) t :: Bool) :: Type)
+       Sing t -> Sing t -> Sing (Occurs t t :: Bool) :: Type)
     sDisjoint ::
       (forall (t :: Schema) (t :: Schema).
-       Sing t
-       -> Sing t -> Sing (Apply (Apply DisjointSym0 t) t :: Bool) :: Type)
+       Sing t -> Sing t -> Sing (Disjoint t t :: Bool) :: Type)
     sAttrNotIn ::
       (forall (t :: Attribute) (t :: Schema).
-       Sing t
-       -> Sing t
-          -> Sing (Apply (Apply AttrNotInSym0 t) t :: Bool) :: Type)
+       Sing t -> Sing t -> Sing (AttrNotIn t t :: Bool) :: Type)
     sAppend ::
       (forall (t :: Schema) (t :: Schema).
-       Sing t
-       -> Sing t -> Sing (Apply (Apply AppendSym0 t) t :: Schema) :: Type)
+       Sing t -> Sing t -> Sing (Append t t :: Schema) :: Type)
     sLookup _ (SSch SNil) = sUndefined
     sLookup
       (sName :: Sing name)
@@ -1242,7 +1236,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
                    (sAttrs :: Sing attrs)))
       = let
           sScrutinee_0123456789876543210 ::
-            Sing @_ (Let0123456789876543210Scrutinee_0123456789876543210Sym0 name name' u attrs)
+            Sing @_ (Let0123456789876543210Scrutinee_0123456789876543210 name name' u attrs)
           sScrutinee_0123456789876543210
             = applySing (applySing (singFun2 @(==@#@$) (%==)) sName) sName'
         in

--- a/singletons-base/tests/compile-and-dump/GradingClient/Main.golden
+++ b/singletons-base/tests/compile-and-dump/GradingClient/Main.golden
@@ -73,13 +73,13 @@ GradingClient/Main.hs:(0,0)-(0,0): Splicing declarations
     type LastName :: [AChar]
     type family LastName :: [AChar] where
       LastName = Apply (Apply (:@#@$) CLSym0) (Apply (Apply (:@#@$) CASym0) (Apply (Apply (:@#@$) CSSym0) (Apply (Apply (:@#@$) CTSym0) NilSym0)))
-    sNames :: (Sing (NamesSym0 :: Schema) :: Type)
-    sGradingSchema :: (Sing (GradingSchemaSym0 :: Schema) :: Type)
-    sMajorName :: (Sing (MajorNameSym0 :: [AChar]) :: Type)
-    sGradeName :: (Sing (GradeNameSym0 :: [AChar]) :: Type)
-    sYearName :: (Sing (YearNameSym0 :: [AChar]) :: Type)
-    sFirstName :: (Sing (FirstNameSym0 :: [AChar]) :: Type)
-    sLastName :: (Sing (LastNameSym0 :: [AChar]) :: Type)
+    sNames :: (Sing (Names :: Schema) :: Type)
+    sGradingSchema :: (Sing (GradingSchema :: Schema) :: Type)
+    sMajorName :: (Sing (MajorName :: [AChar]) :: Type)
+    sGradeName :: (Sing (GradeName :: [AChar]) :: Type)
+    sYearName :: (Sing (YearName :: [AChar]) :: Type)
+    sFirstName :: (Sing (FirstName :: [AChar]) :: Type)
+    sLastName :: (Sing (LastName :: [AChar]) :: Type)
     sNames
       = applySing
           (singFun1 @SchSym0 SSch)

--- a/singletons-base/tests/compile-and-dump/InsertionSort/InsertionSortImp.golden
+++ b/singletons-base/tests/compile-and-dump/InsertionSort/InsertionSortImp.golden
@@ -133,15 +133,13 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
       Leq ('Succ a) ('Succ b) = Apply (Apply LeqSym0 a) b
     sInsertionSort ::
       (forall (t :: [Nat]).
-       Sing t -> Sing (Apply InsertionSortSym0 t :: [Nat]) :: Type)
+       Sing t -> Sing (InsertionSort t :: [Nat]) :: Type)
     sInsert ::
       (forall (t :: Nat) (t :: [Nat]).
-       Sing t
-       -> Sing t -> Sing (Apply (Apply InsertSym0 t) t :: [Nat]) :: Type)
+       Sing t -> Sing t -> Sing (Insert t t :: [Nat]) :: Type)
     sLeq ::
       (forall (t :: Nat) (t :: Nat).
-       Sing t
-       -> Sing t -> Sing (Apply (Apply LeqSym0 t) t :: Bool) :: Type)
+       Sing t -> Sing t -> Sing (Leq t t :: Bool) :: Type)
     sInsertionSort SNil = SNil
     sInsertionSort (SCons (sH :: Sing h) (sT :: Sing t))
       = applySing
@@ -152,7 +150,7 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
     sInsert (sN :: Sing n) (SCons (sH :: Sing h) (sT :: Sing t))
       = let
           sScrutinee_0123456789876543210 ::
-            Sing @_ (Let0123456789876543210Scrutinee_0123456789876543210Sym0 n h t)
+            Sing @_ (Let0123456789876543210Scrutinee_0123456789876543210 n h t)
           sScrutinee_0123456789876543210
             = applySing (applySing (singFun2 @LeqSym0 sLeq) sN) sH
         in

--- a/singletons-base/tests/compile-and-dump/Promote/Newtypes.golden
+++ b/singletons-base/tests/compile-and-dump/Promote/Newtypes.golden
@@ -48,26 +48,5 @@ Promote/Newtypes.hs:(0,0)-(0,0): Splicing declarations
     type TFHelper_0123456789876543210 :: Foo -> Foo -> Bool
     type family TFHelper_0123456789876543210 (a :: Foo) (a :: Foo) :: Bool where
       TFHelper_0123456789876543210 (Foo a_0123456789876543210) (Foo b_0123456789876543210) = Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210
-    type TFHelper_0123456789876543210Sym0 :: (~>) Foo ((~>) Foo Bool)
-    data TFHelper_0123456789876543210Sym0 :: (~>) Foo ((~>) Foo Bool)
-      where
-        TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Foo @((~>) Foo Bool) TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym0KindInference ())
-    type TFHelper_0123456789876543210Sym1 :: Foo -> (~>) Foo Bool
-    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Foo) :: (~>) Foo Bool
-      where
-        TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Foo @Bool (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym1KindInference ())
-    type TFHelper_0123456789876543210Sym2 :: Foo -> Foo -> Bool
-    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: Foo) (a0123456789876543210 :: Foo) :: Bool where
-      TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq Foo where
-      type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
+      type (==) a a = TFHelper_0123456789876543210 a a

--- a/singletons-base/tests/compile-and-dump/Singletons/AsPattern.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/AsPattern.golden
@@ -172,31 +172,29 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
       MaybePlus ('Just n) = Apply JustSym0 (Apply (Apply PlusSym0 (Apply SuccSym0 ZeroSym0)) n)
       MaybePlus 'Nothing = Let0123456789876543210PSym0
     sFoo ::
-      (forall (t :: [Nat]).
-       Sing t -> Sing (Apply FooSym0 t :: [Nat]) :: Type)
+      (forall (t :: [Nat]). Sing t -> Sing (Foo t :: [Nat]) :: Type)
     sTup ::
       (forall (t :: (Nat, Nat)).
-       Sing t -> Sing (Apply TupSym0 t :: (Nat, Nat)) :: Type)
+       Sing t -> Sing (Tup t :: (Nat, Nat)) :: Type)
     sBaz_ ::
       (forall (t :: Maybe Baz).
-       Sing t -> Sing (Apply Baz_Sym0 t :: Maybe Baz) :: Type)
+       Sing t -> Sing (Baz_ t :: Maybe Baz) :: Type)
     sBar ::
       (forall (t :: Maybe Nat).
-       Sing t -> Sing (Apply BarSym0 t :: Maybe Nat) :: Type)
+       Sing t -> Sing (Bar t :: Maybe Nat) :: Type)
     sMaybePlus ::
       (forall (t :: Maybe Nat).
-       Sing t -> Sing (Apply MaybePlusSym0 t :: Maybe Nat) :: Type)
+       Sing t -> Sing (MaybePlus t :: Maybe Nat) :: Type)
     sFoo SNil
       = let
-          sP :: Sing @_ Let0123456789876543210PSym0
+          sP :: Sing @_ Let0123456789876543210P
           sP = SNil
         in sP
     sFoo
       (SCons (sWild_0123456789876543210 :: Sing wild_0123456789876543210)
              SNil)
       = let
-          sP ::
-            Sing @_ (Let0123456789876543210PSym0 wild_0123456789876543210)
+          sP :: Sing @_ (Let0123456789876543210P wild_0123456789876543210)
           sP
             = applySing
                 (applySing (singFun2 @(:@#@$) SCons) sWild_0123456789876543210)
@@ -208,7 +206,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
                     (sWild_0123456789876543210 :: Sing wild_0123456789876543210)))
       = let
           sP ::
-            Sing @_ (Let0123456789876543210PSym0 wild_0123456789876543210 wild_0123456789876543210 wild_0123456789876543210)
+            Sing @_ (Let0123456789876543210P wild_0123456789876543210 wild_0123456789876543210 wild_0123456789876543210)
           sP
             = applySing
                 (applySing (singFun2 @(:@#@$) SCons) sWild_0123456789876543210)
@@ -221,7 +219,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
                (sWild_0123456789876543210 :: Sing wild_0123456789876543210))
       = let
           sP ::
-            Sing @_ (Let0123456789876543210PSym0 wild_0123456789876543210 wild_0123456789876543210)
+            Sing @_ (Let0123456789876543210P wild_0123456789876543210 wild_0123456789876543210)
           sP
             = applySing
                 (applySing
@@ -230,7 +228,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
         in sP
     sBaz_ SNothing
       = let
-          sP :: Sing @_ Let0123456789876543210PSym0
+          sP :: Sing @_ Let0123456789876543210P
           sP = SNothing
         in sP
     sBaz_
@@ -239,7 +237,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
                    (sWild_0123456789876543210 :: Sing wild_0123456789876543210)))
       = let
           sP ::
-            Sing @_ (Let0123456789876543210PSym0 wild_0123456789876543210 wild_0123456789876543210 wild_0123456789876543210)
+            Sing @_ (Let0123456789876543210P wild_0123456789876543210 wild_0123456789876543210 wild_0123456789876543210)
           sP
             = applySing
                 (singFun1 @JustSym0 SJust)
@@ -252,8 +250,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
     sBar
       (SJust (sWild_0123456789876543210 :: Sing wild_0123456789876543210))
       = let
-          sX ::
-            Sing @_ (Let0123456789876543210XSym0 wild_0123456789876543210)
+          sX :: Sing @_ (Let0123456789876543210X wild_0123456789876543210)
           sX = applySing (singFun1 @JustSym0 SJust) sWild_0123456789876543210
         in sX
     sBar SNothing = SNothing
@@ -267,7 +264,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
              sN)
     sMaybePlus SNothing
       = let
-          sP :: Sing @_ Let0123456789876543210PSym0
+          sP :: Sing @_ Let0123456789876543210P
           sP = SNothing
         in sP
     instance SingI (FooSym0 :: (~>) [Nat] [Nat]) where

--- a/singletons-base/tests/compile-and-dump/Singletons/BoundedDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/BoundedDeriving.golden
@@ -88,78 +88,48 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
     type MinBound_0123456789876543210 :: Foo1
     type family MinBound_0123456789876543210 :: Foo1 where
       MinBound_0123456789876543210 = Foo1Sym0
-    type MinBound_0123456789876543210Sym0 :: Foo1
-    type family MinBound_0123456789876543210Sym0 :: Foo1 where
-      MinBound_0123456789876543210Sym0 = MinBound_0123456789876543210
     type MaxBound_0123456789876543210 :: Foo1
     type family MaxBound_0123456789876543210 :: Foo1 where
       MaxBound_0123456789876543210 = Foo1Sym0
-    type MaxBound_0123456789876543210Sym0 :: Foo1
-    type family MaxBound_0123456789876543210Sym0 :: Foo1 where
-      MaxBound_0123456789876543210Sym0 = MaxBound_0123456789876543210
     instance PBounded Foo1 where
-      type MinBound = MinBound_0123456789876543210Sym0
-      type MaxBound = MaxBound_0123456789876543210Sym0
+      type MinBound = MinBound_0123456789876543210
+      type MaxBound = MaxBound_0123456789876543210
     type MinBound_0123456789876543210 :: Foo2
     type family MinBound_0123456789876543210 :: Foo2 where
       MinBound_0123456789876543210 = ASym0
-    type MinBound_0123456789876543210Sym0 :: Foo2
-    type family MinBound_0123456789876543210Sym0 :: Foo2 where
-      MinBound_0123456789876543210Sym0 = MinBound_0123456789876543210
     type MaxBound_0123456789876543210 :: Foo2
     type family MaxBound_0123456789876543210 :: Foo2 where
       MaxBound_0123456789876543210 = ESym0
-    type MaxBound_0123456789876543210Sym0 :: Foo2
-    type family MaxBound_0123456789876543210Sym0 :: Foo2 where
-      MaxBound_0123456789876543210Sym0 = MaxBound_0123456789876543210
     instance PBounded Foo2 where
-      type MinBound = MinBound_0123456789876543210Sym0
-      type MaxBound = MaxBound_0123456789876543210Sym0
+      type MinBound = MinBound_0123456789876543210
+      type MaxBound = MaxBound_0123456789876543210
     type MinBound_0123456789876543210 :: forall a. Foo3 a
     type family MinBound_0123456789876543210 @a :: Foo3 a where
       MinBound_0123456789876543210 @a = Apply Foo3Sym0 MinBoundSym0
-    type MinBound_0123456789876543210Sym0 :: forall a. Foo3 a
-    type family MinBound_0123456789876543210Sym0 @a :: Foo3 a where
-      MinBound_0123456789876543210Sym0 = MinBound_0123456789876543210
     type MaxBound_0123456789876543210 :: forall a. Foo3 a
     type family MaxBound_0123456789876543210 @a :: Foo3 a where
       MaxBound_0123456789876543210 @a = Apply Foo3Sym0 MaxBoundSym0
-    type MaxBound_0123456789876543210Sym0 :: forall a. Foo3 a
-    type family MaxBound_0123456789876543210Sym0 @a :: Foo3 a where
-      MaxBound_0123456789876543210Sym0 = MaxBound_0123456789876543210
     instance PBounded (Foo3 a) where
-      type MinBound = MinBound_0123456789876543210Sym0
-      type MaxBound = MaxBound_0123456789876543210Sym0
+      type MinBound = MinBound_0123456789876543210
+      type MaxBound = MaxBound_0123456789876543210
     type MinBound_0123456789876543210 :: forall a b. Foo4 a b
     type family MinBound_0123456789876543210 @a @b :: Foo4 a b where
       MinBound_0123456789876543210 @a @b = Foo41Sym0
-    type MinBound_0123456789876543210Sym0 :: forall a b. Foo4 a b
-    type family MinBound_0123456789876543210Sym0 @a @b :: Foo4 a b where
-      MinBound_0123456789876543210Sym0 = MinBound_0123456789876543210
     type MaxBound_0123456789876543210 :: forall a b. Foo4 a b
     type family MaxBound_0123456789876543210 @a @b :: Foo4 a b where
       MaxBound_0123456789876543210 @a @b = Foo42Sym0
-    type MaxBound_0123456789876543210Sym0 :: forall a b. Foo4 a b
-    type family MaxBound_0123456789876543210Sym0 @a @b :: Foo4 a b where
-      MaxBound_0123456789876543210Sym0 = MaxBound_0123456789876543210
     instance PBounded (Foo4 a b) where
-      type MinBound = MinBound_0123456789876543210Sym0
-      type MaxBound = MaxBound_0123456789876543210Sym0
+      type MinBound = MinBound_0123456789876543210
+      type MaxBound = MaxBound_0123456789876543210
     type MinBound_0123456789876543210 :: Pair
     type family MinBound_0123456789876543210 :: Pair where
       MinBound_0123456789876543210 = Apply (Apply PairSym0 MinBoundSym0) MinBoundSym0
-    type MinBound_0123456789876543210Sym0 :: Pair
-    type family MinBound_0123456789876543210Sym0 :: Pair where
-      MinBound_0123456789876543210Sym0 = MinBound_0123456789876543210
     type MaxBound_0123456789876543210 :: Pair
     type family MaxBound_0123456789876543210 :: Pair where
       MaxBound_0123456789876543210 = Apply (Apply PairSym0 MaxBoundSym0) MaxBoundSym0
-    type MaxBound_0123456789876543210Sym0 :: Pair
-    type family MaxBound_0123456789876543210Sym0 :: Pair where
-      MaxBound_0123456789876543210Sym0 = MaxBound_0123456789876543210
     instance PBounded Pair where
-      type MinBound = MinBound_0123456789876543210Sym0
-      type MaxBound = MaxBound_0123456789876543210Sym0
+      type MinBound = MinBound_0123456789876543210
+      type MaxBound = MaxBound_0123456789876543210
     data SFoo1 :: Foo1 -> Type where SFoo1 :: SFoo1 (Foo1 :: Foo1)
     type instance Sing @Foo1 = SFoo1
     instance SingKind Foo1 where

--- a/singletons-base/tests/compile-and-dump/Singletons/BoxUnBox.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/BoxUnBox.golden
@@ -34,8 +34,7 @@ Singletons/BoxUnBox.hs:(0,0)-(0,0): Splicing declarations
     type family UnBox @a (a :: Box a) :: a where
       UnBox (FBox a) = a
     sUnBox ::
-      (forall (t :: Box a).
-       Sing t -> Sing (Apply UnBoxSym0 t :: a) :: Type)
+      (forall (t :: Box a). Sing t -> Sing (UnBox t :: a) :: Type)
     sUnBox (SFBox (sA :: Sing a)) = sA
     instance SingI (UnBoxSym0 :: (~>) (Box a) a) where
       sing = singFun1 @UnBoxSym0 sUnBox

--- a/singletons-base/tests/compile-and-dump/Singletons/CaseExpressions.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/CaseExpressions.golden
@@ -168,18 +168,17 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
     type Foo1 :: a -> Maybe a -> a
     type family Foo1 @a (a :: a) (a :: Maybe a) :: a where
       Foo1 d x = Case_0123456789876543210 d x x
-    sFoo5 ::
-      (forall (t :: a). Sing t -> Sing (Apply Foo5Sym0 t :: a) :: Type)
-    sFoo4 :: forall a (t :: a). Sing t -> Sing (Apply Foo4Sym0 t :: a)
+    sFoo5 :: (forall (t :: a). Sing t -> Sing (Foo5 t :: a) :: Type)
+    sFoo4 :: forall a (t :: a). Sing t -> Sing (Foo4 t :: a)
     sFoo3 ::
       (forall (t :: a) (t :: b).
-       Sing t -> Sing t -> Sing (Apply (Apply Foo3Sym0 t) t :: a) :: Type)
+       Sing t -> Sing t -> Sing (Foo3 t t :: a) :: Type)
     sFoo2 ::
       (forall (t :: a) (t :: Maybe a).
-       Sing t -> Sing t -> Sing (Apply (Apply Foo2Sym0 t) t :: a) :: Type)
+       Sing t -> Sing t -> Sing (Foo2 t t :: a) :: Type)
     sFoo1 ::
       (forall (t :: a) (t :: Maybe a).
-       Sing t -> Sing t -> Sing (Apply (Apply Foo1Sym0 t) t :: a) :: Type)
+       Sing t -> Sing t -> Sing (Foo1 t t :: a) :: Type)
     sFoo5 (sX :: Sing x)
       = id
           @(Sing (Case_0123456789876543210 x x))
@@ -201,13 +200,13 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
           (case sX of
              (sY :: Sing y)
                -> let
-                    sZ :: (Sing (Let0123456789876543210ZSym0 a y x :: a) :: Type)
+                    sZ :: (Sing (Let0123456789876543210Z a y x :: a) :: Type)
                     sZ = sY
                   in sZ)
     sFoo3 (sA :: Sing a) (sB :: Sing b)
       = let
           sScrutinee_0123456789876543210 ::
-            Sing @_ (Let0123456789876543210Scrutinee_0123456789876543210Sym0 a b)
+            Sing @_ (Let0123456789876543210Scrutinee_0123456789876543210 a b)
           sScrutinee_0123456789876543210
             = applySing (applySing (singFun2 @Tuple2Sym0 STuple2) sA) sB
         in
@@ -218,7 +217,7 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
     sFoo2 (sD :: Sing d) _
       = let
           sScrutinee_0123456789876543210 ::
-            Sing @_ (Let0123456789876543210Scrutinee_0123456789876543210Sym0 d)
+            Sing @_ (Let0123456789876543210Scrutinee_0123456789876543210 d)
           sScrutinee_0123456789876543210
             = applySing (singFun1 @JustSym0 SJust) sD
         in

--- a/singletons-base/tests/compile-and-dump/Singletons/Classes.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Classes.golden
@@ -162,143 +162,36 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     type TFHelper_0123456789876543210 :: forall a. a -> a -> Ordering
     type family TFHelper_0123456789876543210 @a (a :: a) (a :: a) :: Ordering where
       TFHelper_0123456789876543210 @a (a_0123456789876543210 :: a) (a_0123456789876543210 :: a) = Apply (Apply MycompareSym0 a_0123456789876543210) a_0123456789876543210
-    type TFHelper_0123456789876543210Sym0 :: forall a. (~>) a ((~>) a Ordering)
-    data TFHelper_0123456789876543210Sym0 :: (~>) a ((~>) a Ordering)
-      where
-        TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @a @((~>) a Ordering) TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym0KindInference ())
-    type TFHelper_0123456789876543210Sym1 :: forall a. a
-                                                       -> (~>) a Ordering
-    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: a) :: (~>) a Ordering
-      where
-        TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @a @Ordering (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym1KindInference ())
-    type TFHelper_0123456789876543210Sym2 :: forall a. a
-                                                       -> a -> Ordering
-    type family TFHelper_0123456789876543210Sym2 @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Ordering where
-      TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     class PMyOrd a where
       type family Mycompare (arg :: a) (arg :: a) :: Ordering
       type family (<=>) (arg :: a) (arg :: a) :: Ordering
-      type (<=>) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
+      type (<=>) a a = TFHelper_0123456789876543210 a a
     type Mycompare_0123456789876543210 :: Nat -> Nat -> Ordering
     type family Mycompare_0123456789876543210 (a :: Nat) (a :: Nat) :: Ordering where
       Mycompare_0123456789876543210 'Zero 'Zero = EQSym0
       Mycompare_0123456789876543210 'Zero ('Succ _) = LTSym0
       Mycompare_0123456789876543210 ('Succ _) 'Zero = GTSym0
       Mycompare_0123456789876543210 ('Succ n) ('Succ m) = Apply (Apply MycompareSym0 m) n
-    type Mycompare_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Ordering)
-    data Mycompare_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Ordering)
-      where
-        Mycompare_0123456789876543210Sym0KindInference :: SameKind (Apply Mycompare_0123456789876543210Sym0 arg) (Mycompare_0123456789876543210Sym1 arg) =>
-                                                          Mycompare_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Nat @((~>) Nat Ordering) Mycompare_0123456789876543210Sym0 a0123456789876543210 = Mycompare_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Mycompare_0123456789876543210Sym0KindInference ())
-    type Mycompare_0123456789876543210Sym1 :: Nat -> (~>) Nat Ordering
-    data Mycompare_0123456789876543210Sym1 (a0123456789876543210 :: Nat) :: (~>) Nat Ordering
-      where
-        Mycompare_0123456789876543210Sym1KindInference :: SameKind (Apply (Mycompare_0123456789876543210Sym1 a0123456789876543210) arg) (Mycompare_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                          Mycompare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @Ordering (Mycompare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Mycompare_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Mycompare_0123456789876543210Sym1KindInference ())
-    type Mycompare_0123456789876543210Sym2 :: Nat -> Nat -> Ordering
-    type family Mycompare_0123456789876543210Sym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Ordering where
-      Mycompare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PMyOrd Nat where
-      type Mycompare a a = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
+      type Mycompare a a = Mycompare_0123456789876543210 a a
     type Mycompare_0123456789876543210 :: () -> () -> Ordering
     type family Mycompare_0123456789876543210 (a :: ()) (a :: ()) :: Ordering where
       Mycompare_0123456789876543210 _ a_0123456789876543210 = Apply (Apply ConstSym0 EQSym0) a_0123456789876543210
-    type Mycompare_0123456789876543210Sym0 :: (~>) () ((~>) () Ordering)
-    data Mycompare_0123456789876543210Sym0 :: (~>) () ((~>) () Ordering)
-      where
-        Mycompare_0123456789876543210Sym0KindInference :: SameKind (Apply Mycompare_0123456789876543210Sym0 arg) (Mycompare_0123456789876543210Sym1 arg) =>
-                                                          Mycompare_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @() @((~>) () Ordering) Mycompare_0123456789876543210Sym0 a0123456789876543210 = Mycompare_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Mycompare_0123456789876543210Sym0KindInference ())
-    type Mycompare_0123456789876543210Sym1 :: () -> (~>) () Ordering
-    data Mycompare_0123456789876543210Sym1 (a0123456789876543210 :: ()) :: (~>) () Ordering
-      where
-        Mycompare_0123456789876543210Sym1KindInference :: SameKind (Apply (Mycompare_0123456789876543210Sym1 a0123456789876543210) arg) (Mycompare_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                          Mycompare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @() @Ordering (Mycompare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Mycompare_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Mycompare_0123456789876543210Sym1KindInference ())
-    type Mycompare_0123456789876543210Sym2 :: () -> () -> Ordering
-    type family Mycompare_0123456789876543210Sym2 (a0123456789876543210 :: ()) (a0123456789876543210 :: ()) :: Ordering where
-      Mycompare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PMyOrd () where
-      type Mycompare a a = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
+      type Mycompare a a = Mycompare_0123456789876543210 a a
     type Mycompare_0123456789876543210 :: Foo -> Foo -> Ordering
     type family Mycompare_0123456789876543210 (a :: Foo) (a :: Foo) :: Ordering where
       Mycompare_0123456789876543210 a_0123456789876543210 a_0123456789876543210 = Apply (Apply FooCompareSym0 a_0123456789876543210) a_0123456789876543210
-    type Mycompare_0123456789876543210Sym0 :: (~>) Foo ((~>) Foo Ordering)
-    data Mycompare_0123456789876543210Sym0 :: (~>) Foo ((~>) Foo Ordering)
-      where
-        Mycompare_0123456789876543210Sym0KindInference :: SameKind (Apply Mycompare_0123456789876543210Sym0 arg) (Mycompare_0123456789876543210Sym1 arg) =>
-                                                          Mycompare_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Foo @((~>) Foo Ordering) Mycompare_0123456789876543210Sym0 a0123456789876543210 = Mycompare_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Mycompare_0123456789876543210Sym0KindInference ())
-    type Mycompare_0123456789876543210Sym1 :: Foo -> (~>) Foo Ordering
-    data Mycompare_0123456789876543210Sym1 (a0123456789876543210 :: Foo) :: (~>) Foo Ordering
-      where
-        Mycompare_0123456789876543210Sym1KindInference :: SameKind (Apply (Mycompare_0123456789876543210Sym1 a0123456789876543210) arg) (Mycompare_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                          Mycompare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Foo @Ordering (Mycompare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Mycompare_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Mycompare_0123456789876543210Sym1KindInference ())
-    type Mycompare_0123456789876543210Sym2 :: Foo -> Foo -> Ordering
-    type family Mycompare_0123456789876543210Sym2 (a0123456789876543210 :: Foo) (a0123456789876543210 :: Foo) :: Ordering where
-      Mycompare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PMyOrd Foo where
-      type Mycompare a a = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
+      type Mycompare a a = Mycompare_0123456789876543210 a a
     type TFHelper_0123456789876543210 :: Foo2 -> Foo2 -> Bool
     type family TFHelper_0123456789876543210 (a :: Foo2) (a :: Foo2) :: Bool where
       TFHelper_0123456789876543210 F F = TrueSym0
       TFHelper_0123456789876543210 G G = TrueSym0
       TFHelper_0123456789876543210 F G = FalseSym0
       TFHelper_0123456789876543210 G F = FalseSym0
-    type TFHelper_0123456789876543210Sym0 :: (~>) Foo2 ((~>) Foo2 Bool)
-    data TFHelper_0123456789876543210Sym0 :: (~>) Foo2 ((~>) Foo2 Bool)
-      where
-        TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Foo2 @((~>) Foo2 Bool) TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym0KindInference ())
-    type TFHelper_0123456789876543210Sym1 :: Foo2 -> (~>) Foo2 Bool
-    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Foo2) :: (~>) Foo2 Bool
-      where
-        TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Foo2 @Bool (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym1KindInference ())
-    type TFHelper_0123456789876543210Sym2 :: Foo2 -> Foo2 -> Bool
-    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: Foo2) (a0123456789876543210 :: Foo2) :: Bool where
-      TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq Foo2 where
-      type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
+      type (==) a a = TFHelper_0123456789876543210 a a
     sFooCompare ::
       (forall (t :: Foo) (t :: Foo).
        Sing t
@@ -365,8 +258,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       infix 4 %<=>
       default (%<=>) ::
                 (forall (t :: a) (t :: a).
-                 ((Apply (Apply (<=>@#@$) t) t :: Ordering)
-                  ~ Apply (Apply TFHelper_0123456789876543210Sym0 t) t) =>
+                 (((<=>) t t :: Ordering) ~ TFHelper_0123456789876543210 t t) =>
                  Sing t
                  -> Sing t
                     -> Sing (Apply (Apply (<=>@#@$) t) t :: Ordering) :: Type)
@@ -452,58 +344,15 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       Mycompare_0123456789876543210 'F 'F = EQSym0
       Mycompare_0123456789876543210 'F _ = LTSym0
       Mycompare_0123456789876543210 _ _ = GTSym0
-    type Mycompare_0123456789876543210Sym0 :: (~>) Foo2 ((~>) Foo2 Ordering)
-    data Mycompare_0123456789876543210Sym0 :: (~>) Foo2 ((~>) Foo2 Ordering)
-      where
-        Mycompare_0123456789876543210Sym0KindInference :: SameKind (Apply Mycompare_0123456789876543210Sym0 arg) (Mycompare_0123456789876543210Sym1 arg) =>
-                                                          Mycompare_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Foo2 @((~>) Foo2 Ordering) Mycompare_0123456789876543210Sym0 a0123456789876543210 = Mycompare_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Mycompare_0123456789876543210Sym0KindInference ())
-    type Mycompare_0123456789876543210Sym1 :: Foo2
-                                              -> (~>) Foo2 Ordering
-    data Mycompare_0123456789876543210Sym1 (a0123456789876543210 :: Foo2) :: (~>) Foo2 Ordering
-      where
-        Mycompare_0123456789876543210Sym1KindInference :: SameKind (Apply (Mycompare_0123456789876543210Sym1 a0123456789876543210) arg) (Mycompare_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                          Mycompare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Foo2 @Ordering (Mycompare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Mycompare_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Mycompare_0123456789876543210Sym1KindInference ())
-    type Mycompare_0123456789876543210Sym2 :: Foo2 -> Foo2 -> Ordering
-    type family Mycompare_0123456789876543210Sym2 (a0123456789876543210 :: Foo2) (a0123456789876543210 :: Foo2) :: Ordering where
-      Mycompare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PMyOrd Foo2 where
-      type Mycompare a a = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
+      type Mycompare a a = Mycompare_0123456789876543210 a a
     type Compare_0123456789876543210 :: Foo2 -> Foo2 -> Ordering
     type family Compare_0123456789876543210 (a :: Foo2) (a :: Foo2) :: Ordering where
       Compare_0123456789876543210 'F 'F = EQSym0
       Compare_0123456789876543210 'F _ = LTSym0
       Compare_0123456789876543210 _ _ = GTSym0
-    type Compare_0123456789876543210Sym0 :: (~>) Foo2 ((~>) Foo2 Ordering)
-    data Compare_0123456789876543210Sym0 :: (~>) Foo2 ((~>) Foo2 Ordering)
-      where
-        Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Foo2 @((~>) Foo2 Ordering) Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym0KindInference ())
-    type Compare_0123456789876543210Sym1 :: Foo2 -> (~>) Foo2 Ordering
-    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Foo2) :: (~>) Foo2 Ordering
-      where
-        Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Foo2 @Ordering (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym1KindInference ())
-    type Compare_0123456789876543210Sym2 :: Foo2 -> Foo2 -> Ordering
-    type family Compare_0123456789876543210Sym2 (a0123456789876543210 :: Foo2) (a0123456789876543210 :: Foo2) :: Ordering where
-      Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd Foo2 where
-      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
+      type Compare a a = Compare_0123456789876543210 a a
 Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     singletons
       [d| data Nat' = Zero' | Succ' Nat'
@@ -540,30 +389,8 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       Mycompare_0123456789876543210 Zero' (Succ' _) = LTSym0
       Mycompare_0123456789876543210 (Succ' _) Zero' = GTSym0
       Mycompare_0123456789876543210 (Succ' n) (Succ' m) = Apply (Apply MycompareSym0 m) n
-    type Mycompare_0123456789876543210Sym0 :: (~>) Nat' ((~>) Nat' Ordering)
-    data Mycompare_0123456789876543210Sym0 :: (~>) Nat' ((~>) Nat' Ordering)
-      where
-        Mycompare_0123456789876543210Sym0KindInference :: SameKind (Apply Mycompare_0123456789876543210Sym0 arg) (Mycompare_0123456789876543210Sym1 arg) =>
-                                                          Mycompare_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Nat' @((~>) Nat' Ordering) Mycompare_0123456789876543210Sym0 a0123456789876543210 = Mycompare_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Mycompare_0123456789876543210Sym0KindInference ())
-    type Mycompare_0123456789876543210Sym1 :: Nat'
-                                              -> (~>) Nat' Ordering
-    data Mycompare_0123456789876543210Sym1 (a0123456789876543210 :: Nat') :: (~>) Nat' Ordering
-      where
-        Mycompare_0123456789876543210Sym1KindInference :: SameKind (Apply (Mycompare_0123456789876543210Sym1 a0123456789876543210) arg) (Mycompare_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                          Mycompare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Nat' @Ordering (Mycompare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Mycompare_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Mycompare_0123456789876543210Sym1KindInference ())
-    type Mycompare_0123456789876543210Sym2 :: Nat' -> Nat' -> Ordering
-    type family Mycompare_0123456789876543210Sym2 (a0123456789876543210 :: Nat') (a0123456789876543210 :: Nat') :: Ordering where
-      Mycompare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PMyOrd Nat' where
-      type Mycompare a a = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
+      type Mycompare a a = Mycompare_0123456789876543210 a a
     data SNat' :: Nat' -> Type
       where
         SZero' :: SNat' (Zero' :: Nat')

--- a/singletons-base/tests/compile-and-dump/Singletons/Classes.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Classes.golden
@@ -194,13 +194,10 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       type (==) a a = TFHelper_0123456789876543210 a a
     sFooCompare ::
       (forall (t :: Foo) (t :: Foo).
-       Sing t
-       -> Sing t
-          -> Sing (Apply (Apply FooCompareSym0 t) t :: Ordering) :: Type)
+       Sing t -> Sing t -> Sing (FooCompare t t :: Ordering) :: Type)
     sConst ::
       (forall (t :: a) (t :: b).
-       Sing t
-       -> Sing t -> Sing (Apply (Apply ConstSym0 t) t :: a) :: Type)
+       Sing t -> Sing t -> Sing (Const t t :: a) :: Type)
     sFooCompare SA SA = SEQ
     sFooCompare SA SB = SLT
     sFooCompare SB SB = SGT
@@ -247,21 +244,15 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     class SMyOrd a where
       sMycompare ::
         (forall (t :: a) (t :: a).
-         Sing t
-         -> Sing t
-            -> Sing (Apply (Apply MycompareSym0 t) t :: Ordering) :: Type)
+         Sing t -> Sing t -> Sing (Mycompare t t :: Ordering) :: Type)
       (%<=>) ::
         (forall (t :: a) (t :: a).
-         Sing t
-         -> Sing t
-            -> Sing (Apply (Apply (<=>@#@$) t) t :: Ordering) :: Type)
+         Sing t -> Sing t -> Sing ((<=>) t t :: Ordering) :: Type)
       infix 4 %<=>
       default (%<=>) ::
                 (forall (t :: a) (t :: a).
                  (((<=>) t t :: Ordering) ~ TFHelper_0123456789876543210 t t) =>
-                 Sing t
-                 -> Sing t
-                    -> Sing (Apply (Apply (<=>@#@$) t) t :: Ordering) :: Type)
+                 Sing t -> Sing t -> Sing ((<=>) t t :: Ordering) :: Type)
       (%<=>)
         (sA_0123456789876543210 :: Sing a_0123456789876543210)
         (sA_0123456789876543210 :: Sing a_0123456789876543210)

--- a/singletons-base/tests/compile-and-dump/Singletons/Classes2.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Classes2.golden
@@ -34,31 +34,8 @@ Singletons/Classes2.hs:(0,0)-(0,0): Splicing declarations
       Mycompare_0123456789876543210 ZeroFoo (SuccFoo _) = LTSym0
       Mycompare_0123456789876543210 (SuccFoo _) ZeroFoo = GTSym0
       Mycompare_0123456789876543210 (SuccFoo n) (SuccFoo m) = Apply (Apply MycompareSym0 m) n
-    type Mycompare_0123456789876543210Sym0 :: (~>) NatFoo ((~>) NatFoo Ordering)
-    data Mycompare_0123456789876543210Sym0 :: (~>) NatFoo ((~>) NatFoo Ordering)
-      where
-        Mycompare_0123456789876543210Sym0KindInference :: SameKind (Apply Mycompare_0123456789876543210Sym0 arg) (Mycompare_0123456789876543210Sym1 arg) =>
-                                                          Mycompare_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @NatFoo @((~>) NatFoo Ordering) Mycompare_0123456789876543210Sym0 a0123456789876543210 = Mycompare_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Mycompare_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Mycompare_0123456789876543210Sym0KindInference ())
-    type Mycompare_0123456789876543210Sym1 :: NatFoo
-                                              -> (~>) NatFoo Ordering
-    data Mycompare_0123456789876543210Sym1 (a0123456789876543210 :: NatFoo) :: (~>) NatFoo Ordering
-      where
-        Mycompare_0123456789876543210Sym1KindInference :: SameKind (Apply (Mycompare_0123456789876543210Sym1 a0123456789876543210) arg) (Mycompare_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                          Mycompare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @NatFoo @Ordering (Mycompare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Mycompare_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Mycompare_0123456789876543210Sym1KindInference ())
-    type Mycompare_0123456789876543210Sym2 :: NatFoo
-                                              -> NatFoo -> Ordering
-    type family Mycompare_0123456789876543210Sym2 (a0123456789876543210 :: NatFoo) (a0123456789876543210 :: NatFoo) :: Ordering where
-      Mycompare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Mycompare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PMyOrd NatFoo where
-      type Mycompare a a = Apply (Apply Mycompare_0123456789876543210Sym0 a) a
+      type Mycompare a a = Mycompare_0123456789876543210 a a
     data SNatFoo :: NatFoo -> Type
       where
         SZeroFoo :: SNatFoo (ZeroFoo :: NatFoo)

--- a/singletons-base/tests/compile-and-dump/Singletons/Contains.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Contains.golden
@@ -32,9 +32,7 @@ Singletons/Contains.hs:(0,0)-(0,0): Splicing declarations
       Contains elt ('(:) h t) = Apply (Apply (||@#@$) (Apply (Apply (==@#@$) elt) h)) (Apply (Apply ContainsSym0 elt) t)
     sContains ::
       (forall (t :: a) (t :: [a]).
-       SEq a =>
-       Sing t
-       -> Sing t -> Sing (Apply (Apply ContainsSym0 t) t :: Bool) :: Type)
+       SEq a => Sing t -> Sing t -> Sing (Contains t t :: Bool) :: Type)
     sContains _ SNil = SFalse
     sContains (sElt :: Sing elt) (SCons (sH :: Sing h) (sT :: Sing t))
       = applySing

--- a/singletons-base/tests/compile-and-dump/Singletons/DataValues.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/DataValues.golden
@@ -58,10 +58,10 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
       ShowsPrec_0123456789876543210 @a @b (p_0123456789876543210 :: GHC.Num.Natural.Natural) (Pair arg_0123456789876543210 arg_0123456789876543210 :: Pair a b) (a_0123456789876543210 :: Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Pair ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
     instance PShow (Pair a b) where
       type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
-    sAList :: Sing @_ AListSym0
-    sTuple :: Sing @_ TupleSym0
-    sComplex :: Sing @_ ComplexSym0
-    sPr :: Sing @_ PrSym0
+    sAList :: Sing @_ AList
+    sTuple :: Sing @_ Tuple
+    sComplex :: Sing @_ Complex
+    sPr :: Sing @_ Pr
     sAList
       = applySing
           (applySing (singFun2 @(:@#@$) SCons) SZero)

--- a/singletons-base/tests/compile-and-dump/Singletons/DataValues.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/DataValues.golden
@@ -56,45 +56,8 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
                                                     -> Pair a b -> Symbol -> Symbol
     type family ShowsPrec_0123456789876543210 @a @b (a :: GHC.Num.Natural.Natural) (a :: Pair a b) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 @a @b (p_0123456789876543210 :: GHC.Num.Natural.Natural) (Pair arg_0123456789876543210 arg_0123456789876543210 :: Pair a b) (a_0123456789876543210 :: Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Pair ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym0 :: forall a
-                                                     b. (~>) GHC.Num.Natural.Natural ((~>) (Pair a b) ((~>) Symbol Symbol))
-    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) (Pair a b) ((~>) Symbol Symbol))
-      where
-        ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @GHC.Num.Natural.Natural @((~>) (Pair a b) ((~>) Symbol Symbol)) ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym0KindInference ())
-    type ShowsPrec_0123456789876543210Sym1 :: forall a
-                                                     b. GHC.Num.Natural.Natural
-                                                        -> (~>) (Pair a b) ((~>) Symbol Symbol)
-    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Num.Natural.Natural) :: (~>) (Pair a b) ((~>) Symbol Symbol)
-      where
-        ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Pair a b) @((~>) Symbol Symbol) (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym1KindInference ())
-    type ShowsPrec_0123456789876543210Sym2 :: forall a
-                                                     b. GHC.Num.Natural.Natural
-                                                        -> Pair a b -> (~>) Symbol Symbol
-    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: Pair a b) :: (~>) Symbol Symbol
-      where
-        ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @Symbol @Symbol (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym2KindInference ())
-    type ShowsPrec_0123456789876543210Sym3 :: forall a
-                                                     b. GHC.Num.Natural.Natural
-                                                        -> Pair a b -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210Sym3 @a @b (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: Pair a b) (a0123456789876543210 :: Symbol) :: Symbol where
-      ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow (Pair a b) where
-      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
     sAList :: Sing @_ AListSym0
     sTuple :: Sing @_ TupleSym0
     sComplex :: Sing @_ ComplexSym0

--- a/singletons-base/tests/compile-and-dump/Singletons/EmptyShowDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/EmptyShowDeriving.golden
@@ -11,41 +11,8 @@ Singletons/EmptyShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                                           -> Foo -> GHC.Types.Symbol -> GHC.Types.Symbol
     type family ShowsPrec_0123456789876543210 (a :: GHC.Num.Natural.Natural) (a :: Foo) (a :: GHC.Types.Symbol) :: GHC.Types.Symbol where
       ShowsPrec_0123456789876543210 _ v_0123456789876543210 a_0123456789876543210 = Apply (Case_0123456789876543210 v_0123456789876543210 a_0123456789876543210 v_0123456789876543210) a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) Foo ((~>) GHC.Types.Symbol GHC.Types.Symbol))
-    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) Foo ((~>) GHC.Types.Symbol GHC.Types.Symbol))
-      where
-        ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @GHC.Num.Natural.Natural @((~>) Foo ((~>) GHC.Types.Symbol GHC.Types.Symbol)) ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym0KindInference ())
-    type ShowsPrec_0123456789876543210Sym1 :: GHC.Num.Natural.Natural
-                                              -> (~>) Foo ((~>) GHC.Types.Symbol GHC.Types.Symbol)
-    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Num.Natural.Natural) :: (~>) Foo ((~>) GHC.Types.Symbol GHC.Types.Symbol)
-      where
-        ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Foo @((~>) GHC.Types.Symbol GHC.Types.Symbol) (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym1KindInference ())
-    type ShowsPrec_0123456789876543210Sym2 :: GHC.Num.Natural.Natural
-                                              -> Foo -> (~>) GHC.Types.Symbol GHC.Types.Symbol
-    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: Foo) :: (~>) GHC.Types.Symbol GHC.Types.Symbol
-      where
-        ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @GHC.Types.Symbol @GHC.Types.Symbol (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym2KindInference ())
-    type ShowsPrec_0123456789876543210Sym3 :: GHC.Num.Natural.Natural
-                                              -> Foo -> GHC.Types.Symbol -> GHC.Types.Symbol
-    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: Foo) (a0123456789876543210 :: GHC.Types.Symbol) :: GHC.Types.Symbol where
-      ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow Foo where
-      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
     data SFoo :: Foo -> Type
     type instance Sing @Foo = SFoo
     instance SingKind Foo where

--- a/singletons-base/tests/compile-and-dump/Singletons/EnumDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/EnumDeriving.golden
@@ -36,40 +36,14 @@ Singletons/EnumDeriving.hs:(0,0)-(0,0): Splicing declarations
     type ToEnum_0123456789876543210 :: GHC.Num.Natural.Natural -> Foo
     type family ToEnum_0123456789876543210 (a :: GHC.Num.Natural.Natural) :: Foo where
       ToEnum_0123456789876543210 n = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (FromInteger 0))
-    type ToEnum_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural Foo
-    data ToEnum_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural Foo
-      where
-        ToEnum_0123456789876543210Sym0KindInference :: SameKind (Apply ToEnum_0123456789876543210Sym0 arg) (ToEnum_0123456789876543210Sym1 arg) =>
-                                                       ToEnum_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @GHC.Num.Natural.Natural @Foo ToEnum_0123456789876543210Sym0 a0123456789876543210 = ToEnum_0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ToEnum_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) ToEnum_0123456789876543210Sym0KindInference ())
-    type ToEnum_0123456789876543210Sym1 :: GHC.Num.Natural.Natural
-                                           -> Foo
-    type family ToEnum_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Num.Natural.Natural) :: Foo where
-      ToEnum_0123456789876543210Sym1 a0123456789876543210 = ToEnum_0123456789876543210 a0123456789876543210
     type FromEnum_0123456789876543210 :: Foo -> GHC.Num.Natural.Natural
     type family FromEnum_0123456789876543210 (a :: Foo) :: GHC.Num.Natural.Natural where
       FromEnum_0123456789876543210 Bar = FromInteger 0
       FromEnum_0123456789876543210 Baz = FromInteger 1
       FromEnum_0123456789876543210 Bum = FromInteger 2
-    type FromEnum_0123456789876543210Sym0 :: (~>) Foo GHC.Num.Natural.Natural
-    data FromEnum_0123456789876543210Sym0 :: (~>) Foo GHC.Num.Natural.Natural
-      where
-        FromEnum_0123456789876543210Sym0KindInference :: SameKind (Apply FromEnum_0123456789876543210Sym0 arg) (FromEnum_0123456789876543210Sym1 arg) =>
-                                                         FromEnum_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Foo @GHC.Num.Natural.Natural FromEnum_0123456789876543210Sym0 a0123456789876543210 = FromEnum_0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings FromEnum_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) FromEnum_0123456789876543210Sym0KindInference ())
-    type FromEnum_0123456789876543210Sym1 :: Foo
-                                             -> GHC.Num.Natural.Natural
-    type family FromEnum_0123456789876543210Sym1 (a0123456789876543210 :: Foo) :: GHC.Num.Natural.Natural where
-      FromEnum_0123456789876543210Sym1 a0123456789876543210 = FromEnum_0123456789876543210 a0123456789876543210
     instance PEnum Foo where
-      type ToEnum a = Apply ToEnum_0123456789876543210Sym0 a
-      type FromEnum a = Apply FromEnum_0123456789876543210Sym0 a
+      type ToEnum a = ToEnum_0123456789876543210 a
+      type FromEnum a = FromEnum_0123456789876543210 a
     data SFoo :: Foo -> Type
       where
         SBar :: SFoo (Bar :: Foo)
@@ -152,40 +126,14 @@ Singletons/EnumDeriving.hs:0:0:: Splicing declarations
     type ToEnum_0123456789876543210 :: GHC.Num.Natural.Natural -> Quux
     type family ToEnum_0123456789876543210 (a :: GHC.Num.Natural.Natural) :: Quux where
       ToEnum_0123456789876543210 n = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (FromInteger 0))
-    type ToEnum_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural Quux
-    data ToEnum_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural Quux
-      where
-        ToEnum_0123456789876543210Sym0KindInference :: SameKind (Apply ToEnum_0123456789876543210Sym0 arg) (ToEnum_0123456789876543210Sym1 arg) =>
-                                                       ToEnum_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @GHC.Num.Natural.Natural @Quux ToEnum_0123456789876543210Sym0 a0123456789876543210 = ToEnum_0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ToEnum_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) ToEnum_0123456789876543210Sym0KindInference ())
-    type ToEnum_0123456789876543210Sym1 :: GHC.Num.Natural.Natural
-                                           -> Quux
-    type family ToEnum_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Num.Natural.Natural) :: Quux where
-      ToEnum_0123456789876543210Sym1 a0123456789876543210 = ToEnum_0123456789876543210 a0123456789876543210
     type FromEnum_0123456789876543210 :: Quux
                                          -> GHC.Num.Natural.Natural
     type family FromEnum_0123456789876543210 (a :: Quux) :: GHC.Num.Natural.Natural where
       FromEnum_0123456789876543210 'Q1 = FromInteger 0
       FromEnum_0123456789876543210 'Q2 = FromInteger 1
-    type FromEnum_0123456789876543210Sym0 :: (~>) Quux GHC.Num.Natural.Natural
-    data FromEnum_0123456789876543210Sym0 :: (~>) Quux GHC.Num.Natural.Natural
-      where
-        FromEnum_0123456789876543210Sym0KindInference :: SameKind (Apply FromEnum_0123456789876543210Sym0 arg) (FromEnum_0123456789876543210Sym1 arg) =>
-                                                         FromEnum_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Quux @GHC.Num.Natural.Natural FromEnum_0123456789876543210Sym0 a0123456789876543210 = FromEnum_0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings FromEnum_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) FromEnum_0123456789876543210Sym0KindInference ())
-    type FromEnum_0123456789876543210Sym1 :: Quux
-                                             -> GHC.Num.Natural.Natural
-    type family FromEnum_0123456789876543210Sym1 (a0123456789876543210 :: Quux) :: GHC.Num.Natural.Natural where
-      FromEnum_0123456789876543210Sym1 a0123456789876543210 = FromEnum_0123456789876543210 a0123456789876543210
     instance PEnum Quux where
-      type ToEnum a = Apply ToEnum_0123456789876543210Sym0 a
-      type FromEnum a = Apply FromEnum_0123456789876543210Sym0 a
+      type ToEnum a = ToEnum_0123456789876543210 a
+      type FromEnum a = FromEnum_0123456789876543210 a
     instance SEnum Quux where
       sToEnum (sN :: Sing n)
         = id

--- a/singletons-base/tests/compile-and-dump/Singletons/EqInstances.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/EqInstances.golden
@@ -7,29 +7,8 @@ Singletons/EqInstances.hs:0:0:: Splicing declarations
       TFHelper_0123456789876543210 'FLeaf ('(:+:) _ _) = FalseSym0
       TFHelper_0123456789876543210 ('(:+:) _ _) 'FLeaf = FalseSym0
       TFHelper_0123456789876543210 ('(:+:) a_0123456789876543210 a_0123456789876543210) ('(:+:) b_0123456789876543210 b_0123456789876543210) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)
-    type TFHelper_0123456789876543210Sym0 :: (~>) Foo ((~>) Foo Bool)
-    data TFHelper_0123456789876543210Sym0 :: (~>) Foo ((~>) Foo Bool)
-      where
-        TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Foo @((~>) Foo Bool) TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym0KindInference ())
-    type TFHelper_0123456789876543210Sym1 :: Foo -> (~>) Foo Bool
-    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Foo) :: (~>) Foo Bool
-      where
-        TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Foo @Bool (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym1KindInference ())
-    type TFHelper_0123456789876543210Sym2 :: Foo -> Foo -> Bool
-    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: Foo) (a0123456789876543210 :: Foo) :: Bool where
-      TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq Foo where
-      type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
+      type (==) a a = TFHelper_0123456789876543210 a a
     instance SEq Foo => SEq Foo where
       (%==) SFLeaf SFLeaf = STrue
       (%==) SFLeaf ((:%+:) _ _) = SFalse
@@ -51,28 +30,7 @@ Singletons/EqInstances.hs:0:0:: Splicing declarations
     type TFHelper_0123456789876543210 :: Empty -> Empty -> Bool
     type family TFHelper_0123456789876543210 (a :: Empty) (a :: Empty) :: Bool where
       TFHelper_0123456789876543210 _ _ = TrueSym0
-    type TFHelper_0123456789876543210Sym0 :: (~>) Empty ((~>) Empty Bool)
-    data TFHelper_0123456789876543210Sym0 :: (~>) Empty ((~>) Empty Bool)
-      where
-        TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Empty @((~>) Empty Bool) TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym0KindInference ())
-    type TFHelper_0123456789876543210Sym1 :: Empty -> (~>) Empty Bool
-    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Empty) :: (~>) Empty Bool
-      where
-        TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Empty @Bool (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym1KindInference ())
-    type TFHelper_0123456789876543210Sym2 :: Empty -> Empty -> Bool
-    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: Empty) (a0123456789876543210 :: Empty) :: Bool where
-      TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq Empty where
-      type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
+      type (==) a a = TFHelper_0123456789876543210 a a
     instance SEq Empty where
       (%==) _ _ = STrue

--- a/singletons-base/tests/compile-and-dump/Singletons/Error.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Error.golden
@@ -22,8 +22,7 @@ Singletons/Error.hs:(0,0)-(0,0): Splicing declarations
     type family Head @a (a :: [a]) :: a where
       Head ('(:) a _) = a
       Head '[] = Apply ErrorSym0 "head: empty list"
-    sHead ::
-      (forall (t :: [a]). Sing t -> Sing (Apply HeadSym0 t :: a) :: Type)
+    sHead :: (forall (t :: [a]). Sing t -> Sing (Head t :: a) :: Type)
     sHead (SCons (sA :: Sing a) _) = sA
     sHead SNil
       = applySing

--- a/singletons-base/tests/compile-and-dump/Singletons/Fixity.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Fixity.golden
@@ -67,8 +67,7 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
     infix 4 %====
     (%====) ::
       (forall (t :: a) (t :: a).
-       Sing t
-       -> Sing t -> Sing (Apply (Apply (====@#@$) t) t :: a) :: Type)
+       Sing t -> Sing t -> Sing ((====) t t :: a) :: Type)
     (%====) (sA :: Sing a) _ = sA
     instance SingI ((====@#@$) :: (~>) a ((~>) a a)) where
       sing = singFun2 @(====@#@$) (%====)
@@ -80,9 +79,7 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
     class SMyOrd a where
       (%<=>) ::
         (forall (t :: a) (t :: a).
-         Sing t
-         -> Sing t
-            -> Sing (Apply (Apply (<=>@#@$) t) t :: Ordering) :: Type)
+         Sing t -> Sing t -> Sing ((<=>) t t :: Ordering) :: Type)
       infix 4 %<=>
     instance SMyOrd a =>
              SingI ((<=>@#@$) :: (~>) a ((~>) a Ordering)) where

--- a/singletons-base/tests/compile-and-dump/Singletons/FunDeps.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/FunDeps.golden
@@ -58,13 +58,11 @@ Singletons/FunDeps.hs:(0,0)-(0,0): Splicing declarations
     instance PFD Bool Natural where
       type Meth a = Meth_0123456789876543210 a
       type L2r a = L2r_0123456789876543210 a
-    sT1 :: Sing @_ T1Sym0
+    sT1 :: Sing @_ T1
     sT1 = applySing (singFun1 @MethSym0 sMeth) STrue
     class SFD a b | a -> b where
-      sMeth ::
-        (forall (t :: a). Sing t -> Sing (Apply MethSym0 t :: a) :: Type)
-      sL2r ::
-        (forall (t :: a). Sing t -> Sing (Apply L2rSym0 t :: b) :: Type)
+      sMeth :: (forall (t :: a). Sing t -> Sing (Meth t :: a) :: Type)
+      sL2r :: (forall (t :: a). Sing t -> Sing (L2r t :: b) :: Type)
     instance SFD Bool Natural where
       sMeth (sA_0123456789876543210 :: Sing a_0123456789876543210)
         = applySing (singFun1 @NotSym0 sNot) sA_0123456789876543210

--- a/singletons-base/tests/compile-and-dump/Singletons/FunDeps.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/FunDeps.golden
@@ -51,37 +51,13 @@ Singletons/FunDeps.hs:(0,0)-(0,0): Splicing declarations
     type Meth_0123456789876543210 :: Bool -> Bool
     type family Meth_0123456789876543210 (a :: Bool) :: Bool where
       Meth_0123456789876543210 a_0123456789876543210 = Apply NotSym0 a_0123456789876543210
-    type Meth_0123456789876543210Sym0 :: (~>) Bool Bool
-    data Meth_0123456789876543210Sym0 :: (~>) Bool Bool
-      where
-        Meth_0123456789876543210Sym0KindInference :: SameKind (Apply Meth_0123456789876543210Sym0 arg) (Meth_0123456789876543210Sym1 arg) =>
-                                                     Meth_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Bool @Bool Meth_0123456789876543210Sym0 a0123456789876543210 = Meth_0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings Meth_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Meth_0123456789876543210Sym0KindInference ())
-    type Meth_0123456789876543210Sym1 :: Bool -> Bool
-    type family Meth_0123456789876543210Sym1 (a0123456789876543210 :: Bool) :: Bool where
-      Meth_0123456789876543210Sym1 a0123456789876543210 = Meth_0123456789876543210 a0123456789876543210
     type L2r_0123456789876543210 :: Bool -> Natural
     type family L2r_0123456789876543210 (a :: Bool) :: Natural where
       L2r_0123456789876543210 'False = FromInteger 0
       L2r_0123456789876543210 'True = FromInteger 1
-    type L2r_0123456789876543210Sym0 :: (~>) Bool Natural
-    data L2r_0123456789876543210Sym0 :: (~>) Bool Natural
-      where
-        L2r_0123456789876543210Sym0KindInference :: SameKind (Apply L2r_0123456789876543210Sym0 arg) (L2r_0123456789876543210Sym1 arg) =>
-                                                    L2r_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Bool @Natural L2r_0123456789876543210Sym0 a0123456789876543210 = L2r_0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings L2r_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) L2r_0123456789876543210Sym0KindInference ())
-    type L2r_0123456789876543210Sym1 :: Bool -> Natural
-    type family L2r_0123456789876543210Sym1 (a0123456789876543210 :: Bool) :: Natural where
-      L2r_0123456789876543210Sym1 a0123456789876543210 = L2r_0123456789876543210 a0123456789876543210
     instance PFD Bool Natural where
-      type Meth a = Apply Meth_0123456789876543210Sym0 a
-      type L2r a = Apply L2r_0123456789876543210Sym0 a
+      type Meth a = Meth_0123456789876543210 a
+      type L2r a = L2r_0123456789876543210 a
     sT1 :: Sing @_ T1Sym0
     sT1 = applySing (singFun1 @MethSym0 sMeth) STrue
     class SFD a b | a -> b where

--- a/singletons-base/tests/compile-and-dump/Singletons/FunctorLikeDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/FunctorLikeDeriving.golden
@@ -89,31 +89,6 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
     type family Fmap_0123456789876543210 @a @b @x (a :: (~>) a b) (a :: T x a) :: T x b where
       Fmap_0123456789876543210 @a @b @x (_f_0123456789876543210 :: (~>) a b) (MkT1 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 :: T x a) = Apply (Apply (Apply (Apply MkT1Sym0 (Apply (Lambda_0123456789876543210Sym0 x _f_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210) a_0123456789876543210)) (Apply _f_0123456789876543210 a_0123456789876543210)) (Apply (Apply FmapSym0 _f_0123456789876543210) a_0123456789876543210)) (Apply (Apply FmapSym0 (Apply FmapSym0 _f_0123456789876543210)) a_0123456789876543210)
       Fmap_0123456789876543210 @a @b @x (_f_0123456789876543210 :: (~>) a b) (MkT2 a_0123456789876543210 :: T x a) = Apply MkT2Sym0 (Apply (Lambda_0123456789876543210Sym0 x _f_0123456789876543210 a_0123456789876543210) a_0123456789876543210)
-    type Fmap_0123456789876543210Sym0 :: forall a
-                                                b
-                                                x. (~>) ((~>) a b) ((~>) (T x a) (T x b))
-    data Fmap_0123456789876543210Sym0 :: (~>) ((~>) a b) ((~>) (T x a) (T x b))
-      where
-        Fmap_0123456789876543210Sym0KindInference :: SameKind (Apply Fmap_0123456789876543210Sym0 arg) (Fmap_0123456789876543210Sym1 arg) =>
-                                                     Fmap_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @((~>) a b) @((~>) (T x a) (T x b)) Fmap_0123456789876543210Sym0 a0123456789876543210 = Fmap_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Fmap_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Fmap_0123456789876543210Sym0KindInference ())
-    type Fmap_0123456789876543210Sym1 :: forall a b x. (~>) a b
-                                                       -> (~>) (T x a) (T x b)
-    data Fmap_0123456789876543210Sym1 (a0123456789876543210 :: (~>) a b) :: (~>) (T x a) (T x b)
-      where
-        Fmap_0123456789876543210Sym1KindInference :: SameKind (Apply (Fmap_0123456789876543210Sym1 a0123456789876543210) arg) (Fmap_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                     Fmap_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(T x a) @(T x b) (Fmap_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Fmap_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Fmap_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Fmap_0123456789876543210Sym1KindInference ())
-    type Fmap_0123456789876543210Sym2 :: forall a b x. (~>) a b
-                                                       -> T x a -> T x b
-    type family Fmap_0123456789876543210Sym2 @a @b @x (a0123456789876543210 :: (~>) a b) (a0123456789876543210 :: T x a) :: T x b where
-      Fmap_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Fmap_0123456789876543210 a0123456789876543210 a0123456789876543210
     type family Lambda_0123456789876543210 x0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 n_0123456789876543210 where
       Lambda_0123456789876543210 x _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 n_0123456789876543210 = n_0123456789876543210
     data Lambda_0123456789876543210Sym0 x0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 n_01234567898765432100123456789876543210
@@ -155,34 +130,9 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
     type family TFHelper_0123456789876543210 @a @x @b (a :: a) (a :: T x b) :: T x a where
       TFHelper_0123456789876543210 @a @x @b (_z_0123456789876543210 :: a) (MkT1 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 :: T x b) = Apply (Apply (Apply (Apply MkT1Sym0 (Apply (Lambda_0123456789876543210Sym0 x _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210) a_0123456789876543210)) (Apply (Lambda_0123456789876543210Sym0 x _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210) a_0123456789876543210)) (Apply (Apply (<$@#@$) _z_0123456789876543210) a_0123456789876543210)) (Apply (Apply FmapSym0 (Apply (<$@#@$) _z_0123456789876543210)) a_0123456789876543210)
       TFHelper_0123456789876543210 @a @x @b (_z_0123456789876543210 :: a) (MkT2 a_0123456789876543210 :: T x b) = Apply MkT2Sym0 (Apply (Lambda_0123456789876543210Sym0 x _z_0123456789876543210 a_0123456789876543210) a_0123456789876543210)
-    type TFHelper_0123456789876543210Sym0 :: forall a
-                                                    x
-                                                    b. (~>) a ((~>) (T x b) (T x a))
-    data TFHelper_0123456789876543210Sym0 :: (~>) a ((~>) (T x b) (T x a))
-      where
-        TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @a @((~>) (T x b) (T x a)) TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym0KindInference ())
-    type TFHelper_0123456789876543210Sym1 :: forall a x b. a
-                                                           -> (~>) (T x b) (T x a)
-    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: a) :: (~>) (T x b) (T x a)
-      where
-        TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(T x b) @(T x a) (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym1KindInference ())
-    type TFHelper_0123456789876543210Sym2 :: forall a x b. a
-                                                           -> T x b -> T x a
-    type family TFHelper_0123456789876543210Sym2 @a @x @b (a0123456789876543210 :: a) (a0123456789876543210 :: T x b) :: T x a where
-      TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PFunctor (T x) where
-      type Fmap a a = Apply (Apply Fmap_0123456789876543210Sym0 a) a
-      type (<$) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
+      type Fmap a a = Fmap_0123456789876543210 a a
+      type (<$) a a = TFHelper_0123456789876543210 a a
     type family Lambda_0123456789876543210 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 n_0123456789876543210 where
       Lambda_0123456789876543210 x _f_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 n_0123456789876543210 = MemptySym0
     data Lambda_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 n_01234567898765432100123456789876543210
@@ -212,31 +162,6 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
     type family FoldMap_0123456789876543210 @a @m @x (a :: (~>) a m) (a :: T x a) :: m where
       FoldMap_0123456789876543210 @a @m @x (_f_0123456789876543210 :: (~>) a m) (MkT1 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 :: T x a) = Apply (Apply MappendSym0 (Apply (Lambda_0123456789876543210Sym0 x _f_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210) a_0123456789876543210)) (Apply (Apply MappendSym0 (Apply _f_0123456789876543210 a_0123456789876543210)) (Apply (Apply MappendSym0 (Apply (Apply FoldMapSym0 _f_0123456789876543210) a_0123456789876543210)) (Apply (Apply FoldMapSym0 (Apply FoldMapSym0 _f_0123456789876543210)) a_0123456789876543210)))
       FoldMap_0123456789876543210 @a @m @x (_f_0123456789876543210 :: (~>) a m) (MkT2 a_0123456789876543210 :: T x a) = Apply (Lambda_0123456789876543210Sym0 x _f_0123456789876543210 a_0123456789876543210) a_0123456789876543210
-    type FoldMap_0123456789876543210Sym0 :: forall a
-                                                   m
-                                                   x. (~>) ((~>) a m) ((~>) (T x a) m)
-    data FoldMap_0123456789876543210Sym0 :: (~>) ((~>) a m) ((~>) (T x a) m)
-      where
-        FoldMap_0123456789876543210Sym0KindInference :: SameKind (Apply FoldMap_0123456789876543210Sym0 arg) (FoldMap_0123456789876543210Sym1 arg) =>
-                                                        FoldMap_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @((~>) a m) @((~>) (T x a) m) FoldMap_0123456789876543210Sym0 a0123456789876543210 = FoldMap_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings FoldMap_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) FoldMap_0123456789876543210Sym0KindInference ())
-    type FoldMap_0123456789876543210Sym1 :: forall a m x. (~>) a m
-                                                          -> (~>) (T x a) m
-    data FoldMap_0123456789876543210Sym1 (a0123456789876543210 :: (~>) a m) :: (~>) (T x a) m
-      where
-        FoldMap_0123456789876543210Sym1KindInference :: SameKind (Apply (FoldMap_0123456789876543210Sym1 a0123456789876543210) arg) (FoldMap_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                        FoldMap_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(T x a) @m (FoldMap_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = FoldMap_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (FoldMap_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) FoldMap_0123456789876543210Sym1KindInference ())
-    type FoldMap_0123456789876543210Sym2 :: forall a m x. (~>) a m
-                                                          -> T x a -> m
-    type family FoldMap_0123456789876543210Sym2 @a @m @x (a0123456789876543210 :: (~>) a m) (a0123456789876543210 :: T x a) :: m where
-      FoldMap_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = FoldMap_0123456789876543210 a0123456789876543210 a0123456789876543210
     type family Lambda_0123456789876543210 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 n1_0123456789876543210 n2_0123456789876543210 where
       Lambda_0123456789876543210 x _f_0123456789876543210 _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 n1_0123456789876543210 n2_0123456789876543210 = n2_0123456789876543210
     data Lambda_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 n1_01234567898765432100123456789876543210
@@ -342,207 +267,42 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
     type family Foldr_0123456789876543210 @a @b @x (a :: (~>) a ((~>) b b)) (a :: b) (a :: T x a) :: b where
       Foldr_0123456789876543210 @a @b @x (_f_0123456789876543210 :: (~>) a ((~>) b b)) (_z_0123456789876543210 :: b) (MkT1 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 :: T x a) = Apply (Apply (Lambda_0123456789876543210Sym0 x _f_0123456789876543210 _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210) a_0123456789876543210) (Apply (Apply _f_0123456789876543210 a_0123456789876543210) (Apply (Apply (Lambda_0123456789876543210Sym0 x _f_0123456789876543210 _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210) a_0123456789876543210) (Apply (Apply (Lambda_0123456789876543210Sym0 x _f_0123456789876543210 _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210) a_0123456789876543210) _z_0123456789876543210)))
       Foldr_0123456789876543210 @a @b @x (_f_0123456789876543210 :: (~>) a ((~>) b b)) (_z_0123456789876543210 :: b) (MkT2 a_0123456789876543210 :: T x a) = Apply (Apply (Lambda_0123456789876543210Sym0 x _f_0123456789876543210 _z_0123456789876543210 a_0123456789876543210) a_0123456789876543210) _z_0123456789876543210
-    type Foldr_0123456789876543210Sym0 :: forall a
-                                                 b
-                                                 x. (~>) ((~>) a ((~>) b b)) ((~>) b ((~>) (T x a) b))
-    data Foldr_0123456789876543210Sym0 :: (~>) ((~>) a ((~>) b b)) ((~>) b ((~>) (T x a) b))
-      where
-        Foldr_0123456789876543210Sym0KindInference :: SameKind (Apply Foldr_0123456789876543210Sym0 arg) (Foldr_0123456789876543210Sym1 arg) =>
-                                                      Foldr_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @((~>) a ((~>) b b)) @((~>) b ((~>) (T x a) b)) Foldr_0123456789876543210Sym0 a0123456789876543210 = Foldr_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Foldr_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Foldr_0123456789876543210Sym0KindInference ())
-    type Foldr_0123456789876543210Sym1 :: forall a
-                                                 b
-                                                 x. (~>) a ((~>) b b) -> (~>) b ((~>) (T x a) b)
-    data Foldr_0123456789876543210Sym1 (a0123456789876543210 :: (~>) a ((~>) b b)) :: (~>) b ((~>) (T x a) b)
-      where
-        Foldr_0123456789876543210Sym1KindInference :: SameKind (Apply (Foldr_0123456789876543210Sym1 a0123456789876543210) arg) (Foldr_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                      Foldr_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @((~>) (T x a) b) (Foldr_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Foldr_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Foldr_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Foldr_0123456789876543210Sym1KindInference ())
-    type Foldr_0123456789876543210Sym2 :: forall a
-                                                 b
-                                                 x. (~>) a ((~>) b b) -> b -> (~>) (T x a) b
-    data Foldr_0123456789876543210Sym2 (a0123456789876543210 :: (~>) a ((~>) b b)) (a0123456789876543210 :: b) :: (~>) (T x a) b
-      where
-        Foldr_0123456789876543210Sym2KindInference :: SameKind (Apply (Foldr_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (Foldr_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                                      Foldr_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @(T x a) @b (Foldr_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = Foldr_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Foldr_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Foldr_0123456789876543210Sym2KindInference ())
-    type Foldr_0123456789876543210Sym3 :: forall a
-                                                 b
-                                                 x. (~>) a ((~>) b b) -> b -> T x a -> b
-    type family Foldr_0123456789876543210Sym3 @a @b @x (a0123456789876543210 :: (~>) a ((~>) b b)) (a0123456789876543210 :: b) (a0123456789876543210 :: T x a) :: b where
-      Foldr_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = Foldr_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PFoldable (T x) where
-      type FoldMap a a = Apply (Apply FoldMap_0123456789876543210Sym0 a) a
-      type Foldr a a a = Apply (Apply (Apply Foldr_0123456789876543210Sym0 a) a) a
+      type FoldMap a a = FoldMap_0123456789876543210 a a
+      type Foldr a a a = Foldr_0123456789876543210 a a a
     type Traverse_0123456789876543210 :: forall a f b x. (~>) a (f b)
                                                          -> T x a -> f (T x b)
     type family Traverse_0123456789876543210 @a @f @b @x (a :: (~>) a (f b)) (a :: T x a) :: f (T x b) where
       Traverse_0123456789876543210 @a @f @b @x (_f_0123456789876543210 :: (~>) a (f b)) (MkT1 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 :: T x a) = Apply (Apply (<*>@#@$) (Apply (Apply (<*>@#@$) (Apply (Apply (Apply LiftA2Sym0 MkT1Sym0) (Apply PureSym0 a_0123456789876543210)) (Apply _f_0123456789876543210 a_0123456789876543210))) (Apply (Apply TraverseSym0 _f_0123456789876543210) a_0123456789876543210))) (Apply (Apply TraverseSym0 (Apply TraverseSym0 _f_0123456789876543210)) a_0123456789876543210)
       Traverse_0123456789876543210 @a @f @b @x (_f_0123456789876543210 :: (~>) a (f b)) (MkT2 a_0123456789876543210 :: T x a) = Apply (Apply FmapSym0 MkT2Sym0) (Apply PureSym0 a_0123456789876543210)
-    type Traverse_0123456789876543210Sym0 :: forall a
-                                                    f
-                                                    b
-                                                    x. (~>) ((~>) a (f b)) ((~>) (T x a) (f (T x b)))
-    data Traverse_0123456789876543210Sym0 :: (~>) ((~>) a (f b)) ((~>) (T x a) (f (T x b)))
-      where
-        Traverse_0123456789876543210Sym0KindInference :: SameKind (Apply Traverse_0123456789876543210Sym0 arg) (Traverse_0123456789876543210Sym1 arg) =>
-                                                         Traverse_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @((~>) a (f b)) @((~>) (T x a) (f (T x b))) Traverse_0123456789876543210Sym0 a0123456789876543210 = Traverse_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Traverse_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Traverse_0123456789876543210Sym0KindInference ())
-    type Traverse_0123456789876543210Sym1 :: forall a
-                                                    f
-                                                    b
-                                                    x. (~>) a (f b) -> (~>) (T x a) (f (T x b))
-    data Traverse_0123456789876543210Sym1 (a0123456789876543210 :: (~>) a (f b)) :: (~>) (T x a) (f (T x b))
-      where
-        Traverse_0123456789876543210Sym1KindInference :: SameKind (Apply (Traverse_0123456789876543210Sym1 a0123456789876543210) arg) (Traverse_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         Traverse_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(T x a) @(f (T x b)) (Traverse_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Traverse_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Traverse_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Traverse_0123456789876543210Sym1KindInference ())
-    type Traverse_0123456789876543210Sym2 :: forall a
-                                                    f
-                                                    b
-                                                    x. (~>) a (f b) -> T x a -> f (T x b)
-    type family Traverse_0123456789876543210Sym2 @a @f @b @x (a0123456789876543210 :: (~>) a (f b)) (a0123456789876543210 :: T x a) :: f (T x b) where
-      Traverse_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Traverse_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PTraversable (T x) where
-      type Traverse a a = Apply (Apply Traverse_0123456789876543210Sym0 a) a
+      type Traverse a a = Traverse_0123456789876543210 a a
     type family Case_0123456789876543210 v_01234567898765432100123456789876543210 t where
     type Fmap_0123456789876543210 :: forall a b. (~>) a b
                                                  -> Empty a -> Empty b
     type family Fmap_0123456789876543210 @a @b (a :: (~>) a b) (a :: Empty a) :: Empty b where
       Fmap_0123456789876543210 @a @b _ v_0123456789876543210 = Case_0123456789876543210 v_0123456789876543210 v_0123456789876543210
-    type Fmap_0123456789876543210Sym0 :: forall a
-                                                b. (~>) ((~>) a b) ((~>) (Empty a) (Empty b))
-    data Fmap_0123456789876543210Sym0 :: (~>) ((~>) a b) ((~>) (Empty a) (Empty b))
-      where
-        Fmap_0123456789876543210Sym0KindInference :: SameKind (Apply Fmap_0123456789876543210Sym0 arg) (Fmap_0123456789876543210Sym1 arg) =>
-                                                     Fmap_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @((~>) a b) @((~>) (Empty a) (Empty b)) Fmap_0123456789876543210Sym0 a0123456789876543210 = Fmap_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Fmap_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Fmap_0123456789876543210Sym0KindInference ())
-    type Fmap_0123456789876543210Sym1 :: forall a b. (~>) a b
-                                                     -> (~>) (Empty a) (Empty b)
-    data Fmap_0123456789876543210Sym1 (a0123456789876543210 :: (~>) a b) :: (~>) (Empty a) (Empty b)
-      where
-        Fmap_0123456789876543210Sym1KindInference :: SameKind (Apply (Fmap_0123456789876543210Sym1 a0123456789876543210) arg) (Fmap_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                     Fmap_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Empty a) @(Empty b) (Fmap_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Fmap_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Fmap_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Fmap_0123456789876543210Sym1KindInference ())
-    type Fmap_0123456789876543210Sym2 :: forall a b. (~>) a b
-                                                     -> Empty a -> Empty b
-    type family Fmap_0123456789876543210Sym2 @a @b (a0123456789876543210 :: (~>) a b) (a0123456789876543210 :: Empty a) :: Empty b where
-      Fmap_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Fmap_0123456789876543210 a0123456789876543210 a0123456789876543210
     type family Case_0123456789876543210 v_01234567898765432100123456789876543210 t where
     type TFHelper_0123456789876543210 :: forall a b. a
                                                      -> Empty b -> Empty a
     type family TFHelper_0123456789876543210 @a @b (a :: a) (a :: Empty b) :: Empty a where
       TFHelper_0123456789876543210 @a @b _ v_0123456789876543210 = Case_0123456789876543210 v_0123456789876543210 v_0123456789876543210
-    type TFHelper_0123456789876543210Sym0 :: forall a
-                                                    b. (~>) a ((~>) (Empty b) (Empty a))
-    data TFHelper_0123456789876543210Sym0 :: (~>) a ((~>) (Empty b) (Empty a))
-      where
-        TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @a @((~>) (Empty b) (Empty a)) TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym0KindInference ())
-    type TFHelper_0123456789876543210Sym1 :: forall a b. a
-                                                         -> (~>) (Empty b) (Empty a)
-    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: a) :: (~>) (Empty b) (Empty a)
-      where
-        TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Empty b) @(Empty a) (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym1KindInference ())
-    type TFHelper_0123456789876543210Sym2 :: forall a b. a
-                                                         -> Empty b -> Empty a
-    type family TFHelper_0123456789876543210Sym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: Empty b) :: Empty a where
-      TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PFunctor Empty where
-      type Fmap a a = Apply (Apply Fmap_0123456789876543210Sym0 a) a
-      type (<$) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
+      type Fmap a a = Fmap_0123456789876543210 a a
+      type (<$) a a = TFHelper_0123456789876543210 a a
     type FoldMap_0123456789876543210 :: forall a m. (~>) a m
                                                     -> Empty a -> m
     type family FoldMap_0123456789876543210 @a @m (a :: (~>) a m) (a :: Empty a) :: m where
       FoldMap_0123456789876543210 @a @m _ _ = MemptySym0
-    type FoldMap_0123456789876543210Sym0 :: forall a
-                                                   m. (~>) ((~>) a m) ((~>) (Empty a) m)
-    data FoldMap_0123456789876543210Sym0 :: (~>) ((~>) a m) ((~>) (Empty a) m)
-      where
-        FoldMap_0123456789876543210Sym0KindInference :: SameKind (Apply FoldMap_0123456789876543210Sym0 arg) (FoldMap_0123456789876543210Sym1 arg) =>
-                                                        FoldMap_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @((~>) a m) @((~>) (Empty a) m) FoldMap_0123456789876543210Sym0 a0123456789876543210 = FoldMap_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings FoldMap_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) FoldMap_0123456789876543210Sym0KindInference ())
-    type FoldMap_0123456789876543210Sym1 :: forall a m. (~>) a m
-                                                        -> (~>) (Empty a) m
-    data FoldMap_0123456789876543210Sym1 (a0123456789876543210 :: (~>) a m) :: (~>) (Empty a) m
-      where
-        FoldMap_0123456789876543210Sym1KindInference :: SameKind (Apply (FoldMap_0123456789876543210Sym1 a0123456789876543210) arg) (FoldMap_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                        FoldMap_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Empty a) @m (FoldMap_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = FoldMap_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (FoldMap_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) FoldMap_0123456789876543210Sym1KindInference ())
-    type FoldMap_0123456789876543210Sym2 :: forall a m. (~>) a m
-                                                        -> Empty a -> m
-    type family FoldMap_0123456789876543210Sym2 @a @m (a0123456789876543210 :: (~>) a m) (a0123456789876543210 :: Empty a) :: m where
-      FoldMap_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = FoldMap_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PFoldable Empty where
-      type FoldMap a a = Apply (Apply FoldMap_0123456789876543210Sym0 a) a
+      type FoldMap a a = FoldMap_0123456789876543210 a a
     type family Case_0123456789876543210 v_01234567898765432100123456789876543210 t where
     type Traverse_0123456789876543210 :: forall a f b. (~>) a (f b)
                                                        -> Empty a -> f (Empty b)
     type family Traverse_0123456789876543210 @a @f @b (a :: (~>) a (f b)) (a :: Empty a) :: f (Empty b) where
       Traverse_0123456789876543210 @a @f @b _ v_0123456789876543210 = Apply PureSym0 (Case_0123456789876543210 v_0123456789876543210 v_0123456789876543210)
-    type Traverse_0123456789876543210Sym0 :: forall a
-                                                    f
-                                                    b. (~>) ((~>) a (f b)) ((~>) (Empty a) (f (Empty b)))
-    data Traverse_0123456789876543210Sym0 :: (~>) ((~>) a (f b)) ((~>) (Empty a) (f (Empty b)))
-      where
-        Traverse_0123456789876543210Sym0KindInference :: SameKind (Apply Traverse_0123456789876543210Sym0 arg) (Traverse_0123456789876543210Sym1 arg) =>
-                                                         Traverse_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @((~>) a (f b)) @((~>) (Empty a) (f (Empty b))) Traverse_0123456789876543210Sym0 a0123456789876543210 = Traverse_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Traverse_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Traverse_0123456789876543210Sym0KindInference ())
-    type Traverse_0123456789876543210Sym1 :: forall a f b. (~>) a (f b)
-                                                           -> (~>) (Empty a) (f (Empty b))
-    data Traverse_0123456789876543210Sym1 (a0123456789876543210 :: (~>) a (f b)) :: (~>) (Empty a) (f (Empty b))
-      where
-        Traverse_0123456789876543210Sym1KindInference :: SameKind (Apply (Traverse_0123456789876543210Sym1 a0123456789876543210) arg) (Traverse_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         Traverse_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Empty a) @(f (Empty b)) (Traverse_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Traverse_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Traverse_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Traverse_0123456789876543210Sym1KindInference ())
-    type Traverse_0123456789876543210Sym2 :: forall a f b. (~>) a (f b)
-                                                           -> Empty a -> f (Empty b)
-    type family Traverse_0123456789876543210Sym2 @a @f @b (a0123456789876543210 :: (~>) a (f b)) (a0123456789876543210 :: Empty a) :: f (Empty b) where
-      Traverse_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Traverse_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PTraversable Empty where
-      type Traverse a a = Apply (Apply Traverse_0123456789876543210Sym0 a) a
+      type Traverse a a = Traverse_0123456789876543210 a a
     data ST :: forall x a. T x a -> Type
       where
         SMkT1 :: forall x

--- a/singletons-base/tests/compile-and-dump/Singletons/HigherOrder.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/HigherOrder.golden
@@ -264,33 +264,22 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
       Map f ('(:) h t) = Apply (Apply (:@#@$) (Apply f h)) (Apply (Apply MapSym0 f) t)
     sEtad ::
       (forall (t :: [Nat]) (t :: [Bool]).
-       Sing t
-       -> Sing t -> Sing (Apply (Apply EtadSym0 t) t :: [Nat]) :: Type)
+       Sing t -> Sing t -> Sing (Etad t t :: [Nat]) :: Type)
     sSplunge ::
       (forall (t :: [Nat]) (t :: [Bool]).
-       Sing t
-       -> Sing t -> Sing (Apply (Apply SplungeSym0 t) t :: [Nat]) :: Type)
+       Sing t -> Sing t -> Sing (Splunge t t :: [Nat]) :: Type)
     sFoo ::
       (forall (t :: (~>) ((~>) a b) ((~>) a b)) (t :: (~>) a b) (t :: a).
-       Sing t
-       -> Sing t
-          -> Sing t
-             -> Sing (Apply (Apply (Apply FooSym0 t) t) t :: b) :: Type)
+       Sing t -> Sing t -> Sing t -> Sing (Foo t t t :: b) :: Type)
     sZipWith ::
       (forall (t :: (~>) a ((~>) b c)) (t :: [a]) (t :: [b]).
-       Sing t
-       -> Sing t
-          -> Sing t
-             -> Sing (Apply (Apply (Apply ZipWithSym0 t) t) t :: [c]) :: Type)
+       Sing t -> Sing t -> Sing t -> Sing (ZipWith t t t :: [c]) :: Type)
     sLiftMaybe ::
       (forall (t :: (~>) a b) (t :: Maybe a).
-       Sing t
-       -> Sing t
-          -> Sing (Apply (Apply LiftMaybeSym0 t) t :: Maybe b) :: Type)
+       Sing t -> Sing t -> Sing (LiftMaybe t t :: Maybe b) :: Type)
     sMap ::
       (forall (t :: (~>) a b) (t :: [a]).
-       Sing t
-       -> Sing t -> Sing (Apply (Apply MapSym0 t) t :: [b]) :: Type)
+       Sing t -> Sing t -> Sing (Map t t :: [b]) :: Type)
     sEtad
       (sA_0123456789876543210 :: Sing a_0123456789876543210)
       (sA_0123456789876543210 :: Sing a_0123456789876543210)

--- a/singletons-base/tests/compile-and-dump/Singletons/LambdaCase.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/LambdaCase.golden
@@ -141,13 +141,13 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
       Foo1 d x = Apply (Lambda_0123456789876543210Sym0 d x) x
     sFoo3 ::
       (forall (t :: a) (t :: b).
-       Sing t -> Sing t -> Sing (Apply (Apply Foo3Sym0 t) t :: a) :: Type)
+       Sing t -> Sing t -> Sing (Foo3 t t :: a) :: Type)
     sFoo2 ::
       (forall (t :: a) (t :: Maybe a).
-       Sing t -> Sing t -> Sing (Apply (Apply Foo2Sym0 t) t :: a) :: Type)
+       Sing t -> Sing t -> Sing (Foo2 t t :: a) :: Type)
     sFoo1 ::
       (forall (t :: a) (t :: Maybe a).
-       Sing t -> Sing t -> Sing (Apply (Apply Foo1Sym0 t) t :: a) :: Type)
+       Sing t -> Sing t -> Sing (Foo1 t t :: a) :: Type)
     sFoo3 (sA :: Sing a) (sB :: Sing b)
       = applySing
           (singFun1

--- a/singletons-base/tests/compile-and-dump/Singletons/Lambdas.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Lambdas.golden
@@ -399,34 +399,29 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     type family Foo0 @a @b (a :: a) (a :: b) :: a where
       Foo0 a_0123456789876543210 a_0123456789876543210 = Apply (Apply (Lambda_0123456789876543210Sym0 a_0123456789876543210 a_0123456789876543210) a_0123456789876543210) a_0123456789876543210
     sFoo8 ::
-      (forall (t :: Foo a b).
-       Sing t -> Sing (Apply Foo8Sym0 t :: a) :: Type)
+      (forall (t :: Foo a b). Sing t -> Sing (Foo8 t :: a) :: Type)
     sFoo7 ::
       (forall (t :: a) (t :: b).
-       Sing t -> Sing t -> Sing (Apply (Apply Foo7Sym0 t) t :: b) :: Type)
+       Sing t -> Sing t -> Sing (Foo7 t t :: b) :: Type)
     sFoo6 ::
       (forall (t :: a) (t :: b).
-       Sing t -> Sing t -> Sing (Apply (Apply Foo6Sym0 t) t :: a) :: Type)
+       Sing t -> Sing t -> Sing (Foo6 t t :: a) :: Type)
     sFoo5 ::
       (forall (t :: a) (t :: b).
-       Sing t -> Sing t -> Sing (Apply (Apply Foo5Sym0 t) t :: b) :: Type)
+       Sing t -> Sing t -> Sing (Foo5 t t :: b) :: Type)
     sFoo4 ::
       (forall (t :: a) (t :: b) (t :: c).
-       Sing t
-       -> Sing t
-          -> Sing t
-             -> Sing (Apply (Apply (Apply Foo4Sym0 t) t) t :: a) :: Type)
-    sFoo3 ::
-      (forall (t :: a). Sing t -> Sing (Apply Foo3Sym0 t :: a) :: Type)
+       Sing t -> Sing t -> Sing t -> Sing (Foo4 t t t :: a) :: Type)
+    sFoo3 :: (forall (t :: a). Sing t -> Sing (Foo3 t :: a) :: Type)
     sFoo2 ::
       (forall (t :: a) (t :: b).
-       Sing t -> Sing t -> Sing (Apply (Apply Foo2Sym0 t) t :: a) :: Type)
+       Sing t -> Sing t -> Sing (Foo2 t t :: a) :: Type)
     sFoo1 ::
       (forall (t :: a) (t :: b).
-       Sing t -> Sing t -> Sing (Apply (Apply Foo1Sym0 t) t :: a) :: Type)
+       Sing t -> Sing t -> Sing (Foo1 t t :: a) :: Type)
     sFoo0 ::
       (forall (t :: a) (t :: b).
-       Sing t -> Sing t -> Sing (Apply (Apply Foo0Sym0 t) t :: a) :: Type)
+       Sing t -> Sing t -> Sing (Foo0 t t :: a) :: Type)
     sFoo8 (sX :: Sing x)
       = applySing
           (singFun1

--- a/singletons-base/tests/compile-and-dump/Singletons/LambdasComprehensive.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/LambdasComprehensive.golden
@@ -35,8 +35,8 @@ Singletons/LambdasComprehensive.hs:(0,0)-(0,0): Splicing declarations
     type Foo :: [Nat]
     type family Foo :: [Nat] where
       Foo = Apply (Apply MapSym0 Lambda_0123456789876543210Sym0) (Apply (Apply (:@#@$) (Apply LeftSym0 ZeroSym0)) (Apply (Apply (:@#@$) (Apply RightSym0 (Apply SuccSym0 ZeroSym0))) NilSym0))
-    sBar :: (Sing (BarSym0 :: [Nat]) :: Type)
-    sFoo :: (Sing (FooSym0 :: [Nat]) :: Type)
+    sBar :: (Sing (Bar :: [Nat]) :: Type)
+    sFoo :: (Sing (Foo :: [Nat]) :: Type)
     sBar
       = applySing
           (applySing

--- a/singletons-base/tests/compile-and-dump/Singletons/LetStatements.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/LetStatements.golden
@@ -587,52 +587,39 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     type family Foo1 (a :: Nat) :: Nat where
       Foo1 x = Let0123456789876543210YSym0 x
     sFoo14 ::
-      (forall (t :: Nat).
-       Sing t -> Sing (Apply Foo14Sym0 t :: (Nat, Nat)) :: Type)
+      (forall (t :: Nat). Sing t -> Sing (Foo14 t :: (Nat, Nat)) :: Type)
     sFoo13_ ::
-      (forall (t :: a). Sing t -> Sing (Apply Foo13_Sym0 t :: a) :: Type)
-    sFoo13 ::
-      forall a (t :: a). Sing t -> Sing (Apply Foo13Sym0 t :: a)
+      (forall (t :: a). Sing t -> Sing (Foo13_ t :: a) :: Type)
+    sFoo13 :: forall a (t :: a). Sing t -> Sing (Foo13 t :: a)
     sFoo12 ::
-      (forall (t :: Nat).
-       Sing t -> Sing (Apply Foo12Sym0 t :: Nat) :: Type)
+      (forall (t :: Nat). Sing t -> Sing (Foo12 t :: Nat) :: Type)
     sFoo11 ::
-      (forall (t :: Nat).
-       Sing t -> Sing (Apply Foo11Sym0 t :: Nat) :: Type)
+      (forall (t :: Nat). Sing t -> Sing (Foo11 t :: Nat) :: Type)
     sFoo10 ::
-      (forall (t :: Nat).
-       Sing t -> Sing (Apply Foo10Sym0 t :: Nat) :: Type)
+      (forall (t :: Nat). Sing t -> Sing (Foo10 t :: Nat) :: Type)
     sFoo9 ::
-      (forall (t :: Nat).
-       Sing t -> Sing (Apply Foo9Sym0 t :: Nat) :: Type)
+      (forall (t :: Nat). Sing t -> Sing (Foo9 t :: Nat) :: Type)
     sFoo8 ::
-      (forall (t :: Nat).
-       Sing t -> Sing (Apply Foo8Sym0 t :: Nat) :: Type)
+      (forall (t :: Nat). Sing t -> Sing (Foo8 t :: Nat) :: Type)
     sFoo7 ::
-      (forall (t :: Nat).
-       Sing t -> Sing (Apply Foo7Sym0 t :: Nat) :: Type)
+      (forall (t :: Nat). Sing t -> Sing (Foo7 t :: Nat) :: Type)
     sFoo6 ::
-      (forall (t :: Nat).
-       Sing t -> Sing (Apply Foo6Sym0 t :: Nat) :: Type)
+      (forall (t :: Nat). Sing t -> Sing (Foo6 t :: Nat) :: Type)
     sFoo5 ::
-      (forall (t :: Nat).
-       Sing t -> Sing (Apply Foo5Sym0 t :: Nat) :: Type)
+      (forall (t :: Nat). Sing t -> Sing (Foo5 t :: Nat) :: Type)
     sFoo4 ::
-      (forall (t :: Nat).
-       Sing t -> Sing (Apply Foo4Sym0 t :: Nat) :: Type)
+      (forall (t :: Nat). Sing t -> Sing (Foo4 t :: Nat) :: Type)
     sFoo3 ::
-      (forall (t :: Nat).
-       Sing t -> Sing (Apply Foo3Sym0 t :: Nat) :: Type)
-    sFoo2 :: (Sing (Foo2Sym0 :: Nat) :: Type)
+      (forall (t :: Nat). Sing t -> Sing (Foo3 t :: Nat) :: Type)
+    sFoo2 :: (Sing (Foo2 :: Nat) :: Type)
     sFoo1 ::
-      (forall (t :: Nat).
-       Sing t -> Sing (Apply Foo1Sym0 t :: Nat) :: Type)
+      (forall (t :: Nat). Sing t -> Sing (Foo1 t :: Nat) :: Type)
     sFoo14 (sX :: Sing x)
       = let
-          sZ :: Sing @_ (Let0123456789876543210ZSym0 x)
-          sY :: Sing @_ (Let0123456789876543210YSym0 x)
+          sZ :: Sing @_ (Let0123456789876543210Z x)
+          sY :: Sing @_ (Let0123456789876543210Y x)
           sX_0123456789876543210 ::
-            Sing @_ (Let0123456789876543210X_0123456789876543210Sym0 x)
+            Sing @_ (Let0123456789876543210X_0123456789876543210 x)
           sZ
             = id
                 @(Sing (Case_0123456789876543210 x (Let0123456789876543210X_0123456789876543210Sym0 x)))
@@ -655,7 +642,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     sFoo13_ (sY :: Sing y) = sY
     sFoo13 (sX :: Sing x)
       = let
-          sBar :: (Sing (Let0123456789876543210BarSym0 a x :: a) :: Type)
+          sBar :: (Sing (Let0123456789876543210Bar a x :: a) :: Type)
           sBar = sX
         in applySing (singFun1 @Foo13_Sym0 sFoo13_) sBar
     sFoo12 (sX :: Sing x)
@@ -663,8 +650,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
           (%+) ::
             (forall (t :: Nat) (t :: Nat).
              Sing t
-             -> Sing t
-                -> Sing (Apply (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$) x) t) t :: Nat) :: Type)
+             -> Sing t -> Sing ((<<<%%%%%%%%%%%%%%%%%%%%) x t t :: Nat) :: Type)
           (%+) SZero (sM :: Sing m) = sM
           (%+) (SSucc (sN :: Sing n)) (sM :: Sing m)
             = applySing
@@ -680,12 +666,11 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
                (applySing (singFun1 @SuccSym0 SSucc) SZero))
     sFoo11 (sX :: Sing x)
       = let
-          sZ :: (Sing (Let0123456789876543210ZSym0 x :: Nat) :: Type)
+          sZ :: (Sing (Let0123456789876543210Z x :: Nat) :: Type)
           (%+) ::
             (forall (t :: Nat) (t :: Nat).
              Sing t
-             -> Sing t
-                -> Sing (Apply (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$) x) t) t :: Nat) :: Type)
+             -> Sing t -> Sing ((<<<%%%%%%%%%%%%%%%%%%%%) x t t :: Nat) :: Type)
           sZ = sX
           (%+) SZero (sM :: Sing m) = sM
           (%+) (SSucc (sN :: Sing n)) (sM :: Sing m)
@@ -705,8 +690,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
           (%+) ::
             (forall (t :: Nat) (t :: Nat).
              Sing t
-             -> Sing t
-                -> Sing (Apply (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$) x) t) t :: Nat) :: Type)
+             -> Sing t -> Sing ((<<<%%%%%%%%%%%%%%%%%%%%) x t t :: Nat) :: Type)
           (%+) SZero (sM :: Sing m) = sM
           (%+) (SSucc (sN :: Sing n)) (sM :: Sing m)
             = applySing
@@ -724,8 +708,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       = let
           sZ ::
             (forall (t :: Nat).
-             Sing t
-             -> Sing (Apply (Let0123456789876543210ZSym0 x) t :: Nat) :: Type)
+             Sing t -> Sing (Let0123456789876543210Z x t :: Nat) :: Type)
           sZ (sA_0123456789876543210 :: Sing a_0123456789876543210)
             = applySing
                 (singFun1
@@ -735,7 +718,7 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         in applySing (singFun1 @(Let0123456789876543210ZSym0 x) sZ) sX
     sFoo8 (sX :: Sing x)
       = let
-          sZ :: (Sing (Let0123456789876543210ZSym0 x :: Nat) :: Type)
+          sZ :: (Sing (Let0123456789876543210Z x :: Nat) :: Type)
           sZ
             = applySing
                 (singFun1
@@ -745,29 +728,27 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
         in sZ
     sFoo7 (sX :: Sing x)
       = let
-          sX :: (Sing (Let0123456789876543210XSym0 x :: Nat) :: Type)
+          sX :: (Sing (Let0123456789876543210X x :: Nat) :: Type)
           sX = SZero
         in sX
     sFoo6 (sX :: Sing x)
       = let
           sF ::
             (forall (t :: Nat).
-             Sing t
-             -> Sing (Apply (Let0123456789876543210FSym0 x) t :: Nat) :: Type)
+             Sing t -> Sing (Let0123456789876543210F x t :: Nat) :: Type)
           sF (sY :: Sing y) = applySing (singFun1 @SuccSym0 SSucc) sY in
         let
-          sZ :: (Sing (Let0123456789876543210ZSym0 x :: Nat) :: Type)
+          sZ :: (Sing (Let0123456789876543210Z x :: Nat) :: Type)
           sZ = applySing (singFun1 @(Let0123456789876543210FSym0 x) sF) sX
         in sZ
     sFoo5 (sX :: Sing x)
       = let
           sF ::
             (forall (t :: Nat).
-             Sing t
-             -> Sing (Apply (Let0123456789876543210FSym0 x) t :: Nat) :: Type)
+             Sing t -> Sing (Let0123456789876543210F x t :: Nat) :: Type)
           sF (sY :: Sing y)
             = let
-                sZ :: (Sing (Let0123456789876543210ZSym0 y x :: Nat) :: Type)
+                sZ :: (Sing (Let0123456789876543210Z y x :: Nat) :: Type)
                 sZ = applySing (singFun1 @SuccSym0 SSucc) sY
               in applySing (singFun1 @SuccSym0 SSucc) sZ
         in applySing (singFun1 @(Let0123456789876543210FSym0 x) sF) sX
@@ -775,25 +756,24 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       = let
           sF ::
             (forall (t :: Nat).
-             Sing t
-             -> Sing (Apply (Let0123456789876543210FSym0 x) t :: Nat) :: Type)
+             Sing t -> Sing (Let0123456789876543210F x t :: Nat) :: Type)
           sF (sY :: Sing y) = applySing (singFun1 @SuccSym0 SSucc) sY
         in applySing (singFun1 @(Let0123456789876543210FSym0 x) sF) sX
     sFoo3 (sX :: Sing x)
       = let
-          sY :: (Sing (Let0123456789876543210YSym0 x :: Nat) :: Type)
+          sY :: (Sing (Let0123456789876543210Y x :: Nat) :: Type)
           sY = applySing (singFun1 @SuccSym0 SSucc) sX
         in sY
     sFoo2
       = let
-          sZ :: Sing @_ Let0123456789876543210ZSym0
-          sY :: Sing @_ Let0123456789876543210YSym0
+          sZ :: Sing @_ Let0123456789876543210Z
+          sY :: Sing @_ Let0123456789876543210Y
           sZ = applySing (singFun1 @SuccSym0 SSucc) sY
           sY = applySing (singFun1 @SuccSym0 SSucc) SZero
         in sZ
     sFoo1 (sX :: Sing x)
       = let
-          sY :: (Sing (Let0123456789876543210YSym0 x :: Nat) :: Type)
+          sY :: (Sing (Let0123456789876543210Y x :: Nat) :: Type)
           sY = applySing (singFun1 @SuccSym0 SSucc) SZero
         in sY
     instance SingI (Foo14Sym0 :: (~>) Nat (Nat, Nat)) where

--- a/singletons-base/tests/compile-and-dump/Singletons/Maybe.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Maybe.golden
@@ -28,74 +28,16 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
       TFHelper_0123456789876543210 @a (Nothing :: Maybe a) (Just _ :: Maybe a) = FalseSym0
       TFHelper_0123456789876543210 @a (Just _ :: Maybe a) (Nothing :: Maybe a) = FalseSym0
       TFHelper_0123456789876543210 @a (Just a_0123456789876543210 :: Maybe a) (Just b_0123456789876543210 :: Maybe a) = Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210
-    type TFHelper_0123456789876543210Sym0 :: forall a. (~>) (Maybe a) ((~>) (Maybe a) Bool)
-    data TFHelper_0123456789876543210Sym0 :: (~>) (Maybe a) ((~>) (Maybe a) Bool)
-      where
-        TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @(Maybe a) @((~>) (Maybe a) Bool) TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym0KindInference ())
-    type TFHelper_0123456789876543210Sym1 :: forall a. Maybe a
-                                                       -> (~>) (Maybe a) Bool
-    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Maybe a) :: (~>) (Maybe a) Bool
-      where
-        TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Maybe a) @Bool (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym1KindInference ())
-    type TFHelper_0123456789876543210Sym2 :: forall a. Maybe a
-                                                       -> Maybe a -> Bool
-    type family TFHelper_0123456789876543210Sym2 @a (a0123456789876543210 :: Maybe a) (a0123456789876543210 :: Maybe a) :: Bool where
-      TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq (Maybe a) where
-      type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
+      type (==) a a = TFHelper_0123456789876543210 a a
     type ShowsPrec_0123456789876543210 :: forall a. GHC.Num.Natural.Natural
                                                     -> Maybe a
                                                        -> GHC.Types.Symbol -> GHC.Types.Symbol
     type family ShowsPrec_0123456789876543210 @a (a :: GHC.Num.Natural.Natural) (a :: Maybe a) (a :: GHC.Types.Symbol) :: GHC.Types.Symbol where
       ShowsPrec_0123456789876543210 @a (_ :: GHC.Num.Natural.Natural) (Nothing :: Maybe a) (a_0123456789876543210 :: GHC.Types.Symbol) = Apply (Apply ShowStringSym0 "Nothing") a_0123456789876543210
       ShowsPrec_0123456789876543210 @a (p_0123456789876543210 :: GHC.Num.Natural.Natural) (Just arg_0123456789876543210 :: Maybe a) (a_0123456789876543210 :: GHC.Types.Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Just ")) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym0 :: forall a. (~>) GHC.Num.Natural.Natural ((~>) (Maybe a) ((~>) GHC.Types.Symbol GHC.Types.Symbol))
-    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) (Maybe a) ((~>) GHC.Types.Symbol GHC.Types.Symbol))
-      where
-        ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @GHC.Num.Natural.Natural @((~>) (Maybe a) ((~>) GHC.Types.Symbol GHC.Types.Symbol)) ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym0KindInference ())
-    type ShowsPrec_0123456789876543210Sym1 :: forall a. GHC.Num.Natural.Natural
-                                                        -> (~>) (Maybe a) ((~>) GHC.Types.Symbol GHC.Types.Symbol)
-    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Num.Natural.Natural) :: (~>) (Maybe a) ((~>) GHC.Types.Symbol GHC.Types.Symbol)
-      where
-        ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Maybe a) @((~>) GHC.Types.Symbol GHC.Types.Symbol) (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym1KindInference ())
-    type ShowsPrec_0123456789876543210Sym2 :: forall a. GHC.Num.Natural.Natural
-                                                        -> Maybe a
-                                                           -> (~>) GHC.Types.Symbol GHC.Types.Symbol
-    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: Maybe a) :: (~>) GHC.Types.Symbol GHC.Types.Symbol
-      where
-        ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @GHC.Types.Symbol @GHC.Types.Symbol (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym2KindInference ())
-    type ShowsPrec_0123456789876543210Sym3 :: forall a. GHC.Num.Natural.Natural
-                                                        -> Maybe a
-                                                           -> GHC.Types.Symbol -> GHC.Types.Symbol
-    type family ShowsPrec_0123456789876543210Sym3 @a (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: Maybe a) (a0123456789876543210 :: GHC.Types.Symbol) :: GHC.Types.Symbol where
-      ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow (Maybe a) where
-      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
     data SMaybe :: forall a. Maybe a -> Type
       where
         SNothing :: forall a. SMaybe (Nothing :: Maybe a)

--- a/singletons-base/tests/compile-and-dump/Singletons/Nat.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Nat.golden
@@ -82,98 +82,23 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
       TFHelper_0123456789876543210 Zero (Succ _) = FalseSym0
       TFHelper_0123456789876543210 (Succ _) Zero = FalseSym0
       TFHelper_0123456789876543210 (Succ a_0123456789876543210) (Succ b_0123456789876543210) = Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210
-    type TFHelper_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Bool)
-    data TFHelper_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Bool)
-      where
-        TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Nat @((~>) Nat Bool) TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym0KindInference ())
-    type TFHelper_0123456789876543210Sym1 :: Nat -> (~>) Nat Bool
-    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Nat) :: (~>) Nat Bool
-      where
-        TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @Bool (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym1KindInference ())
-    type TFHelper_0123456789876543210Sym2 :: Nat -> Nat -> Bool
-    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Bool where
-      TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq Nat where
-      type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
+      type (==) a a = TFHelper_0123456789876543210 a a
     type ShowsPrec_0123456789876543210 :: GHC.Num.Natural.Natural
                                           -> Nat -> GHC.Types.Symbol -> GHC.Types.Symbol
     type family ShowsPrec_0123456789876543210 (a :: GHC.Num.Natural.Natural) (a :: Nat) (a :: GHC.Types.Symbol) :: GHC.Types.Symbol where
       ShowsPrec_0123456789876543210 _ Zero a_0123456789876543210 = Apply (Apply ShowStringSym0 "Zero") a_0123456789876543210
       ShowsPrec_0123456789876543210 p_0123456789876543210 (Succ arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Succ ")) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) Nat ((~>) GHC.Types.Symbol GHC.Types.Symbol))
-    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) Nat ((~>) GHC.Types.Symbol GHC.Types.Symbol))
-      where
-        ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @GHC.Num.Natural.Natural @((~>) Nat ((~>) GHC.Types.Symbol GHC.Types.Symbol)) ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym0KindInference ())
-    type ShowsPrec_0123456789876543210Sym1 :: GHC.Num.Natural.Natural
-                                              -> (~>) Nat ((~>) GHC.Types.Symbol GHC.Types.Symbol)
-    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Num.Natural.Natural) :: (~>) Nat ((~>) GHC.Types.Symbol GHC.Types.Symbol)
-      where
-        ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @((~>) GHC.Types.Symbol GHC.Types.Symbol) (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym1KindInference ())
-    type ShowsPrec_0123456789876543210Sym2 :: GHC.Num.Natural.Natural
-                                              -> Nat -> (~>) GHC.Types.Symbol GHC.Types.Symbol
-    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: Nat) :: (~>) GHC.Types.Symbol GHC.Types.Symbol
-      where
-        ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @GHC.Types.Symbol @GHC.Types.Symbol (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym2KindInference ())
-    type ShowsPrec_0123456789876543210Sym3 :: GHC.Num.Natural.Natural
-                                              -> Nat -> GHC.Types.Symbol -> GHC.Types.Symbol
-    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: Nat) (a0123456789876543210 :: GHC.Types.Symbol) :: GHC.Types.Symbol where
-      ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow Nat where
-      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
     type Compare_0123456789876543210 :: Nat -> Nat -> Ordering
     type family Compare_0123456789876543210 (a :: Nat) (a :: Nat) :: Ordering where
       Compare_0123456789876543210 Zero Zero = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
       Compare_0123456789876543210 (Succ a_0123456789876543210) (Succ b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0)
       Compare_0123456789876543210 Zero (Succ _) = LTSym0
       Compare_0123456789876543210 (Succ _) Zero = GTSym0
-    type Compare_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Ordering)
-    data Compare_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Ordering)
-      where
-        Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Nat @((~>) Nat Ordering) Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym0KindInference ())
-    type Compare_0123456789876543210Sym1 :: Nat -> (~>) Nat Ordering
-    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Nat) :: (~>) Nat Ordering
-      where
-        Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @Ordering (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym1KindInference ())
-    type Compare_0123456789876543210Sym2 :: Nat -> Nat -> Ordering
-    type family Compare_0123456789876543210Sym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Ordering where
-      Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd Nat where
-      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
+      type Compare a a = Compare_0123456789876543210 a a
     sPred ::
       (forall (t :: Nat).
        Sing t -> Sing (Apply PredSym0 t :: Nat) :: Type)

--- a/singletons-base/tests/compile-and-dump/Singletons/Nat.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Nat.golden
@@ -100,12 +100,10 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
     instance POrd Nat where
       type Compare a a = Compare_0123456789876543210 a a
     sPred ::
-      (forall (t :: Nat).
-       Sing t -> Sing (Apply PredSym0 t :: Nat) :: Type)
+      (forall (t :: Nat). Sing t -> Sing (Pred t :: Nat) :: Type)
     sPlus ::
       (forall (t :: Nat) (t :: Nat).
-       Sing t
-       -> Sing t -> Sing (Apply (Apply PlusSym0 t) t :: Nat) :: Type)
+       Sing t -> Sing t -> Sing (Plus t t :: Nat) :: Type)
     sPred SZero = SZero
     sPred (SSucc (sN :: Sing n)) = sN
     sPlus SZero (sM :: Sing m) = sM

--- a/singletons-base/tests/compile-and-dump/Singletons/Natural.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Natural.golden
@@ -45,8 +45,7 @@ Singletons/Natural.hs:(0,0)-(0,0): Splicing declarations
       AddAge (MkAge (x :: Natural)) (MkAge (y :: Natural)) = Apply MkAgeSym0 (Apply (Apply (+@#@$) x) y :: Natural)
     sAddAge ::
       (forall (t :: Age) (t :: Age).
-       Sing t
-       -> Sing t -> Sing (Apply (Apply AddAgeSym0 t) t :: Age) :: Type)
+       Sing t -> Sing t -> Sing (AddAge t t :: Age) :: Type)
     sAddAge (SMkAge (sX :: Sing x)) (SMkAge (sY :: Sing y))
       = case (,) (sX :: Sing x) (sY :: Sing y) of
           (,) (_ :: Sing (x :: Natural)) (_ :: Sing (y :: Natural))

--- a/singletons-base/tests/compile-and-dump/Singletons/NegativeLiterals.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/NegativeLiterals.golden
@@ -11,11 +11,11 @@ Singletons/NegativeLiterals.hs:(0,0)-(0,0): Splicing declarations
     type F :: Natural
     type family F :: Natural where
       F = Negate (FromInteger 1)
-    sF :: (Sing (FSym0 :: Natural) :: Type)
+    sF :: (Sing (F :: Natural) :: Type)
     sF = sNegate (sFromInteger (sing :: Sing 1))
-
 Singletons/NegativeLiterals.hs:0:0: warning: [GHC-97441] [-Woverflowed-literals]
     Literal -1 is negative but Natural only supports positive numbers
   |
 8 | $(singletons [d|
   |  ^^^^^^^^^^^^^^^...
+

--- a/singletons-base/tests/compile-and-dump/Singletons/Operators.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Operators.golden
@@ -84,11 +84,9 @@ Singletons/Operators.hs:(0,0)-(0,0): Splicing declarations
       Child ((:+:) a _) = a
     (%+) ::
       (forall (t :: Nat) (t :: Nat).
-       Sing t
-       -> Sing t -> Sing (Apply (Apply (+@#@$) t) t :: Nat) :: Type)
+       Sing t -> Sing t -> Sing ((+) t t :: Nat) :: Type)
     sChild ::
-      (forall (t :: Foo).
-       Sing t -> Sing (Apply ChildSym0 t :: Foo) :: Type)
+      (forall (t :: Foo). Sing t -> Sing (Child t :: Foo) :: Type)
     (%+) SZero (sM :: Sing m) = sM
     (%+) (SSucc (sN :: Sing n)) (sM :: Sing m)
       = applySing

--- a/singletons-base/tests/compile-and-dump/Singletons/OrdDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/OrdDeriving.golden
@@ -283,58 +283,16 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       TFHelper_0123456789876543210 Zero (Succ _) = FalseSym0
       TFHelper_0123456789876543210 (Succ _) Zero = FalseSym0
       TFHelper_0123456789876543210 (Succ a_0123456789876543210) (Succ b_0123456789876543210) = Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210
-    type TFHelper_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Bool)
-    data TFHelper_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Bool)
-      where
-        TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Nat @((~>) Nat Bool) TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym0KindInference ())
-    type TFHelper_0123456789876543210Sym1 :: Nat -> (~>) Nat Bool
-    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Nat) :: (~>) Nat Bool
-      where
-        TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @Bool (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym1KindInference ())
-    type TFHelper_0123456789876543210Sym2 :: Nat -> Nat -> Bool
-    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Bool where
-      TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq Nat where
-      type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
+      type (==) a a = TFHelper_0123456789876543210 a a
     type Compare_0123456789876543210 :: Nat -> Nat -> Ordering
     type family Compare_0123456789876543210 (a :: Nat) (a :: Nat) :: Ordering where
       Compare_0123456789876543210 Zero Zero = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
       Compare_0123456789876543210 (Succ a_0123456789876543210) (Succ b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0)
       Compare_0123456789876543210 Zero (Succ _) = LTSym0
       Compare_0123456789876543210 (Succ _) Zero = GTSym0
-    type Compare_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Ordering)
-    data Compare_0123456789876543210Sym0 :: (~>) Nat ((~>) Nat Ordering)
-      where
-        Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Nat @((~>) Nat Ordering) Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym0KindInference ())
-    type Compare_0123456789876543210Sym1 :: Nat -> (~>) Nat Ordering
-    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Nat) :: (~>) Nat Ordering
-      where
-        Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @Ordering (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym1KindInference ())
-    type Compare_0123456789876543210Sym2 :: Nat -> Nat -> Ordering
-    type family Compare_0123456789876543210Sym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Ordering where
-      Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd Nat where
-      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
+      type Compare a a = Compare_0123456789876543210 a a
     type TFHelper_0123456789876543210 :: forall a b c d. Foo a b c d
                                                          -> Foo a b c d -> Bool
     type family TFHelper_0123456789876543210 @a @b @c @d (a :: Foo a b c d) (a :: Foo a b c d) :: Bool where
@@ -374,38 +332,8 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       TFHelper_0123456789876543210 @a @b @c @d (F _ _ _ _ :: Foo a b c d) (D _ _ _ _ :: Foo a b c d) = FalseSym0
       TFHelper_0123456789876543210 @a @b @c @d (F _ _ _ _ :: Foo a b c d) (E _ _ _ _ :: Foo a b c d) = FalseSym0
       TFHelper_0123456789876543210 @a @b @c @d (F a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 :: Foo a b c d) (F b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 :: Foo a b c d) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)))
-    type TFHelper_0123456789876543210Sym0 :: forall a
-                                                    b
-                                                    c
-                                                    d. (~>) (Foo a b c d) ((~>) (Foo a b c d) Bool)
-    data TFHelper_0123456789876543210Sym0 :: (~>) (Foo a b c d) ((~>) (Foo a b c d) Bool)
-      where
-        TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @(Foo a b c d) @((~>) (Foo a b c d) Bool) TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym0KindInference ())
-    type TFHelper_0123456789876543210Sym1 :: forall a
-                                                    b
-                                                    c
-                                                    d. Foo a b c d -> (~>) (Foo a b c d) Bool
-    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Foo a b c d) :: (~>) (Foo a b c d) Bool
-      where
-        TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Foo a b c d) @Bool (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym1KindInference ())
-    type TFHelper_0123456789876543210Sym2 :: forall a
-                                                    b
-                                                    c
-                                                    d. Foo a b c d -> Foo a b c d -> Bool
-    type family TFHelper_0123456789876543210Sym2 @a @b @c @d (a0123456789876543210 :: Foo a b c d) (a0123456789876543210 :: Foo a b c d) :: Bool where
-      TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq (Foo a b c d) where
-      type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
+      type (==) a a = TFHelper_0123456789876543210 a a
     type Compare_0123456789876543210 :: forall a b c d. Foo a b c d
                                                         -> Foo a b c d -> Ordering
     type family Compare_0123456789876543210 @a @b @c @d (a :: Foo a b c d) (a :: Foo a b c d) :: Ordering where
@@ -445,34 +373,8 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       Compare_0123456789876543210 @a @b @c @d (F _ _ _ _ :: Foo a b c d) (C _ _ _ _ :: Foo a b c d) = GTSym0
       Compare_0123456789876543210 @a @b @c @d (F _ _ _ _ :: Foo a b c d) (D _ _ _ _ :: Foo a b c d) = GTSym0
       Compare_0123456789876543210 @a @b @c @d (F _ _ _ _ :: Foo a b c d) (E _ _ _ _ :: Foo a b c d) = GTSym0
-    type Compare_0123456789876543210Sym0 :: forall a
-                                                   b
-                                                   c
-                                                   d. (~>) (Foo a b c d) ((~>) (Foo a b c d) Ordering)
-    data Compare_0123456789876543210Sym0 :: (~>) (Foo a b c d) ((~>) (Foo a b c d) Ordering)
-      where
-        Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @(Foo a b c d) @((~>) (Foo a b c d) Ordering) Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym0KindInference ())
-    type Compare_0123456789876543210Sym1 :: forall a b c d. Foo a b c d
-                                                            -> (~>) (Foo a b c d) Ordering
-    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Foo a b c d) :: (~>) (Foo a b c d) Ordering
-      where
-        Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Foo a b c d) @Ordering (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym1KindInference ())
-    type Compare_0123456789876543210Sym2 :: forall a b c d. Foo a b c d
-                                                            -> Foo a b c d -> Ordering
-    type family Compare_0123456789876543210Sym2 @a @b @c @d (a0123456789876543210 :: Foo a b c d) (a0123456789876543210 :: Foo a b c d) :: Ordering where
-      Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd (Foo a b c d) where
-      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
+      type Compare a a = Compare_0123456789876543210 a a
     data SNat :: Nat -> Type
       where
         SZero :: SNat (Zero :: Nat)

--- a/singletons-base/tests/compile-and-dump/Singletons/OverloadedStrings.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/OverloadedStrings.golden
@@ -29,10 +29,9 @@ Singletons/OverloadedStrings.hs:(0,0)-(0,0): Splicing declarations
     type SymId :: Symbol -> Symbol
     type family SymId (a :: Symbol) :: Symbol where
       SymId x = x
-    sFoo :: (Sing (FooSym0 :: Symbol) :: Type)
+    sFoo :: (Sing (Foo :: Symbol) :: Type)
     sSymId ::
-      (forall (t :: Symbol).
-       Sing t -> Sing (Apply SymIdSym0 t :: Symbol) :: Type)
+      (forall (t :: Symbol). Sing t -> Sing (SymId t :: Symbol) :: Type)
     sFoo
       = applySing
           (singFun1 @SymIdSym0 sSymId) (sFromString (sing :: Sing "foo"))

--- a/singletons-base/tests/compile-and-dump/Singletons/PatternMatching.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/PatternMatching.golden
@@ -56,45 +56,8 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
                                                     -> Pair a b -> Symbol -> Symbol
     type family ShowsPrec_0123456789876543210 @a @b (a :: GHC.Num.Natural.Natural) (a :: Pair a b) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 @a @b (p_0123456789876543210 :: GHC.Num.Natural.Natural) (Pair arg_0123456789876543210 arg_0123456789876543210 :: Pair a b) (a_0123456789876543210 :: Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Pair ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym0 :: forall a
-                                                     b. (~>) GHC.Num.Natural.Natural ((~>) (Pair a b) ((~>) Symbol Symbol))
-    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) (Pair a b) ((~>) Symbol Symbol))
-      where
-        ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @GHC.Num.Natural.Natural @((~>) (Pair a b) ((~>) Symbol Symbol)) ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym0KindInference ())
-    type ShowsPrec_0123456789876543210Sym1 :: forall a
-                                                     b. GHC.Num.Natural.Natural
-                                                        -> (~>) (Pair a b) ((~>) Symbol Symbol)
-    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Num.Natural.Natural) :: (~>) (Pair a b) ((~>) Symbol Symbol)
-      where
-        ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Pair a b) @((~>) Symbol Symbol) (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym1KindInference ())
-    type ShowsPrec_0123456789876543210Sym2 :: forall a
-                                                     b. GHC.Num.Natural.Natural
-                                                        -> Pair a b -> (~>) Symbol Symbol
-    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: Pair a b) :: (~>) Symbol Symbol
-      where
-        ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @Symbol @Symbol (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym2KindInference ())
-    type ShowsPrec_0123456789876543210Sym3 :: forall a
-                                                     b. GHC.Num.Natural.Natural
-                                                        -> Pair a b -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210Sym3 @a @b (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: Pair a b) (a0123456789876543210 :: Symbol) :: Symbol where
-      ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow (Pair a b) where
-      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
     sAList :: Sing @_ AListSym0
     sTuple :: Sing @_ TupleSym0
     sComplex :: Sing @_ ComplexSym0

--- a/singletons-base/tests/compile-and-dump/Singletons/PatternMatching.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/PatternMatching.golden
@@ -58,10 +58,10 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
       ShowsPrec_0123456789876543210 @a @b (p_0123456789876543210 :: GHC.Num.Natural.Natural) (Pair arg_0123456789876543210 arg_0123456789876543210 :: Pair a b) (a_0123456789876543210 :: Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Pair ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
     instance PShow (Pair a b) where
       type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
-    sAList :: Sing @_ AListSym0
-    sTuple :: Sing @_ TupleSym0
-    sComplex :: Sing @_ ComplexSym0
-    sPr :: Sing @_ PrSym0
+    sAList :: Sing @_ AList
+    sTuple :: Sing @_ Tuple
+    sComplex :: Sing @_ Complex
+    sPr :: Sing @_ Pr
     sAList
       = applySing
           (applySing (singFun2 @(:@#@$) SCons) SZero)
@@ -362,34 +362,31 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
       Sz = Case_0123456789876543210 X_0123456789876543210Sym0
     type family X_0123456789876543210 where
       X_0123456789876543210 = PrSym0
-    sSilly ::
-      (forall (t :: a). Sing t -> Sing (Apply SillySym0 t :: ()) :: Type)
+    sSilly :: (forall (t :: a). Sing t -> Sing (Silly t :: ()) :: Type)
     sFoo2 ::
-      (forall (t :: (a, b)).
-       Sing t -> Sing (Apply Foo2Sym0 t :: a) :: Type)
+      (forall (t :: (a, b)). Sing t -> Sing (Foo2 t :: a) :: Type)
     sFoo1 ::
-      (forall (t :: (a, b)).
-       Sing t -> Sing (Apply Foo1Sym0 t :: a) :: Type)
-    sBlimy :: Sing @_ BlimySym0
-    sLsz :: (Sing (LszSym0 :: Nat) :: Type)
-    sX_0123456789876543210 :: Sing @_ X_0123456789876543210Sym0
-    sTt :: Sing @_ TtSym0
-    sTjz :: Sing @_ TjzSym0
-    sTf :: Sing @_ TfSym0
-    sX_0123456789876543210 :: Sing @_ X_0123456789876543210Sym0
-    sFls :: (Sing (FlsSym0 :: Bool) :: Type)
-    sZz :: Sing @_ ZzSym0
-    sJz :: Sing @_ JzSym0
-    sX_0123456789876543210 :: Sing @_ X_0123456789876543210Sym0
-    sLz :: Sing @_ LzSym0
-    sSz :: Sing @_ SzSym0
-    sX_0123456789876543210 :: Sing @_ X_0123456789876543210Sym0
+      (forall (t :: (a, b)). Sing t -> Sing (Foo1 t :: a) :: Type)
+    sBlimy :: Sing @_ Blimy
+    sLsz :: (Sing (Lsz :: Nat) :: Type)
+    sX_0123456789876543210 :: Sing @_ X_0123456789876543210
+    sTt :: Sing @_ Tt
+    sTjz :: Sing @_ Tjz
+    sTf :: Sing @_ Tf
+    sX_0123456789876543210 :: Sing @_ X_0123456789876543210
+    sFls :: (Sing (Fls :: Bool) :: Type)
+    sZz :: Sing @_ Zz
+    sJz :: Sing @_ Jz
+    sX_0123456789876543210 :: Sing @_ X_0123456789876543210
+    sLz :: Sing @_ Lz
+    sSz :: Sing @_ Sz
+    sX_0123456789876543210 :: Sing @_ X_0123456789876543210
     sSilly (sX :: Sing x)
       = id
           @(Sing (Case_0123456789876543210 x x)) (case sX of _ -> STuple0)
     sFoo2 (STuple2 (sX :: Sing x) (sY :: Sing y))
       = let
-          sT :: Sing @_ (Let0123456789876543210TSym0 x y)
+          sT :: Sing @_ (Let0123456789876543210T x y)
           sT = applySing (applySing (singFun2 @Tuple2Sym0 STuple2) sX) sY
         in
           id

--- a/singletons-base/tests/compile-and-dump/Singletons/PolyKinds.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/PolyKinds.golden
@@ -21,7 +21,7 @@ Singletons/PolyKinds.hs:(0,0)-(0,0): Splicing declarations
     class SCls (a :: k) where
       sFff ::
         (forall (t :: Proxy (a :: k)).
-         Sing t -> Sing (Apply FffSym0 t :: ()) :: Type)
+         Sing t -> Sing (Fff t :: ()) :: Type)
     instance SCls a =>
              SingI (FffSym0 :: (~>) (Proxy (a :: k)) ()) where
       sing = singFun1 @FffSym0 sFff

--- a/singletons-base/tests/compile-and-dump/Singletons/PolyKindsApp.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/PolyKindsApp.golden
@@ -13,4 +13,4 @@ Singletons/PolyKindsApp.hs:(0,0)-(0,0): Splicing declarations
     class PCls (a :: k -> Type) where
       type family Fff :: (a :: k -> Type) (b :: k)
     class SCls (a :: k -> Type) where
-      sFff :: (Sing (FffSym0 :: (a :: k -> Type) (b :: k)) :: Type)
+      sFff :: (Sing (Fff :: (a :: k -> Type) (b :: k)) :: Type)

--- a/singletons-base/tests/compile-and-dump/Singletons/Records.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Records.golden
@@ -51,10 +51,8 @@ Singletons/Records.hs:(0,0)-(0,0): Splicing declarations
     type family Field1 @a (a :: Record a) :: a where
       Field1 @a (MkRecord field _ :: Record a) = field
     sField2 ::
-      forall a (t :: Record a). Sing t
-                                -> Sing (Apply Field2Sym0 t :: Bool)
-    sField1 ::
-      forall a (t :: Record a). Sing t -> Sing (Apply Field1Sym0 t :: a)
+      forall a (t :: Record a). Sing t -> Sing (Field2 t :: Bool)
+    sField1 :: forall a (t :: Record a). Sing t -> Sing (Field1 t :: a)
     sField2 (SMkRecord _ (sField :: Sing field)) = sField
     sField1 (SMkRecord (sField :: Sing field) _) = sField
     instance SingI (Field2Sym0 :: (~>) (Record a) Bool) where

--- a/singletons-base/tests/compile-and-dump/Singletons/ReturnFunc.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/ReturnFunc.golden
@@ -73,15 +73,11 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
       ReturnFunc _ a_0123456789876543210 = Apply SuccSym0 a_0123456789876543210
     sIdFoo ::
       (forall (t :: c) (t :: a).
-       Sing t
-       -> Sing t -> Sing (Apply (Apply IdFooSym0 t) t :: a) :: Type)
-    sId ::
-      (forall (t :: a). Sing t -> Sing (Apply IdSym0 t :: a) :: Type)
+       Sing t -> Sing t -> Sing (IdFoo t t :: a) :: Type)
+    sId :: (forall (t :: a). Sing t -> Sing (Id t :: a) :: Type)
     sReturnFunc ::
       (forall (t :: Nat) (t :: Nat).
-       Sing t
-       -> Sing t
-          -> Sing (Apply (Apply ReturnFuncSym0 t) t :: Nat) :: Type)
+       Sing t -> Sing t -> Sing (ReturnFunc t t :: Nat) :: Type)
     sIdFoo _ (sA_0123456789876543210 :: Sing a_0123456789876543210)
       = applySing (singFun1 @IdSym0 sId) sA_0123456789876543210
     sId (sX :: Sing x) = sX

--- a/singletons-base/tests/compile-and-dump/Singletons/Sections.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Sections.golden
@@ -72,13 +72,12 @@ Singletons/Sections.hs:(0,0)-(0,0): Splicing declarations
     type family (+) (a :: Nat) (a :: Nat) :: Nat where
       (+) 'Zero m = m
       (+) ('Succ n) m = Apply SuccSym0 (Apply (Apply (+@#@$) n) m)
-    sFoo3 :: (Sing (Foo3Sym0 :: [Nat]) :: Type)
-    sFoo2 :: (Sing (Foo2Sym0 :: [Nat]) :: Type)
-    sFoo1 :: (Sing (Foo1Sym0 :: [Nat]) :: Type)
+    sFoo3 :: (Sing (Foo3 :: [Nat]) :: Type)
+    sFoo2 :: (Sing (Foo2 :: [Nat]) :: Type)
+    sFoo1 :: (Sing (Foo1 :: [Nat]) :: Type)
     (%+) ::
       (forall (t :: Nat) (t :: Nat).
-       Sing t
-       -> Sing t -> Sing (Apply (Apply (+@#@$) t) t :: Nat) :: Type)
+       Sing t -> Sing t -> Sing ((+) t t :: Nat) :: Type)
     sFoo3
       = applySing
           (applySing

--- a/singletons-base/tests/compile-and-dump/Singletons/ShowDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/ShowDeriving.golden
@@ -184,11 +184,9 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     infixl 5 :%*:
     infixl 5 `SMkFoo2b`
     (%***) ::
-      (forall (t :: Foo3).
-       Sing t -> Sing (Apply (***@#@$) t :: Bool) :: Type)
+      (forall (t :: Foo3). Sing t -> Sing ((***) t :: Bool) :: Type)
     sGetFoo3a ::
-      (forall (t :: Foo3).
-       Sing t -> Sing (Apply GetFoo3aSym0 t :: Bool) :: Type)
+      (forall (t :: Foo3). Sing t -> Sing (GetFoo3a t :: Bool) :: Type)
     (%***) (SMkFoo3 _ (sField :: Sing field)) = sField
     sGetFoo3a (SMkFoo3 (sField :: Sing field) _) = sField
     instance SingI ((***@#@$) :: (~>) Foo3 Bool) where

--- a/singletons-base/tests/compile-and-dump/Singletons/ShowDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/ShowDeriving.golden
@@ -163,41 +163,8 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                                           -> Foo1 -> Symbol -> Symbol
     type family ShowsPrec_0123456789876543210 (a :: GHC.Num.Natural.Natural) (a :: Foo1) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 _ MkFoo1 a_0123456789876543210 = Apply (Apply ShowStringSym0 "MkFoo1") a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) Foo1 ((~>) Symbol Symbol))
-    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) Foo1 ((~>) Symbol Symbol))
-      where
-        ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @GHC.Num.Natural.Natural @((~>) Foo1 ((~>) Symbol Symbol)) ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym0KindInference ())
-    type ShowsPrec_0123456789876543210Sym1 :: GHC.Num.Natural.Natural
-                                              -> (~>) Foo1 ((~>) Symbol Symbol)
-    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Num.Natural.Natural) :: (~>) Foo1 ((~>) Symbol Symbol)
-      where
-        ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Foo1 @((~>) Symbol Symbol) (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym1KindInference ())
-    type ShowsPrec_0123456789876543210Sym2 :: GHC.Num.Natural.Natural
-                                              -> Foo1 -> (~>) Symbol Symbol
-    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: Foo1) :: (~>) Symbol Symbol
-      where
-        ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @Symbol @Symbol (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym2KindInference ())
-    type ShowsPrec_0123456789876543210Sym3 :: GHC.Num.Natural.Natural
-                                              -> Foo1 -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: Foo1) (a0123456789876543210 :: Symbol) :: Symbol where
-      ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow Foo1 where
-      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
     type ShowsPrec_0123456789876543210 :: forall a. GHC.Num.Natural.Natural
                                                     -> Foo2 a -> Symbol -> Symbol
     type family ShowsPrec_0123456789876543210 @a (a :: GHC.Num.Natural.Natural) (a :: Foo2 a) (a :: Symbol) :: Symbol where
@@ -205,80 +172,14 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
       ShowsPrec_0123456789876543210 @a (p_0123456789876543210 :: GHC.Num.Natural.Natural) (MkFoo2b argL_0123456789876543210 argR_0123456789876543210 :: Foo2 a) (a_0123456789876543210 :: Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 5))) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 6)) argL_0123456789876543210)) (Apply (Apply (.@#@$) (Apply ShowStringSym0 " `MkFoo2b` ")) (Apply (Apply ShowsPrecSym0 (FromInteger 6)) argR_0123456789876543210)))) a_0123456789876543210
       ShowsPrec_0123456789876543210 @a (p_0123456789876543210 :: GHC.Num.Natural.Natural) ((:*:) arg_0123456789876543210 arg_0123456789876543210 :: Foo2 a) (a_0123456789876543210 :: Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "(:*:) ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
       ShowsPrec_0123456789876543210 @a (p_0123456789876543210 :: GHC.Num.Natural.Natural) ((:&:) argL_0123456789876543210 argR_0123456789876543210 :: Foo2 a) (a_0123456789876543210 :: Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 5))) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 6)) argL_0123456789876543210)) (Apply (Apply (.@#@$) (Apply ShowStringSym0 " :&: ")) (Apply (Apply ShowsPrecSym0 (FromInteger 6)) argR_0123456789876543210)))) a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym0 :: forall a. (~>) GHC.Num.Natural.Natural ((~>) (Foo2 a) ((~>) Symbol Symbol))
-    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) (Foo2 a) ((~>) Symbol Symbol))
-      where
-        ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @GHC.Num.Natural.Natural @((~>) (Foo2 a) ((~>) Symbol Symbol)) ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym0KindInference ())
-    type ShowsPrec_0123456789876543210Sym1 :: forall a. GHC.Num.Natural.Natural
-                                                        -> (~>) (Foo2 a) ((~>) Symbol Symbol)
-    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Num.Natural.Natural) :: (~>) (Foo2 a) ((~>) Symbol Symbol)
-      where
-        ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Foo2 a) @((~>) Symbol Symbol) (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym1KindInference ())
-    type ShowsPrec_0123456789876543210Sym2 :: forall a. GHC.Num.Natural.Natural
-                                                        -> Foo2 a -> (~>) Symbol Symbol
-    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: Foo2 a) :: (~>) Symbol Symbol
-      where
-        ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @Symbol @Symbol (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym2KindInference ())
-    type ShowsPrec_0123456789876543210Sym3 :: forall a. GHC.Num.Natural.Natural
-                                                        -> Foo2 a -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210Sym3 @a (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: Foo2 a) (a0123456789876543210 :: Symbol) :: Symbol where
-      ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow (Foo2 a) where
-      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
     type ShowsPrec_0123456789876543210 :: GHC.Num.Natural.Natural
                                           -> Foo3 -> Symbol -> Symbol
     type family ShowsPrec_0123456789876543210 (a :: GHC.Num.Natural.Natural) (a :: Foo3) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 p_0123456789876543210 (MkFoo3 arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "MkFoo3 ")) (Apply (Apply (.@#@$) (Apply ShowCharSym0 '{')) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "getFoo3a = ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 0)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowCommaSpaceSym0) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "(***) = ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 0)) arg_0123456789876543210)) (Apply ShowCharSym0 '}'))))))))) a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) Foo3 ((~>) Symbol Symbol))
-    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) Foo3 ((~>) Symbol Symbol))
-      where
-        ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @GHC.Num.Natural.Natural @((~>) Foo3 ((~>) Symbol Symbol)) ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym0KindInference ())
-    type ShowsPrec_0123456789876543210Sym1 :: GHC.Num.Natural.Natural
-                                              -> (~>) Foo3 ((~>) Symbol Symbol)
-    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Num.Natural.Natural) :: (~>) Foo3 ((~>) Symbol Symbol)
-      where
-        ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Foo3 @((~>) Symbol Symbol) (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym1KindInference ())
-    type ShowsPrec_0123456789876543210Sym2 :: GHC.Num.Natural.Natural
-                                              -> Foo3 -> (~>) Symbol Symbol
-    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: Foo3) :: (~>) Symbol Symbol
-      where
-        ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @Symbol @Symbol (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym2KindInference ())
-    type ShowsPrec_0123456789876543210Sym3 :: GHC.Num.Natural.Natural
-                                              -> Foo3 -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: Foo3) (a0123456789876543210 :: Symbol) :: Symbol where
-      ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow Foo3 where
-      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
     infixl 5 :%&:
     infixl 5 :%*:
     infixl 5 `SMkFoo2b`

--- a/singletons-base/tests/compile-and-dump/Singletons/StandaloneDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/StandaloneDeriving.golden
@@ -57,212 +57,52 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
                                                    -> T a () -> Bool
     type family TFHelper_0123456789876543210 @a (a :: T a ()) (a :: T a ()) :: Bool where
       TFHelper_0123456789876543210 @a ((:*:) a_0123456789876543210 a_0123456789876543210 :: T a ()) ((:*:) b_0123456789876543210 b_0123456789876543210 :: T a ()) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)
-    type TFHelper_0123456789876543210Sym0 :: forall a. (~>) (T a ()) ((~>) (T a ()) Bool)
-    data TFHelper_0123456789876543210Sym0 :: (~>) (T a ()) ((~>) (T a ()) Bool)
-      where
-        TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @(T a ()) @((~>) (T a ()) Bool) TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym0KindInference ())
-    type TFHelper_0123456789876543210Sym1 :: forall a. T a ()
-                                                       -> (~>) (T a ()) Bool
-    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: T a ()) :: (~>) (T a ()) Bool
-      where
-        TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(T a ()) @Bool (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym1KindInference ())
-    type TFHelper_0123456789876543210Sym2 :: forall a. T a ()
-                                                       -> T a () -> Bool
-    type family TFHelper_0123456789876543210Sym2 @a (a0123456789876543210 :: T a ()) (a0123456789876543210 :: T a ()) :: Bool where
-      TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq (T a ()) where
-      type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
+      type (==) a a = TFHelper_0123456789876543210 a a
     type Compare_0123456789876543210 :: forall a. T a ()
                                                   -> T a () -> Ordering
     type family Compare_0123456789876543210 @a (a :: T a ()) (a :: T a ()) :: Ordering where
       Compare_0123456789876543210 @a ((:*:) a_0123456789876543210 a_0123456789876543210 :: T a ()) ((:*:) b_0123456789876543210 b_0123456789876543210 :: T a ()) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0))
-    type Compare_0123456789876543210Sym0 :: forall a. (~>) (T a ()) ((~>) (T a ()) Ordering)
-    data Compare_0123456789876543210Sym0 :: (~>) (T a ()) ((~>) (T a ()) Ordering)
-      where
-        Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @(T a ()) @((~>) (T a ()) Ordering) Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym0KindInference ())
-    type Compare_0123456789876543210Sym1 :: forall a. T a ()
-                                                      -> (~>) (T a ()) Ordering
-    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: T a ()) :: (~>) (T a ()) Ordering
-      where
-        Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(T a ()) @Ordering (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym1KindInference ())
-    type Compare_0123456789876543210Sym2 :: forall a. T a ()
-                                                      -> T a () -> Ordering
-    type family Compare_0123456789876543210Sym2 @a (a0123456789876543210 :: T a ()) (a0123456789876543210 :: T a ()) :: Ordering where
-      Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd (T a ()) where
-      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
+      type Compare a a = Compare_0123456789876543210 a a
     type ShowsPrec_0123456789876543210 :: forall a. GHC.Num.Natural.Natural
                                                     -> T a () -> Symbol -> Symbol
     type family ShowsPrec_0123456789876543210 @a (a :: GHC.Num.Natural.Natural) (a :: T a ()) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 @a (p_0123456789876543210 :: GHC.Num.Natural.Natural) ((:*:) argL_0123456789876543210 argR_0123456789876543210 :: T a ()) (a_0123456789876543210 :: Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 6))) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 7)) argL_0123456789876543210)) (Apply (Apply (.@#@$) (Apply ShowStringSym0 " :*: ")) (Apply (Apply ShowsPrecSym0 (FromInteger 7)) argR_0123456789876543210)))) a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym0 :: forall a. (~>) GHC.Num.Natural.Natural ((~>) (T a ()) ((~>) Symbol Symbol))
-    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) (T a ()) ((~>) Symbol Symbol))
-      where
-        ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @GHC.Num.Natural.Natural @((~>) (T a ()) ((~>) Symbol Symbol)) ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym0KindInference ())
-    type ShowsPrec_0123456789876543210Sym1 :: forall a. GHC.Num.Natural.Natural
-                                                        -> (~>) (T a ()) ((~>) Symbol Symbol)
-    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Num.Natural.Natural) :: (~>) (T a ()) ((~>) Symbol Symbol)
-      where
-        ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(T a ()) @((~>) Symbol Symbol) (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym1KindInference ())
-    type ShowsPrec_0123456789876543210Sym2 :: forall a. GHC.Num.Natural.Natural
-                                                        -> T a () -> (~>) Symbol Symbol
-    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: T a ()) :: (~>) Symbol Symbol
-      where
-        ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @Symbol @Symbol (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym2KindInference ())
-    type ShowsPrec_0123456789876543210Sym3 :: forall a. GHC.Num.Natural.Natural
-                                                        -> T a () -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210Sym3 @a (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: T a ()) (a0123456789876543210 :: Symbol) :: Symbol where
-      ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow (T a ()) where
-      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
     type TFHelper_0123456789876543210 :: S -> S -> Bool
     type family TFHelper_0123456789876543210 (a :: S) (a :: S) :: Bool where
       TFHelper_0123456789876543210 S1 S1 = TrueSym0
       TFHelper_0123456789876543210 S1 S2 = FalseSym0
       TFHelper_0123456789876543210 S2 S1 = FalseSym0
       TFHelper_0123456789876543210 S2 S2 = TrueSym0
-    type TFHelper_0123456789876543210Sym0 :: (~>) S ((~>) S Bool)
-    data TFHelper_0123456789876543210Sym0 :: (~>) S ((~>) S Bool)
-      where
-        TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @S @((~>) S Bool) TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym0KindInference ())
-    type TFHelper_0123456789876543210Sym1 :: S -> (~>) S Bool
-    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: S) :: (~>) S Bool
-      where
-        TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @S @Bool (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym1KindInference ())
-    type TFHelper_0123456789876543210Sym2 :: S -> S -> Bool
-    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: S) (a0123456789876543210 :: S) :: Bool where
-      TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq S where
-      type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
+      type (==) a a = TFHelper_0123456789876543210 a a
     type Compare_0123456789876543210 :: S -> S -> Ordering
     type family Compare_0123456789876543210 (a :: S) (a :: S) :: Ordering where
       Compare_0123456789876543210 S1 S1 = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
       Compare_0123456789876543210 S2 S2 = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
       Compare_0123456789876543210 S1 S2 = LTSym0
       Compare_0123456789876543210 S2 S1 = GTSym0
-    type Compare_0123456789876543210Sym0 :: (~>) S ((~>) S Ordering)
-    data Compare_0123456789876543210Sym0 :: (~>) S ((~>) S Ordering)
-      where
-        Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @S @((~>) S Ordering) Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym0KindInference ())
-    type Compare_0123456789876543210Sym1 :: S -> (~>) S Ordering
-    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: S) :: (~>) S Ordering
-      where
-        Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @S @Ordering (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym1KindInference ())
-    type Compare_0123456789876543210Sym2 :: S -> S -> Ordering
-    type family Compare_0123456789876543210Sym2 (a0123456789876543210 :: S) (a0123456789876543210 :: S) :: Ordering where
-      Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd S where
-      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
+      type Compare a a = Compare_0123456789876543210 a a
     type ShowsPrec_0123456789876543210 :: GHC.Num.Natural.Natural
                                           -> S -> Symbol -> Symbol
     type family ShowsPrec_0123456789876543210 (a :: GHC.Num.Natural.Natural) (a :: S) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 _ S1 a_0123456789876543210 = Apply (Apply ShowStringSym0 "S1") a_0123456789876543210
       ShowsPrec_0123456789876543210 _ S2 a_0123456789876543210 = Apply (Apply ShowStringSym0 "S2") a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) S ((~>) Symbol Symbol))
-    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) S ((~>) Symbol Symbol))
-      where
-        ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @GHC.Num.Natural.Natural @((~>) S ((~>) Symbol Symbol)) ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym0KindInference ())
-    type ShowsPrec_0123456789876543210Sym1 :: GHC.Num.Natural.Natural
-                                              -> (~>) S ((~>) Symbol Symbol)
-    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Num.Natural.Natural) :: (~>) S ((~>) Symbol Symbol)
-      where
-        ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @S @((~>) Symbol Symbol) (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym1KindInference ())
-    type ShowsPrec_0123456789876543210Sym2 :: GHC.Num.Natural.Natural
-                                              -> S -> (~>) Symbol Symbol
-    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: S) :: (~>) Symbol Symbol
-      where
-        ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @Symbol @Symbol (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym2KindInference ())
-    type ShowsPrec_0123456789876543210Sym3 :: GHC.Num.Natural.Natural
-                                              -> S -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: S) (a0123456789876543210 :: Symbol) :: Symbol where
-      ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow S where
-      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
     type MinBound_0123456789876543210 :: S
     type family MinBound_0123456789876543210 :: S where
       MinBound_0123456789876543210 = S1Sym0
-    type MinBound_0123456789876543210Sym0 :: S
-    type family MinBound_0123456789876543210Sym0 :: S where
-      MinBound_0123456789876543210Sym0 = MinBound_0123456789876543210
     type MaxBound_0123456789876543210 :: S
     type family MaxBound_0123456789876543210 :: S where
       MaxBound_0123456789876543210 = S2Sym0
-    type MaxBound_0123456789876543210Sym0 :: S
-    type family MaxBound_0123456789876543210Sym0 :: S where
-      MaxBound_0123456789876543210Sym0 = MaxBound_0123456789876543210
     instance PBounded S where
-      type MinBound = MinBound_0123456789876543210Sym0
-      type MaxBound = MaxBound_0123456789876543210Sym0
+      type MinBound = MinBound_0123456789876543210
+      type MaxBound = MaxBound_0123456789876543210
     type family Case_0123456789876543210 n0123456789876543210 t where
       Case_0123456789876543210 n 'True = S2Sym0
       Case_0123456789876543210 n 'False = Apply ErrorSym0 "toEnum: bad argument"
@@ -272,38 +112,13 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
     type ToEnum_0123456789876543210 :: GHC.Num.Natural.Natural -> S
     type family ToEnum_0123456789876543210 (a :: GHC.Num.Natural.Natural) :: S where
       ToEnum_0123456789876543210 n = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (FromInteger 0))
-    type ToEnum_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural S
-    data ToEnum_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural S
-      where
-        ToEnum_0123456789876543210Sym0KindInference :: SameKind (Apply ToEnum_0123456789876543210Sym0 arg) (ToEnum_0123456789876543210Sym1 arg) =>
-                                                       ToEnum_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @GHC.Num.Natural.Natural @S ToEnum_0123456789876543210Sym0 a0123456789876543210 = ToEnum_0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ToEnum_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) ToEnum_0123456789876543210Sym0KindInference ())
-    type ToEnum_0123456789876543210Sym1 :: GHC.Num.Natural.Natural -> S
-    type family ToEnum_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Num.Natural.Natural) :: S where
-      ToEnum_0123456789876543210Sym1 a0123456789876543210 = ToEnum_0123456789876543210 a0123456789876543210
     type FromEnum_0123456789876543210 :: S -> GHC.Num.Natural.Natural
     type family FromEnum_0123456789876543210 (a :: S) :: GHC.Num.Natural.Natural where
       FromEnum_0123456789876543210 S1 = FromInteger 0
       FromEnum_0123456789876543210 S2 = FromInteger 1
-    type FromEnum_0123456789876543210Sym0 :: (~>) S GHC.Num.Natural.Natural
-    data FromEnum_0123456789876543210Sym0 :: (~>) S GHC.Num.Natural.Natural
-      where
-        FromEnum_0123456789876543210Sym0KindInference :: SameKind (Apply FromEnum_0123456789876543210Sym0 arg) (FromEnum_0123456789876543210Sym1 arg) =>
-                                                         FromEnum_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @S @GHC.Num.Natural.Natural FromEnum_0123456789876543210Sym0 a0123456789876543210 = FromEnum_0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings FromEnum_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) FromEnum_0123456789876543210Sym0KindInference ())
-    type FromEnum_0123456789876543210Sym1 :: S
-                                             -> GHC.Num.Natural.Natural
-    type family FromEnum_0123456789876543210Sym1 (a0123456789876543210 :: S) :: GHC.Num.Natural.Natural where
-      FromEnum_0123456789876543210Sym1 a0123456789876543210 = FromEnum_0123456789876543210 a0123456789876543210
     instance PEnum S where
-      type ToEnum a = Apply ToEnum_0123456789876543210Sym0 a
-      type FromEnum a = Apply FromEnum_0123456789876543210Sym0 a
+      type ToEnum a = ToEnum_0123456789876543210 a
+      type FromEnum a = FromEnum_0123456789876543210 a
     infixl 6 :%*:
     data ST :: forall a b. T a b -> Type
       where

--- a/singletons-base/tests/compile-and-dump/Singletons/Star.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Star.golden
@@ -75,29 +75,8 @@ Singletons/Star.hs:0:0:: Splicing declarations
       TFHelper_0123456789876543210 (Vec _ _) String = FalseSym0
       TFHelper_0123456789876543210 (Vec _ _) (Maybe _) = FalseSym0
       TFHelper_0123456789876543210 (Vec a_0123456789876543210 a_0123456789876543210) (Vec b_0123456789876543210 b_0123456789876543210) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)
-    type TFHelper_0123456789876543210Sym0 :: (~>) Type ((~>) Type Bool)
-    data TFHelper_0123456789876543210Sym0 :: (~>) Type ((~>) Type Bool)
-      where
-        TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Type @((~>) Type Bool) TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym0KindInference ())
-    type TFHelper_0123456789876543210Sym1 :: Type -> (~>) Type Bool
-    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Type) :: (~>) Type Bool
-      where
-        TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Type @Bool (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym1KindInference ())
-    type TFHelper_0123456789876543210Sym2 :: Type -> Type -> Bool
-    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: Type) (a0123456789876543210 :: Type) :: Bool where
-      TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq Type where
-      type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
+      type (==) a a = TFHelper_0123456789876543210 a a
     type Compare_0123456789876543210 :: Type -> Type -> Ordering
     type family Compare_0123456789876543210 (a :: Type) (a :: Type) :: Ordering where
       Compare_0123456789876543210 Nat Nat = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
@@ -125,29 +104,8 @@ Singletons/Star.hs:0:0:: Splicing declarations
       Compare_0123456789876543210 (Vec _ _) Int = GTSym0
       Compare_0123456789876543210 (Vec _ _) String = GTSym0
       Compare_0123456789876543210 (Vec _ _) (Maybe _) = GTSym0
-    type Compare_0123456789876543210Sym0 :: (~>) Type ((~>) Type Ordering)
-    data Compare_0123456789876543210Sym0 :: (~>) Type ((~>) Type Ordering)
-      where
-        Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Type @((~>) Type Ordering) Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym0KindInference ())
-    type Compare_0123456789876543210Sym1 :: Type -> (~>) Type Ordering
-    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Type) :: (~>) Type Ordering
-      where
-        Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Type @Ordering (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym1KindInference ())
-    type Compare_0123456789876543210Sym2 :: Type -> Type -> Ordering
-    type family Compare_0123456789876543210Sym2 (a0123456789876543210 :: Type) (a0123456789876543210 :: Type) :: Ordering where
-      Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd Type where
-      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
+      type Compare a a = Compare_0123456789876543210 a a
     type ShowsPrec_0123456789876543210 :: GHC.Num.Natural.Natural
                                           -> Type -> Symbol -> Symbol
     type family ShowsPrec_0123456789876543210 (a :: GHC.Num.Natural.Natural) (a :: Type) (a :: Symbol) :: Symbol where
@@ -156,41 +114,8 @@ Singletons/Star.hs:0:0:: Splicing declarations
       ShowsPrec_0123456789876543210 _ String a_0123456789876543210 = Apply (Apply ShowStringSym0 "String") a_0123456789876543210
       ShowsPrec_0123456789876543210 p_0123456789876543210 (Maybe arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Maybe ")) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
       ShowsPrec_0123456789876543210 p_0123456789876543210 (Vec arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Vec ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) Type ((~>) Symbol Symbol))
-    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) Type ((~>) Symbol Symbol))
-      where
-        ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @GHC.Num.Natural.Natural @((~>) Type ((~>) Symbol Symbol)) ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym0KindInference ())
-    type ShowsPrec_0123456789876543210Sym1 :: GHC.Num.Natural.Natural
-                                              -> (~>) Type ((~>) Symbol Symbol)
-    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Num.Natural.Natural) :: (~>) Type ((~>) Symbol Symbol)
-      where
-        ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Type @((~>) Symbol Symbol) (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym1KindInference ())
-    type ShowsPrec_0123456789876543210Sym2 :: GHC.Num.Natural.Natural
-                                              -> Type -> (~>) Symbol Symbol
-    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: Type) :: (~>) Symbol Symbol
-      where
-        ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @Symbol @Symbol (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym2KindInference ())
-    type ShowsPrec_0123456789876543210Sym3 :: GHC.Num.Natural.Natural
-                                              -> Type -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: Type) (a0123456789876543210 :: Symbol) :: Symbol where
-      ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow Type where
-      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
     data SRep :: Type -> Type
       where
         SNat :: SRep (Nat :: Type)

--- a/singletons-base/tests/compile-and-dump/Singletons/T124.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T124.golden
@@ -22,9 +22,7 @@ Singletons/T124.hs:(0,0)-(0,0): Splicing declarations
     type family Foo (a :: Bool) :: () where
       Foo 'True = Tuple0Sym0
       Foo 'False = Tuple0Sym0
-    sFoo ::
-      (forall (t :: Bool).
-       Sing t -> Sing (Apply FooSym0 t :: ()) :: Type)
+    sFoo :: (forall (t :: Bool). Sing t -> Sing (Foo t :: ()) :: Type)
     sFoo STrue = STuple0
     sFoo SFalse = STuple0
     instance SingI (FooSym0 :: (~>) Bool ()) where

--- a/singletons-base/tests/compile-and-dump/Singletons/T136.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T136.golden
@@ -34,35 +34,11 @@ Singletons/T136.hs:(0,0)-(0,0): Splicing declarations
       Succ_0123456789876543210 '[] = Apply (Apply (:@#@$) TrueSym0) NilSym0
       Succ_0123456789876543210 ('(:) 'False as) = Apply (Apply (:@#@$) TrueSym0) as
       Succ_0123456789876543210 ('(:) 'True as) = Apply (Apply (:@#@$) FalseSym0) (Apply SuccSym0 as)
-    type Succ_0123456789876543210Sym0 :: (~>) [Bool] [Bool]
-    data Succ_0123456789876543210Sym0 :: (~>) [Bool] [Bool]
-      where
-        Succ_0123456789876543210Sym0KindInference :: SameKind (Apply Succ_0123456789876543210Sym0 arg) (Succ_0123456789876543210Sym1 arg) =>
-                                                     Succ_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @[Bool] @[Bool] Succ_0123456789876543210Sym0 a0123456789876543210 = Succ_0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings Succ_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Succ_0123456789876543210Sym0KindInference ())
-    type Succ_0123456789876543210Sym1 :: [Bool] -> [Bool]
-    type family Succ_0123456789876543210Sym1 (a0123456789876543210 :: [Bool]) :: [Bool] where
-      Succ_0123456789876543210Sym1 a0123456789876543210 = Succ_0123456789876543210 a0123456789876543210
     type Pred_0123456789876543210 :: [Bool] -> [Bool]
     type family Pred_0123456789876543210 (a :: [Bool]) :: [Bool] where
       Pred_0123456789876543210 '[] = Apply ErrorSym0 "pred 0"
       Pred_0123456789876543210 ('(:) 'False as) = Apply (Apply (:@#@$) TrueSym0) (Apply PredSym0 as)
       Pred_0123456789876543210 ('(:) 'True as) = Apply (Apply (:@#@$) FalseSym0) as
-    type Pred_0123456789876543210Sym0 :: (~>) [Bool] [Bool]
-    data Pred_0123456789876543210Sym0 :: (~>) [Bool] [Bool]
-      where
-        Pred_0123456789876543210Sym0KindInference :: SameKind (Apply Pred_0123456789876543210Sym0 arg) (Pred_0123456789876543210Sym1 arg) =>
-                                                     Pred_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @[Bool] @[Bool] Pred_0123456789876543210Sym0 a0123456789876543210 = Pred_0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings Pred_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Pred_0123456789876543210Sym0KindInference ())
-    type Pred_0123456789876543210Sym1 :: [Bool] -> [Bool]
-    type family Pred_0123456789876543210Sym1 (a0123456789876543210 :: [Bool]) :: [Bool] where
-      Pred_0123456789876543210Sym1 a0123456789876543210 = Pred_0123456789876543210 a0123456789876543210
     type family Case_0123456789876543210 i0123456789876543210 arg_01234567898765432100123456789876543210 t where
       Case_0123456789876543210 i arg_0123456789876543210 'True = NilSym0
       Case_0123456789876543210 i arg_0123456789876543210 'False = Apply SuccSym0 (Apply ToEnumSym0 (Apply PredSym0 i))
@@ -75,43 +51,17 @@ Singletons/T136.hs:(0,0)-(0,0): Splicing declarations
                                        -> [Bool]
     type family ToEnum_0123456789876543210 (a :: GHC.Num.Natural.Natural) :: [Bool] where
       ToEnum_0123456789876543210 arg_0123456789876543210 = Case_0123456789876543210 arg_0123456789876543210 arg_0123456789876543210
-    type ToEnum_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural [Bool]
-    data ToEnum_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural [Bool]
-      where
-        ToEnum_0123456789876543210Sym0KindInference :: SameKind (Apply ToEnum_0123456789876543210Sym0 arg) (ToEnum_0123456789876543210Sym1 arg) =>
-                                                       ToEnum_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @GHC.Num.Natural.Natural @[Bool] ToEnum_0123456789876543210Sym0 a0123456789876543210 = ToEnum_0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ToEnum_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) ToEnum_0123456789876543210Sym0KindInference ())
-    type ToEnum_0123456789876543210Sym1 :: GHC.Num.Natural.Natural
-                                           -> [Bool]
-    type family ToEnum_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Num.Natural.Natural) :: [Bool] where
-      ToEnum_0123456789876543210Sym1 a0123456789876543210 = ToEnum_0123456789876543210 a0123456789876543210
     type FromEnum_0123456789876543210 :: [Bool]
                                          -> GHC.Num.Natural.Natural
     type family FromEnum_0123456789876543210 (a :: [Bool]) :: GHC.Num.Natural.Natural where
       FromEnum_0123456789876543210 '[] = FromInteger 0
       FromEnum_0123456789876543210 ('(:) 'False as) = Apply (Apply (*@#@$) (FromInteger 2)) (Apply FromEnumSym0 as)
       FromEnum_0123456789876543210 ('(:) 'True as) = Apply (Apply (+@#@$) (FromInteger 1)) (Apply (Apply (*@#@$) (FromInteger 2)) (Apply FromEnumSym0 as))
-    type FromEnum_0123456789876543210Sym0 :: (~>) [Bool] GHC.Num.Natural.Natural
-    data FromEnum_0123456789876543210Sym0 :: (~>) [Bool] GHC.Num.Natural.Natural
-      where
-        FromEnum_0123456789876543210Sym0KindInference :: SameKind (Apply FromEnum_0123456789876543210Sym0 arg) (FromEnum_0123456789876543210Sym1 arg) =>
-                                                         FromEnum_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @[Bool] @GHC.Num.Natural.Natural FromEnum_0123456789876543210Sym0 a0123456789876543210 = FromEnum_0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings FromEnum_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) FromEnum_0123456789876543210Sym0KindInference ())
-    type FromEnum_0123456789876543210Sym1 :: [Bool]
-                                             -> GHC.Num.Natural.Natural
-    type family FromEnum_0123456789876543210Sym1 (a0123456789876543210 :: [Bool]) :: GHC.Num.Natural.Natural where
-      FromEnum_0123456789876543210Sym1 a0123456789876543210 = FromEnum_0123456789876543210 a0123456789876543210
     instance PEnum [Bool] where
-      type Succ a = Apply Succ_0123456789876543210Sym0 a
-      type Pred a = Apply Pred_0123456789876543210Sym0 a
-      type ToEnum a = Apply ToEnum_0123456789876543210Sym0 a
-      type FromEnum a = Apply FromEnum_0123456789876543210Sym0 a
+      type Succ a = Succ_0123456789876543210 a
+      type Pred a = Pred_0123456789876543210 a
+      type ToEnum a = ToEnum_0123456789876543210 a
+      type FromEnum a = FromEnum_0123456789876543210 a
     instance SEnum [Bool] where
       sSucc SNil
         = applySing (applySing (singFun2 @(:@#@$) SCons) STrue) SNil

--- a/singletons-base/tests/compile-and-dump/Singletons/T136b.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T136b.golden
@@ -19,8 +19,7 @@ Singletons/T136b.hs:(0,0)-(0,0): Splicing declarations
     class PC a where
       type family Meth (arg :: a) :: a
     class SC a where
-      sMeth ::
-        (forall (t :: a). Sing t -> Sing (Apply MethSym0 t :: a) :: Type)
+      sMeth :: (forall (t :: a). Sing t -> Sing (Meth t :: a) :: Type)
     instance SC a => SingI (MethSym0 :: (~>) a a) where
       sing = singFun1 @MethSym0 sMeth
 Singletons/T136b.hs:(0,0)-(0,0): Splicing declarations

--- a/singletons-base/tests/compile-and-dump/Singletons/T136b.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T136b.golden
@@ -33,20 +33,8 @@ Singletons/T136b.hs:(0,0)-(0,0): Splicing declarations
     type Meth_0123456789876543210 :: Bool -> Bool
     type family Meth_0123456789876543210 (a :: Bool) :: Bool where
       Meth_0123456789876543210 a_0123456789876543210 = Apply NotSym0 a_0123456789876543210
-    type Meth_0123456789876543210Sym0 :: (~>) Bool Bool
-    data Meth_0123456789876543210Sym0 :: (~>) Bool Bool
-      where
-        Meth_0123456789876543210Sym0KindInference :: SameKind (Apply Meth_0123456789876543210Sym0 arg) (Meth_0123456789876543210Sym1 arg) =>
-                                                     Meth_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Bool @Bool Meth_0123456789876543210Sym0 a0123456789876543210 = Meth_0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings Meth_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Meth_0123456789876543210Sym0KindInference ())
-    type Meth_0123456789876543210Sym1 :: Bool -> Bool
-    type family Meth_0123456789876543210Sym1 (a0123456789876543210 :: Bool) :: Bool where
-      Meth_0123456789876543210Sym1 a0123456789876543210 = Meth_0123456789876543210 a0123456789876543210
     instance PC Bool where
-      type Meth a = Apply Meth_0123456789876543210Sym0 a
+      type Meth a = Meth_0123456789876543210 a
     instance SC Bool where
       sMeth (sA_0123456789876543210 :: Sing a_0123456789876543210)
         = applySing (singFun1 @NotSym0 sNot) sA_0123456789876543210

--- a/singletons-base/tests/compile-and-dump/Singletons/T145.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T145.golden
@@ -29,8 +29,7 @@ Singletons/T145.hs:(0,0)-(0,0): Splicing declarations
     class SColumn (f :: Type -> Type) where
       sCol ::
         (forall (t :: f a) (t :: a).
-         Sing t
-         -> Sing t -> Sing (Apply (Apply ColSym0 t) t :: Bool) :: Type)
+         Sing t -> Sing t -> Sing (Col t t :: Bool) :: Type)
     instance SColumn f =>
              SingI (ColSym0 :: (~>) (f a) ((~>) a Bool)) where
       sing = singFun2 @ColSym0 sCol

--- a/singletons-base/tests/compile-and-dump/Singletons/T150.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T150.golden
@@ -262,26 +262,22 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
       HeadVec (VCons x _) = x
     sTransitivity ::
       (forall (t :: Equal a b) (t :: Equal b c).
-       Sing t
-       -> Sing t
-          -> Sing (Apply (Apply TransitivitySym0 t) t :: Equal a c) :: Type)
+       Sing t -> Sing t -> Sing (Transitivity t t :: Equal a c) :: Type)
     sSymmetry ::
       (forall (t :: Equal a b).
-       Sing t -> Sing (Apply SymmetrySym0 t :: Equal b a) :: Type)
+       Sing t -> Sing (Symmetry t :: Equal b a) :: Type)
     sMapVec ::
       (forall (t :: (~>) a b) (t :: Vec n a).
-       Sing t
-       -> Sing t
-          -> Sing (Apply (Apply MapVecSym0 t) t :: Vec n b) :: Type)
+       Sing t -> Sing t -> Sing (MapVec t t :: Vec n b) :: Type)
     (%!) ::
       (forall (t :: Vec n a) (t :: Fin n).
-       Sing t -> Sing t -> Sing (Apply (Apply (!@#@$) t) t :: a) :: Type)
+       Sing t -> Sing t -> Sing ((!) t t :: a) :: Type)
     sTailVec ::
       (forall (t :: Vec ('Succ n) a).
-       Sing t -> Sing (Apply TailVecSym0 t :: Vec n a) :: Type)
+       Sing t -> Sing (TailVec t :: Vec n a) :: Type)
     sHeadVec ::
       (forall (t :: Vec ('Succ n) a).
-       Sing t -> Sing (Apply HeadVecSym0 t :: a) :: Type)
+       Sing t -> Sing (HeadVec t :: a) :: Type)
     sTransitivity SReflexive SReflexive = SReflexive
     sSymmetry SReflexive = SReflexive
     sMapVec _ SVNil = SVNil

--- a/singletons-base/tests/compile-and-dump/Singletons/T160.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T160.golden
@@ -28,11 +28,11 @@ Singletons/T160.hs:(0,0)-(0,0): Splicing declarations
       Foo x = Case_0123456789876543210 x (Let0123456789876543210Scrutinee_0123456789876543210Sym0 x)
     sFoo ::
       (forall (t :: a).
-       (SNum a, SEq a) => Sing t -> Sing (Apply FooSym0 t :: a) :: Type)
+       (SNum a, SEq a) => Sing t -> Sing (Foo t :: a) :: Type)
     sFoo (sX :: Sing x)
       = let
           sScrutinee_0123456789876543210 ::
-            Sing @_ (Let0123456789876543210Scrutinee_0123456789876543210Sym0 x)
+            Sing @_ (Let0123456789876543210Scrutinee_0123456789876543210 x)
           sScrutinee_0123456789876543210
             = applySing
                 (applySing (singFun2 @(==@#@$) (%==)) sX)

--- a/singletons-base/tests/compile-and-dump/Singletons/T166.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T166.golden
@@ -59,22 +59,10 @@ Singletons/T166.hs:(0,0)-(0,0): Splicing declarations
     type Foo_0123456789876543210 :: forall a. a -> [Bool]
     type family Foo_0123456789876543210 @a (a :: a) :: [Bool] where
       Foo_0123456789876543210 @a (x :: a) = Lambda_0123456789876543210Sym0 a x
-    type Foo_0123456789876543210Sym0 :: forall a. (~>) a [Bool]
-    data Foo_0123456789876543210Sym0 :: (~>) a [Bool]
-      where
-        Foo_0123456789876543210Sym0KindInference :: SameKind (Apply Foo_0123456789876543210Sym0 arg) (Foo_0123456789876543210Sym1 arg) =>
-                                                    Foo_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @a @[Bool] Foo_0123456789876543210Sym0 a0123456789876543210 = Foo_0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings Foo_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Foo_0123456789876543210Sym0KindInference ())
-    type Foo_0123456789876543210Sym1 :: forall a. a -> [Bool]
-    type family Foo_0123456789876543210Sym1 @a (a0123456789876543210 :: a) :: [Bool] where
-      Foo_0123456789876543210Sym1 a0123456789876543210 = Foo_0123456789876543210 a0123456789876543210
     class PFoo a where
       type family FoosPrec (arg :: Natural) (arg :: a) (arg :: [Bool]) :: [Bool]
       type family Foo (arg :: a) :: [Bool]
-      type Foo a = Apply Foo_0123456789876543210Sym0 a
+      type Foo a = Foo_0123456789876543210 a
     class SFoo a where
       sFoosPrec ::
         (forall (t :: Natural) (t :: a) (t :: [Bool]).
@@ -87,8 +75,7 @@ Singletons/T166.hs:(0,0)-(0,0): Splicing declarations
          Sing t -> Sing (Apply FooSym0 t :: [Bool]) :: Type)
       default sFoo ::
                 (forall (t :: a).
-                 ((Apply FooSym0 t :: [Bool])
-                  ~ Apply Foo_0123456789876543210Sym0 t) =>
+                 ((Foo t :: [Bool]) ~ Foo_0123456789876543210 t) =>
                  Sing t -> Sing (Apply FooSym0 t :: [Bool]) :: Type)
       sFoo (sX :: Sing x)
         = singFun1

--- a/singletons-base/tests/compile-and-dump/Singletons/T166.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T166.golden
@@ -67,16 +67,12 @@ Singletons/T166.hs:(0,0)-(0,0): Splicing declarations
       sFoosPrec ::
         (forall (t :: Natural) (t :: a) (t :: [Bool]).
          Sing t
-         -> Sing t
-            -> Sing t
-               -> Sing (Apply (Apply (Apply FoosPrecSym0 t) t) t :: [Bool]) :: Type)
-      sFoo ::
-        (forall (t :: a).
-         Sing t -> Sing (Apply FooSym0 t :: [Bool]) :: Type)
+         -> Sing t -> Sing t -> Sing (FoosPrec t t t :: [Bool]) :: Type)
+      sFoo :: (forall (t :: a). Sing t -> Sing (Foo t :: [Bool]) :: Type)
       default sFoo ::
                 (forall (t :: a).
                  ((Foo t :: [Bool]) ~ Foo_0123456789876543210 t) =>
-                 Sing t -> Sing (Apply FooSym0 t :: [Bool]) :: Type)
+                 Sing t -> Sing (Foo t :: [Bool]) :: Type)
       sFoo (sX :: Sing x)
         = singFun1
             @(Lambda_0123456789876543210Sym0 a x)

--- a/singletons-base/tests/compile-and-dump/Singletons/T167.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T167.golden
@@ -72,20 +72,14 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
       sFoosPrec ::
         (forall (t :: Natural) (t :: a) (t :: [Bool]).
          Sing t
-         -> Sing t
-            -> Sing t
-               -> Sing (Apply (Apply (Apply FoosPrecSym0 t) t) t :: [Bool]) :: Type)
+         -> Sing t -> Sing t -> Sing (FoosPrec t t t :: [Bool]) :: Type)
       sFooList ::
         (forall (t :: a) (t :: [Bool]).
-         Sing t
-         -> Sing t
-            -> Sing (Apply (Apply FooListSym0 t) t :: [Bool]) :: Type)
+         Sing t -> Sing t -> Sing (FooList t t :: [Bool]) :: Type)
       default sFooList ::
                 (forall (t :: a) (t :: [Bool]).
                  ((FooList t t :: [Bool]) ~ FooList_0123456789876543210 t t) =>
-                 Sing t
-                 -> Sing t
-                    -> Sing (Apply (Apply FooListSym0 t) t :: [Bool]) :: Type)
+                 Sing t -> Sing t -> Sing (FooList t t :: [Bool]) :: Type)
       sFooList
         (sA_0123456789876543210 :: Sing a_0123456789876543210)
         (sA_0123456789876543210 :: Sing a_0123456789876543210)

--- a/singletons-base/tests/compile-and-dump/Singletons/T167.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T167.golden
@@ -58,72 +58,16 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
     type FooList_0123456789876543210 :: forall a. a -> [Bool] -> [Bool]
     type family FooList_0123456789876543210 @a (a :: a) (a :: [Bool]) :: [Bool] where
       FooList_0123456789876543210 @a (a_0123456789876543210 :: a) (a_0123456789876543210 :: [Bool]) = Apply (Apply UndefinedSym0 a_0123456789876543210) a_0123456789876543210
-    type FooList_0123456789876543210Sym0 :: forall a. (~>) a ((~>) [Bool] [Bool])
-    data FooList_0123456789876543210Sym0 :: (~>) a ((~>) [Bool] [Bool])
-      where
-        FooList_0123456789876543210Sym0KindInference :: SameKind (Apply FooList_0123456789876543210Sym0 arg) (FooList_0123456789876543210Sym1 arg) =>
-                                                        FooList_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @a @((~>) [Bool] [Bool]) FooList_0123456789876543210Sym0 a0123456789876543210 = FooList_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings FooList_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) FooList_0123456789876543210Sym0KindInference ())
-    type FooList_0123456789876543210Sym1 :: forall a. a
-                                                      -> (~>) [Bool] [Bool]
-    data FooList_0123456789876543210Sym1 (a0123456789876543210 :: a) :: (~>) [Bool] [Bool]
-      where
-        FooList_0123456789876543210Sym1KindInference :: SameKind (Apply (FooList_0123456789876543210Sym1 a0123456789876543210) arg) (FooList_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                        FooList_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @[Bool] @[Bool] (FooList_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = FooList_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (FooList_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) FooList_0123456789876543210Sym1KindInference ())
-    type FooList_0123456789876543210Sym2 :: forall a. a
-                                                      -> [Bool] -> [Bool]
-    type family FooList_0123456789876543210Sym2 @a (a0123456789876543210 :: a) (a0123456789876543210 :: [Bool]) :: [Bool] where
-      FooList_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = FooList_0123456789876543210 a0123456789876543210 a0123456789876543210
     class PFoo a where
       type family FoosPrec (arg :: Natural) (arg :: a) (arg :: [Bool]) :: [Bool]
       type family FooList (arg :: a) (arg :: [Bool]) :: [Bool]
-      type FooList a a = Apply (Apply FooList_0123456789876543210Sym0 a) a
+      type FooList a a = FooList_0123456789876543210 a a
     type FoosPrec_0123456789876543210 :: forall a. Natural
                                                    -> [a] -> [Bool] -> [Bool]
     type family FoosPrec_0123456789876543210 @a (a :: Natural) (a :: [a]) (a :: [Bool]) :: [Bool] where
       FoosPrec_0123456789876543210 @a (_ :: Natural) (a_0123456789876543210 :: [a]) (a_0123456789876543210 :: [Bool]) = Apply (Apply FooListSym0 a_0123456789876543210) a_0123456789876543210
-    type FoosPrec_0123456789876543210Sym0 :: forall a. (~>) Natural ((~>) [a] ((~>) [Bool] [Bool]))
-    data FoosPrec_0123456789876543210Sym0 :: (~>) Natural ((~>) [a] ((~>) [Bool] [Bool]))
-      where
-        FoosPrec_0123456789876543210Sym0KindInference :: SameKind (Apply FoosPrec_0123456789876543210Sym0 arg) (FoosPrec_0123456789876543210Sym1 arg) =>
-                                                         FoosPrec_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Natural @((~>) [a] ((~>) [Bool] [Bool])) FoosPrec_0123456789876543210Sym0 a0123456789876543210 = FoosPrec_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings FoosPrec_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) FoosPrec_0123456789876543210Sym0KindInference ())
-    type FoosPrec_0123456789876543210Sym1 :: forall a. Natural
-                                                       -> (~>) [a] ((~>) [Bool] [Bool])
-    data FoosPrec_0123456789876543210Sym1 (a0123456789876543210 :: Natural) :: (~>) [a] ((~>) [Bool] [Bool])
-      where
-        FoosPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (FoosPrec_0123456789876543210Sym1 a0123456789876543210) arg) (FoosPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         FoosPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @[a] @((~>) [Bool] [Bool]) (FoosPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = FoosPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (FoosPrec_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) FoosPrec_0123456789876543210Sym1KindInference ())
-    type FoosPrec_0123456789876543210Sym2 :: forall a. Natural
-                                                       -> [a] -> (~>) [Bool] [Bool]
-    data FoosPrec_0123456789876543210Sym2 (a0123456789876543210 :: Natural) (a0123456789876543210 :: [a]) :: (~>) [Bool] [Bool]
-      where
-        FoosPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (FoosPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (FoosPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                                         FoosPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @[Bool] @[Bool] (FoosPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = FoosPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (FoosPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) FoosPrec_0123456789876543210Sym2KindInference ())
-    type FoosPrec_0123456789876543210Sym3 :: forall a. Natural
-                                                       -> [a] -> [Bool] -> [Bool]
-    type family FoosPrec_0123456789876543210Sym3 @a (a0123456789876543210 :: Natural) (a0123456789876543210 :: [a]) (a0123456789876543210 :: [Bool]) :: [Bool] where
-      FoosPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = FoosPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PFoo [a] where
-      type FoosPrec a a a = Apply (Apply (Apply FoosPrec_0123456789876543210Sym0 a) a) a
+      type FoosPrec a a a = FoosPrec_0123456789876543210 a a a
     class SFoo a where
       sFoosPrec ::
         (forall (t :: Natural) (t :: a) (t :: [Bool]).
@@ -138,8 +82,7 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
             -> Sing (Apply (Apply FooListSym0 t) t :: [Bool]) :: Type)
       default sFooList ::
                 (forall (t :: a) (t :: [Bool]).
-                 ((Apply (Apply FooListSym0 t) t :: [Bool])
-                  ~ Apply (Apply FooList_0123456789876543210Sym0 t) t) =>
+                 ((FooList t t :: [Bool]) ~ FooList_0123456789876543210 t t) =>
                  Sing t
                  -> Sing t
                     -> Sing (Apply (Apply FooListSym0 t) t :: [Bool]) :: Type)

--- a/singletons-base/tests/compile-and-dump/Singletons/T172.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T172.golden
@@ -27,8 +27,7 @@ Singletons/T172.hs:(0,0)-(0,0): Splicing declarations
       ($>) a_0123456789876543210 a_0123456789876543210 = Apply (Apply (+@#@$) a_0123456789876543210) a_0123456789876543210
     (%$>) ::
       (forall (t :: Natural) (t :: Natural).
-       Sing t
-       -> Sing t -> Sing (Apply (Apply ($>@#@$) t) t :: Natural) :: Type)
+       Sing t -> Sing t -> Sing (($>) t t :: Natural) :: Type)
     (%$>)
       (sA_0123456789876543210 :: Sing a_0123456789876543210)
       (sA_0123456789876543210 :: Sing a_0123456789876543210)

--- a/singletons-base/tests/compile-and-dump/Singletons/T175.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T175.golden
@@ -39,14 +39,14 @@ Singletons/T175.hs:(0,0)-(0,0): Splicing declarations
       type family Quux1 :: a
       type Quux1 = Quux1_0123456789876543210
     class PBar2 a
-    sQuux2 :: (SBar2 a => Sing (Quux2Sym0 :: a) :: Type)
+    sQuux2 :: (SBar2 a => Sing (Quux2 :: a) :: Type)
     sQuux2 = sBaz
     class SFoo a where
-      sBaz :: (Sing (BazSym0 :: a) :: Type)
+      sBaz :: (Sing (Baz :: a) :: Type)
     class SFoo a => SBar1 a where
-      sQuux1 :: (Sing (Quux1Sym0 :: a) :: Type)
+      sQuux1 :: (Sing (Quux1 :: a) :: Type)
       default sQuux1 ::
                 (((Quux1 :: a) ~ Quux1_0123456789876543210) =>
-                 Sing (Quux1Sym0 :: a) :: Type)
+                 Sing (Quux1 :: a) :: Type)
       sQuux1 = sBaz
     class SFoo a => SBar2 a

--- a/singletons-base/tests/compile-and-dump/Singletons/T175.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T175.golden
@@ -35,12 +35,9 @@ Singletons/T175.hs:(0,0)-(0,0): Splicing declarations
     type Quux1_0123456789876543210 :: forall a. a
     type family Quux1_0123456789876543210 @a :: a where
       Quux1_0123456789876543210 @a = BazSym0
-    type Quux1_0123456789876543210Sym0 :: forall a. a
-    type family Quux1_0123456789876543210Sym0 @a :: a where
-      Quux1_0123456789876543210Sym0 = Quux1_0123456789876543210
     class PBar1 a where
       type family Quux1 :: a
-      type Quux1 = Quux1_0123456789876543210Sym0
+      type Quux1 = Quux1_0123456789876543210
     class PBar2 a
     sQuux2 :: (SBar2 a => Sing (Quux2Sym0 :: a) :: Type)
     sQuux2 = sBaz
@@ -49,7 +46,7 @@ Singletons/T175.hs:(0,0)-(0,0): Splicing declarations
     class SFoo a => SBar1 a where
       sQuux1 :: (Sing (Quux1Sym0 :: a) :: Type)
       default sQuux1 ::
-                (((Quux1Sym0 :: a) ~ Quux1_0123456789876543210Sym0) =>
+                (((Quux1 :: a) ~ Quux1_0123456789876543210) =>
                  Sing (Quux1Sym0 :: a) :: Type)
       sQuux1 = sBaz
     class SFoo a => SBar2 a

--- a/singletons-base/tests/compile-and-dump/Singletons/T176.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T176.golden
@@ -115,11 +115,9 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
       type family Bar2 (arg :: a) (arg :: b) :: b
       type family Baz2 :: a
     sQuux2 ::
-      (forall (t :: a).
-       SFoo2 a => Sing t -> Sing (Apply Quux2Sym0 t :: a) :: Type)
+      (forall (t :: a). SFoo2 a => Sing t -> Sing (Quux2 t :: a) :: Type)
     sQuux1 ::
-      (forall (t :: a).
-       SFoo1 a => Sing t -> Sing (Apply Quux1Sym0 t :: a) :: Type)
+      (forall (t :: a). SFoo1 a => Sing t -> Sing (Quux1 t :: a) :: Type)
     sQuux2 (sX :: Sing x)
       = applySing (applySing (singFun2 @Bar2Sym0 sBar2) sX) sBaz2
     sQuux1 (sX :: Sing x)
@@ -140,13 +138,13 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
     class SFoo1 a where
       sBar1 ::
         (forall (t :: a) (t :: (~>) a b).
-         Sing t -> Sing t -> Sing (Apply (Apply Bar1Sym0 t) t :: b) :: Type)
-      sBaz1 :: (Sing (Baz1Sym0 :: a) :: Type)
+         Sing t -> Sing t -> Sing (Bar1 t t :: b) :: Type)
+      sBaz1 :: (Sing (Baz1 :: a) :: Type)
     class SFoo2 a where
       sBar2 ::
         (forall (t :: a) (t :: b).
-         Sing t -> Sing t -> Sing (Apply (Apply Bar2Sym0 t) t :: b) :: Type)
-      sBaz2 :: (Sing (Baz2Sym0 :: a) :: Type)
+         Sing t -> Sing t -> Sing (Bar2 t t :: b) :: Type)
+      sBaz2 :: (Sing (Baz2 :: a) :: Type)
     instance SFoo1 a =>
              SingI (Bar1Sym0 :: (~>) a ((~>) ((~>) a b) b)) where
       sing = singFun2 @Bar1Sym0 sBar1

--- a/singletons-base/tests/compile-and-dump/Singletons/T178.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T178.golden
@@ -42,29 +42,8 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
       TFHelper_0123456789876543210 Many Str = FalseSym0
       TFHelper_0123456789876543210 Many Opt = FalseSym0
       TFHelper_0123456789876543210 Many Many = TrueSym0
-    type TFHelper_0123456789876543210Sym0 :: (~>) Occ ((~>) Occ Bool)
-    data TFHelper_0123456789876543210Sym0 :: (~>) Occ ((~>) Occ Bool)
-      where
-        TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Occ @((~>) Occ Bool) TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym0KindInference ())
-    type TFHelper_0123456789876543210Sym1 :: Occ -> (~>) Occ Bool
-    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Occ) :: (~>) Occ Bool
-      where
-        TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Occ @Bool (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym1KindInference ())
-    type TFHelper_0123456789876543210Sym2 :: Occ -> Occ -> Bool
-    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: Occ) (a0123456789876543210 :: Occ) :: Bool where
-      TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq Occ where
-      type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
+      type (==) a a = TFHelper_0123456789876543210 a a
     type Compare_0123456789876543210 :: Occ -> Occ -> Ordering
     type family Compare_0123456789876543210 (a :: Occ) (a :: Occ) :: Ordering where
       Compare_0123456789876543210 Str Str = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
@@ -76,70 +55,16 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
       Compare_0123456789876543210 Opt Many = LTSym0
       Compare_0123456789876543210 Many Str = GTSym0
       Compare_0123456789876543210 Many Opt = GTSym0
-    type Compare_0123456789876543210Sym0 :: (~>) Occ ((~>) Occ Ordering)
-    data Compare_0123456789876543210Sym0 :: (~>) Occ ((~>) Occ Ordering)
-      where
-        Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Occ @((~>) Occ Ordering) Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym0KindInference ())
-    type Compare_0123456789876543210Sym1 :: Occ -> (~>) Occ Ordering
-    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Occ) :: (~>) Occ Ordering
-      where
-        Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Occ @Ordering (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym1KindInference ())
-    type Compare_0123456789876543210Sym2 :: Occ -> Occ -> Ordering
-    type family Compare_0123456789876543210Sym2 (a0123456789876543210 :: Occ) (a0123456789876543210 :: Occ) :: Ordering where
-      Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd Occ where
-      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
+      type Compare a a = Compare_0123456789876543210 a a
     type ShowsPrec_0123456789876543210 :: Natural
                                           -> Occ -> Symbol -> Symbol
     type family ShowsPrec_0123456789876543210 (a :: Natural) (a :: Occ) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 _ Str a_0123456789876543210 = Apply (Apply ShowStringSym0 "Str") a_0123456789876543210
       ShowsPrec_0123456789876543210 _ Opt a_0123456789876543210 = Apply (Apply ShowStringSym0 "Opt") a_0123456789876543210
       ShowsPrec_0123456789876543210 _ Many a_0123456789876543210 = Apply (Apply ShowStringSym0 "Many") a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym0 :: (~>) Natural ((~>) Occ ((~>) Symbol Symbol))
-    data ShowsPrec_0123456789876543210Sym0 :: (~>) Natural ((~>) Occ ((~>) Symbol Symbol))
-      where
-        ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Natural @((~>) Occ ((~>) Symbol Symbol)) ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym0KindInference ())
-    type ShowsPrec_0123456789876543210Sym1 :: Natural
-                                              -> (~>) Occ ((~>) Symbol Symbol)
-    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: Natural) :: (~>) Occ ((~>) Symbol Symbol)
-      where
-        ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Occ @((~>) Symbol Symbol) (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym1KindInference ())
-    type ShowsPrec_0123456789876543210Sym2 :: Natural
-                                              -> Occ -> (~>) Symbol Symbol
-    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: Natural) (a0123456789876543210 :: Occ) :: (~>) Symbol Symbol
-      where
-        ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @Symbol @Symbol (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym2KindInference ())
-    type ShowsPrec_0123456789876543210Sym3 :: Natural
-                                              -> Occ -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: Natural) (a0123456789876543210 :: Occ) (a0123456789876543210 :: Symbol) :: Symbol where
-      ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow Occ where
-      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
     sEmpty :: (Sing (EmptySym0 :: [(Symbol, Occ)]) :: Type)
     sEmpty = SNil
     data SOcc :: Occ -> Type

--- a/singletons-base/tests/compile-and-dump/Singletons/T178.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T178.golden
@@ -65,7 +65,7 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
       ShowsPrec_0123456789876543210 _ Many a_0123456789876543210 = Apply (Apply ShowStringSym0 "Many") a_0123456789876543210
     instance PShow Occ where
       type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
-    sEmpty :: (Sing (EmptySym0 :: [(Symbol, Occ)]) :: Type)
+    sEmpty :: (Sing (Empty :: [(Symbol, Occ)]) :: Type)
     sEmpty = SNil
     data SOcc :: Occ -> Type
       where

--- a/singletons-base/tests/compile-and-dump/Singletons/T183.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T183.golden
@@ -295,34 +295,28 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
       F2 (x :: Maybe a) = x :: Maybe a
     type family F1 a where
       F1 (x :: Maybe Bool) = x :: Maybe Bool
-    sFoo9 ::
-      (forall (t :: a). Sing t -> Sing (Apply Foo9Sym0 t :: a) :: Type)
+    sFoo9 :: (forall (t :: a). Sing t -> Sing (Foo9 t :: a) :: Type)
     sFoo8 ::
-      forall a (t :: Maybe a). Sing t
-                               -> Sing (Apply Foo8Sym0 t :: Maybe a)
+      forall a (t :: Maybe a). Sing t -> Sing (Foo8 t :: Maybe a)
     sFoo7 ::
       (forall (t :: a) (t :: b).
-       Sing t -> Sing t -> Sing (Apply (Apply Foo7Sym0 t) t :: a) :: Type)
+       Sing t -> Sing t -> Sing (Foo7 t t :: a) :: Type)
     sFoo6 ::
       (forall (t :: Maybe (Maybe a)).
-       Sing t -> Sing (Apply Foo6Sym0 t :: Maybe (Maybe a)) :: Type)
+       Sing t -> Sing (Foo6 t :: Maybe (Maybe a)) :: Type)
     sFoo5 ::
       (forall (t :: Maybe (Maybe a)).
-       Sing t -> Sing (Apply Foo5Sym0 t :: Maybe (Maybe a)) :: Type)
+       Sing t -> Sing (Foo5 t :: Maybe (Maybe a)) :: Type)
     sFoo4 ::
-      (forall (t :: (a, b)).
-       Sing t -> Sing (Apply Foo4Sym0 t :: (b, a)) :: Type)
-    sFoo3 ::
-      forall a (t :: Maybe a). Sing t -> Sing (Apply Foo3Sym0 t :: a)
-    sFoo2 ::
-      forall a (t :: Maybe a). Sing t -> Sing (Apply Foo2Sym0 t :: a)
+      (forall (t :: (a, b)). Sing t -> Sing (Foo4 t :: (b, a)) :: Type)
+    sFoo3 :: forall a (t :: Maybe a). Sing t -> Sing (Foo3 t :: a)
+    sFoo2 :: forall a (t :: Maybe a). Sing t -> Sing (Foo2 t :: a)
     sFoo1 ::
-      (forall (t :: Maybe a).
-       Sing t -> Sing (Apply Foo1Sym0 t :: a) :: Type)
-    sG :: forall arg. Sing arg -> Sing (Apply GSym0 arg)
-    sF3 :: forall arg. Sing arg -> Sing (Apply F3Sym0 arg)
-    sF2 :: forall arg. Sing arg -> Sing (Apply F2Sym0 arg)
-    sF1 :: forall arg. Sing arg -> Sing (Apply F1Sym0 arg)
+      (forall (t :: Maybe a). Sing t -> Sing (Foo1 t :: a) :: Type)
+    sG :: forall arg. Sing arg -> Sing (G arg)
+    sF3 :: forall arg. Sing arg -> Sing (F3 arg)
+    sF2 :: forall arg. Sing arg -> Sing (F2 arg)
+    sF1 :: forall arg. Sing arg -> Sing (F1 arg)
     sFoo9 (sX :: Sing x)
       = case sX :: Sing x of
           (_ :: Sing (x :: a))
@@ -330,8 +324,7 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
                  sG ::
                    (forall (t :: a) (t :: b).
                     Sing t
-                    -> Sing t
-                       -> Sing (Apply (Apply (Let0123456789876543210GSym0 a x) t) t :: a) :: Type)
+                    -> Sing t -> Sing (Let0123456789876543210G a x t t :: a) :: Type)
                  sG (sY :: Sing y) _ = sY
                in
                  applySing
@@ -348,8 +341,7 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
           (,) (_ :: Sing (wild_0123456789876543210 :: a))
               (_ :: Sing ('Just (wild_0123456789876543210 :: a) :: Maybe a))
             -> let
-                 sX ::
-                   Sing @_ (Let0123456789876543210XSym0 a wild_0123456789876543210)
+                 sX :: Sing @_ (Let0123456789876543210X a wild_0123456789876543210)
                  sX
                    = applySing
                        (singFun1 @JustSym0 SJust)
@@ -361,7 +353,7 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
       = case SNothing of
           (_ :: Sing ('Nothing :: Maybe a))
             -> let
-                 sX :: Sing @_ (Let0123456789876543210XSym0 a)
+                 sX :: Sing @_ (Let0123456789876543210X a)
                  sX = SNothing :: Sing (NothingSym0 :: Maybe a)
                in sX
     sFoo7
@@ -380,7 +372,7 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
           (_ :: Sing ('Just x :: Maybe (Maybe a)))
             -> let
                  sScrutinee_0123456789876543210 ::
-                   Sing @_ (Let0123456789876543210Scrutinee_0123456789876543210Sym0 a x)
+                   Sing @_ (Let0123456789876543210Scrutinee_0123456789876543210 a x)
                  sScrutinee_0123456789876543210 = sX :: Sing (x :: Maybe a)
                in
                  id
@@ -435,7 +427,7 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
     sG (sX :: Sing x)
       = let
           sScrutinee_0123456789876543210 ::
-            Sing @_ (Let0123456789876543210Scrutinee_0123456789876543210Sym0 x)
+            Sing @_ (Let0123456789876543210Scrutinee_0123456789876543210 x)
           sScrutinee_0123456789876543210
             = applySing (singFun1 @JustSym0 SJust) sX
         in

--- a/singletons-base/tests/compile-and-dump/Singletons/T184.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T184.golden
@@ -212,22 +212,16 @@ Singletons/T184.hs:(0,0)-(0,0): Splicing declarations
     type family Boogie @a (a :: Maybe a) (a :: Maybe Bool) :: Maybe a where
       Boogie ma mb = Apply (Apply (>>=@#@$) ma) (Lambda_0123456789876543210Sym0 ma mb)
     sTrues ::
-      (forall (t :: [Bool]).
-       Sing t -> Sing (Apply TruesSym0 t :: [Bool]) :: Type)
+      (forall (t :: [Bool]). Sing t -> Sing (Trues t :: [Bool]) :: Type)
     sCartProd ::
       (forall (t :: [a]) (t :: [b]).
-       Sing t
-       -> Sing t
-          -> Sing (Apply (Apply CartProdSym0 t) t :: [(a, b)]) :: Type)
+       Sing t -> Sing t -> Sing (CartProd t t :: [(a, b)]) :: Type)
     sZip' ::
       (forall (t :: [a]) (t :: [b]).
-       Sing t
-       -> Sing t -> Sing (Apply (Apply Zip'Sym0 t) t :: [(a, b)]) :: Type)
+       Sing t -> Sing t -> Sing (Zip' t t :: [(a, b)]) :: Type)
     sBoogie ::
       (forall (t :: Maybe a) (t :: Maybe Bool).
-       Sing t
-       -> Sing t
-          -> Sing (Apply (Apply BoogieSym0 t) t :: Maybe a) :: Type)
+       Sing t -> Sing t -> Sing (Boogie t t :: Maybe a) :: Type)
     sTrues (sXs :: Sing xs)
       = applySing
           (applySing (singFun2 @(>>=@#@$) (%>>=)) sXs)

--- a/singletons-base/tests/compile-and-dump/Singletons/T187.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T187.golden
@@ -11,56 +11,13 @@ Singletons/T187.hs:(0,0)-(0,0): Splicing declarations
     type TFHelper_0123456789876543210 :: Empty -> Empty -> Bool
     type family TFHelper_0123456789876543210 (a :: Empty) (a :: Empty) :: Bool where
       TFHelper_0123456789876543210 _ _ = TrueSym0
-    type TFHelper_0123456789876543210Sym0 :: (~>) Empty ((~>) Empty Bool)
-    data TFHelper_0123456789876543210Sym0 :: (~>) Empty ((~>) Empty Bool)
-      where
-        TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Empty @((~>) Empty Bool) TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym0KindInference ())
-    type TFHelper_0123456789876543210Sym1 :: Empty -> (~>) Empty Bool
-    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Empty) :: (~>) Empty Bool
-      where
-        TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Empty @Bool (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym1KindInference ())
-    type TFHelper_0123456789876543210Sym2 :: Empty -> Empty -> Bool
-    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: Empty) (a0123456789876543210 :: Empty) :: Bool where
-      TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq Empty where
-      type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
+      type (==) a a = TFHelper_0123456789876543210 a a
     type Compare_0123456789876543210 :: Empty -> Empty -> Ordering
     type family Compare_0123456789876543210 (a :: Empty) (a :: Empty) :: Ordering where
       Compare_0123456789876543210 _ _ = EQSym0
-    type Compare_0123456789876543210Sym0 :: (~>) Empty ((~>) Empty Ordering)
-    data Compare_0123456789876543210Sym0 :: (~>) Empty ((~>) Empty Ordering)
-      where
-        Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Empty @((~>) Empty Ordering) Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym0KindInference ())
-    type Compare_0123456789876543210Sym1 :: Empty
-                                            -> (~>) Empty Ordering
-    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Empty) :: (~>) Empty Ordering
-      where
-        Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Empty @Ordering (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym1KindInference ())
-    type Compare_0123456789876543210Sym2 :: Empty -> Empty -> Ordering
-    type family Compare_0123456789876543210Sym2 (a0123456789876543210 :: Empty) (a0123456789876543210 :: Empty) :: Ordering where
-      Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd Empty where
-      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
+      type Compare a a = Compare_0123456789876543210 a a
     data SEmpty :: Empty -> Type
     type instance Sing @Empty = SEmpty
     instance SingKind Empty where

--- a/singletons-base/tests/compile-and-dump/Singletons/T190.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T190.golden
@@ -13,146 +13,40 @@ Singletons/T190.hs:0:0:: Splicing declarations
     type TFHelper_0123456789876543210 :: T -> T -> Bool
     type family TFHelper_0123456789876543210 (a :: T) (a :: T) :: Bool where
       TFHelper_0123456789876543210 T T = TrueSym0
-    type TFHelper_0123456789876543210Sym0 :: (~>) T ((~>) T Bool)
-    data TFHelper_0123456789876543210Sym0 :: (~>) T ((~>) T Bool)
-      where
-        TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @T @((~>) T Bool) TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym0KindInference ())
-    type TFHelper_0123456789876543210Sym1 :: T -> (~>) T Bool
-    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: T) :: (~>) T Bool
-      where
-        TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @T @Bool (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym1KindInference ())
-    type TFHelper_0123456789876543210Sym2 :: T -> T -> Bool
-    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: T) (a0123456789876543210 :: T) :: Bool where
-      TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq T where
-      type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
+      type (==) a a = TFHelper_0123456789876543210 a a
     type Compare_0123456789876543210 :: T -> T -> Ordering
     type family Compare_0123456789876543210 (a :: T) (a :: T) :: Ordering where
       Compare_0123456789876543210 T T = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
-    type Compare_0123456789876543210Sym0 :: (~>) T ((~>) T Ordering)
-    data Compare_0123456789876543210Sym0 :: (~>) T ((~>) T Ordering)
-      where
-        Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @T @((~>) T Ordering) Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym0KindInference ())
-    type Compare_0123456789876543210Sym1 :: T -> (~>) T Ordering
-    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: T) :: (~>) T Ordering
-      where
-        Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @T @Ordering (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym1KindInference ())
-    type Compare_0123456789876543210Sym2 :: T -> T -> Ordering
-    type family Compare_0123456789876543210Sym2 (a0123456789876543210 :: T) (a0123456789876543210 :: T) :: Ordering where
-      Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd T where
-      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
+      type Compare a a = Compare_0123456789876543210 a a
     type family Case_0123456789876543210 n0123456789876543210 t where
       Case_0123456789876543210 n 'True = TSym0
       Case_0123456789876543210 n 'False = Apply ErrorSym0 "toEnum: bad argument"
     type ToEnum_0123456789876543210 :: GHC.Num.Natural.Natural -> T
     type family ToEnum_0123456789876543210 (a :: GHC.Num.Natural.Natural) :: T where
       ToEnum_0123456789876543210 n = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (FromInteger 0))
-    type ToEnum_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural T
-    data ToEnum_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural T
-      where
-        ToEnum_0123456789876543210Sym0KindInference :: SameKind (Apply ToEnum_0123456789876543210Sym0 arg) (ToEnum_0123456789876543210Sym1 arg) =>
-                                                       ToEnum_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @GHC.Num.Natural.Natural @T ToEnum_0123456789876543210Sym0 a0123456789876543210 = ToEnum_0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ToEnum_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) ToEnum_0123456789876543210Sym0KindInference ())
-    type ToEnum_0123456789876543210Sym1 :: GHC.Num.Natural.Natural -> T
-    type family ToEnum_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Num.Natural.Natural) :: T where
-      ToEnum_0123456789876543210Sym1 a0123456789876543210 = ToEnum_0123456789876543210 a0123456789876543210
     type FromEnum_0123456789876543210 :: T -> GHC.Num.Natural.Natural
     type family FromEnum_0123456789876543210 (a :: T) :: GHC.Num.Natural.Natural where
       FromEnum_0123456789876543210 T = FromInteger 0
-    type FromEnum_0123456789876543210Sym0 :: (~>) T GHC.Num.Natural.Natural
-    data FromEnum_0123456789876543210Sym0 :: (~>) T GHC.Num.Natural.Natural
-      where
-        FromEnum_0123456789876543210Sym0KindInference :: SameKind (Apply FromEnum_0123456789876543210Sym0 arg) (FromEnum_0123456789876543210Sym1 arg) =>
-                                                         FromEnum_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @T @GHC.Num.Natural.Natural FromEnum_0123456789876543210Sym0 a0123456789876543210 = FromEnum_0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings FromEnum_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) FromEnum_0123456789876543210Sym0KindInference ())
-    type FromEnum_0123456789876543210Sym1 :: T
-                                             -> GHC.Num.Natural.Natural
-    type family FromEnum_0123456789876543210Sym1 (a0123456789876543210 :: T) :: GHC.Num.Natural.Natural where
-      FromEnum_0123456789876543210Sym1 a0123456789876543210 = FromEnum_0123456789876543210 a0123456789876543210
     instance PEnum T where
-      type ToEnum a = Apply ToEnum_0123456789876543210Sym0 a
-      type FromEnum a = Apply FromEnum_0123456789876543210Sym0 a
+      type ToEnum a = ToEnum_0123456789876543210 a
+      type FromEnum a = FromEnum_0123456789876543210 a
     type MinBound_0123456789876543210 :: T
     type family MinBound_0123456789876543210 :: T where
       MinBound_0123456789876543210 = TSym0
-    type MinBound_0123456789876543210Sym0 :: T
-    type family MinBound_0123456789876543210Sym0 :: T where
-      MinBound_0123456789876543210Sym0 = MinBound_0123456789876543210
     type MaxBound_0123456789876543210 :: T
     type family MaxBound_0123456789876543210 :: T where
       MaxBound_0123456789876543210 = TSym0
-    type MaxBound_0123456789876543210Sym0 :: T
-    type family MaxBound_0123456789876543210Sym0 :: T where
-      MaxBound_0123456789876543210Sym0 = MaxBound_0123456789876543210
     instance PBounded T where
-      type MinBound = MinBound_0123456789876543210Sym0
-      type MaxBound = MaxBound_0123456789876543210Sym0
+      type MinBound = MinBound_0123456789876543210
+      type MaxBound = MaxBound_0123456789876543210
     type ShowsPrec_0123456789876543210 :: GHC.Num.Natural.Natural
                                           -> T -> GHC.Types.Symbol -> GHC.Types.Symbol
     type family ShowsPrec_0123456789876543210 (a :: GHC.Num.Natural.Natural) (a :: T) (a :: GHC.Types.Symbol) :: GHC.Types.Symbol where
       ShowsPrec_0123456789876543210 _ T a_0123456789876543210 = Apply (Apply ShowStringSym0 "T") a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) T ((~>) GHC.Types.Symbol GHC.Types.Symbol))
-    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) T ((~>) GHC.Types.Symbol GHC.Types.Symbol))
-      where
-        ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @GHC.Num.Natural.Natural @((~>) T ((~>) GHC.Types.Symbol GHC.Types.Symbol)) ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym0KindInference ())
-    type ShowsPrec_0123456789876543210Sym1 :: GHC.Num.Natural.Natural
-                                              -> (~>) T ((~>) GHC.Types.Symbol GHC.Types.Symbol)
-    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Num.Natural.Natural) :: (~>) T ((~>) GHC.Types.Symbol GHC.Types.Symbol)
-      where
-        ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @T @((~>) GHC.Types.Symbol GHC.Types.Symbol) (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym1KindInference ())
-    type ShowsPrec_0123456789876543210Sym2 :: GHC.Num.Natural.Natural
-                                              -> T -> (~>) GHC.Types.Symbol GHC.Types.Symbol
-    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: T) :: (~>) GHC.Types.Symbol GHC.Types.Symbol
-      where
-        ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @GHC.Types.Symbol @GHC.Types.Symbol (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym2KindInference ())
-    type ShowsPrec_0123456789876543210Sym3 :: GHC.Num.Natural.Natural
-                                              -> T -> GHC.Types.Symbol -> GHC.Types.Symbol
-    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: T) (a0123456789876543210 :: GHC.Types.Symbol) :: GHC.Types.Symbol where
-      ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow T where
-      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
     data ST :: T -> Type where ST :: ST (T :: T)
     type instance Sing @T = ST
     instance SingKind T where

--- a/singletons-base/tests/compile-and-dump/Singletons/T197.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T197.golden
@@ -36,8 +36,7 @@ Singletons/T197.hs:(0,0)-(0,0): Splicing declarations
     infixl 5 %$$:
     (%$$:) ::
       (forall (t :: Bool) (t :: Bool).
-       Sing t
-       -> Sing t -> Sing (Apply (Apply ($$:@#@$) t) t :: Bool) :: Type)
+       Sing t -> Sing t -> Sing (($$:) t t :: Bool) :: Type)
     (%$$:) _ _ = SFalse
     instance SingI (($$:@#@$) :: (~>) Bool ((~>) Bool Bool)) where
       sing = singFun2 @($$:@#@$) (%$$:)

--- a/singletons-base/tests/compile-and-dump/Singletons/T200.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T200.golden
@@ -113,14 +113,10 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
       ($$:) x y = Apply (Apply (:$$:@#@$) x) y
     (%<>:) ::
       (forall (t :: ErrorMessage) (t :: ErrorMessage).
-       Sing t
-       -> Sing t
-          -> Sing (Apply (Apply (<>:@#@$) t) t :: ErrorMessage) :: Type)
+       Sing t -> Sing t -> Sing ((<>:) t t :: ErrorMessage) :: Type)
     (%$$:) ::
       (forall (t :: ErrorMessage) (t :: ErrorMessage).
-       Sing t
-       -> Sing t
-          -> Sing (Apply (Apply ($$:@#@$) t) t :: ErrorMessage) :: Type)
+       Sing t -> Sing t -> Sing (($$:) t t :: ErrorMessage) :: Type)
     (%<>:) (sX :: Sing x) (sY :: Sing y)
       = applySing (applySing (singFun2 @(:<>:@#@$) (:%<>:)) sX) sY
     (%$$:) (sX :: Sing x) (sY :: Sing y)

--- a/singletons-base/tests/compile-and-dump/Singletons/T209.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T209.golden
@@ -55,10 +55,7 @@ Singletons/T209.hs:(0,0)-(0,0): Splicing declarations
     instance PC a (Maybe a)
     sM ::
       (forall (t :: a) (t :: b) (t :: Bool).
-       Sing t
-       -> Sing t
-          -> Sing t
-             -> Sing (Apply (Apply (Apply MSym0 t) t) t :: Bool) :: Type)
+       Sing t -> Sing t -> Sing t -> Sing (M t t t :: Bool) :: Type)
     sM _ _ (sX :: Sing x) = sX
     instance SingI (MSym0 :: (~>) a ((~>) b ((~>) Bool Bool))) where
       sing = singFun3 @MSym0 sM

--- a/singletons-base/tests/compile-and-dump/Singletons/T229.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T229.golden
@@ -20,8 +20,7 @@ Singletons/T229.hs:(0,0)-(0,0): Splicing declarations
     type family US___foo (a :: Bool) :: Bool where
       US___foo _ = TrueSym0
     ___sfoo ::
-      (forall (t :: Bool).
-       Sing t -> Sing (Apply US___fooSym0 t :: Bool) :: Type)
+      (forall (t :: Bool). Sing t -> Sing (US___foo t :: Bool) :: Type)
     ___sfoo _ = STrue
     instance SingI (US___fooSym0 :: (~>) Bool Bool) where
       sing = singFun1 @US___fooSym0 ___sfoo

--- a/singletons-base/tests/compile-and-dump/Singletons/T271.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T271.golden
@@ -41,120 +41,26 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
                                                      -> Constant a b -> Bool
     type family TFHelper_0123456789876543210 @a @b (a :: Constant a b) (a :: Constant a b) :: Bool where
       TFHelper_0123456789876543210 @a @b (Constant a_0123456789876543210 :: Constant a b) (Constant b_0123456789876543210 :: Constant a b) = Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210
-    type TFHelper_0123456789876543210Sym0 :: forall a
-                                                    b. (~>) (Constant a b) ((~>) (Constant a b) Bool)
-    data TFHelper_0123456789876543210Sym0 :: (~>) (Constant a b) ((~>) (Constant a b) Bool)
-      where
-        TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @(Constant a b) @((~>) (Constant a b) Bool) TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym0KindInference ())
-    type TFHelper_0123456789876543210Sym1 :: forall a b. Constant a b
-                                                         -> (~>) (Constant a b) Bool
-    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Constant a b) :: (~>) (Constant a b) Bool
-      where
-        TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Constant a b) @Bool (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym1KindInference ())
-    type TFHelper_0123456789876543210Sym2 :: forall a b. Constant a b
-                                                         -> Constant a b -> Bool
-    type family TFHelper_0123456789876543210Sym2 @a @b (a0123456789876543210 :: Constant a b) (a0123456789876543210 :: Constant a b) :: Bool where
-      TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq (Constant a b) where
-      type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
+      type (==) a a = TFHelper_0123456789876543210 a a
     type Compare_0123456789876543210 :: forall a b. Constant a b
                                                     -> Constant a b -> Ordering
     type family Compare_0123456789876543210 @a @b (a :: Constant a b) (a :: Constant a b) :: Ordering where
       Compare_0123456789876543210 @a @b (Constant a_0123456789876543210 :: Constant a b) (Constant b_0123456789876543210 :: Constant a b) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0)
-    type Compare_0123456789876543210Sym0 :: forall a
-                                                   b. (~>) (Constant a b) ((~>) (Constant a b) Ordering)
-    data Compare_0123456789876543210Sym0 :: (~>) (Constant a b) ((~>) (Constant a b) Ordering)
-      where
-        Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @(Constant a b) @((~>) (Constant a b) Ordering) Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym0KindInference ())
-    type Compare_0123456789876543210Sym1 :: forall a b. Constant a b
-                                                        -> (~>) (Constant a b) Ordering
-    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Constant a b) :: (~>) (Constant a b) Ordering
-      where
-        Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Constant a b) @Ordering (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym1KindInference ())
-    type Compare_0123456789876543210Sym2 :: forall a b. Constant a b
-                                                        -> Constant a b -> Ordering
-    type family Compare_0123456789876543210Sym2 @a @b (a0123456789876543210 :: Constant a b) (a0123456789876543210 :: Constant a b) :: Ordering where
-      Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd (Constant a b) where
-      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
+      type Compare a a = Compare_0123456789876543210 a a
     type TFHelper_0123456789876543210 :: forall a. Identity a
                                                    -> Identity a -> Bool
     type family TFHelper_0123456789876543210 @a (a :: Identity a) (a :: Identity a) :: Bool where
       TFHelper_0123456789876543210 @a (Identity a_0123456789876543210 :: Identity a) (Identity b_0123456789876543210 :: Identity a) = Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210
-    type TFHelper_0123456789876543210Sym0 :: forall a. (~>) (Identity a) ((~>) (Identity a) Bool)
-    data TFHelper_0123456789876543210Sym0 :: (~>) (Identity a) ((~>) (Identity a) Bool)
-      where
-        TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @(Identity a) @((~>) (Identity a) Bool) TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym0KindInference ())
-    type TFHelper_0123456789876543210Sym1 :: forall a. Identity a
-                                                       -> (~>) (Identity a) Bool
-    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: Identity a) :: (~>) (Identity a) Bool
-      where
-        TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Identity a) @Bool (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym1KindInference ())
-    type TFHelper_0123456789876543210Sym2 :: forall a. Identity a
-                                                       -> Identity a -> Bool
-    type family TFHelper_0123456789876543210Sym2 @a (a0123456789876543210 :: Identity a) (a0123456789876543210 :: Identity a) :: Bool where
-      TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq (Identity a) where
-      type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
+      type (==) a a = TFHelper_0123456789876543210 a a
     type Compare_0123456789876543210 :: forall a. Identity a
                                                   -> Identity a -> Ordering
     type family Compare_0123456789876543210 @a (a :: Identity a) (a :: Identity a) :: Ordering where
       Compare_0123456789876543210 @a (Identity a_0123456789876543210 :: Identity a) (Identity b_0123456789876543210 :: Identity a) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0)
-    type Compare_0123456789876543210Sym0 :: forall a. (~>) (Identity a) ((~>) (Identity a) Ordering)
-    data Compare_0123456789876543210Sym0 :: (~>) (Identity a) ((~>) (Identity a) Ordering)
-      where
-        Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @(Identity a) @((~>) (Identity a) Ordering) Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym0KindInference ())
-    type Compare_0123456789876543210Sym1 :: forall a. Identity a
-                                                      -> (~>) (Identity a) Ordering
-    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: Identity a) :: (~>) (Identity a) Ordering
-      where
-        Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Identity a) @Ordering (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym1KindInference ())
-    type Compare_0123456789876543210Sym2 :: forall a. Identity a
-                                                      -> Identity a -> Ordering
-    type family Compare_0123456789876543210Sym2 @a (a0123456789876543210 :: Identity a) (a0123456789876543210 :: Identity a) :: Ordering where
-      Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd (Identity a) where
-      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
+      type Compare a a = Compare_0123456789876543210 a a
     data SConstant :: forall (a :: Type) (b :: Type).
                       Constant a b -> Type
       where

--- a/singletons-base/tests/compile-and-dump/Singletons/T287.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T287.golden
@@ -47,32 +47,8 @@ Singletons/T287.hs:(0,0)-(0,0): Splicing declarations
                                                      -> (~>) a b -> (~>) a b
     type family TFHelper_0123456789876543210 @a @b (a :: (~>) a b) (a :: (~>) a b) :: (~>) a b where
       TFHelper_0123456789876543210 @a @b (f :: (~>) a b) (g :: (~>) a b) = Lambda_0123456789876543210Sym0 a b f g
-    type TFHelper_0123456789876543210Sym0 :: forall a
-                                                    b. (~>) ((~>) a b) ((~>) ((~>) a b) ((~>) a b))
-    data TFHelper_0123456789876543210Sym0 :: (~>) ((~>) a b) ((~>) ((~>) a b) ((~>) a b))
-      where
-        TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @((~>) a b) @((~>) ((~>) a b) ((~>) a b)) TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym0KindInference ())
-    type TFHelper_0123456789876543210Sym1 :: forall a b. (~>) a b
-                                                         -> (~>) ((~>) a b) ((~>) a b)
-    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: (~>) a b) :: (~>) ((~>) a b) ((~>) a b)
-      where
-        TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @((~>) a b) @((~>) a b) (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym1KindInference ())
-    type TFHelper_0123456789876543210Sym2 :: forall a b. (~>) a b
-                                                         -> (~>) a b -> (~>) a b
-    type family TFHelper_0123456789876543210Sym2 @a @b (a0123456789876543210 :: (~>) a b) (a0123456789876543210 :: (~>) a b) :: (~>) a b where
-      TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PS ((~>) a b) where
-      type (<<>>) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
+      type (<<>>) a a = TFHelper_0123456789876543210 a a
     class SS a where
       (%<<>>) ::
         (forall (t :: a) (t :: a).

--- a/singletons-base/tests/compile-and-dump/Singletons/T287.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T287.golden
@@ -52,8 +52,7 @@ Singletons/T287.hs:(0,0)-(0,0): Splicing declarations
     class SS a where
       (%<<>>) ::
         (forall (t :: a) (t :: a).
-         Sing t
-         -> Sing t -> Sing (Apply (Apply (<<>>@#@$) t) t :: a) :: Type)
+         Sing t -> Sing t -> Sing ((<<>>) t t :: a) :: Type)
     instance SS b => SS ((~>) a b) where
       (%<<>>) (sF :: Sing f) (sG :: Sing g)
         = singFun1

--- a/singletons-base/tests/compile-and-dump/Singletons/T29.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T29.golden
@@ -74,17 +74,13 @@ Singletons/T29.hs:(0,0)-(0,0): Splicing declarations
     type family Foo (a :: Bool) :: Bool where
       Foo x = Apply (Apply ($@#@$) NotSym0) x
     sBan ::
-      (forall (t :: Bool).
-       Sing t -> Sing (Apply BanSym0 t :: Bool) :: Type)
+      (forall (t :: Bool). Sing t -> Sing (Ban t :: Bool) :: Type)
     sBaz ::
-      (forall (t :: Bool).
-       Sing t -> Sing (Apply BazSym0 t :: Bool) :: Type)
+      (forall (t :: Bool). Sing t -> Sing (Baz t :: Bool) :: Type)
     sBar ::
-      (forall (t :: Bool).
-       Sing t -> Sing (Apply BarSym0 t :: Bool) :: Type)
+      (forall (t :: Bool). Sing t -> Sing (Bar t :: Bool) :: Type)
     sFoo ::
-      (forall (t :: Bool).
-       Sing t -> Sing (Apply FooSym0 t :: Bool) :: Type)
+      (forall (t :: Bool). Sing t -> Sing (Foo t :: Bool) :: Type)
     sBan (sX :: Sing x)
       = applySing
           (applySing

--- a/singletons-base/tests/compile-and-dump/Singletons/T296.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T296.golden
@@ -45,15 +45,13 @@ Singletons/T296.hs:(0,0)-(0,0): Splicing declarations
     type F :: forall a. MyProxy a -> MyProxy a
     type family F @a (a :: MyProxy a) :: MyProxy a where
       F @a (MyProxy :: MyProxy a) = Let0123456789876543210XSym0 a
-    sF ::
-      forall a (t :: MyProxy a). Sing t
-                                 -> Sing (Apply FSym0 t :: MyProxy a)
+    sF :: forall a (t :: MyProxy a). Sing t -> Sing (F t :: MyProxy a)
     sF SMyProxy
       = let
-          sX :: Sing @_ (Let0123456789876543210XSym0 a)
+          sX :: Sing @_ (Let0123456789876543210X a)
           sX
             = let
-                sZ :: (Sing (Let0123456789876543210ZSym0 a :: MyProxy a) :: Type)
+                sZ :: (Sing (Let0123456789876543210Z a :: MyProxy a) :: Type)
                 sZ = SMyProxy
               in sZ
         in sX

--- a/singletons-base/tests/compile-and-dump/Singletons/T297.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T297.golden
@@ -42,13 +42,13 @@ Singletons/T297.hs:(0,0)-(0,0): Splicing declarations
       FSym1 a0123456789876543210 = F a0123456789876543210
     type family F a where
       F MyProxy = Let0123456789876543210XSym0
-    sF :: forall arg. Sing arg -> Sing (Apply FSym0 arg)
+    sF :: forall arg. Sing arg -> Sing (F arg)
     sF SMyProxy
       = let
-          sX :: Sing @_ Let0123456789876543210XSym0
+          sX :: Sing @_ Let0123456789876543210X
           sX
             = let
-                sZ :: (Sing (Let0123456789876543210ZSym0 :: MyProxy a) :: Type)
+                sZ :: (Sing (Let0123456789876543210Z :: MyProxy a) :: Type)
                 sZ = SMyProxy
               in sZ
         in sX

--- a/singletons-base/tests/compile-and-dump/Singletons/T312.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T312.golden
@@ -60,27 +60,6 @@ Singletons/T312.hs:(0,0)-(0,0): Splicing declarations
     type Bar_0123456789876543210 :: forall a b. a -> b -> b
     type family Bar_0123456789876543210 @a @b (a :: a) (a :: b) :: b where
       Bar_0123456789876543210 @a @b (_ :: a) (x :: b) = x
-    type Bar_0123456789876543210Sym0 :: forall a b. (~>) a ((~>) b b)
-    data Bar_0123456789876543210Sym0 :: (~>) a ((~>) b b)
-      where
-        Bar_0123456789876543210Sym0KindInference :: SameKind (Apply Bar_0123456789876543210Sym0 arg) (Bar_0123456789876543210Sym1 arg) =>
-                                                    Bar_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @a @((~>) b b) Bar_0123456789876543210Sym0 a0123456789876543210 = Bar_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Bar_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Bar_0123456789876543210Sym0KindInference ())
-    type Bar_0123456789876543210Sym1 :: forall a b. a -> (~>) b b
-    data Bar_0123456789876543210Sym1 (a0123456789876543210 :: a) :: (~>) b b
-      where
-        Bar_0123456789876543210Sym1KindInference :: SameKind (Apply (Bar_0123456789876543210Sym1 a0123456789876543210) arg) (Bar_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                    Bar_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @b (Bar_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Bar_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Bar_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Bar_0123456789876543210Sym1KindInference ())
-    type Bar_0123456789876543210Sym2 :: forall a b. a -> b -> b
-    type family Bar_0123456789876543210Sym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: b where
-      Bar_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Bar_0123456789876543210 a0123456789876543210 a0123456789876543210
     data Let0123456789876543210HSym0 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 :: (~>) c0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)
       where
         Let0123456789876543210HSym0KindInference :: SameKind (Apply (Let0123456789876543210HSym0 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (Let0123456789876543210HSym1 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
@@ -104,32 +83,11 @@ Singletons/T312.hs:(0,0)-(0,0): Splicing declarations
     type Baz_0123456789876543210 :: forall a b. a -> b -> b
     type family Baz_0123456789876543210 @a @b (a :: a) (a :: b) :: b where
       Baz_0123456789876543210 @a @b (a_0123456789876543210 :: a) (a_0123456789876543210 :: b) = Apply (Apply (Let0123456789876543210HSym0 a b a_0123456789876543210 a_0123456789876543210) a_0123456789876543210) a_0123456789876543210
-    type Baz_0123456789876543210Sym0 :: forall a b. (~>) a ((~>) b b)
-    data Baz_0123456789876543210Sym0 :: (~>) a ((~>) b b)
-      where
-        Baz_0123456789876543210Sym0KindInference :: SameKind (Apply Baz_0123456789876543210Sym0 arg) (Baz_0123456789876543210Sym1 arg) =>
-                                                    Baz_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @a @((~>) b b) Baz_0123456789876543210Sym0 a0123456789876543210 = Baz_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Baz_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Baz_0123456789876543210Sym0KindInference ())
-    type Baz_0123456789876543210Sym1 :: forall a b. a -> (~>) b b
-    data Baz_0123456789876543210Sym1 (a0123456789876543210 :: a) :: (~>) b b
-      where
-        Baz_0123456789876543210Sym1KindInference :: SameKind (Apply (Baz_0123456789876543210Sym1 a0123456789876543210) arg) (Baz_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                    Baz_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @b (Baz_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Baz_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Baz_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Baz_0123456789876543210Sym1KindInference ())
-    type Baz_0123456789876543210Sym2 :: forall a b. a -> b -> b
-    type family Baz_0123456789876543210Sym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: b where
-      Baz_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Baz_0123456789876543210 a0123456789876543210 a0123456789876543210
     class PFoo a where
       type family Bar (arg :: a) (arg :: b) :: b
       type family Baz (arg :: a) (arg :: b) :: b
-      type Bar a a = Apply (Apply Bar_0123456789876543210Sym0 a) a
-      type Baz a a = Apply (Apply Baz_0123456789876543210Sym0 a) a
+      type Bar a a = Bar_0123456789876543210 a a
+      type Baz a a = Baz_0123456789876543210 a a
     class SFoo a where
       sBar ::
         (forall (t :: a) (t :: b).
@@ -139,12 +97,11 @@ Singletons/T312.hs:(0,0)-(0,0): Splicing declarations
                                     -> Sing t -> Sing (Apply (Apply BazSym0 t) t :: b)
       default sBar ::
                 (forall (t :: a) (t :: b).
-                 ((Apply (Apply BarSym0 t) t :: b)
-                  ~ Apply (Apply Bar_0123456789876543210Sym0 t) t) =>
+                 ((Bar t t :: b) ~ Bar_0123456789876543210 t t) =>
                  Sing t -> Sing t -> Sing (Apply (Apply BarSym0 t) t :: b) :: Type)
       default sBaz ::
-                forall b (t :: a) (t :: b). ((Apply (Apply BazSym0 t) t :: b)
-                                             ~ Apply (Apply Baz_0123456789876543210Sym0 t) t) =>
+                forall b (t :: a) (t :: b). ((Baz t t :: b)
+                                             ~ Baz_0123456789876543210 t t) =>
                                             Sing t
                                             -> Sing t -> Sing (Apply (Apply BazSym0 t) t :: b)
       sBar _ (sX :: Sing x) = sX

--- a/singletons-base/tests/compile-and-dump/Singletons/T312.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T312.golden
@@ -91,19 +91,17 @@ Singletons/T312.hs:(0,0)-(0,0): Splicing declarations
     class SFoo a where
       sBar ::
         (forall (t :: a) (t :: b).
-         Sing t -> Sing t -> Sing (Apply (Apply BarSym0 t) t :: b) :: Type)
+         Sing t -> Sing t -> Sing (Bar t t :: b) :: Type)
       sBaz ::
-        forall b (t :: a) (t :: b). Sing t
-                                    -> Sing t -> Sing (Apply (Apply BazSym0 t) t :: b)
+        forall b (t :: a) (t :: b). Sing t -> Sing t -> Sing (Baz t t :: b)
       default sBar ::
                 (forall (t :: a) (t :: b).
                  ((Bar t t :: b) ~ Bar_0123456789876543210 t t) =>
-                 Sing t -> Sing t -> Sing (Apply (Apply BarSym0 t) t :: b) :: Type)
+                 Sing t -> Sing t -> Sing (Bar t t :: b) :: Type)
       default sBaz ::
                 forall b (t :: a) (t :: b). ((Baz t t :: b)
                                              ~ Baz_0123456789876543210 t t) =>
-                                            Sing t
-                                            -> Sing t -> Sing (Apply (Apply BazSym0 t) t :: b)
+                                            Sing t -> Sing t -> Sing (Baz t t :: b)
       sBar _ (sX :: Sing x) = sX
       sBaz
         (sA_0123456789876543210 :: Sing a_0123456789876543210)
@@ -114,7 +112,7 @@ Singletons/T312.hs:(0,0)-(0,0): Splicing declarations
                   sH ::
                     forall c (t :: c) (t :: b). Sing t
                                                 -> Sing t
-                                                   -> Sing (Apply (Apply (Let0123456789876543210HSym0 a b a_0123456789876543210 a_0123456789876543210) t) t :: b)
+                                                   -> Sing (Let0123456789876543210H a b a_0123456789876543210 a_0123456789876543210 t t :: b)
                   sH _ (sX :: Sing x) = sX
                 in
                   singFun2

--- a/singletons-base/tests/compile-and-dump/Singletons/T322.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T322.golden
@@ -36,8 +36,7 @@ Singletons/T322.hs:(0,0)-(0,0): Splicing declarations
     infixr 2 %!
     (%!) ::
       (forall (t :: Bool) (t :: Bool).
-       Sing t
-       -> Sing t -> Sing (Apply (Apply (!@#@$) t) t :: Bool) :: Type)
+       Sing t -> Sing t -> Sing ((!) t t :: Bool) :: Type)
     (%!)
       (sA_0123456789876543210 :: Sing a_0123456789876543210)
       (sA_0123456789876543210 :: Sing a_0123456789876543210)

--- a/singletons-base/tests/compile-and-dump/Singletons/T326.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T326.golden
@@ -59,8 +59,7 @@ Singletons/T326.hs:0:0:: Splicing declarations
     class SC2 (a :: Type) where
       (%<%%>) ::
         (forall (t :: a) (t :: a).
-         Sing t
-         -> Sing t -> Sing (Apply (Apply (<%%>@#@$) t) t :: a) :: Type)
+         Sing t -> Sing t -> Sing ((<%%>) t t :: a) :: Type)
     type SC2 :: Type -> Constraint
     infixl 9 %<%%>
     instance SC2 a => SingI ((<%%>@#@$) :: (~>) a ((~>) a a)) where

--- a/singletons-base/tests/compile-and-dump/Singletons/T33.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T33.golden
@@ -22,8 +22,7 @@ Singletons/T33.hs:(0,0)-(0,0): Splicing declarations
     type family Foo (a :: (Bool, Bool)) :: () where
       Foo '(_, _) = Tuple0Sym0
     sFoo ::
-      (forall (t :: (Bool, Bool)).
-       Sing t -> Sing (Apply FooSym0 t :: ()) :: Type)
+      (forall (t :: (Bool, Bool)). Sing t -> Sing (Foo t :: ()) :: Type)
     sFoo (STuple2 _ _) = STuple0
     instance SingI (FooSym0 :: (~>) (Bool, Bool) ()) where
       sing = singFun1 @FooSym0 sFoo

--- a/singletons-base/tests/compile-and-dump/Singletons/T332.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T332.golden
@@ -52,8 +52,7 @@ Singletons/T332.hs:(0,0)-(0,0): Splicing declarations
     type B :: Bar -> ()
     type family B (a :: Bar) :: () where
       B MkBar = Tuple0Sym0
-    sB ::
-      (forall (t :: Bar). Sing t -> Sing (Apply BSym0 t :: ()) :: Type)
+    sB :: (forall (t :: Bar). Sing t -> Sing (B t :: ()) :: Type)
     sB SMkBar = STuple0
     instance SingI (BSym0 :: (~>) Bar ()) where
       sing = singFun1 @BSym0 sB

--- a/singletons-base/tests/compile-and-dump/Singletons/T358.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T358.golden
@@ -70,18 +70,15 @@ Singletons/T358.hs:(0,0)-(0,0): Splicing declarations
       type Method2a a = Method2a_0123456789876543210 a
       type Method2b a = Method2b_0123456789876543210 a
     class SC1 (f :: k -> Type) where
-      sMethod1 :: (Sing (Method1Sym0 :: f a) :: Type)
+      sMethod1 :: (Sing (Method1 :: f a) :: Type)
     class SC2 a where
-      sMethod2a ::
-        forall b (t :: b). Sing t -> Sing (Apply Method2aSym0 t :: a)
-      sMethod2b ::
-        forall b (t :: b). Sing t -> Sing (Apply Method2bSym0 t :: a)
+      sMethod2a :: forall b (t :: b). Sing t -> Sing (Method2a t :: a)
+      sMethod2b :: forall b (t :: b). Sing t -> Sing (Method2b t :: a)
     instance SC1 [] where
-      sMethod1 :: (Sing (Method1Sym0 :: [a]) :: Type)
+      sMethod1 :: (Sing (Method1 :: [a]) :: Type)
       sMethod1 = SNil
     instance SC2 [a] where
-      sMethod2b ::
-        forall b (t :: b). Sing t -> Sing (Apply Method2bSym0 t :: [a])
+      sMethod2b :: forall b (t :: b). Sing t -> Sing (Method2b t :: [a])
       sMethod2a _ = SNil
       sMethod2b _ = SNil
     instance SC2 a => SingI (Method2aSym0 :: (~>) b a) where

--- a/singletons-base/tests/compile-and-dump/Singletons/T358.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T358.golden
@@ -58,44 +58,17 @@ Singletons/T358.hs:(0,0)-(0,0): Splicing declarations
     type Method1_0123456789876543210 :: forall a. [a]
     type family Method1_0123456789876543210 @a :: [a] where
       Method1_0123456789876543210 @a = NilSym0
-    type Method1_0123456789876543210Sym0 :: forall a. [a]
-    type family Method1_0123456789876543210Sym0 @a :: [a] where
-      Method1_0123456789876543210Sym0 = Method1_0123456789876543210
     instance PC1 [] where
-      type Method1 = Method1_0123456789876543210Sym0
+      type Method1 = Method1_0123456789876543210
     type Method2a_0123456789876543210 :: forall b a. b -> [a]
     type family Method2a_0123456789876543210 @b @a (a :: b) :: [a] where
       Method2a_0123456789876543210 @b @a (_ :: b) = NilSym0
-    type Method2a_0123456789876543210Sym0 :: forall b a. (~>) b [a]
-    data Method2a_0123456789876543210Sym0 :: (~>) b [a]
-      where
-        Method2a_0123456789876543210Sym0KindInference :: SameKind (Apply Method2a_0123456789876543210Sym0 arg) (Method2a_0123456789876543210Sym1 arg) =>
-                                                         Method2a_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @b @[a] Method2a_0123456789876543210Sym0 a0123456789876543210 = Method2a_0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings Method2a_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Method2a_0123456789876543210Sym0KindInference ())
-    type Method2a_0123456789876543210Sym1 :: forall b a. b -> [a]
-    type family Method2a_0123456789876543210Sym1 @b @a (a0123456789876543210 :: b) :: [a] where
-      Method2a_0123456789876543210Sym1 a0123456789876543210 = Method2a_0123456789876543210 a0123456789876543210
     type Method2b_0123456789876543210 :: forall b a. b -> [a]
     type family Method2b_0123456789876543210 @b @a (a :: b) :: [a] where
       Method2b_0123456789876543210 @b @a (_ :: b) = NilSym0
-    type Method2b_0123456789876543210Sym0 :: forall b a. (~>) b [a]
-    data Method2b_0123456789876543210Sym0 :: (~>) b [a]
-      where
-        Method2b_0123456789876543210Sym0KindInference :: SameKind (Apply Method2b_0123456789876543210Sym0 arg) (Method2b_0123456789876543210Sym1 arg) =>
-                                                         Method2b_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @b @[a] Method2b_0123456789876543210Sym0 a0123456789876543210 = Method2b_0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings Method2b_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Method2b_0123456789876543210Sym0KindInference ())
-    type Method2b_0123456789876543210Sym1 :: forall b a. b -> [a]
-    type family Method2b_0123456789876543210Sym1 @b @a (a0123456789876543210 :: b) :: [a] where
-      Method2b_0123456789876543210Sym1 a0123456789876543210 = Method2b_0123456789876543210 a0123456789876543210
     instance PC2 [a] where
-      type Method2a a = Apply Method2a_0123456789876543210Sym0 a
-      type Method2b a = Apply Method2b_0123456789876543210Sym0 a
+      type Method2a a = Method2a_0123456789876543210 a
+      type Method2b a = Method2b_0123456789876543210 a
     class SC1 (f :: k -> Type) where
       sMethod1 :: (Sing (Method1Sym0 :: f a) :: Type)
     class SC2 a where

--- a/singletons-base/tests/compile-and-dump/Singletons/T367.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T367.golden
@@ -29,8 +29,7 @@ Singletons/T367.hs:(0,0)-(0,0): Splicing declarations
       Const' x _ = x
     sConst' ::
       (forall (t :: a) (t :: b).
-       Sing t
-       -> Sing t -> Sing (Apply (Apply Const'Sym0 t) t :: a) :: Type)
+       Sing t -> Sing t -> Sing (Const' t t :: a) :: Type)
     sConst' (sX :: Sing x) _ = sX
     instance SingI (Const'Sym0 :: (~>) a ((~>) b a)) where
       sing = singFun2 @Const'Sym0 sConst'

--- a/singletons-base/tests/compile-and-dump/Singletons/T371.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T371.golden
@@ -46,85 +46,15 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
     type family ShowsPrec_0123456789876543210 @a (a :: GHC.Num.Natural.Natural) (a :: X a) (a :: GHC.Types.Symbol) :: GHC.Types.Symbol where
       ShowsPrec_0123456789876543210 @a (_ :: GHC.Num.Natural.Natural) (X1 :: X a) (a_0123456789876543210 :: GHC.Types.Symbol) = Apply (Apply ShowStringSym0 "X1") a_0123456789876543210
       ShowsPrec_0123456789876543210 @a (p_0123456789876543210 :: GHC.Num.Natural.Natural) (X2 arg_0123456789876543210 :: X a) (a_0123456789876543210 :: GHC.Types.Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "X2 ")) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym0 :: forall a. (~>) GHC.Num.Natural.Natural ((~>) (X a) ((~>) GHC.Types.Symbol GHC.Types.Symbol))
-    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) (X a) ((~>) GHC.Types.Symbol GHC.Types.Symbol))
-      where
-        ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @GHC.Num.Natural.Natural @((~>) (X a) ((~>) GHC.Types.Symbol GHC.Types.Symbol)) ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym0KindInference ())
-    type ShowsPrec_0123456789876543210Sym1 :: forall a. GHC.Num.Natural.Natural
-                                                        -> (~>) (X a) ((~>) GHC.Types.Symbol GHC.Types.Symbol)
-    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Num.Natural.Natural) :: (~>) (X a) ((~>) GHC.Types.Symbol GHC.Types.Symbol)
-      where
-        ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(X a) @((~>) GHC.Types.Symbol GHC.Types.Symbol) (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym1KindInference ())
-    type ShowsPrec_0123456789876543210Sym2 :: forall a. GHC.Num.Natural.Natural
-                                                        -> X a
-                                                           -> (~>) GHC.Types.Symbol GHC.Types.Symbol
-    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: X a) :: (~>) GHC.Types.Symbol GHC.Types.Symbol
-      where
-        ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @GHC.Types.Symbol @GHC.Types.Symbol (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym2KindInference ())
-    type ShowsPrec_0123456789876543210Sym3 :: forall a. GHC.Num.Natural.Natural
-                                                        -> X a
-                                                           -> GHC.Types.Symbol -> GHC.Types.Symbol
-    type family ShowsPrec_0123456789876543210Sym3 @a (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: X a) (a0123456789876543210 :: GHC.Types.Symbol) :: GHC.Types.Symbol where
-      ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow (X a) where
-      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
     type ShowsPrec_0123456789876543210 :: forall a. GHC.Num.Natural.Natural
                                                     -> Y a -> GHC.Types.Symbol -> GHC.Types.Symbol
     type family ShowsPrec_0123456789876543210 @a (a :: GHC.Num.Natural.Natural) (a :: Y a) (a :: GHC.Types.Symbol) :: GHC.Types.Symbol where
       ShowsPrec_0123456789876543210 @a (_ :: GHC.Num.Natural.Natural) (Y1 :: Y a) (a_0123456789876543210 :: GHC.Types.Symbol) = Apply (Apply ShowStringSym0 "Y1") a_0123456789876543210
       ShowsPrec_0123456789876543210 @a (p_0123456789876543210 :: GHC.Num.Natural.Natural) (Y2 arg_0123456789876543210 :: Y a) (a_0123456789876543210 :: GHC.Types.Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Y2 ")) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym0 :: forall a. (~>) GHC.Num.Natural.Natural ((~>) (Y a) ((~>) GHC.Types.Symbol GHC.Types.Symbol))
-    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) (Y a) ((~>) GHC.Types.Symbol GHC.Types.Symbol))
-      where
-        ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @GHC.Num.Natural.Natural @((~>) (Y a) ((~>) GHC.Types.Symbol GHC.Types.Symbol)) ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym0KindInference ())
-    type ShowsPrec_0123456789876543210Sym1 :: forall a. GHC.Num.Natural.Natural
-                                                        -> (~>) (Y a) ((~>) GHC.Types.Symbol GHC.Types.Symbol)
-    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Num.Natural.Natural) :: (~>) (Y a) ((~>) GHC.Types.Symbol GHC.Types.Symbol)
-      where
-        ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Y a) @((~>) GHC.Types.Symbol GHC.Types.Symbol) (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym1KindInference ())
-    type ShowsPrec_0123456789876543210Sym2 :: forall a. GHC.Num.Natural.Natural
-                                                        -> Y a
-                                                           -> (~>) GHC.Types.Symbol GHC.Types.Symbol
-    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: Y a) :: (~>) GHC.Types.Symbol GHC.Types.Symbol
-      where
-        ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @GHC.Types.Symbol @GHC.Types.Symbol (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym2KindInference ())
-    type ShowsPrec_0123456789876543210Sym3 :: forall a. GHC.Num.Natural.Natural
-                                                        -> Y a
-                                                           -> GHC.Types.Symbol -> GHC.Types.Symbol
-    type family ShowsPrec_0123456789876543210Sym3 @a (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: Y a) (a0123456789876543210 :: GHC.Types.Symbol) :: GHC.Types.Symbol where
-      ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow (Y a) where
-      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
     data SX :: forall (a :: Type). X a -> Type
       where
         SX1 :: forall (a :: Type). SX (X1 :: X a)

--- a/singletons-base/tests/compile-and-dump/Singletons/T376.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T376.golden
@@ -29,7 +29,7 @@ Singletons/T376.hs:(0,0)-(0,0): Splicing declarations
       F g a_0123456789876543210 = Apply (g :: (~>) () ()) a_0123456789876543210
     sF ::
       (forall (t :: (~>) () ()) (t :: ()).
-       Sing t -> Sing t -> Sing (Apply (Apply FSym0 t) t :: ()) :: Type)
+       Sing t -> Sing t -> Sing (F t t :: ()) :: Type)
     sF
       (sG :: Sing g)
       (sA_0123456789876543210 :: Sing a_0123456789876543210)

--- a/singletons-base/tests/compile-and-dump/Singletons/T378a.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T378a.golden
@@ -54,7 +54,7 @@ Singletons/T378a.hs:(0,0)-(0,0): Splicing declarations
       ConstBA @b @a (x :: a) (_ :: b) = x
     sConstBA ::
       forall b a (t :: a) (t :: b). Sing t
-                                    -> Sing t -> Sing (Apply (Apply ConstBASym0 t) t :: a)
+                                    -> Sing t -> Sing (ConstBA t t :: a)
     sConstBA (sX :: Sing x) _ = sX
     instance SingI (ConstBASym0 :: (~>) a ((~>) b a)) where
       sing = singFun2 @ConstBASym0 sConstBA

--- a/singletons-base/tests/compile-and-dump/Singletons/T378b.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T378b.golden
@@ -77,11 +77,10 @@ Singletons/T378b.hs:(0,0)-(0,0): Splicing declarations
     class PC x y
     sNatMinus ::
       (forall (t :: Nat) (t :: Nat).
-       Sing t
-       -> Sing t -> Sing (Apply (Apply NatMinusSym0 t) t :: Nat) :: Type)
+       Sing t -> Sing t -> Sing (NatMinus t t :: Nat) :: Type)
     sF ::
       forall b a (t :: a) (t :: b). Sing t
-                                    -> Sing t -> Sing (Apply (Apply FSym0 t) t :: ())
+                                    -> Sing t -> Sing (F t t :: ())
     sNatMinus SZero _ = SZero
     sNatMinus (SSucc (sA :: Sing a)) (SSucc (sB :: Sing b))
       = applySing (applySing (singFun2 @NatMinusSym0 sNatMinus) sA) sB
@@ -89,8 +88,7 @@ Singletons/T378b.hs:(0,0)-(0,0): Splicing declarations
       (SSucc (sWild_0123456789876543210 :: Sing wild_0123456789876543210))
       SZero
       = let
-          sA ::
-            Sing @_ (Let0123456789876543210ASym0 wild_0123456789876543210)
+          sA :: Sing @_ (Let0123456789876543210A wild_0123456789876543210)
           sA = applySing (singFun1 @SuccSym0 SSucc) sWild_0123456789876543210
         in sA
     sF _ _ = STuple0

--- a/singletons-base/tests/compile-and-dump/Singletons/T410.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T410.golden
@@ -36,26 +36,5 @@ Singletons/T410.hs:(0,0)-(0,0): Splicing declarations
     type Equals_0123456789876543210 :: () -> () -> Bool
     type family Equals_0123456789876543210 (a :: ()) (a :: ()) :: Bool where
       Equals_0123456789876543210 '() '() = TrueSym0
-    type Equals_0123456789876543210Sym0 :: (~>) () ((~>) () Bool)
-    data Equals_0123456789876543210Sym0 :: (~>) () ((~>) () Bool)
-      where
-        Equals_0123456789876543210Sym0KindInference :: SameKind (Apply Equals_0123456789876543210Sym0 arg) (Equals_0123456789876543210Sym1 arg) =>
-                                                       Equals_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @() @((~>) () Bool) Equals_0123456789876543210Sym0 a0123456789876543210 = Equals_0123456789876543210Sym1 a0123456789876543210
-    instance Data.Singletons.TH.SuppressUnusedWarnings.SuppressUnusedWarnings Equals_0123456789876543210Sym0 where
-      Data.Singletons.TH.SuppressUnusedWarnings.suppressUnusedWarnings
-        = snd ((,) Equals_0123456789876543210Sym0KindInference ())
-    type Equals_0123456789876543210Sym1 :: () -> (~>) () Bool
-    data Equals_0123456789876543210Sym1 (a0123456789876543210 :: ()) :: (~>) () Bool
-      where
-        Equals_0123456789876543210Sym1KindInference :: SameKind (Apply (Equals_0123456789876543210Sym1 a0123456789876543210) arg) (Equals_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                       Equals_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @() @Bool (Equals_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Equals_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance Data.Singletons.TH.SuppressUnusedWarnings.SuppressUnusedWarnings (Equals_0123456789876543210Sym1 a0123456789876543210) where
-      Data.Singletons.TH.SuppressUnusedWarnings.suppressUnusedWarnings
-        = snd ((,) Equals_0123456789876543210Sym1KindInference ())
-    type Equals_0123456789876543210Sym2 :: () -> () -> Bool
-    type family Equals_0123456789876543210Sym2 (a0123456789876543210 :: ()) (a0123456789876543210 :: ()) :: Bool where
-      Equals_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Equals_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq () where
-      type Equals a a = Apply (Apply Equals_0123456789876543210Sym0 a) a
+      type Equals a a = Equals_0123456789876543210 a a

--- a/singletons-base/tests/compile-and-dump/Singletons/T412.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T412.golden
@@ -150,10 +150,8 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
     infixr 5 `sD1A`
     infixr 5 `SMkD1`
     infix 5 `SC1`
-    sD1B ::
-      forall a b (t :: D1 a b). Sing t -> Sing (Apply D1BSym0 t :: b)
-    sD1A ::
-      forall a b (t :: D1 a b). Sing t -> Sing (Apply D1ASym0 t :: a)
+    sD1B :: forall a b (t :: D1 a b). Sing t -> Sing (D1B t :: b)
+    sD1A :: forall a b (t :: D1 a b). Sing t -> Sing (D1A t :: a)
     sD1B (SMkD1 _ (sField :: Sing field)) = sField
     sD1A (SMkD1 (sField :: Sing field) _) = sField
     instance SingI (D1BSym0 :: (~>) (D1 a b) b) where
@@ -174,8 +172,7 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
     class SC1 a b where
       sM1 ::
         (forall (t :: a) (t :: b).
-         Sing t
-         -> Sing t -> Sing (Apply (Apply M1Sym0 t) t :: Bool) :: Type)
+         Sing t -> Sing t -> Sing (M1 t t :: Bool) :: Type)
       infix 6 `sM1`
     instance (SingI n, SingI n) => SingI (MkD1 (n :: a) (n :: b)) where
       sing = SMkD1 sing sing
@@ -231,8 +228,7 @@ Singletons/T412.hs:0:0:: Splicing declarations
     class SC2 (a :: Type) (b :: Type) where
       sM2 ::
         (forall (t :: a) (t :: b).
-         Sing t
-         -> Sing t -> Sing (Apply (Apply M2Sym0 t) t :: Bool) :: Type)
+         Sing t -> Sing t -> Sing (M2 t t :: Bool) :: Type)
     type SC2 :: Type -> Type -> Constraint
     infix 5 `SC2`
     infix 6 `sM2`
@@ -343,10 +339,10 @@ Singletons/T412.hs:0:0:: Splicing declarations
       D2A @a @b ('MkD2 field _ :: D2 a b) = field
     sD2B ::
       forall (a :: Type) (b :: Type) (t :: D2 a b). Sing t
-                                                    -> Sing (Apply D2BSym0 t :: b)
+                                                    -> Sing (D2B t :: b)
     sD2A ::
       forall (a :: Type) (b :: Type) (t :: D2 a b). Sing t
-                                                    -> Sing (Apply D2ASym0 t :: a)
+                                                    -> Sing (D2A t :: a)
     sD2B (SMkD2 _ (sField :: Sing field)) = sField
     sD2A (SMkD2 (sField :: Sing field) _) = sField
     instance SingI (D2BSym0 :: (~>) (D2 a b) b) where

--- a/singletons-base/tests/compile-and-dump/Singletons/T443.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T443.golden
@@ -78,10 +78,9 @@ Singletons/T443.hs:(0,0)-(0,0): Splicing declarations
       Head ((:>) field _) = field
     sTail ::
       (forall (t :: Vec (S n) a).
-       Sing t -> Sing (Apply TailSym0 t :: Vec n a) :: Type)
+       Sing t -> Sing (Tail t :: Vec n a) :: Type)
     sHead ::
-      (forall (t :: Vec (S n) a).
-       Sing t -> Sing (Apply HeadSym0 t :: a) :: Type)
+      (forall (t :: Vec (S n) a). Sing t -> Sing (Head t :: a) :: Type)
     sTail ((:%>) _ (sField :: Sing field)) = sField
     sHead ((:%>) (sField :: Sing field) _) = sField
     instance SingI (TailSym0 :: (~>) (Vec (S n) a) (Vec n a)) where

--- a/singletons-base/tests/compile-and-dump/Singletons/T450.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T450.golden
@@ -94,9 +94,7 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
       AppendMessage ('PMkMessage (x :: Symbol)) ('PMkMessage (y :: Symbol)) = Apply PMkMessageSym0 (Apply (Apply (<>@#@$) x) y :: Symbol)
     sAppendMessage ::
       (forall (t :: PMessage) (t :: PMessage).
-       Sing t
-       -> Sing t
-          -> Sing (Apply (Apply AppendMessageSym0 t) t :: PMessage) :: Type)
+       Sing t -> Sing t -> Sing (AppendMessage t t :: PMessage) :: Type)
     sAppendMessage
       (SMkMessage (sX :: Sing x))
       (SMkMessage (sY :: Sing y))
@@ -185,8 +183,7 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
     sComposeFunction ::
       (forall (t :: PFunction b c) (t :: PFunction a b).
        Sing t
-       -> Sing t
-          -> Sing (Apply (Apply ComposeFunctionSym0 t) t :: PFunction a c) :: Type)
+       -> Sing t -> Sing (ComposeFunction t t :: PFunction a c) :: Type)
     sComposeFunction
       (SMkFunction (sF :: Sing f))
       (SMkFunction (sG :: Sing g))

--- a/singletons-base/tests/compile-and-dump/Singletons/T487.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T487.golden
@@ -49,13 +49,12 @@ Singletons/T487.hs:(0,0)-(0,0): Splicing declarations
     type ExprEx :: Char
     type family ExprEx :: Char where
       ExprEx = 'a'
-    sCharToNatEx :: (Sing (CharToNatExSym0 :: Natural) :: Type)
-    sNatToCharEx :: (Sing (NatToCharExSym0 :: Char) :: Type)
-    sUnconsEx :: (Sing (UnconsExSym0 :: Maybe (Char, Symbol)) :: Type)
+    sCharToNatEx :: (Sing (CharToNatEx :: Natural) :: Type)
+    sNatToCharEx :: (Sing (NatToCharEx :: Char) :: Type)
+    sUnconsEx :: (Sing (UnconsEx :: Maybe (Char, Symbol)) :: Type)
     sConsEx ::
-      (forall (t :: Char).
-       Sing t -> Sing (Apply ConsExSym0 t :: Symbol) :: Type)
-    sExprEx :: (Sing (ExprExSym0 :: Char) :: Type)
+      (forall (t :: Char). Sing t -> Sing (ConsEx t :: Symbol) :: Type)
+    sExprEx :: (Sing (ExprEx :: Char) :: Type)
     sCharToNatEx
       = applySing (singFun1 @CharToNatSym0 sCharToNat) (sing :: Sing 'a')
     sNatToCharEx

--- a/singletons-base/tests/compile-and-dump/Singletons/T489.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T489.golden
@@ -44,11 +44,9 @@ Singletons/T489.hs:(0,0)-(0,0): Splicing declarations
       Blah ('Just @a x) = Apply (Apply (:@#@$) (x :: a)) NilSym0
       Blah ('Nothing @a) = NilSym0 :: [a]
     sFlurmp ::
-      (forall (t :: Maybe ()).
-       Sing t -> Sing (Apply FlurmpSym0 t :: ()) :: Type)
+      (forall (t :: Maybe ()). Sing t -> Sing (Flurmp t :: ()) :: Type)
     sBlah ::
-      (forall (t :: Maybe a).
-       Sing t -> Sing (Apply BlahSym0 t :: [a]) :: Type)
+      (forall (t :: Maybe a). Sing t -> Sing (Blah t :: [a]) :: Type)
     sFlurmp (SNothing @_) = STuple0
     sFlurmp (SJust STuple0) = STuple0
     sBlah (SJust @a (sX :: Sing x))

--- a/singletons-base/tests/compile-and-dump/Singletons/T536.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T536.golden
@@ -66,7 +66,7 @@ Singletons/T536.hs:(0,0)-(0,0): Splicing declarations
     type Hello :: PMessage
     type family Hello :: PMessage where
       Hello = Data.Singletons.Apply PMkMessageSym0 (FromString "hello")
-    sHello :: (Data.Singletons.Sing (HelloSym0 :: PMessage) :: Type)
+    sHello :: (Data.Singletons.Sing (Hello :: PMessage) :: Type)
     sHello
       = Data.Singletons.applySing
           (Data.Singletons.singFun1 @PMkMessageSym0 SMkMessage)

--- a/singletons-base/tests/compile-and-dump/Singletons/T54.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T54.golden
@@ -25,14 +25,12 @@ Singletons/T54.hs:(0,0)-(0,0): Splicing declarations
     type G :: Bool -> Bool
     type family G (a :: Bool) :: Bool where
       G e = Apply (Case_0123456789876543210 e (Let0123456789876543210Scrutinee_0123456789876543210Sym0 e)) e
-    sG ::
-      (forall (t :: Bool).
-       Sing t -> Sing (Apply GSym0 t :: Bool) :: Type)
+    sG :: (forall (t :: Bool). Sing t -> Sing (G t :: Bool) :: Type)
     sG (sE :: Sing e)
       = applySing
           (let
              sScrutinee_0123456789876543210 ::
-               Sing @_ (Let0123456789876543210Scrutinee_0123456789876543210Sym0 e)
+               Sing @_ (Let0123456789876543210Scrutinee_0123456789876543210 e)
              sScrutinee_0123456789876543210
                = applySing
                    (applySing (singFun2 @(:@#@$) SCons) (singFun1 @NotSym0 sNot)) SNil

--- a/singletons-base/tests/compile-and-dump/Singletons/T555.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T555.golden
@@ -20,31 +20,8 @@ Singletons/T555.hs:(0,0)-(0,0): Splicing declarations
       TFHelper_0123456789876543210 Location Quaternion = FalseSym0
       TFHelper_0123456789876543210 Quaternion Location = FalseSym0
       TFHelper_0123456789876543210 Quaternion Quaternion = TrueSym0
-    type TFHelper_0123456789876543210Sym0 :: (~>) MyPropKind ((~>) MyPropKind Bool)
-    data TFHelper_0123456789876543210Sym0 :: (~>) MyPropKind ((~>) MyPropKind Bool)
-      where
-        TFHelper_0123456789876543210Sym0KindInference :: SameKind (Apply TFHelper_0123456789876543210Sym0 arg) (TFHelper_0123456789876543210Sym1 arg) =>
-                                                         TFHelper_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @MyPropKind @((~>) MyPropKind Bool) TFHelper_0123456789876543210Sym0 a0123456789876543210 = TFHelper_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings TFHelper_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym0KindInference ())
-    type TFHelper_0123456789876543210Sym1 :: MyPropKind
-                                             -> (~>) MyPropKind Bool
-    data TFHelper_0123456789876543210Sym1 (a0123456789876543210 :: MyPropKind) :: (~>) MyPropKind Bool
-      where
-        TFHelper_0123456789876543210Sym1KindInference :: SameKind (Apply (TFHelper_0123456789876543210Sym1 a0123456789876543210) arg) (TFHelper_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                         TFHelper_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @MyPropKind @Bool (TFHelper_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (TFHelper_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) TFHelper_0123456789876543210Sym1KindInference ())
-    type TFHelper_0123456789876543210Sym2 :: MyPropKind
-                                             -> MyPropKind -> Bool
-    type family TFHelper_0123456789876543210Sym2 (a0123456789876543210 :: MyPropKind) (a0123456789876543210 :: MyPropKind) :: Bool where
-      TFHelper_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = TFHelper_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PEq MyPropKind where
-      type (==) a a = Apply (Apply TFHelper_0123456789876543210Sym0 a) a
+      type (==) a a = TFHelper_0123456789876543210 a a
     type Compare_0123456789876543210 :: MyPropKind
                                         -> MyPropKind -> Ordering
     type family Compare_0123456789876543210 (a :: MyPropKind) (a :: MyPropKind) :: Ordering where
@@ -52,71 +29,15 @@ Singletons/T555.hs:(0,0)-(0,0): Splicing declarations
       Compare_0123456789876543210 Quaternion Quaternion = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
       Compare_0123456789876543210 Location Quaternion = LTSym0
       Compare_0123456789876543210 Quaternion Location = GTSym0
-    type Compare_0123456789876543210Sym0 :: (~>) MyPropKind ((~>) MyPropKind Ordering)
-    data Compare_0123456789876543210Sym0 :: (~>) MyPropKind ((~>) MyPropKind Ordering)
-      where
-        Compare_0123456789876543210Sym0KindInference :: SameKind (Apply Compare_0123456789876543210Sym0 arg) (Compare_0123456789876543210Sym1 arg) =>
-                                                        Compare_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @MyPropKind @((~>) MyPropKind Ordering) Compare_0123456789876543210Sym0 a0123456789876543210 = Compare_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings Compare_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym0KindInference ())
-    type Compare_0123456789876543210Sym1 :: MyPropKind
-                                            -> (~>) MyPropKind Ordering
-    data Compare_0123456789876543210Sym1 (a0123456789876543210 :: MyPropKind) :: (~>) MyPropKind Ordering
-      where
-        Compare_0123456789876543210Sym1KindInference :: SameKind (Apply (Compare_0123456789876543210Sym1 a0123456789876543210) arg) (Compare_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                        Compare_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @MyPropKind @Ordering (Compare_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Compare_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Compare_0123456789876543210Sym1KindInference ())
-    type Compare_0123456789876543210Sym2 :: MyPropKind
-                                            -> MyPropKind -> Ordering
-    type family Compare_0123456789876543210Sym2 (a0123456789876543210 :: MyPropKind) (a0123456789876543210 :: MyPropKind) :: Ordering where
-      Compare_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = Compare_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance POrd MyPropKind where
-      type Compare a a = Apply (Apply Compare_0123456789876543210Sym0 a) a
+      type Compare a a = Compare_0123456789876543210 a a
     type ShowsPrec_0123456789876543210 :: GHC.Num.Natural.Natural
                                           -> MyPropKind -> Symbol -> Symbol
     type family ShowsPrec_0123456789876543210 (a :: GHC.Num.Natural.Natural) (a :: MyPropKind) (a :: Symbol) :: Symbol where
       ShowsPrec_0123456789876543210 _ Location a_0123456789876543210 = Apply (Apply ShowStringSym0 "Location") a_0123456789876543210
       ShowsPrec_0123456789876543210 _ Quaternion a_0123456789876543210 = Apply (Apply ShowStringSym0 "Quaternion") a_0123456789876543210
-    type ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) MyPropKind ((~>) Symbol Symbol))
-    data ShowsPrec_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural ((~>) MyPropKind ((~>) Symbol Symbol))
-      where
-        ShowsPrec_0123456789876543210Sym0KindInference :: SameKind (Apply ShowsPrec_0123456789876543210Sym0 arg) (ShowsPrec_0123456789876543210Sym1 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @GHC.Num.Natural.Natural @((~>) MyPropKind ((~>) Symbol Symbol)) ShowsPrec_0123456789876543210Sym0 a0123456789876543210 = ShowsPrec_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings ShowsPrec_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym0KindInference ())
-    type ShowsPrec_0123456789876543210Sym1 :: GHC.Num.Natural.Natural
-                                              -> (~>) MyPropKind ((~>) Symbol Symbol)
-    data ShowsPrec_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Num.Natural.Natural) :: (~>) MyPropKind ((~>) Symbol Symbol)
-      where
-        ShowsPrec_0123456789876543210Sym1KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @MyPropKind @((~>) Symbol Symbol) (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym1KindInference ())
-    type ShowsPrec_0123456789876543210Sym2 :: GHC.Num.Natural.Natural
-                                              -> MyPropKind -> (~>) Symbol Symbol
-    data ShowsPrec_0123456789876543210Sym2 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: MyPropKind) :: (~>) Symbol Symbol
-      where
-        ShowsPrec_0123456789876543210Sym2KindInference :: SameKind (Apply (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) arg) (ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                                          ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @Symbol @Symbol (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ShowsPrec_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) ShowsPrec_0123456789876543210Sym2KindInference ())
-    type ShowsPrec_0123456789876543210Sym3 :: GHC.Num.Natural.Natural
-                                              -> MyPropKind -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210Sym3 (a0123456789876543210 :: GHC.Num.Natural.Natural) (a0123456789876543210 :: MyPropKind) (a0123456789876543210 :: Symbol) :: Symbol where
-      ShowsPrec_0123456789876543210Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ShowsPrec_0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PShow MyPropKind where
-      type ShowsPrec a a a = Apply (Apply (Apply ShowsPrec_0123456789876543210Sym0 a) a) a
+      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
     data SMyPropKind :: MyPropKind -> Type
       where
         SLocation :: SMyPropKind (Location :: MyPropKind)

--- a/singletons-base/tests/compile-and-dump/Singletons/T563.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T563.golden
@@ -53,8 +53,7 @@ Singletons/T563.hs:(0,0)-(0,0): Splicing declarations
     type family UnFoo' (a :: Foo) :: Bool where
       UnFoo' a_0123456789876543210 = Apply UnFooSym0 a_0123456789876543210
     sUnFoo' ::
-      (forall (t :: Foo).
-       Sing t -> Sing (Apply UnFoo'Sym0 t :: Bool) :: Type)
+      (forall (t :: Foo). Sing t -> Sing (UnFoo' t :: Bool) :: Type)
     sUnFoo' (sA_0123456789876543210 :: Sing a_0123456789876543210)
       = applySing sUnFoo sA_0123456789876543210
     instance SingI (UnFoo'Sym0 :: (~>) Foo Bool) where

--- a/singletons-base/tests/compile-and-dump/Singletons/T571.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T571.golden
@@ -19,8 +19,7 @@ Singletons/T571.hs:(0,0)-(0,0): Splicing declarations
     type F :: a -> a
     type family F @a (a :: a) :: a where
       F x = x
-    sF ::
-      (forall (t :: a). Sing t -> Sing (Apply FSym0 t :: a) :: Type)
+    sF :: (forall (t :: a). Sing t -> Sing (F t :: a) :: Type)
     sF (sX :: Sing x) = sX
     instance SingI (FSym0 :: (~>) a a) where
       sing = singFun1 @FSym0 sF
@@ -55,7 +54,7 @@ Singletons/T571.hs:(0,0)-(0,0): Splicing declarations
       G f x = Apply f x
     sG ::
       (forall (t :: (~>) a a) (t :: a).
-       Sing t -> Sing t -> Sing (Apply (Apply GSym0 t) t :: a) :: Type)
+       Sing t -> Sing t -> Sing (G t t :: a) :: Type)
     sG (sF :: Sing f) (sX :: Sing x) = applySing sF sX
     instance SingI (GSym0 :: (~>) ((~>) a a) ((~>) a a)) where
       sing = singFun2 @GSym0 sG

--- a/singletons-base/tests/compile-and-dump/Singletons/T581.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T581.golden
@@ -168,52 +168,43 @@ Singletons/T581.hs:(0,0)-(0,0): Splicing declarations
     instance PC3 [a] where
       type M3 a a = M3_0123456789876543210 a a
     class SC1 a where
-      sM1 ::
-        forall b (t :: a). Sing t -> Sing (Apply M1Sym0 t :: Maybe (a, b))
+      sM1 :: forall b (t :: a). Sing t -> Sing (M1 t :: Maybe (a, b))
       default sM1 ::
                 forall b (t :: a). ((M1 t :: Maybe (a, b))
                                     ~ M1_0123456789876543210 t) =>
-                                   Sing t -> Sing (Apply M1Sym0 t :: Maybe (a, b))
+                                   Sing t -> Sing (M1 t :: Maybe (a, b))
       sM1 _ = SNothing :: Sing (NothingSym0 :: Maybe (a, b))
     class SC2 a where
-      sM2 ::
-        (forall (t :: b).
-         Sing t -> Sing (Apply M2Sym0 t :: Maybe a) :: Type)
+      sM2 :: (forall (t :: b). Sing t -> Sing (M2 t :: Maybe a) :: Type)
       default sM2 ::
                 (forall (t :: b).
                  ((M2 t :: Maybe a) ~ M2_0123456789876543210 t) =>
-                 Sing t -> Sing (Apply M2Sym0 t :: Maybe a) :: Type)
+                 Sing t -> Sing (M2 t :: Maybe a) :: Type)
       sM2 _ = SNothing :: Sing (NothingSym0 :: Maybe a)
     class SC3 a where
       sM3 ::
         forall b (t :: a) (t :: b). Sing t
-                                    -> Sing t -> Sing (Apply (Apply M3Sym0 t) t :: (a, b))
+                                    -> Sing t -> Sing (M3 t t :: (a, b))
       default sM3 ::
                 forall b (t :: a) (t :: b). ((M3 t t :: (a, b))
                                              ~ M3_0123456789876543210 t t) =>
-                                            Sing t
-                                            -> Sing t -> Sing (Apply (Apply M3Sym0 t) t :: (a, b))
+                                            Sing t -> Sing t -> Sing (M3 t t :: (a, b))
       sM3 (sX :: Sing x) (sY :: Sing y)
         = applySing (applySing (singFun2 @Tuple2Sym0 STuple2) sX) sY ::
             Sing (Apply (Apply Tuple2Sym0 x) y :: (a, b))
     instance SC1 [a] where
-      sM1 ::
-        forall b (t :: [a]). Sing t
-                             -> Sing (Apply M1Sym0 t :: Maybe ([a], b))
+      sM1 :: forall b (t :: [a]). Sing t -> Sing (M1 t :: Maybe ([a], b))
       sM1 _ = SNothing :: Sing (NothingSym0 :: Maybe ([a], b))
     instance SC2 [a] where
       sM2 ::
-        (forall (t :: b).
-         Sing t -> Sing (Apply M2Sym0 t :: Maybe [a]) :: Type)
+        (forall (t :: b). Sing t -> Sing (M2 t :: Maybe [a]) :: Type)
       sM2 _ = SNothing :: Sing (NothingSym0 :: Maybe [a])
     instance SC2 (Maybe a) where
       sM2 _ = SNothing :: Sing (NothingSym0 :: Maybe (Maybe a))
     instance SC3 (Maybe a) where
       sM3 ::
         (forall (t :: Maybe a) (t :: b).
-         Sing t
-         -> Sing t
-            -> Sing (Apply (Apply M3Sym0 t) t :: (Maybe a, b)) :: Type)
+         Sing t -> Sing t -> Sing (M3 t t :: (Maybe a, b)) :: Type)
       sM3 (sX :: Sing x) (sY :: Sing y)
         = applySing
             (applySing

--- a/singletons-base/tests/compile-and-dump/Singletons/T581.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T581.golden
@@ -63,24 +63,9 @@ Singletons/T581.hs:(0,0)-(0,0): Splicing declarations
     type family M1_0123456789876543210 @a @b (a :: a) :: Maybe (a,
                                                                 b) where
       M1_0123456789876543210 @a @b (_ :: a) = NothingSym0 :: Maybe (a, b)
-    type M1_0123456789876543210Sym0 :: forall a b. (~>) a (Maybe (a,
-                                                                  b))
-    data M1_0123456789876543210Sym0 :: (~>) a (Maybe (a, b))
-      where
-        M1_0123456789876543210Sym0KindInference :: SameKind (Apply M1_0123456789876543210Sym0 arg) (M1_0123456789876543210Sym1 arg) =>
-                                                   M1_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @a @(Maybe (a,
-                                    b)) M1_0123456789876543210Sym0 a0123456789876543210 = M1_0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings M1_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) M1_0123456789876543210Sym0KindInference ())
-    type M1_0123456789876543210Sym1 :: forall a b. a -> Maybe (a, b)
-    type family M1_0123456789876543210Sym1 @a @b (a0123456789876543210 :: a) :: Maybe (a,
-                                                                                       b) where
-      M1_0123456789876543210Sym1 a0123456789876543210 = M1_0123456789876543210 a0123456789876543210
     class PC1 a where
       type family M1 (arg :: a) :: Maybe (a, b)
-      type M1 a = Apply M1_0123456789876543210Sym0 a
+      type M1 a = M1_0123456789876543210 a
     type M2Sym0 :: forall b a. (~>) b (Maybe a)
     data M2Sym0 :: (~>) b (Maybe a)
       where
@@ -95,21 +80,9 @@ Singletons/T581.hs:(0,0)-(0,0): Splicing declarations
     type M2_0123456789876543210 :: forall b a. b -> Maybe a
     type family M2_0123456789876543210 @b @a (a :: b) :: Maybe a where
       M2_0123456789876543210 @b @a (_ :: b) = NothingSym0 :: Maybe a
-    type M2_0123456789876543210Sym0 :: forall b a. (~>) b (Maybe a)
-    data M2_0123456789876543210Sym0 :: (~>) b (Maybe a)
-      where
-        M2_0123456789876543210Sym0KindInference :: SameKind (Apply M2_0123456789876543210Sym0 arg) (M2_0123456789876543210Sym1 arg) =>
-                                                   M2_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @b @(Maybe a) M2_0123456789876543210Sym0 a0123456789876543210 = M2_0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings M2_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) M2_0123456789876543210Sym0KindInference ())
-    type M2_0123456789876543210Sym1 :: forall b a. b -> Maybe a
-    type family M2_0123456789876543210Sym1 @b @a (a0123456789876543210 :: b) :: Maybe a where
-      M2_0123456789876543210Sym1 a0123456789876543210 = M2_0123456789876543210 a0123456789876543210
     class PC2 a where
       type family M2 (arg :: b) :: Maybe a
-      type M2 a = Apply M2_0123456789876543210Sym0 a
+      type M2 a = M2_0123456789876543210 a
     type M3Sym0 :: forall a b. (~>) a ((~>) b (a, b))
     data M3Sym0 :: (~>) a ((~>) b (a, b))
       where
@@ -137,93 +110,26 @@ Singletons/T581.hs:(0,0)-(0,0): Splicing declarations
                                                                    b) where
       M3_0123456789876543210 @a @b (x :: a) (y :: b) = Apply (Apply Tuple2Sym0 x) y :: (a,
                                                                                         b)
-    type M3_0123456789876543210Sym0 :: forall a b. (~>) a ((~>) b (a,
-                                                                   b))
-    data M3_0123456789876543210Sym0 :: (~>) a ((~>) b (a, b))
-      where
-        M3_0123456789876543210Sym0KindInference :: SameKind (Apply M3_0123456789876543210Sym0 arg) (M3_0123456789876543210Sym1 arg) =>
-                                                   M3_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @a @((~>) b (a,
-                                     b)) M3_0123456789876543210Sym0 a0123456789876543210 = M3_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings M3_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) M3_0123456789876543210Sym0KindInference ())
-    type M3_0123456789876543210Sym1 :: forall a b. a -> (~>) b (a, b)
-    data M3_0123456789876543210Sym1 (a0123456789876543210 :: a) :: (~>) b (a,
-                                                                           b)
-      where
-        M3_0123456789876543210Sym1KindInference :: SameKind (Apply (M3_0123456789876543210Sym1 a0123456789876543210) arg) (M3_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                   M3_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @(a,
-                             b) (M3_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = M3_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (M3_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) M3_0123456789876543210Sym1KindInference ())
-    type M3_0123456789876543210Sym2 :: forall a b. a -> b -> (a, b)
-    type family M3_0123456789876543210Sym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: (a,
-                                                                                                             b) where
-      M3_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = M3_0123456789876543210 a0123456789876543210 a0123456789876543210
     class PC3 a where
       type family M3 (arg :: a) (arg :: b) :: (a, b)
-      type M3 a a = Apply (Apply M3_0123456789876543210Sym0 a) a
+      type M3 a a = M3_0123456789876543210 a a
     type M1_0123456789876543210 :: forall a b. [a] -> Maybe ([a], b)
     type family M1_0123456789876543210 @a @b (a :: [a]) :: Maybe ([a],
                                                                   b) where
       M1_0123456789876543210 @a @b (_ :: [a]) = NothingSym0 :: Maybe ([a],
                                                                       b)
-    type M1_0123456789876543210Sym0 :: forall a
-                                              b. (~>) [a] (Maybe ([a], b))
-    data M1_0123456789876543210Sym0 :: (~>) [a] (Maybe ([a], b))
-      where
-        M1_0123456789876543210Sym0KindInference :: SameKind (Apply M1_0123456789876543210Sym0 arg) (M1_0123456789876543210Sym1 arg) =>
-                                                   M1_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @[a] @(Maybe ([a],
-                                      b)) M1_0123456789876543210Sym0 a0123456789876543210 = M1_0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings M1_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) M1_0123456789876543210Sym0KindInference ())
-    type M1_0123456789876543210Sym1 :: forall a b. [a]
-                                                   -> Maybe ([a], b)
-    type family M1_0123456789876543210Sym1 @a @b (a0123456789876543210 :: [a]) :: Maybe ([a],
-                                                                                         b) where
-      M1_0123456789876543210Sym1 a0123456789876543210 = M1_0123456789876543210 a0123456789876543210
     instance PC1 [a] where
-      type M1 a = Apply M1_0123456789876543210Sym0 a
+      type M1 a = M1_0123456789876543210 a
     type M2_0123456789876543210 :: forall b a. b -> Maybe [a]
     type family M2_0123456789876543210 @b @a (a :: b) :: Maybe [a] where
       M2_0123456789876543210 @b @a (_ :: b) = NothingSym0 :: Maybe [a]
-    type M2_0123456789876543210Sym0 :: forall b a. (~>) b (Maybe [a])
-    data M2_0123456789876543210Sym0 :: (~>) b (Maybe [a])
-      where
-        M2_0123456789876543210Sym0KindInference :: SameKind (Apply M2_0123456789876543210Sym0 arg) (M2_0123456789876543210Sym1 arg) =>
-                                                   M2_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @b @(Maybe [a]) M2_0123456789876543210Sym0 a0123456789876543210 = M2_0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings M2_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) M2_0123456789876543210Sym0KindInference ())
-    type M2_0123456789876543210Sym1 :: forall b a. b -> Maybe [a]
-    type family M2_0123456789876543210Sym1 @b @a (a0123456789876543210 :: b) :: Maybe [a] where
-      M2_0123456789876543210Sym1 a0123456789876543210 = M2_0123456789876543210 a0123456789876543210
     instance PC2 [a] where
-      type M2 a = Apply M2_0123456789876543210Sym0 a
+      type M2 a = M2_0123456789876543210 a
     type M2_0123456789876543210 :: forall b a. b -> Maybe (Maybe a)
     type family M2_0123456789876543210 @b @a (a :: b) :: Maybe (Maybe a) where
       M2_0123456789876543210 @b @a (_ :: b) = NothingSym0 :: Maybe (Maybe a)
-    type M2_0123456789876543210Sym0 :: forall b
-                                              a. (~>) b (Maybe (Maybe a))
-    data M2_0123456789876543210Sym0 :: (~>) b (Maybe (Maybe a))
-      where
-        M2_0123456789876543210Sym0KindInference :: SameKind (Apply M2_0123456789876543210Sym0 arg) (M2_0123456789876543210Sym1 arg) =>
-                                                   M2_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @b @(Maybe (Maybe a)) M2_0123456789876543210Sym0 a0123456789876543210 = M2_0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings M2_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) M2_0123456789876543210Sym0KindInference ())
-    type M2_0123456789876543210Sym1 :: forall b a. b -> Maybe (Maybe a)
-    type family M2_0123456789876543210Sym1 @b @a (a0123456789876543210 :: b) :: Maybe (Maybe a) where
-      M2_0123456789876543210Sym1 a0123456789876543210 = M2_0123456789876543210 a0123456789876543210
     instance PC2 (Maybe a) where
-      type M2 a = Apply M2_0123456789876543210Sym0 a
+      type M2 a = M2_0123456789876543210 a
     type family Lambda_0123456789876543210 a0123456789876543210 x0123456789876543210 y0123456789876543210 xx where
       Lambda_0123456789876543210 a x y xx = xx :: a
     data Lambda_0123456789876543210Sym0 a0123456789876543210 x0123456789876543210 y0123456789876543210 xx0123456789876543210
@@ -241,37 +147,8 @@ Singletons/T581.hs:(0,0)-(0,0): Splicing declarations
     type family M3_0123456789876543210 @a @b (a :: Maybe a) (a :: b) :: (Maybe a,
                                                                          b) where
       M3_0123456789876543210 @a @b (x :: Maybe a) (y :: b) = Apply (Apply Tuple2Sym0 (Apply (Apply FmapSym0 (Lambda_0123456789876543210Sym0 a x y)) x)) y
-    type M3_0123456789876543210Sym0 :: forall a
-                                              b. (~>) (Maybe a) ((~>) b (Maybe a, b))
-    data M3_0123456789876543210Sym0 :: (~>) (Maybe a) ((~>) b (Maybe a,
-                                                               b))
-      where
-        M3_0123456789876543210Sym0KindInference :: SameKind (Apply M3_0123456789876543210Sym0 arg) (M3_0123456789876543210Sym1 arg) =>
-                                                   M3_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @(Maybe a) @((~>) b (Maybe a,
-                                             b)) M3_0123456789876543210Sym0 a0123456789876543210 = M3_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings M3_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) M3_0123456789876543210Sym0KindInference ())
-    type M3_0123456789876543210Sym1 :: forall a b. Maybe a
-                                                   -> (~>) b (Maybe a, b)
-    data M3_0123456789876543210Sym1 (a0123456789876543210 :: Maybe a) :: (~>) b (Maybe a,
-                                                                                 b)
-      where
-        M3_0123456789876543210Sym1KindInference :: SameKind (Apply (M3_0123456789876543210Sym1 a0123456789876543210) arg) (M3_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                   M3_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @(Maybe a,
-                             b) (M3_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = M3_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (M3_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) M3_0123456789876543210Sym1KindInference ())
-    type M3_0123456789876543210Sym2 :: forall a b. Maybe a
-                                                   -> b -> (Maybe a, b)
-    type family M3_0123456789876543210Sym2 @a @b (a0123456789876543210 :: Maybe a) (a0123456789876543210 :: b) :: (Maybe a,
-                                                                                                                   b) where
-      M3_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = M3_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PC3 (Maybe a) where
-      type M3 a a = Apply (Apply M3_0123456789876543210Sym0 a) a
+      type M3 a a = M3_0123456789876543210 a a
     type family Lambda_0123456789876543210 a0123456789876543210 x0123456789876543210 y0123456789876543210 xx where
       Lambda_0123456789876543210 a x y xx = xx :: a
     data Lambda_0123456789876543210Sym0 a0123456789876543210 x0123456789876543210 y0123456789876543210 xx0123456789876543210
@@ -288,41 +165,14 @@ Singletons/T581.hs:(0,0)-(0,0): Splicing declarations
     type family M3_0123456789876543210 @a @b (a :: [a]) (a :: b) :: ([a],
                                                                      b) where
       M3_0123456789876543210 @a @b (x :: [a]) (y :: b) = Apply (Apply Tuple2Sym0 (Apply (Apply FmapSym0 (Lambda_0123456789876543210Sym0 a x y)) x)) y
-    type M3_0123456789876543210Sym0 :: forall a
-                                              b. (~>) [a] ((~>) b ([a], b))
-    data M3_0123456789876543210Sym0 :: (~>) [a] ((~>) b ([a], b))
-      where
-        M3_0123456789876543210Sym0KindInference :: SameKind (Apply M3_0123456789876543210Sym0 arg) (M3_0123456789876543210Sym1 arg) =>
-                                                   M3_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @[a] @((~>) b ([a],
-                                       b)) M3_0123456789876543210Sym0 a0123456789876543210 = M3_0123456789876543210Sym1 a0123456789876543210
-    instance SuppressUnusedWarnings M3_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) M3_0123456789876543210Sym0KindInference ())
-    type M3_0123456789876543210Sym1 :: forall a b. [a]
-                                                   -> (~>) b ([a], b)
-    data M3_0123456789876543210Sym1 (a0123456789876543210 :: [a]) :: (~>) b ([a],
-                                                                             b)
-      where
-        M3_0123456789876543210Sym1KindInference :: SameKind (Apply (M3_0123456789876543210Sym1 a0123456789876543210) arg) (M3_0123456789876543210Sym2 a0123456789876543210 arg) =>
-                                                   M3_0123456789876543210Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @([a],
-                             b) (M3_0123456789876543210Sym1 a0123456789876543210) a0123456789876543210 = M3_0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (M3_0123456789876543210Sym1 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) M3_0123456789876543210Sym1KindInference ())
-    type M3_0123456789876543210Sym2 :: forall a b. [a] -> b -> ([a], b)
-    type family M3_0123456789876543210Sym2 @a @b (a0123456789876543210 :: [a]) (a0123456789876543210 :: b) :: ([a],
-                                                                                                               b) where
-      M3_0123456789876543210Sym2 a0123456789876543210 a0123456789876543210 = M3_0123456789876543210 a0123456789876543210 a0123456789876543210
     instance PC3 [a] where
-      type M3 a a = Apply (Apply M3_0123456789876543210Sym0 a) a
+      type M3 a a = M3_0123456789876543210 a a
     class SC1 a where
       sM1 ::
         forall b (t :: a). Sing t -> Sing (Apply M1Sym0 t :: Maybe (a, b))
       default sM1 ::
-                forall b (t :: a). ((Apply M1Sym0 t :: Maybe (a, b))
-                                    ~ Apply M1_0123456789876543210Sym0 t) =>
+                forall b (t :: a). ((M1 t :: Maybe (a, b))
+                                    ~ M1_0123456789876543210 t) =>
                                    Sing t -> Sing (Apply M1Sym0 t :: Maybe (a, b))
       sM1 _ = SNothing :: Sing (NothingSym0 :: Maybe (a, b))
     class SC2 a where
@@ -331,8 +181,7 @@ Singletons/T581.hs:(0,0)-(0,0): Splicing declarations
          Sing t -> Sing (Apply M2Sym0 t :: Maybe a) :: Type)
       default sM2 ::
                 (forall (t :: b).
-                 ((Apply M2Sym0 t :: Maybe a)
-                  ~ Apply M2_0123456789876543210Sym0 t) =>
+                 ((M2 t :: Maybe a) ~ M2_0123456789876543210 t) =>
                  Sing t -> Sing (Apply M2Sym0 t :: Maybe a) :: Type)
       sM2 _ = SNothing :: Sing (NothingSym0 :: Maybe a)
     class SC3 a where
@@ -340,8 +189,8 @@ Singletons/T581.hs:(0,0)-(0,0): Splicing declarations
         forall b (t :: a) (t :: b). Sing t
                                     -> Sing t -> Sing (Apply (Apply M3Sym0 t) t :: (a, b))
       default sM3 ::
-                forall b (t :: a) (t :: b). ((Apply (Apply M3Sym0 t) t :: (a, b))
-                                             ~ Apply (Apply M3_0123456789876543210Sym0 t) t) =>
+                forall b (t :: a) (t :: b). ((M3 t t :: (a, b))
+                                             ~ M3_0123456789876543210 t t) =>
                                             Sing t
                                             -> Sing t -> Sing (Apply (Apply M3Sym0 t) t :: (a, b))
       sM3 (sX :: Sing x) (sY :: Sing y)

--- a/singletons-base/tests/compile-and-dump/Singletons/T582.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T582.golden
@@ -128,11 +128,10 @@ Singletons/T582.hs:(0,0)-(0,0): Splicing declarations
     infixl 4 `sFoo`
     (%%%%) ::
       (forall (t :: a) (t :: a).
-       Sing t
-       -> Sing t -> Sing (Apply (Apply (%%%@#@$) t) t :: a) :: Type)
+       Sing t -> Sing t -> Sing ((%%%) t t :: a) :: Type)
     sFoo ::
       (forall (t :: a) (t :: a).
-       Sing t -> Sing t -> Sing (Apply (Apply FooSym0 t) t :: a) :: Type)
+       Sing t -> Sing t -> Sing (Foo t t :: a) :: Type)
     (%%%%) (sX :: Sing x) _ = sX
     sFoo (sX :: Sing x) _ = sX
     instance SingI ((%%%@#@$) :: (~>) a ((~>) a a)) where

--- a/singletons-base/tests/compile-and-dump/Singletons/T585.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T585.golden
@@ -29,7 +29,7 @@ Singletons/T585.hs:(0,0)-(0,0): Splicing declarations
       Konst @a (x :: a) (_ :: b) = x
     sKonst ::
       forall a {b} (t :: a) (t :: b). Sing t
-                                      -> Sing t -> Sing (Apply (Apply KonstSym0 t) t :: a)
+                                      -> Sing t -> Sing (Konst t t :: a)
     sKonst (sX :: Sing x) _ = sX
     instance SingI (KonstSym0 :: (~>) a ((~>) b a)) where
       sing = singFun2 @KonstSym0 sKonst

--- a/singletons-base/tests/compile-and-dump/Singletons/T78.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T78.golden
@@ -26,8 +26,7 @@ Singletons/T78.hs:(0,0)-(0,0): Splicing declarations
       Foo ('Just 'True) = TrueSym0
       Foo 'Nothing = FalseSym0
     sFoo ::
-      (forall (t :: Maybe Bool).
-       Sing t -> Sing (Apply FooSym0 t :: Bool) :: Type)
+      (forall (t :: Maybe Bool). Sing t -> Sing (Foo t :: Bool) :: Type)
     sFoo (SJust SFalse) = SFalse
     sFoo (SJust STrue) = STrue
     sFoo SNothing = SFalse

--- a/singletons-base/tests/compile-and-dump/Singletons/T89.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T89.golden
@@ -16,38 +16,12 @@ Singletons/T89.hs:0:0:: Splicing declarations
     type ToEnum_0123456789876543210 :: GHC.Num.Natural.Natural -> Foo
     type family ToEnum_0123456789876543210 (a :: GHC.Num.Natural.Natural) :: Foo where
       ToEnum_0123456789876543210 n = Case_0123456789876543210 n (Apply (Apply (==@#@$) n) (FromInteger 0))
-    type ToEnum_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural Foo
-    data ToEnum_0123456789876543210Sym0 :: (~>) GHC.Num.Natural.Natural Foo
-      where
-        ToEnum_0123456789876543210Sym0KindInference :: SameKind (Apply ToEnum_0123456789876543210Sym0 arg) (ToEnum_0123456789876543210Sym1 arg) =>
-                                                       ToEnum_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @GHC.Num.Natural.Natural @Foo ToEnum_0123456789876543210Sym0 a0123456789876543210 = ToEnum_0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ToEnum_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) ToEnum_0123456789876543210Sym0KindInference ())
-    type ToEnum_0123456789876543210Sym1 :: GHC.Num.Natural.Natural
-                                           -> Foo
-    type family ToEnum_0123456789876543210Sym1 (a0123456789876543210 :: GHC.Num.Natural.Natural) :: Foo where
-      ToEnum_0123456789876543210Sym1 a0123456789876543210 = ToEnum_0123456789876543210 a0123456789876543210
     type FromEnum_0123456789876543210 :: Foo -> GHC.Num.Natural.Natural
     type family FromEnum_0123456789876543210 (a :: Foo) :: GHC.Num.Natural.Natural where
       FromEnum_0123456789876543210 Foo = FromInteger 0
-    type FromEnum_0123456789876543210Sym0 :: (~>) Foo GHC.Num.Natural.Natural
-    data FromEnum_0123456789876543210Sym0 :: (~>) Foo GHC.Num.Natural.Natural
-      where
-        FromEnum_0123456789876543210Sym0KindInference :: SameKind (Apply FromEnum_0123456789876543210Sym0 arg) (FromEnum_0123456789876543210Sym1 arg) =>
-                                                         FromEnum_0123456789876543210Sym0 a0123456789876543210
-    type instance Apply @Foo @GHC.Num.Natural.Natural FromEnum_0123456789876543210Sym0 a0123456789876543210 = FromEnum_0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings FromEnum_0123456789876543210Sym0 where
-      suppressUnusedWarnings
-        = snd ((,) FromEnum_0123456789876543210Sym0KindInference ())
-    type FromEnum_0123456789876543210Sym1 :: Foo
-                                             -> GHC.Num.Natural.Natural
-    type family FromEnum_0123456789876543210Sym1 (a0123456789876543210 :: Foo) :: GHC.Num.Natural.Natural where
-      FromEnum_0123456789876543210Sym1 a0123456789876543210 = FromEnum_0123456789876543210 a0123456789876543210
     instance PEnum Foo where
-      type ToEnum a = Apply ToEnum_0123456789876543210Sym0 a
-      type FromEnum a = Apply FromEnum_0123456789876543210Sym0 a
+      type ToEnum a = ToEnum_0123456789876543210 a
+      type FromEnum a = FromEnum_0123456789876543210 a
     data SFoo :: Foo -> Type where SFoo :: SFoo (Foo :: Foo)
     type instance Sing @Foo = SFoo
     instance SingKind Foo where

--- a/singletons-base/tests/compile-and-dump/Singletons/TopLevelPatterns.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/TopLevelPatterns.golden
@@ -277,33 +277,23 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
     type Otherwise :: Bool
     type family Otherwise :: Bool where
       Otherwise = TrueSym0
-    sM :: (Sing (MSym0 :: Bool) :: Type)
-    sL :: (Sing (LSym0 :: Bool) :: Type)
-    sX_0123456789876543210 :: Sing @_ X_0123456789876543210Sym0
-    sK :: (Sing (KSym0 :: Bool) :: Type)
-    sJ :: (Sing (JSym0 :: Bool) :: Type)
-    sX_0123456789876543210 :: Sing @_ X_0123456789876543210Sym0
-    sI ::
-      (forall (t :: Bool).
-       Sing t -> Sing (Apply ISym0 t :: Bool) :: Type)
-    sH ::
-      (forall (t :: Bool).
-       Sing t -> Sing (Apply HSym0 t :: Bool) :: Type)
-    sX_0123456789876543210 :: Sing @_ X_0123456789876543210Sym0
-    sG ::
-      (forall (t :: Bool).
-       Sing t -> Sing (Apply GSym0 t :: Bool) :: Type)
-    sF ::
-      (forall (t :: Bool).
-       Sing t -> Sing (Apply FSym0 t :: Bool) :: Type)
-    sX_0123456789876543210 :: Sing @_ X_0123456789876543210Sym0
-    sFalse_ :: Sing @_ False_Sym0
+    sM :: (Sing (M :: Bool) :: Type)
+    sL :: (Sing (L :: Bool) :: Type)
+    sX_0123456789876543210 :: Sing @_ X_0123456789876543210
+    sK :: (Sing (K :: Bool) :: Type)
+    sJ :: (Sing (J :: Bool) :: Type)
+    sX_0123456789876543210 :: Sing @_ X_0123456789876543210
+    sI :: (forall (t :: Bool). Sing t -> Sing (I t :: Bool) :: Type)
+    sH :: (forall (t :: Bool). Sing t -> Sing (H t :: Bool) :: Type)
+    sX_0123456789876543210 :: Sing @_ X_0123456789876543210
+    sG :: (forall (t :: Bool). Sing t -> Sing (G t :: Bool) :: Type)
+    sF :: (forall (t :: Bool). Sing t -> Sing (F t :: Bool) :: Type)
+    sX_0123456789876543210 :: Sing @_ X_0123456789876543210
+    sFalse_ :: Sing @_ False_
     sNot ::
-      (forall (t :: Bool).
-       Sing t -> Sing (Apply NotSym0 t :: Bool) :: Type)
-    sId ::
-      (forall (t :: a). Sing t -> Sing (Apply IdSym0 t :: a) :: Type)
-    sOtherwise :: (Sing (OtherwiseSym0 :: Bool) :: Type)
+      (forall (t :: Bool). Sing t -> Sing (Not t :: Bool) :: Type)
+    sId :: (forall (t :: a). Sing t -> Sing (Id t :: a) :: Type)
+    sOtherwise :: (Sing (Otherwise :: Bool) :: Type)
     sM
       = GHC.Internal.Base.id
           @(Sing (Case_0123456789876543210 X_0123456789876543210Sym0))

--- a/singletons-base/tests/compile-and-dump/Singletons/TypeAbstractions.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/TypeAbstractions.golden
@@ -265,17 +265,17 @@ Singletons/TypeAbstractions.hs:(0,0)-(0,0): Splicing declarations
     class SC1 @j @k (a :: j) (b :: k) where
       sMeth1 ::
         (forall (t :: Proxy a).
-         Sing t -> Sing (Apply Meth1Sym0 t :: Proxy b) :: Type)
+         Sing t -> Sing (Meth1 t :: Proxy b) :: Type)
     class SC2 @x @y (a :: x) (b :: y) where
       sMeth2 ::
         (forall (t :: Proxy a).
-         Sing t -> Sing (Apply Meth2Sym0 t :: Proxy b) :: Type)
+         Sing t -> Sing (Meth2 t :: Proxy b) :: Type)
     class SC3 @j (a :: j) @k (b :: k) where
       sMeth3 ::
         (forall (t :: Proxy a).
-         Sing t -> Sing (Apply Meth3Sym0 t :: Proxy b) :: Type)
+         Sing t -> Sing (Meth3 t :: Proxy b) :: Type)
     class SC4 @a where
-      sMeth4 :: (Sing (Meth4Sym0 :: a) :: Type)
+      sMeth4 :: (Sing (Meth4 :: a) :: Type)
     instance (SingI n, SingI n) =>
              SingI (MkD1 (n :: Proxy a) (n :: Proxy b)) where
       sing = SMkD1 sing sing

--- a/singletons-base/tests/compile-and-dump/Singletons/Undef.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Undef.golden
@@ -38,11 +38,9 @@ Singletons/Undef.hs:(0,0)-(0,0): Splicing declarations
     type family Foo (a :: Bool) :: Bool where
       Foo a_0123456789876543210 = Apply UndefinedSym0 a_0123456789876543210
     sBar ::
-      (forall (t :: Bool).
-       Sing t -> Sing (Apply BarSym0 t :: Bool) :: Type)
+      (forall (t :: Bool). Sing t -> Sing (Bar t :: Bool) :: Type)
     sFoo ::
-      (forall (t :: Bool).
-       Sing t -> Sing (Apply FooSym0 t :: Bool) :: Type)
+      (forall (t :: Bool). Sing t -> Sing (Foo t :: Bool) :: Type)
     sBar (sA_0123456789876543210 :: Sing a_0123456789876543210)
       = applySing
           (applySing (singFun1 @ErrorSym0 sError) (sing :: Sing "urk"))

--- a/singletons-th/src/Data/Singletons/TH/Promote/Monad.hs
+++ b/singletons-th/src/Data/Singletons/TH/Promote/Monad.hs
@@ -100,8 +100,9 @@ lambdaBind binds = local add_binds
               , pr_local_vars  = new_locals          `OMap.union` locals }
 
 -- ^ A pair consisting of a term-level 'Name' of a variable, bound in a @let@
--- binding or @where@ clause, and its type-level counterpart.
--- See @Note [Tracking local variables]@.
+-- binding or @where@ clause, and its type-level counterpart. The type will
+-- always be a defunctionalization symbol so that it can be partially applied if
+-- necessary. See @Note [Tracking local variables]@.
 type LetBind = (Name, DType)
 
 -- ^ Bring a list of 'LetBind's into scope for the duration the supplied

--- a/singletons-th/src/Data/Singletons/TH/Single.hs
+++ b/singletons-th/src/Data/Singletons/TH/Single.hs
@@ -446,13 +446,13 @@ singClassD (ClassDecl { cd_cxt  = cls_cxt
       -- Which applies Bar/BarDefault to b, which shouldn't happen.
       let tvs = map tvbToType $
                 filter (\tvb -> extractTvbName tvb `Set.member` bound_kv_set) tvbs
-          prom_meth =  DConT $ defunctionalizedName0 opts meth_name
+          prom_meth = DConT $ promotedValueName opts meth_name Nothing
           default_pred = foldType (DConT equalityName)
                                 -- NB: Need the res_ki here to prevent ambiguous
                                 -- kinds in result-inferred default methods.
                                 -- See #175
-                               [ foldApply prom_meth tvs `DSigT` res_ki
-                               , foldApply prom_dflt tvs ]
+                               [ foldType prom_meth tvs `DSigT` res_ki
+                               , foldType prom_dflt tvs ]
       return $ ravelVanillaDType tvbs (default_pred : cxt) args res
       where
         bound_kv_set = Set.fromList bound_kvs

--- a/singletons-th/src/Data/Singletons/TH/Single/Type.hs
+++ b/singletons-th/src/Data/Singletons/TH/Single/Type.hs
@@ -33,7 +33,7 @@ singType prom ty = do
   prom_args <- mapM promoteType_NC args
   prom_res  <- promoteType_NC res
   let args' = map (\n -> singFamily `DAppT` (DVarT n)) arg_names
-      res'  = singFamily `DAppT` (foldApply prom (map DVarT arg_names) `DSigT` prom_res)
+      res'  = singFamily `DAppT` (foldType prom (map DVarT arg_names) `DSigT` prom_res)
                 -- Make sure to include an explicit `prom_res` kind annotation.
                 -- See Note [Preserve the order of type variables during singling],
                 -- wrinkle 3.

--- a/singletons-th/src/Data/Singletons/TH/Syntax.hs
+++ b/singletons-th/src/Data/Singletons/TH/Syntax.hs
@@ -155,11 +155,28 @@ data instance LetDecRHS Unannotated = UFunction [DClause]
 type ALetDecRHS = LetDecRHS Annotated
 type ULetDecRHS = LetDecRHS Unannotated
 
+-- | A @let@-bound, term-level name that is promoted to the type level. The
+-- first element of the pair (of type 'Name') is the promoted counterpart to the
+-- term-level name, and the second element of the pair (of type @[Name]@) is the
+-- list of local variables that this definition closes over after being
+-- lambda-lifted. (See @Note [Tracking local variables]@ in
+-- "Data.Singletons.TH.Promote.Monad".)
+--
+-- Note that the promoted Name in the first element of the pair is /not/ a
+-- defunctionalization symbol, unlike 'LetBind' in
+-- "Data.Singletons.TH.Promote.Monad". This is because it is sometimes
+-- convenient to fully apply the promoted name to all of its arguments (e.g.,
+-- when singling type signatures), in which case we can avoid needing to involve
+-- defunctionalization symbols at all.
+type LetDecProm = (Name, [Name])
+
 data LetDecEnv ann = LetDecEnv
                    { lde_defns :: OMap Name (LetDecRHS ann)
                    , lde_types :: OMap Name DType  -- type signatures
                    , lde_infix :: OMap Name (Fixity, NamespaceSpecifier) -- infix declarations
-                   , lde_proms :: IfAnn ann (OMap Name DType) () -- possibly, promotions
+                   , lde_proms :: IfAnn ann (OMap Name LetDecProm) ()
+                     -- ^ If annotated, this maps let-bound term 'Name's to
+                     -- their promoted counterparts.
                    }
 type ALetDecEnv = LetDecEnv Annotated
 type ULetDecEnv = LetDecEnv Unannotated


### PR DESCRIPTION
`singletons-th` generates "helper" type families that contain the definitions of class method defaults or instance methods. For example, this:

```hs
class C a where
  m :: a -> b -> a
  m x _ = x
```

Will be promoted to this:

```hs
class PC a where
  type M (x :: a) (y :: b) :: a
  type M x y = MHelperSym0 `Apply` x `Apply` y

type MHelper :: a -> b -> a
type family MHelper x y where
  MHelper x _ = x

type MHelperSym0 :: a ~> b ~> a
type MHelperSym1 :: a -> b ~> a
...
```

Generating defunctionalization symbols for `MHelper` is wasteful, however, as we never really _need_ to partially apply `MHelper`. Instead, we can just generate this code:

```hs
class PC a where
  type M (x :: a) (y :: b) :: a
  type M x y = MHelper x y
```

This takes advantage of the fact that when we apply `MHelper`, we always fully apply it to all of its arguments. This means that we can avoid generating defunctionalization symbols for helper type families altogether, which is a nice optimization.

This patch implements that idea, fixing #608 in the process.