### PR TITLE
Give `asum`, `msum`, and `Product` instances explicit kind signatures

### DIFF
--- a/singletons-base/CHANGES.md
+++ b/singletons-base/CHANGES.md
@@ -55,6 +55,20 @@ next [????.??.??]
   `PAlternative` instances for `Compose`. The fact that these instances were so
   polymorphic to begin with was an oversight, as these instances could not be
   used when `k` was instantiated to any other kind besides `Type`.
+* The kinds of `Asum` and `Msum` are less polymorphic than they were before:
+
+  ```diff
+  -type Asum :: forall {j} {k} (t :: k    -> Type) (f :: j    -> k)    (a :: j).    t (f a) -> f a
+  +type Asum :: forall         (t :: Type -> Type) (f :: Type -> Type) (a :: Type). t (f a) -> f a
+
+  -type Msum :: forall {j} {k} (t :: k    -> Type) (m :: j    -> k)    (a :: j).    t (m a) -> m a
+  +type Msum :: forall         (t :: Type -> Type) (m :: Type -> Type) (a :: Type). t (m a) -> m a
+  ```
+
+  Similarly, the kinds of defunctionalization symbols for these definitions
+  (e.g., `AsumSym0` and `MSym0`) are less polymorphic. The fact that these were
+  kind-polymorphic to begin with was an oversight, as these definitions could
+  not be used when `j` or `k` was instantiated to any other kind besides `Type`.
 
 3.4 [2024.05.12]
 ----------------


### PR DESCRIPTION
This adds more explicit `Type -> Type` kind signatures to definitions that would otherwise be kind-generalized to have overly polymorphic kinds:

* The kinds of `Asum` and `Msum` (the promoted counterparts to the term-level `asum` and `msum` functions, respectively).
* The helper type families generated when promoting the `Alternative` and `MonadPlus` instances for `Data.Functor.Product`. This sort of kind polymorphism isn't observable by users in today's GHC, but it will cause problems later in a future version of GHC that implements [GHC#23515](https://gitlab.haskell.org/ghc/ghc/-/issues/23515). (See #601.)

(I should have added these as part of #606 or #607, but I forgot them due to an oversight.)