### PR TITLE
`singletons-th`: Make `pr_scoped_vars` a list of `LocalVar`s, not `Name`s

### DIFF
--- a/singletons-base/tests/SingletonsBaseTestSuite.hs
+++ b/singletons-base/tests/SingletonsBaseTestSuite.hs
@@ -168,6 +168,7 @@ tests =
     , compileAndDumpStdTest "T361"
     , compileAndDumpStdTest "T601a"
     , compileAndDumpStdTest "T605"
+    , compileAndDumpStdTest "T613"
     ],
     testGroup "Database client"
     [ compileAndDumpTest "GradingClient/Database" ghcOpts

--- a/singletons-base/tests/compile-and-dump/Promote/T613.golden
+++ b/singletons-base/tests/compile-and-dump/Promote/T613.golden
@@ -1,0 +1,31 @@
+Promote/T613.hs:(0,0)-(0,0): Splicing declarations
+    promote
+      [d| f :: forall k (a :: k). Proxy a -> Proxy a
+          f x
+            = y
+            where
+                y = x |]
+  ======>
+    f :: forall k (a :: k). Proxy a -> Proxy a
+    f x
+      = y
+      where
+          y = x
+    type family Let0123456789876543210YSym0 k0123456789876543210 (a0123456789876543210 :: k0123456789876543210) (x0123456789876543210 :: Proxy a0123456789876543210) where
+      Let0123456789876543210YSym0 k0123456789876543210 a0123456789876543210 x0123456789876543210 = Let0123456789876543210Y k0123456789876543210 a0123456789876543210 x0123456789876543210
+    type family Let0123456789876543210Y k0123456789876543210 (a0123456789876543210 :: k0123456789876543210) (x0123456789876543210 :: Proxy a0123456789876543210) where
+      Let0123456789876543210Y k a x = x
+    type FSym0 :: forall k (a :: k). (~>) (Proxy a) (Proxy a)
+    data FSym0 :: (~>) (Proxy a) (Proxy a)
+      where
+        FSym0KindInference :: SameKind (Apply FSym0 arg) (FSym1 arg) =>
+                              FSym0 a0123456789876543210
+    type instance Apply @(Proxy a) @(Proxy a) FSym0 a0123456789876543210 = F a0123456789876543210
+    instance SuppressUnusedWarnings FSym0 where
+      suppressUnusedWarnings = snd ((,) FSym0KindInference ())
+    type FSym1 :: forall k (a :: k). Proxy a -> Proxy a
+    type family FSym1 @k @(a :: k) (a0123456789876543210 :: Proxy a) :: Proxy a where
+      FSym1 a0123456789876543210 = F a0123456789876543210
+    type F :: forall k (a :: k). Proxy a -> Proxy a
+    type family F @k @(a :: k) (a :: Proxy a) :: Proxy a where
+      F @k @a (x :: Proxy a) = Let0123456789876543210YSym0 k a x

--- a/singletons-base/tests/compile-and-dump/Promote/T613.hs
+++ b/singletons-base/tests/compile-and-dump/Promote/T613.hs
@@ -1,0 +1,12 @@
+module T613 where
+
+import Data.Proxy
+import Data.Proxy.Singletons
+import Data.Singletons.TH
+
+$(promote [d|
+  f :: forall k (a :: k). Proxy a -> Proxy a
+  f x = y
+    where
+      y = x
+  |])

--- a/singletons-th/src/Data/Singletons/TH/Promote.hs
+++ b/singletons-th/src/Data/Singletons/TH/Promote.hs
@@ -1393,7 +1393,8 @@ promotePat _ (DLitP lit) = (, ADLitP lit) <$> promoteLitPat lit
 promotePat m_ki (DVarP name) = do
       -- term vars can be symbols... type vars can't!
   tyName <- mkTyName name
-  tell $ PromDPatInfos [(name, (tyName, m_ki))] OSet.empty
+  let lv = LocalVar { lvName = tyName, lvKind = m_ki }
+  tell $ PromDPatInfos [(name, lv)] OSet.empty
   return (DVarT tyName, ADVarP name)
 promotePat _ (DConP name tys pats) = do
   opts <- getOptions
@@ -1584,7 +1585,8 @@ dTypeFamilyHead_with_locals tf_nm local_vars arg_tvbs res_sig =
     -- Ensure that all references to local_nms are substituted away.
     subst1 = Map.fromList $
              zipWith
-               (\(local_nm, _) (local_nm', _) -> (local_nm, DVarT local_nm'))
+               (\(LocalVar { lvName = local_nm }) (LocalVar { lvName = local_nm' }) ->
+                 (local_nm, DVarT local_nm'))
                local_vars
                local_vars'
     (subst2, arg_tvbs') = substTvbs subst1 arg_tvbs

--- a/singletons-th/src/Data/Singletons/TH/Single.hs
+++ b/singletons-th/src/Data/Singletons/TH/Single.hs
@@ -725,7 +725,7 @@ singPat var_proms = go
       tyname <- case Map.lookup name var_proms of
                   Nothing     ->
                     fail "Internal error: unknown variable when singling pattern"
-                  Just (tyname, _) -> return tyname
+                  Just (LocalVar { lvName = tyname }) -> return tyname
       pure $ DVarP (singledValueName opts name)
                `DSigP` (singFamily `DAppT` DVarT tyname)
     go (ADConP name tys pats) = do

--- a/singletons-th/src/Data/Singletons/TH/Syntax.hs
+++ b/singletons-th/src/Data/Singletons/TH/Syntax.hs
@@ -33,7 +33,7 @@ type VarPromotions = [(Name, LocalVar)]
 data PromDPatInfos = PromDPatInfos
   { prom_dpat_vars    :: VarPromotions
       -- Maps term-level pattern variables to their promoted, type-level counterparts.
-  , prom_dpat_sig_kvs :: OSet Name
+  , prom_dpat_sig_kvs :: OSet LocalVar
       -- Kind variables bound by DSigPas.
       -- See Note [Scoped type variables] in Data.Singletons.TH.Promote.Monad.
   }

--- a/singletons-th/src/Data/Singletons/TH/Util.hs
+++ b/singletons-th/src/Data/Singletons/TH/Util.hs
@@ -453,7 +453,8 @@ noExactTyVars = everywhere go
       = InjectivityAnn (noExactName lhs) (map noExactName rhs)
 
     fix_local_var :: LocalVar -> LocalVar
-    fix_local_var (n, mbKind) = (noExactName n, mbKind)
+    fix_local_var (LocalVar { lvName = n, lvKind =  mbKind })
+      = LocalVar { lvName = noExactName n, lvKind = mbKind }
 
 -- Changes a unique Name with a NameU or NameL namespace to a non-unique Name.
 -- See Note [Pitfalls of NameU/NameL] for why this is useful.


### PR DESCRIPTION
Doing so makes it possible to track the kinds of scoped type variables with greater precision during lambda lifting. See the golden output for the new `T613` test case to see an example of this in action.

Fixes https://github.com/goldfirere/singletons/issues/613.