### PR TITLE
`singletons-{th,base}`: Require building with GHC 9.12

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -28,6 +28,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.12.0.20241128
+            compilerKind: ghc
+            compilerVersion: 9.12.0.20241128
+            setup-method: ghcup-prerelease
+            allow-failure: false
           - compiler: ghc-9.10.1
             compilerKind: ghc
             compilerVersion: 9.10.1
@@ -38,9 +43,9 @@ jobs:
             compilerVersion: 9.8.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.5
+          - compiler: ghc-9.6.6
             compilerKind: ghc
-            compilerVersion: 9.6.5
+            compilerVersion: 9.6.6
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.8
@@ -117,6 +122,21 @@ jobs:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
           HCVER: ${{ matrix.compilerVersion }}
+      - name: Install GHC (GHCup prerelease)
+        if: matrix.setup-method == 'ghcup-prerelease'
+        run: |
+          "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.8.yaml;
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
+        env:
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
       - name: Set PATH and environment variables
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
@@ -127,7 +147,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -155,6 +175,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -185,9 +217,9 @@ jobs:
         run: |
           touch cabal.project
           echo "packages: $GITHUB_WORKSPACE/source/./singletons" >> cabal.project
-          if [ $((HCNUMVER >= 91000)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/./singletons-th" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 91000)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/./singletons-base" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 91000)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/./singletons-base-code-generator" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/./singletons-th" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/./singletons-base" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/./singletons-base-code-generator" >> cabal.project ; fi
           cat cabal.project
       - name: sdist
         run: |
@@ -211,23 +243,26 @@ jobs:
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_singletons}" >> cabal.project
-          if [ $((HCNUMVER >= 91000)) -ne 0 ] ; then echo "packages: ${PKGDIR_singletons_th}" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 91000)) -ne 0 ] ; then echo "packages: ${PKGDIR_singletons_base}" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 91000)) -ne 0 ] ; then echo "packages: ${PKGDIR_singletons_base_code_generator}" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then echo "packages: ${PKGDIR_singletons_th}" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then echo "packages: ${PKGDIR_singletons_base}" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then echo "packages: ${PKGDIR_singletons_base_code_generator}" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package singletons" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 91000)) -ne 0 ] ; then echo "package singletons-th" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 91000)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 91000)) -ne 0 ] ; then echo "package singletons-base" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 91000)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 91000)) -ne 0 ] ; then echo "package singletons-base-code-generator" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 91000)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then echo "package singletons-th" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then echo "package singletons-base" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then echo "package singletons-base-code-generator" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           source-repository-package
             type:     git
             location: https://github.com/goldfirere/th-desugar
             tag:      730a0ed799c91324d42b70d3780d6b3215cafc3c
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(Cabal|Cabal-syntax|singletons|singletons-base|singletons-base-code-generator|singletons-th)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
@@ -255,12 +290,12 @@ jobs:
         run: |
           cd ${PKGDIR_singletons} || false
           ${CABAL} -vnormal check
-          if [ $((HCNUMVER >= 91000)) -ne 0 ] ; then cd ${PKGDIR_singletons_th} || false ; fi
-          if [ $((HCNUMVER >= 91000)) -ne 0 ] ; then ${CABAL} -vnormal check ; fi
-          if [ $((HCNUMVER >= 91000)) -ne 0 ] ; then cd ${PKGDIR_singletons_base} || false ; fi
-          if [ $((HCNUMVER >= 91000)) -ne 0 ] ; then ${CABAL} -vnormal check ; fi
-          if [ $((HCNUMVER >= 91000)) -ne 0 ] ; then cd ${PKGDIR_singletons_base_code_generator} || false ; fi
-          if [ $((HCNUMVER >= 91000)) -ne 0 ] ; then ${CABAL} -vnormal check ; fi
+          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then cd ${PKGDIR_singletons_th} || false ; fi
+          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then ${CABAL} -vnormal check ; fi
+          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then cd ${PKGDIR_singletons_base} || false ; fi
+          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then ${CABAL} -vnormal check ; fi
+          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then cd ${PKGDIR_singletons_base_code_generator} || false ; fi
+          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then ${CABAL} -vnormal check ; fi
       - name: haddock
         run: |
           $CABAL v2-haddock --disable-documentation $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -184,7 +184,7 @@ jobs:
                         26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
                         f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
              key-threshold: 3
-          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          active-repositories: hackage.haskell.org
           EOF
           fi
           cat >> $CABAL_CONFIG <<EOF
@@ -261,7 +261,7 @@ jobs:
             tag:      730a0ed799c91324d42b70d3780d6b3215cafc3c
           EOF
           if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          echo "$($HCPKG list --simple-output | xargs -d' ' -n 1 | grep -v "^Cabal" | sed -E 's/([a-zA-Z-]+)-[0-9.]+/allow\-newer\: *:\1/g')" >> cabal.project
           fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(Cabal|Cabal-syntax|singletons|singletons-base|singletons-base-code-generator|singletons-th)$/; }' >> cabal.project.local
           cat cabal.project

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ windows for requirements on the compiler version needed to build each library:
   GHC language extensions, even more so than `singletons` itself. As such, it
   is difficult to maintain support for multiple GHC versions in any given
   release of either library, so they only support the latest major GHC version
-  (currently GHC 9.10).
+  (currently GHC 9.12).
 
 Any code that uses the singleton-generation functionality from `singletons-th`
 or `singletons-base` needs to enable a long list of GHC extensions. This list

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -6,3 +6,6 @@ jobs-selection:         any
 haddock-components:     libs
 -- Needed to avoid https://github.com/haskell/cabal/issues/9917
 installed:              +all -Cabal -Cabal-syntax
+-- Needed to work around https://github.com/haskell/cabal/issues/6522 and
+-- https://github.com/haskell/cabal/issues/10500
+github-patches:         github.yml.patch

--- a/github.yml.patch
+++ b/github.yml.patch
@@ -1,0 +1,22 @@
+diff --git a/.github/workflows/haskell-ci.yml b/.github/workflows/haskell-ci.yml
+index 55fb206..c9db909 100644
+--- a/.github/workflows/haskell-ci.yml
++++ b/.github/workflows/haskell-ci.yml
+@@ -184,7 +184,7 @@ jobs:
+                         26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                         f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+              key-threshold: 3
+-          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
++          active-repositories: hackage.haskell.org
+           EOF
+           fi
+           cat >> $CABAL_CONFIG <<EOF
+@@ -261,7 +261,7 @@ jobs:
+             tag:      730a0ed799c91324d42b70d3780d6b3215cafc3c
+           EOF
+           if $HEADHACKAGE; then
+-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
++          echo "$($HCPKG list --simple-output | xargs -d' ' -n 1 | grep -v "^Cabal" | sed -E 's/([a-zA-Z-]+)-[0-9.]+/allow\-newer\: *:\1/g')" >> cabal.project
+           fi
+           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(Cabal|Cabal-syntax|singletons|singletons-base|singletons-base-code-generator|singletons-th)$/; }' >> cabal.project.local
+           cat cabal.project

--- a/singletons-base-code-generator/singletons-base-code-generator.cabal
+++ b/singletons-base-code-generator/singletons-base-code-generator.cabal
@@ -8,7 +8,7 @@ author:         Ryan Scott <ryan.gl.scott@gmail.com>
 maintainer:     Ryan Scott <ryan.gl.scott@gmail.com>
 bug-reports:    https://github.com/goldfirere/singletons/issues
 stability:      experimental
-tested-with:    GHC == 9.10.1
+tested-with:    GHC == 9.12.1
 extra-doc-files:    CHANGES.md
 extra-source-files: README.md
 license:        BSD-3-Clause

--- a/singletons-base/CHANGES.md
+++ b/singletons-base/CHANGES.md
@@ -74,6 +74,11 @@ next [????.??.??]
   (e.g., `AsumSym0` and `MSym0`) are less polymorphic. The fact that these were
   kind-polymorphic to begin with was an oversight, as these definitions could
   not be used when `j` or `k` was instantiated to any other kind besides `Type`.
+* Define hand-written `Sing` instances such that they explicitly match on their
+  types on the left-hand sides (e.g., define `type instance Sing @Symbol =
+  SSymbol` instead of `type instance Sing = SSymbol`. Doing so will make
+  `singletons-base` future-proof once
+  [GHC#23515](https://gitlab.haskell.org/ghc/ghc/-/issues/23515) is fixed.
 
 3.4 [2024.05.12]
 ----------------

--- a/singletons-base/CHANGES.md
+++ b/singletons-base/CHANGES.md
@@ -3,6 +3,7 @@ Changelog for the `singletons-base` project
 
 3.5 [????.??.??]
 -----------------
+* Require building with GHC 9.12.
 * Remove the use of a custom `Setup.hs` script. This script has now been
   replaced with a [`cabal` code
   generator](https://cabal.readthedocs.io/en/stable/cabal-package-description-file.html#pkg-field-test-suite-code-generators)

--- a/singletons-base/CHANGES.md
+++ b/singletons-base/CHANGES.md
@@ -1,7 +1,7 @@
 Changelog for the `singletons-base` project
 ===========================================
 
-next [????.??.??]
+3.5 [????.??.??]
 -----------------
 * Remove the use of a custom `Setup.hs` script. This script has now been
   replaced with a [`cabal` code

--- a/singletons-base/README.md
+++ b/singletons-base/README.md
@@ -18,7 +18,7 @@ that code with `singletons-base`.
 
 `singletons-base` uses code that relies on bleeding-edge GHC language
 extensions. As such, `singletons-base` only supports the latest major version
-of GHC (currently GHC 9.10). For more information,
+of GHC (currently GHC 9.12). For more information,
 consult the `singletons`
 [`README`](https://github.com/goldfirere/singletons/blob/master/README.md).
 

--- a/singletons-base/singletons-base.cabal
+++ b/singletons-base/singletons-base.cabal
@@ -8,7 +8,7 @@ author:         Richard Eisenberg <rae@cs.brynmawr.edu>, Jan Stolarek <jan.stola
 maintainer:     Ryan Scott <ryan.gl.scott@gmail.com>
 bug-reports:    https://github.com/goldfirere/singletons/issues
 stability:      experimental
-tested-with:    GHC == 9.10.1
+tested-with:    GHC == 9.12.1
 extra-doc-files:    CHANGES.md
 extra-source-files: README.md
                     tests/README.md
@@ -40,7 +40,7 @@ description:
     .
     @singletons-base@ uses code that relies on bleeding-edge GHC language
     extensions. As such, @singletons-base@ only supports the latest major version
-    of GHC (currently GHC 9.10). For more information,
+    of GHC (currently GHC 9.12). For more information,
     consult the @singletons@
     @<https://github.com/goldfirere/singletons/blob/master/README.md README>@.
     .
@@ -67,11 +67,11 @@ source-repository head
 
 library
   hs-source-dirs:     src
-  build-depends:      base             >= 4.20 && < 4.21,
+  build-depends:      base             >= 4.21 && < 4.22,
                       pretty,
                       singletons       == 3.0.*,
                       singletons-th    >= 3.5 && < 3.6,
-                      template-haskell >= 2.22.1 && < 2.23,
+                      template-haskell >= 2.23 && < 2.24,
                       text >= 1.2,
                       th-desugar       >= 1.18 && < 1.19
   default-language:   GHC2021
@@ -150,7 +150,7 @@ test-suite singletons-base-test-suite
   main-is:            SingletonsBaseTestSuite.hs
   other-modules:      SingletonsBaseTestSuiteUtils
 
-  build-depends:      base >= 4.20 && < 4.21,
+  build-depends:      base >= 4.21 && < 4.22,
                       bytestring >= 0.10.9,
                       deepseq >= 1.4.4,
                       filepath >= 1.3,

--- a/singletons-base/singletons-base.cabal
+++ b/singletons-base/singletons-base.cabal
@@ -1,6 +1,6 @@
 cabal-version:  3.8
 name:           singletons-base
-version:        3.4
+version:        3.5
 synopsis:       A promoted and singled version of the base library
 homepage:       http://www.github.com/goldfirere/singletons
 category:       Dependent Types
@@ -70,8 +70,8 @@ library
   build-depends:      base             >= 4.20 && < 4.21,
                       pretty,
                       singletons       == 3.0.*,
-                      singletons-th    >= 3.4  && < 3.5,
-                      template-haskell >= 2.22 && < 2.23,
+                      singletons-th    >= 3.5 && < 3.6,
+                      template-haskell >= 2.22.1 && < 2.23,
                       text >= 1.2,
                       th-desugar       >= 1.18 && < 1.19
   default-language:   GHC2021

--- a/singletons-base/tests/compile-and-dump/Singletons/Classes.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Classes.golden
@@ -145,7 +145,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @a @((~>) a Ordering) (<=>@#@$) a0123456789876543210 = (<=>@#@$$) a0123456789876543210
     instance SuppressUnusedWarnings (<=>@#@$) where
       suppressUnusedWarnings = snd ((,) (:<=>@#@$###) ())
-    infix 4 <=>@#@$
+    infix 4 type <=>@#@$
     type (<=>@#@$$) :: forall a. a -> (~>) a Ordering
     data (<=>@#@$$) (a0123456789876543210 :: a) :: (~>) a Ordering
       where
@@ -154,11 +154,11 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @a @Ordering ((<=>@#@$$) a0123456789876543210) a0123456789876543210 = (<=>) a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ((<=>@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) (:<=>@#@$$###) ())
-    infix 4 <=>@#@$$
+    infix 4 type <=>@#@$$
     type (<=>@#@$$$) :: forall a. a -> a -> Ordering
     type family (<=>@#@$$$) @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Ordering where
       (<=>@#@$$$) a0123456789876543210 a0123456789876543210 = (<=>) a0123456789876543210 a0123456789876543210
-    infix 4 <=>@#@$$$
+    infix 4 type <=>@#@$$$
     type TFHelper_0123456789876543210 :: forall a. a -> a -> Ordering
     type family TFHelper_0123456789876543210 @a (a :: a) (a :: a) :: Ordering where
       TFHelper_0123456789876543210 @a (a_0123456789876543210 :: a) (a_0123456789876543210 :: a) = Apply (Apply MycompareSym0 a_0123456789876543210) a_0123456789876543210
@@ -248,7 +248,7 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       (%<=>) ::
         (forall (t :: a) (t :: a).
          Sing t -> Sing t -> Sing ((<=>) t t :: Ordering) :: Type)
-      infix 4 %<=>
+      infix 4 data %<=>
       default (%<=>) ::
                 (forall (t :: a) (t :: a).
                  (((<=>) t t :: Ordering) ~ TFHelper_0123456789876543210 t t) =>

--- a/singletons-base/tests/compile-and-dump/Singletons/Fixity.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Fixity.golden
@@ -23,7 +23,7 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @a @((~>) a a) (====@#@$) a0123456789876543210 = (====@#@$$) a0123456789876543210
     instance SuppressUnusedWarnings (====@#@$) where
       suppressUnusedWarnings = snd ((,) (:====@#@$###) ())
-    infix 4 ====@#@$
+    infix 4 type ====@#@$
     type (====@#@$$) :: a -> (~>) a a
     data (====@#@$$) (a0123456789876543210 :: a) :: (~>) a a
       where
@@ -32,11 +32,11 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @a @a ((====@#@$$) a0123456789876543210) a0123456789876543210 = (====) a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ((====@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) (:====@#@$$###) ())
-    infix 4 ====@#@$$
+    infix 4 type ====@#@$$
     type (====@#@$$$) :: a -> a -> a
     type family (====@#@$$$) @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: a where
       (====@#@$$$) a0123456789876543210 a0123456789876543210 = (====) a0123456789876543210 a0123456789876543210
-    infix 4 ====@#@$$$
+    infix 4 type ====@#@$$$
     type (====) :: a -> a -> a
     type family (====) @a (a :: a) (a :: a) :: a where
       (====) a _ = a
@@ -48,7 +48,7 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @a @((~>) a Ordering) (<=>@#@$) a0123456789876543210 = (<=>@#@$$) a0123456789876543210
     instance SuppressUnusedWarnings (<=>@#@$) where
       suppressUnusedWarnings = snd ((,) (:<=>@#@$###) ())
-    infix 4 <=>@#@$
+    infix 4 type <=>@#@$
     type (<=>@#@$$) :: forall a. a -> (~>) a Ordering
     data (<=>@#@$$) (a0123456789876543210 :: a) :: (~>) a Ordering
       where
@@ -57,14 +57,14 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @a @Ordering ((<=>@#@$$) a0123456789876543210) a0123456789876543210 = (<=>) a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ((<=>@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) (:<=>@#@$$###) ())
-    infix 4 <=>@#@$$
+    infix 4 type <=>@#@$$
     type (<=>@#@$$$) :: forall a. a -> a -> Ordering
     type family (<=>@#@$$$) @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Ordering where
       (<=>@#@$$$) a0123456789876543210 a0123456789876543210 = (<=>) a0123456789876543210 a0123456789876543210
-    infix 4 <=>@#@$$$
+    infix 4 type <=>@#@$$$
     class PMyOrd a where
       type family (<=>) (arg :: a) (arg :: a) :: Ordering
-    infix 4 %====
+    infix 4 data %====
     (%====) ::
       (forall (t :: a) (t :: a).
        Sing t -> Sing t -> Sing ((====) t t :: a) :: Type)
@@ -80,7 +80,7 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
       (%<=>) ::
         (forall (t :: a) (t :: a).
          Sing t -> Sing t -> Sing ((<=>) t t :: Ordering) :: Type)
-      infix 4 %<=>
+      infix 4 data %<=>
     instance SMyOrd a =>
              SingI ((<=>@#@$) :: (~>) a ((~>) a Ordering)) where
       sing = singFun2 @(<=>@#@$) (%<=>)

--- a/singletons-base/tests/compile-and-dump/Singletons/ShowDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/ShowDeriving.golden
@@ -54,7 +54,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @a @((~>) a (Foo2 a)) MkFoo2bSym0 a0123456789876543210 = MkFoo2bSym1 a0123456789876543210
     instance SuppressUnusedWarnings MkFoo2bSym0 where
       suppressUnusedWarnings = snd ((,) MkFoo2bSym0KindInference ())
-    infixl 5 `MkFoo2bSym0`
+    infixl 5 type `MkFoo2bSym0`
     type MkFoo2bSym1 :: forall a. a -> (~>) a (Foo2 a)
     data MkFoo2bSym1 (a0123456789876543210 :: a) :: (~>) a (Foo2 a)
       where
@@ -63,11 +63,11 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @a @(Foo2 a) (MkFoo2bSym1 a0123456789876543210) a0123456789876543210 = MkFoo2b a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings (MkFoo2bSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) MkFoo2bSym1KindInference ())
-    infixl 5 `MkFoo2bSym1`
+    infixl 5 type `MkFoo2bSym1`
     type MkFoo2bSym2 :: forall a. a -> a -> Foo2 a
     type family MkFoo2bSym2 @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Foo2 a where
       MkFoo2bSym2 a0123456789876543210 a0123456789876543210 = MkFoo2b a0123456789876543210 a0123456789876543210
-    infixl 5 `MkFoo2bSym2`
+    infixl 5 type `MkFoo2bSym2`
     type (:*:@#@$) :: forall a. (~>) a ((~>) a (Foo2 a))
     data (:*:@#@$) :: (~>) a ((~>) a (Foo2 a))
       where
@@ -76,7 +76,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @a @((~>) a (Foo2 a)) (:*:@#@$) a0123456789876543210 = (:*:@#@$$) a0123456789876543210
     instance SuppressUnusedWarnings (:*:@#@$) where
       suppressUnusedWarnings = snd ((,) (::*:@#@$###) ())
-    infixl 5 :*:@#@$
+    infixl 5 type :*:@#@$
     type (:*:@#@$$) :: forall a. a -> (~>) a (Foo2 a)
     data (:*:@#@$$) (a0123456789876543210 :: a) :: (~>) a (Foo2 a)
       where
@@ -85,11 +85,11 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @a @(Foo2 a) ((:*:@#@$$) a0123456789876543210) a0123456789876543210 = (:*:) a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ((:*:@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) (::*:@#@$$###) ())
-    infixl 5 :*:@#@$$
+    infixl 5 type :*:@#@$$
     type (:*:@#@$$$) :: forall a. a -> a -> Foo2 a
     type family (:*:@#@$$$) @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Foo2 a where
       (:*:@#@$$$) a0123456789876543210 a0123456789876543210 = (:*:) a0123456789876543210 a0123456789876543210
-    infixl 5 :*:@#@$$$
+    infixl 5 type :*:@#@$$$
     type (:&:@#@$) :: forall a. (~>) a ((~>) a (Foo2 a))
     data (:&:@#@$) :: (~>) a ((~>) a (Foo2 a))
       where
@@ -98,7 +98,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @a @((~>) a (Foo2 a)) (:&:@#@$) a0123456789876543210 = (:&:@#@$$) a0123456789876543210
     instance SuppressUnusedWarnings (:&:@#@$) where
       suppressUnusedWarnings = snd ((,) (::&:@#@$###) ())
-    infixl 5 :&:@#@$
+    infixl 5 type :&:@#@$
     type (:&:@#@$$) :: forall a. a -> (~>) a (Foo2 a)
     data (:&:@#@$$) (a0123456789876543210 :: a) :: (~>) a (Foo2 a)
       where
@@ -107,11 +107,11 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @a @(Foo2 a) ((:&:@#@$$) a0123456789876543210) a0123456789876543210 = (:&:) a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ((:&:@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) (::&:@#@$$###) ())
-    infixl 5 :&:@#@$$
+    infixl 5 type :&:@#@$$
     type (:&:@#@$$$) :: forall a. a -> a -> Foo2 a
     type family (:&:@#@$$$) @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Foo2 a where
       (:&:@#@$$$) a0123456789876543210 a0123456789876543210 = (:&:) a0123456789876543210 a0123456789876543210
-    infixl 5 :&:@#@$$$
+    infixl 5 type :&:@#@$$$
     type MkFoo3Sym0 :: (~>) Bool ((~>) Bool Foo3)
     data MkFoo3Sym0 :: (~>) Bool ((~>) Bool Foo3)
       where
@@ -180,9 +180,9 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
       ShowsPrec_0123456789876543210 p_0123456789876543210 (MkFoo3 arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "MkFoo3 ")) (Apply (Apply (.@#@$) (Apply ShowCharSym0 '{')) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "getFoo3a = ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 0)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowCommaSpaceSym0) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "(***) = ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 0)) arg_0123456789876543210)) (Apply ShowCharSym0 '}'))))))))) a_0123456789876543210
     instance PShow Foo3 where
       type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
-    infixl 5 :%&:
-    infixl 5 :%*:
-    infixl 5 `SMkFoo2b`
+    infixl 5 data :%&:
+    infixl 5 data :%*:
+    infixl 5 data `SMkFoo2b`
     (%***) ::
       (forall (t :: Foo3). Sing t -> Sing ((***) t :: Bool) :: Type)
     sGetFoo3a ::

--- a/singletons-base/tests/compile-and-dump/Singletons/StandaloneDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/StandaloneDeriving.golden
@@ -33,7 +33,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @a @((~>) b (T a b)) (:*:@#@$) a0123456789876543210 = (:*:@#@$$) a0123456789876543210
     instance SuppressUnusedWarnings (:*:@#@$) where
       suppressUnusedWarnings = snd ((,) (::*:@#@$###) ())
-    infixl 6 :*:@#@$
+    infixl 6 type :*:@#@$
     type (:*:@#@$$) :: forall a b. a -> (~>) b (T a b)
     data (:*:@#@$$) (a0123456789876543210 :: a) :: (~>) b (T a b)
       where
@@ -42,11 +42,11 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @b @(T a b) ((:*:@#@$$) a0123456789876543210) a0123456789876543210 = (:*:) a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ((:*:@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) (::*:@#@$$###) ())
-    infixl 6 :*:@#@$$
+    infixl 6 type :*:@#@$$
     type (:*:@#@$$$) :: forall a b. a -> b -> T a b
     type family (:*:@#@$$$) @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: T a b where
       (:*:@#@$$$) a0123456789876543210 a0123456789876543210 = (:*:) a0123456789876543210 a0123456789876543210
-    infixl 6 :*:@#@$$$
+    infixl 6 type :*:@#@$$$
     type S1Sym0 :: S
     type family S1Sym0 :: S where
       S1Sym0 = S1
@@ -139,7 +139,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance PEnum S where
       type ToEnum a = ToEnum_0123456789876543210 a
       type FromEnum a = FromEnum_0123456789876543210 a
-    infixl 6 :%*:
+    infixl 6 data :%*:
     data ST :: forall a b. T a b -> Type
       where
         (:%*:) :: forall a b (n :: a) (n :: b).

--- a/singletons-base/tests/compile-and-dump/Singletons/T159.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T159.golden
@@ -66,7 +66,7 @@ Singletons/T159.hs:0:0:: Splicing declarations
     type instance Apply @T0 @((~>) T1 T1) C1Sym0 a0123456789876543210 = C1Sym1 a0123456789876543210
     instance SuppressUnusedWarnings C1Sym0 where
       suppressUnusedWarnings = snd ((,) C1Sym0KindInference ())
-    infixr 5 `C1Sym0`
+    infixr 5 type `C1Sym0`
     type C1Sym1 :: T0 -> (~>) T1 T1
     data C1Sym1 (a0123456789876543210 :: T0) :: (~>) T1 T1
       where
@@ -75,11 +75,11 @@ Singletons/T159.hs:0:0:: Splicing declarations
     type instance Apply @T1 @T1 (C1Sym1 a0123456789876543210) a0123456789876543210 = 'C1 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings (C1Sym1 a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) C1Sym1KindInference ())
-    infixr 5 `C1Sym1`
+    infixr 5 type `C1Sym1`
     type C1Sym2 :: T0 -> T1 -> T1
     type family C1Sym2 (a0123456789876543210 :: T0) (a0123456789876543210 :: T1) :: T1 where
       C1Sym2 a0123456789876543210 a0123456789876543210 = 'C1 a0123456789876543210 a0123456789876543210
-    infixr 5 `C1Sym2`
+    infixr 5 type `C1Sym2`
     type (:&&@#@$) :: (~>) T0 ((~>) T1 T1)
     data (:&&@#@$) :: (~>) T0 ((~>) T1 T1)
       where
@@ -88,7 +88,7 @@ Singletons/T159.hs:0:0:: Splicing declarations
     type instance Apply @T0 @((~>) T1 T1) (:&&@#@$) a0123456789876543210 = (:&&@#@$$) a0123456789876543210
     instance SuppressUnusedWarnings (:&&@#@$) where
       suppressUnusedWarnings = snd ((,) (::&&@#@$###) ())
-    infixr 5 :&&@#@$
+    infixr 5 type :&&@#@$
     type (:&&@#@$$) :: T0 -> (~>) T1 T1
     data (:&&@#@$$) (a0123456789876543210 :: T0) :: (~>) T1 T1
       where
@@ -97,11 +97,11 @@ Singletons/T159.hs:0:0:: Splicing declarations
     type instance Apply @T1 @T1 ((:&&@#@$$) a0123456789876543210) a0123456789876543210 = '(:&&) a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ((:&&@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) (::&&@#@$$###) ())
-    infixr 5 :&&@#@$$
+    infixr 5 type :&&@#@$$
     type (:&&@#@$$$) :: T0 -> T1 -> T1
     type family (:&&@#@$$$) (a0123456789876543210 :: T0) (a0123456789876543210 :: T1) :: T1 where
       (:&&@#@$$$) a0123456789876543210 a0123456789876543210 = '(:&&) a0123456789876543210 a0123456789876543210
-    infixr 5 :&&@#@$$$
+    infixr 5 type :&&@#@$$$
     type ST1 :: T1 -> Type
     data ST1 :: T1 -> Type
       where
@@ -123,8 +123,8 @@ Singletons/T159.hs:0:0:: Splicing declarations
       toSing ((:&&) (b :: Demote T0) (b :: Demote T1))
         = (\cases (SomeSing c) (SomeSing c) -> SomeSing ((:%&&) c c))
             (toSing b :: SomeSing T0) (toSing b :: SomeSing T1)
-    infixr 5 `SC1`
-    infixr 5 :%&&
+    infixr 5 data `SC1`
+    infixr 5 data :%&&
     instance SingI 'N1 where
       sing = SN1
     instance (SingI n, SingI n) =>
@@ -177,7 +177,7 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @T0 @((~>) T2 T2) C2Sym0 a0123456789876543210 = C2Sym1 a0123456789876543210
     instance SuppressUnusedWarnings C2Sym0 where
       suppressUnusedWarnings = snd ((,) C2Sym0KindInference ())
-    infixr 5 `C2Sym0`
+    infixr 5 type `C2Sym0`
     type C2Sym1 :: T0 -> (~>) T2 T2
     data C2Sym1 (a0123456789876543210 :: T0) :: (~>) T2 T2
       where
@@ -186,11 +186,11 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @T2 @T2 (C2Sym1 a0123456789876543210) a0123456789876543210 = C2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings (C2Sym1 a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) C2Sym1KindInference ())
-    infixr 5 `C2Sym1`
+    infixr 5 type `C2Sym1`
     type C2Sym2 :: T0 -> T2 -> T2
     type family C2Sym2 (a0123456789876543210 :: T0) (a0123456789876543210 :: T2) :: T2 where
       C2Sym2 a0123456789876543210 a0123456789876543210 = C2 a0123456789876543210 a0123456789876543210
-    infixr 5 `C2Sym2`
+    infixr 5 type `C2Sym2`
     type (:||@#@$) :: (~>) T0 ((~>) T2 T2)
     data (:||@#@$) :: (~>) T0 ((~>) T2 T2)
       where
@@ -199,7 +199,7 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @T0 @((~>) T2 T2) (:||@#@$) a0123456789876543210 = (:||@#@$$) a0123456789876543210
     instance SuppressUnusedWarnings (:||@#@$) where
       suppressUnusedWarnings = snd ((,) (::||@#@$###) ())
-    infixr 5 :||@#@$
+    infixr 5 type :||@#@$
     type (:||@#@$$) :: T0 -> (~>) T2 T2
     data (:||@#@$$) (a0123456789876543210 :: T0) :: (~>) T2 T2
       where
@@ -208,13 +208,13 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @T2 @T2 ((:||@#@$$) a0123456789876543210) a0123456789876543210 = (:||) a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ((:||@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) (::||@#@$$###) ())
-    infixr 5 :||@#@$$
+    infixr 5 type :||@#@$$
     type (:||@#@$$$) :: T0 -> T2 -> T2
     type family (:||@#@$$$) (a0123456789876543210 :: T0) (a0123456789876543210 :: T2) :: T2 where
       (:||@#@$$$) a0123456789876543210 a0123456789876543210 = (:||) a0123456789876543210 a0123456789876543210
-    infixr 5 :||@#@$$$
-    infixr 5 :%||
-    infixr 5 `SC2`
+    infixr 5 type :||@#@$$$
+    infixr 5 data :%||
+    infixr 5 data `SC2`
     data ST2 :: T2 -> Type
       where
         SN2 :: ST2 (N2 :: T2)

--- a/singletons-base/tests/compile-and-dump/Singletons/T197.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T197.golden
@@ -16,7 +16,7 @@ Singletons/T197.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @Bool @((~>) Bool Bool) ($$:@#@$) a0123456789876543210 = ($$:@#@$$) a0123456789876543210
     instance SuppressUnusedWarnings ($$:@#@$) where
       suppressUnusedWarnings = snd ((,) (:$$:@#@$###) ())
-    infixl 5 $$:@#@$
+    infixl 5 type $$:@#@$
     type ($$:@#@$$) :: Bool -> (~>) Bool Bool
     data ($$:@#@$$) (a0123456789876543210 :: Bool) :: (~>) Bool Bool
       where
@@ -25,15 +25,15 @@ Singletons/T197.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @Bool @Bool (($$:@#@$$) a0123456789876543210) a0123456789876543210 = ($$:) a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings (($$:@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) (:$$:@#@$$###) ())
-    infixl 5 $$:@#@$$
+    infixl 5 type $$:@#@$$
     type ($$:@#@$$$) :: Bool -> Bool -> Bool
     type family ($$:@#@$$$) (a0123456789876543210 :: Bool) (a0123456789876543210 :: Bool) :: Bool where
       ($$:@#@$$$) a0123456789876543210 a0123456789876543210 = ($$:) a0123456789876543210 a0123456789876543210
-    infixl 5 $$:@#@$$$
+    infixl 5 type $$:@#@$$$
     type ($$:) :: Bool -> Bool -> Bool
     type family ($$:) (a :: Bool) (a :: Bool) :: Bool where
       ($$:) _ _ = FalseSym0
-    infixl 5 %$$:
+    infixl 5 data %$$:
     (%$$:) ::
       (forall (t :: Bool) (t :: Bool).
        Sing t -> Sing t -> Sing (($$:) t t :: Bool) :: Type)

--- a/singletons-base/tests/compile-and-dump/Singletons/T197b.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T197b.golden
@@ -36,7 +36,7 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @a @((~>) b (Pair a b)) MkPairSym0 a0123456789876543210 = MkPairSym1 a0123456789876543210
     instance SuppressUnusedWarnings MkPairSym0 where
       suppressUnusedWarnings = snd ((,) MkPairSym0KindInference ())
-    infixr 9 `MkPairSym0`
+    infixr 9 type `MkPairSym0`
     type MkPairSym1 :: forall a b. a -> (~>) b (Pair a b)
     data MkPairSym1 (a0123456789876543210 :: a) :: (~>) b (Pair a b)
       where
@@ -45,12 +45,12 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @b @(Pair a b) (MkPairSym1 a0123456789876543210) a0123456789876543210 = MkPair a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings (MkPairSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) MkPairSym1KindInference ())
-    infixr 9 `MkPairSym1`
+    infixr 9 type `MkPairSym1`
     type MkPairSym2 :: forall a b. a -> b -> Pair a b
     type family MkPairSym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: Pair a b where
       MkPairSym2 a0123456789876543210 a0123456789876543210 = MkPair a0123456789876543210 a0123456789876543210
-    infixr 9 `MkPairSym2`
-    infixr 9 `SMkPair`
+    infixr 9 type `MkPairSym2`
+    infixr 9 data `SMkPair`
     data (%:*:) :: forall a b. (:*:) a b -> Type
       where
         (:%*:) :: forall a b (n :: a) (n :: b).

--- a/singletons-base/tests/compile-and-dump/Singletons/T322.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T322.golden
@@ -16,7 +16,7 @@ Singletons/T322.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @Bool @((~>) Bool Bool) (!@#@$) a0123456789876543210 = (!@#@$$) a0123456789876543210
     instance SuppressUnusedWarnings (!@#@$) where
       suppressUnusedWarnings = snd ((,) (:!@#@$###) ())
-    infixr 2 !@#@$
+    infixr 2 type !@#@$
     type (!@#@$$) :: Bool -> (~>) Bool Bool
     data (!@#@$$) (a0123456789876543210 :: Bool) :: (~>) Bool Bool
       where
@@ -25,15 +25,15 @@ Singletons/T322.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @Bool @Bool ((!@#@$$) a0123456789876543210) a0123456789876543210 = (!) a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ((!@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) (:!@#@$$###) ())
-    infixr 2 !@#@$$
+    infixr 2 type !@#@$$
     type (!@#@$$$) :: Bool -> Bool -> Bool
     type family (!@#@$$$) (a0123456789876543210 :: Bool) (a0123456789876543210 :: Bool) :: Bool where
       (!@#@$$$) a0123456789876543210 a0123456789876543210 = (!) a0123456789876543210 a0123456789876543210
-    infixr 2 !@#@$$$
+    infixr 2 type !@#@$$$
     type (!) :: Bool -> Bool -> Bool
     type family (!) (a :: Bool) (a :: Bool) :: Bool where
       (!) a_0123456789876543210 a_0123456789876543210 = Apply (Apply (||@#@$) a_0123456789876543210) a_0123456789876543210
-    infixr 2 %!
+    infixr 2 data %!
     (%!) ::
       (forall (t :: Bool) (t :: Bool).
        Sing t -> Sing t -> Sing ((!) t t :: Bool) :: Type)

--- a/singletons-base/tests/compile-and-dump/Singletons/T326.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T326.golden
@@ -9,7 +9,7 @@ Singletons/T326.hs:0:0:: Splicing declarations
     type instance Apply @a @((~>) a a) (<%>@#@$) a0123456789876543210 = (<%>@#@$$) a0123456789876543210
     instance SuppressUnusedWarnings (<%>@#@$) where
       suppressUnusedWarnings = snd ((,) (:<%>@#@$###) ())
-    infixl 9 <%>@#@$
+    infixl 9 type <%>@#@$
     type (<%>@#@$$) :: forall (a :: Type). a -> (~>) a a
     data (<%>@#@$$) (a0123456789876543210 :: a) :: (~>) a a
       where
@@ -18,15 +18,15 @@ Singletons/T326.hs:0:0:: Splicing declarations
     type instance Apply @a @a ((<%>@#@$$) a0123456789876543210) a0123456789876543210 = (<%>) a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ((<%>@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) (:<%>@#@$$###) ())
-    infixl 9 <%>@#@$$
+    infixl 9 type <%>@#@$$
     type (<%>@#@$$$) :: forall (a :: Type). a -> a -> a
     type family (<%>@#@$$$) @(a :: Type) (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: a where
       (<%>@#@$$$) a0123456789876543210 a0123456789876543210 = (<%>) a0123456789876543210 a0123456789876543210
-    infixl 9 <%>@#@$$$
+    infixl 9 type <%>@#@$$$
     type PC1 :: Type -> Constraint
     class PC1 (a :: Type) where
       type family (<%>) (arg :: a) (arg :: a) :: a
-    infixl 9 <%>
+    infixl 9 type <%>
 Singletons/T326.hs:0:0:: Splicing declarations
     genSingletons [''C2]
   ======>
@@ -38,7 +38,7 @@ Singletons/T326.hs:0:0:: Splicing declarations
     type instance Apply @a @((~>) a a) (<%%>@#@$) a0123456789876543210 = (<%%>@#@$$) a0123456789876543210
     instance SuppressUnusedWarnings (<%%>@#@$) where
       suppressUnusedWarnings = snd ((,) (:<%%>@#@$###) ())
-    infixl 9 <%%>@#@$
+    infixl 9 type <%%>@#@$
     type (<%%>@#@$$) :: forall (a :: Type). a -> (~>) a a
     data (<%%>@#@$$) (a0123456789876543210 :: a) :: (~>) a a
       where
@@ -47,21 +47,21 @@ Singletons/T326.hs:0:0:: Splicing declarations
     type instance Apply @a @a ((<%%>@#@$$) a0123456789876543210) a0123456789876543210 = (<%%>) a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ((<%%>@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) (:<%%>@#@$$###) ())
-    infixl 9 <%%>@#@$$
+    infixl 9 type <%%>@#@$$
     type (<%%>@#@$$$) :: forall (a :: Type). a -> a -> a
     type family (<%%>@#@$$$) @(a :: Type) (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: a where
       (<%%>@#@$$$) a0123456789876543210 a0123456789876543210 = (<%%>) a0123456789876543210 a0123456789876543210
-    infixl 9 <%%>@#@$$$
+    infixl 9 type <%%>@#@$$$
     type PC2 :: Type -> Constraint
     class PC2 (a :: Type) where
       type family (<%%>) (arg :: a) (arg :: a) :: a
-    infixl 9 <%%>
+    infixl 9 type <%%>
     class SC2 (a :: Type) where
       (%<%%>) ::
         (forall (t :: a) (t :: a).
          Sing t -> Sing t -> Sing ((<%%>) t t :: a) :: Type)
     type SC2 :: Type -> Constraint
-    infixl 9 %<%%>
+    infixl 9 data %<%%>
     instance SC2 a => SingI ((<%%>@#@$) :: (~>) a ((~>) a a)) where
       sing = singFun2 @(<%%>@#@$) (%<%%>)
     instance (SC2 a, SingI d) =>

--- a/singletons-base/tests/compile-and-dump/Singletons/T412.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T412.golden
@@ -33,7 +33,7 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @_ @_ T1aSym0 a0123456789876543210 = T1aSym1 a0123456789876543210
     instance SuppressUnusedWarnings T1aSym0 where
       suppressUnusedWarnings = snd ((,) T1aSym0KindInference ())
-    infixl 5 `T1aSym0`
+    infixl 5 type `T1aSym0`
     data T1aSym1 a0123456789876543210 b0123456789876543210
       where
         T1aSym1KindInference :: SameKind (Apply (T1aSym1 a0123456789876543210) arg) (T1aSym2 a0123456789876543210 arg) =>
@@ -41,10 +41,10 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @_ @_ (T1aSym1 a0123456789876543210) b0123456789876543210 = T1a a0123456789876543210 b0123456789876543210
     instance SuppressUnusedWarnings (T1aSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) T1aSym1KindInference ())
-    infixl 5 `T1aSym1`
+    infixl 5 type `T1aSym1`
     type family T1aSym2 a0123456789876543210 b0123456789876543210 where
       T1aSym2 a0123456789876543210 b0123456789876543210 = T1a a0123456789876543210 b0123456789876543210
-    infixl 5 `T1aSym2`
+    infixl 5 type `T1aSym2`
     data T1bSym0 a0123456789876543210
       where
         T1bSym0KindInference :: SameKind (Apply T1bSym0 arg) (T1bSym1 arg) =>
@@ -52,7 +52,7 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @_ @_ T1bSym0 a0123456789876543210 = T1bSym1 a0123456789876543210
     instance SuppressUnusedWarnings T1bSym0 where
       suppressUnusedWarnings = snd ((,) T1bSym0KindInference ())
-    infixl 5 `T1bSym0`
+    infixl 5 type `T1bSym0`
     data T1bSym1 a0123456789876543210 b0123456789876543210
       where
         T1bSym1KindInference :: SameKind (Apply (T1bSym1 a0123456789876543210) arg) (T1bSym2 a0123456789876543210 arg) =>
@@ -60,10 +60,10 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @_ @_ (T1bSym1 a0123456789876543210) b0123456789876543210 = T1b a0123456789876543210 b0123456789876543210
     instance SuppressUnusedWarnings (T1bSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) T1bSym1KindInference ())
-    infixl 5 `T1bSym1`
+    infixl 5 type `T1bSym1`
     type family T1bSym2 a0123456789876543210 b0123456789876543210 where
       T1bSym2 a0123456789876543210 b0123456789876543210 = T1b a0123456789876543210 b0123456789876543210
-    infixl 5 `T1bSym2`
+    infixl 5 type `T1bSym2`
     type MkD1Sym0 :: forall a b. (~>) a ((~>) b (D1 a b))
     data MkD1Sym0 :: (~>) a ((~>) b (D1 a b))
       where
@@ -72,7 +72,7 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @a @((~>) b (D1 a b)) MkD1Sym0 a0123456789876543210 = MkD1Sym1 a0123456789876543210
     instance SuppressUnusedWarnings MkD1Sym0 where
       suppressUnusedWarnings = snd ((,) MkD1Sym0KindInference ())
-    infixr 5 `MkD1Sym0`
+    infixr 5 type `MkD1Sym0`
     type MkD1Sym1 :: forall a b. a -> (~>) b (D1 a b)
     data MkD1Sym1 (a0123456789876543210 :: a) :: (~>) b (D1 a b)
       where
@@ -81,11 +81,11 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @b @(D1 a b) (MkD1Sym1 a0123456789876543210) a0123456789876543210 = MkD1 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings (MkD1Sym1 a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) MkD1Sym1KindInference ())
-    infixr 5 `MkD1Sym1`
+    infixr 5 type `MkD1Sym1`
     type MkD1Sym2 :: forall a b. a -> b -> D1 a b
     type family MkD1Sym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: D1 a b where
       MkD1Sym2 a0123456789876543210 a0123456789876543210 = MkD1 a0123456789876543210 a0123456789876543210
-    infixr 5 `MkD1Sym2`
+    infixr 5 type `MkD1Sym2`
     type D1BSym0 :: forall a b. (~>) (D1 a b) b
     data D1BSym0 :: (~>) (D1 a b) b
       where
@@ -94,11 +94,11 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @(D1 a b) @b D1BSym0 a0123456789876543210 = D1B a0123456789876543210
     instance SuppressUnusedWarnings D1BSym0 where
       suppressUnusedWarnings = snd ((,) D1BSym0KindInference ())
-    infixr 5 `D1BSym0`
+    infixr 5 type `D1BSym0`
     type D1BSym1 :: forall a b. D1 a b -> b
     type family D1BSym1 @a @b (a0123456789876543210 :: D1 a b) :: b where
       D1BSym1 a0123456789876543210 = D1B a0123456789876543210
-    infixr 5 `D1BSym1`
+    infixr 5 type `D1BSym1`
     type D1ASym0 :: forall a b. (~>) (D1 a b) a
     data D1ASym0 :: (~>) (D1 a b) a
       where
@@ -107,20 +107,20 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @(D1 a b) @a D1ASym0 a0123456789876543210 = D1A a0123456789876543210
     instance SuppressUnusedWarnings D1ASym0 where
       suppressUnusedWarnings = snd ((,) D1ASym0KindInference ())
-    infixr 5 `D1ASym0`
+    infixr 5 type `D1ASym0`
     type D1ASym1 :: forall a b. D1 a b -> a
     type family D1ASym1 @a @b (a0123456789876543210 :: D1 a b) :: a where
       D1ASym1 a0123456789876543210 = D1A a0123456789876543210
-    infixr 5 `D1ASym1`
+    infixr 5 type `D1ASym1`
     type D1B :: forall a b. D1 a b -> b
     type family D1B @a @b (a :: D1 a b) :: b where
       D1B @a @b (MkD1 _ field :: D1 a b) = field
     type D1A :: forall a b. D1 a b -> a
     type family D1A @a @b (a :: D1 a b) :: a where
       D1A @a @b (MkD1 field _ :: D1 a b) = field
-    infixr 5 `D1B`
-    infixr 5 `D1A`
-    infix 5 `PC1`
+    infixr 5 type `D1B`
+    infixr 5 type `D1A`
+    infix 5 type `PC1`
     type M1Sym0 :: forall a b. (~>) a ((~>) b Bool)
     data M1Sym0 :: (~>) a ((~>) b Bool)
       where
@@ -129,7 +129,7 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @a @((~>) b Bool) M1Sym0 a0123456789876543210 = M1Sym1 a0123456789876543210
     instance SuppressUnusedWarnings M1Sym0 where
       suppressUnusedWarnings = snd ((,) M1Sym0KindInference ())
-    infix 6 `M1Sym0`
+    infix 6 type `M1Sym0`
     type M1Sym1 :: forall a b. a -> (~>) b Bool
     data M1Sym1 (a0123456789876543210 :: a) :: (~>) b Bool
       where
@@ -138,18 +138,18 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @b @Bool (M1Sym1 a0123456789876543210) a0123456789876543210 = M1 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings (M1Sym1 a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) M1Sym1KindInference ())
-    infix 6 `M1Sym1`
+    infix 6 type `M1Sym1`
     type M1Sym2 :: forall a b. a -> b -> Bool
     type family M1Sym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: Bool where
       M1Sym2 a0123456789876543210 a0123456789876543210 = M1 a0123456789876543210 a0123456789876543210
-    infix 6 `M1Sym2`
+    infix 6 type `M1Sym2`
     class PC1 a b where
       type family M1 (arg :: a) (arg :: b) :: Bool
-      infix 6 `M1`
-    infixr 5 `sD1B`
-    infixr 5 `sD1A`
-    infixr 5 `SMkD1`
-    infix 5 `SC1`
+      infix 6 type `M1`
+    infixr 5 data `sD1B`
+    infixr 5 data `sD1A`
+    infixr 5 data `SMkD1`
+    infix 5 type `SC1`
     sD1B :: forall a b (t :: D1 a b). Sing t -> Sing (D1B t :: b)
     sD1A :: forall a b (t :: D1 a b). Sing t -> Sing (D1A t :: a)
     sD1B (SMkD1 _ (sField :: Sing field)) = sField
@@ -173,7 +173,7 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
       sM1 ::
         (forall (t :: a) (t :: b).
          Sing t -> Sing t -> Sing (M1 t t :: Bool) :: Type)
-      infix 6 `sM1`
+      infix 6 data `sM1`
     instance (SingI n, SingI n) => SingI (MkD1 (n :: a) (n :: b)) where
       sing = SMkD1 sing sing
     instance SingI n => SingI1 (MkD1 (n :: a)) where
@@ -206,7 +206,7 @@ Singletons/T412.hs:0:0:: Splicing declarations
     type instance Apply @a @((~>) b Bool) M2Sym0 a0123456789876543210 = M2Sym1 a0123456789876543210
     instance SuppressUnusedWarnings M2Sym0 where
       suppressUnusedWarnings = snd ((,) M2Sym0KindInference ())
-    infix 6 `M2Sym0`
+    infix 6 type `M2Sym0`
     type M2Sym1 :: forall (a :: Type) (b :: Type). a -> (~>) b Bool
     data M2Sym1 (a0123456789876543210 :: a) :: (~>) b Bool
       where
@@ -215,23 +215,23 @@ Singletons/T412.hs:0:0:: Splicing declarations
     type instance Apply @b @Bool (M2Sym1 a0123456789876543210) a0123456789876543210 = M2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings (M2Sym1 a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) M2Sym1KindInference ())
-    infix 6 `M2Sym1`
+    infix 6 type `M2Sym1`
     type M2Sym2 :: forall (a :: Type) (b :: Type). a -> b -> Bool
     type family M2Sym2 @(a :: Type) @(b :: Type) (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: Bool where
       M2Sym2 a0123456789876543210 a0123456789876543210 = M2 a0123456789876543210 a0123456789876543210
-    infix 6 `M2Sym2`
+    infix 6 type `M2Sym2`
     type PC2 :: Type -> Type -> Constraint
     class PC2 (a :: Type) (b :: Type) where
       type family M2 (arg :: a) (arg :: b) :: Bool
-    infix 5 `PC2`
-    infix 6 `M2`
+    infix 5 type `PC2`
+    infix 6 type `M2`
     class SC2 (a :: Type) (b :: Type) where
       sM2 ::
         (forall (t :: a) (t :: b).
          Sing t -> Sing t -> Sing (M2 t t :: Bool) :: Type)
     type SC2 :: Type -> Type -> Constraint
-    infix 5 `SC2`
-    infix 6 `sM2`
+    infix 5 type `SC2`
+    infix 6 data `sM2`
     instance SC2 a b => SingI (M2Sym0 :: (~>) a ((~>) b Bool)) where
       sing = singFun2 @M2Sym0 sM2
     instance (SC2 a b, SingI d) =>
@@ -247,7 +247,7 @@ Singletons/T412.hs:0:0:: Splicing declarations
     type instance Apply @Type @((~>) Type Type) T2aSym0 a0123456789876543210 = T2aSym1 a0123456789876543210
     instance SuppressUnusedWarnings T2aSym0 where
       suppressUnusedWarnings = snd ((,) T2aSym0KindInference ())
-    infixl 5 `T2aSym0`
+    infixl 5 type `T2aSym0`
     type T2aSym1 :: Type -> (~>) Type Type
     data T2aSym1 (a0123456789876543210 :: Type) :: (~>) Type Type
       where
@@ -256,11 +256,11 @@ Singletons/T412.hs:0:0:: Splicing declarations
     type instance Apply @Type @Type (T2aSym1 a0123456789876543210) a0123456789876543210 = T2a a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings (T2aSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) T2aSym1KindInference ())
-    infixl 5 `T2aSym1`
+    infixl 5 type `T2aSym1`
     type T2aSym2 :: Type -> Type -> Type
     type family T2aSym2 (a0123456789876543210 :: Type) (a0123456789876543210 :: Type) :: Type where
       T2aSym2 a0123456789876543210 a0123456789876543210 = T2a a0123456789876543210 a0123456789876543210
-    infixl 5 `T2aSym2`
+    infixl 5 type `T2aSym2`
     type T2bSym0 :: (~>) Type ((~>) Type Type)
     data T2bSym0 :: (~>) Type ((~>) Type Type)
       where
@@ -269,7 +269,7 @@ Singletons/T412.hs:0:0:: Splicing declarations
     type instance Apply @Type @((~>) Type Type) T2bSym0 a0123456789876543210 = T2bSym1 a0123456789876543210
     instance SuppressUnusedWarnings T2bSym0 where
       suppressUnusedWarnings = snd ((,) T2bSym0KindInference ())
-    infixl 5 `T2bSym0`
+    infixl 5 type `T2bSym0`
     type T2bSym1 :: Type -> (~>) Type Type
     data T2bSym1 (a0123456789876543210 :: Type) :: (~>) Type Type
       where
@@ -278,11 +278,11 @@ Singletons/T412.hs:0:0:: Splicing declarations
     type instance Apply @Type @Type (T2bSym1 a0123456789876543210) a0123456789876543210 = T2b a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings (T2bSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) T2bSym1KindInference ())
-    infixl 5 `T2bSym1`
+    infixl 5 type `T2bSym1`
     type T2bSym2 :: Type -> Type -> Type
     type family T2bSym2 (a0123456789876543210 :: Type) (a0123456789876543210 :: Type) :: Type where
       T2bSym2 a0123456789876543210 a0123456789876543210 = T2b a0123456789876543210 a0123456789876543210
-    infixl 5 `T2bSym2`
+    infixl 5 type `T2bSym2`
     type MkD2Sym0 :: forall (a :: Type)
                             (b :: Type). (~>) a ((~>) b (D2 a b))
     data MkD2Sym0 :: (~>) a ((~>) b (D2 a b))
@@ -292,7 +292,7 @@ Singletons/T412.hs:0:0:: Splicing declarations
     type instance Apply @a @((~>) b (D2 a b)) MkD2Sym0 a0123456789876543210 = MkD2Sym1 a0123456789876543210
     instance SuppressUnusedWarnings MkD2Sym0 where
       suppressUnusedWarnings = snd ((,) MkD2Sym0KindInference ())
-    infixr 5 `MkD2Sym0`
+    infixr 5 type `MkD2Sym0`
     type MkD2Sym1 :: forall (a :: Type) (b :: Type). a
                                                      -> (~>) b (D2 a b)
     data MkD2Sym1 (a0123456789876543210 :: a) :: (~>) b (D2 a b)
@@ -302,13 +302,13 @@ Singletons/T412.hs:0:0:: Splicing declarations
     type instance Apply @b @(D2 a b) (MkD2Sym1 a0123456789876543210) a0123456789876543210 = 'MkD2 a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings (MkD2Sym1 a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) MkD2Sym1KindInference ())
-    infixr 5 `MkD2Sym1`
+    infixr 5 type `MkD2Sym1`
     type MkD2Sym2 :: forall (a :: Type) (b :: Type). a -> b -> D2 a b
     type family MkD2Sym2 @(a :: Type) @(b :: Type) (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: D2 a b where
       MkD2Sym2 a0123456789876543210 a0123456789876543210 = 'MkD2 a0123456789876543210 a0123456789876543210
-    infixr 5 `MkD2Sym2`
-    infixr 5 `D2A`
-    infixr 5 `D2B`
+    infixr 5 type `MkD2Sym2`
+    infixr 5 type `D2A`
+    infixr 5 type `D2B`
     type D2BSym0 :: forall (a :: Type) (b :: Type). (~>) (D2 a b) b
     data D2BSym0 :: (~>) (D2 a b) b
       where
@@ -361,9 +361,9 @@ Singletons/T412.hs:0:0:: Splicing declarations
       toSing (MkD2 (b :: Demote a) (b :: Demote b))
         = (\cases (SomeSing c) (SomeSing c) -> SomeSing (SMkD2 c c))
             (toSing b :: SomeSing a) (toSing b :: SomeSing b)
-    infixr 5 `SMkD2`
-    infixr 5 `sD2A`
-    infixr 5 `sD2B`
+    infixr 5 data `SMkD2`
+    infixr 5 data `sD2A`
+    infixr 5 data `sD2B`
     instance (SingI n, SingI n) =>
              SingI ('MkD2 (n :: a) (n :: b)) where
       sing = SMkD2 sing sing

--- a/singletons-base/tests/compile-and-dump/Singletons/T582.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T582.golden
@@ -1,9 +1,9 @@
 Singletons/T582.hs:(0,0)-(0,0): Splicing declarations
     singletons
-      [d| infixl 4 !!!
-          infixl 4 %%%
-          infixl 4 `Bar`
-          infixl 4 `foo`
+      [d| infixl 4 type !!!
+          infixl 4 data %%%
+          infixl 4 type `Bar`
+          infixl 4 data `foo`
           
           foo :: a -> a -> a
           x `foo` _ = x
@@ -16,16 +16,16 @@ Singletons/T582.hs:(0,0)-(0,0): Splicing declarations
           type x `Bar` y = x
           type x !!! y = x |]
   ======>
-    infixl 4 `foo`
+    infixl 4 data `foo`
     foo :: a -> a -> a
     foo x _ = x
-    infixl 4 `Bar`
+    infixl 4 type `Bar`
     type Bar :: a -> a -> a
     type Bar x y = x
-    infixl 4 %%%
+    infixl 4 data %%%
     (%%%) :: a -> a -> a
     (%%%) x _ = x
-    infixl 4 !!!
+    infixl 4 type !!!
     type (!!!) :: a -> a -> a
     type (!!!) x y = x
     type BarSym0 :: (~>) a ((~>) a a)
@@ -36,7 +36,7 @@ Singletons/T582.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @a @((~>) a a) BarSym0 a0123456789876543210 = BarSym1 a0123456789876543210
     instance SuppressUnusedWarnings BarSym0 where
       suppressUnusedWarnings = snd ((,) BarSym0KindInference ())
-    infixl 4 `BarSym0`
+    infixl 4 type `BarSym0`
     type BarSym1 :: a -> (~>) a a
     data BarSym1 (a0123456789876543210 :: a) :: (~>) a a
       where
@@ -45,11 +45,11 @@ Singletons/T582.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @a @a (BarSym1 a0123456789876543210) a0123456789876543210 = Bar a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings (BarSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) BarSym1KindInference ())
-    infixl 4 `BarSym1`
+    infixl 4 type `BarSym1`
     type BarSym2 :: a -> a -> a
     type family BarSym2 @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: a where
       BarSym2 a0123456789876543210 a0123456789876543210 = Bar a0123456789876543210 a0123456789876543210
-    infixl 4 `BarSym2`
+    infixl 4 type `BarSym2`
     type (!!!@#@$) :: (~>) a ((~>) a a)
     data (!!!@#@$) :: (~>) a ((~>) a a)
       where
@@ -58,7 +58,7 @@ Singletons/T582.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @a @((~>) a a) (!!!@#@$) a0123456789876543210 = (!!!@#@$$) a0123456789876543210
     instance SuppressUnusedWarnings (!!!@#@$) where
       suppressUnusedWarnings = snd ((,) (:!!!@#@$###) ())
-    infixl 4 !!!@#@$
+    infixl 4 type !!!@#@$
     type (!!!@#@$$) :: a -> (~>) a a
     data (!!!@#@$$) (a0123456789876543210 :: a) :: (~>) a a
       where
@@ -67,11 +67,11 @@ Singletons/T582.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @a @a ((!!!@#@$$) a0123456789876543210) a0123456789876543210 = (!!!) a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ((!!!@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) (:!!!@#@$$###) ())
-    infixl 4 !!!@#@$$
+    infixl 4 type !!!@#@$$
     type (!!!@#@$$$) :: a -> a -> a
     type family (!!!@#@$$$) @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: a where
       (!!!@#@$$$) a0123456789876543210 a0123456789876543210 = (!!!) a0123456789876543210 a0123456789876543210
-    infixl 4 !!!@#@$$$
+    infixl 4 type !!!@#@$$$
     type (%%%@#@$) :: (~>) a ((~>) a a)
     data (%%%@#@$) :: (~>) a ((~>) a a)
       where
@@ -80,7 +80,7 @@ Singletons/T582.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @a @((~>) a a) (%%%@#@$) a0123456789876543210 = (%%%@#@$$) a0123456789876543210
     instance SuppressUnusedWarnings (%%%@#@$) where
       suppressUnusedWarnings = snd ((,) (:%%%@#@$###) ())
-    infixl 4 %%%@#@$
+    infixl 4 type %%%@#@$
     type (%%%@#@$$) :: a -> (~>) a a
     data (%%%@#@$$) (a0123456789876543210 :: a) :: (~>) a a
       where
@@ -89,11 +89,11 @@ Singletons/T582.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @a @a ((%%%@#@$$) a0123456789876543210) a0123456789876543210 = (%%%) a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings ((%%%@#@$$) a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) (:%%%@#@$$###) ())
-    infixl 4 %%%@#@$$
+    infixl 4 type %%%@#@$$
     type (%%%@#@$$$) :: a -> a -> a
     type family (%%%@#@$$$) @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: a where
       (%%%@#@$$$) a0123456789876543210 a0123456789876543210 = (%%%) a0123456789876543210 a0123456789876543210
-    infixl 4 %%%@#@$$$
+    infixl 4 type %%%@#@$$$
     type FooSym0 :: (~>) a ((~>) a a)
     data FooSym0 :: (~>) a ((~>) a a)
       where
@@ -102,7 +102,7 @@ Singletons/T582.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @a @((~>) a a) FooSym0 a0123456789876543210 = FooSym1 a0123456789876543210
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings = snd ((,) FooSym0KindInference ())
-    infixl 4 `FooSym0`
+    infixl 4 type `FooSym0`
     type FooSym1 :: a -> (~>) a a
     data FooSym1 (a0123456789876543210 :: a) :: (~>) a a
       where
@@ -111,21 +111,21 @@ Singletons/T582.hs:(0,0)-(0,0): Splicing declarations
     type instance Apply @a @a (FooSym1 a0123456789876543210) a0123456789876543210 = Foo a0123456789876543210 a0123456789876543210
     instance SuppressUnusedWarnings (FooSym1 a0123456789876543210) where
       suppressUnusedWarnings = snd ((,) FooSym1KindInference ())
-    infixl 4 `FooSym1`
+    infixl 4 type `FooSym1`
     type FooSym2 :: a -> a -> a
     type family FooSym2 @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: a where
       FooSym2 a0123456789876543210 a0123456789876543210 = Foo a0123456789876543210 a0123456789876543210
-    infixl 4 `FooSym2`
+    infixl 4 type `FooSym2`
     type (%%%) :: a -> a -> a
     type family (%%%) @a (a :: a) (a :: a) :: a where
       (%%%) x _ = x
     type Foo :: a -> a -> a
     type family Foo @a (a :: a) (a :: a) :: a where
       Foo x _ = x
-    infixl 4 %%%
-    infixl 4 `Foo`
-    infixl 4 %%%%
-    infixl 4 `sFoo`
+    infixl 4 type %%%
+    infixl 4 type `Foo`
+    infixl 4 data %%%%
+    infixl 4 data `sFoo`
     (%%%%) ::
       (forall (t :: a) (t :: a).
        Sing t -> Sing t -> Sing ((%%%) t t :: a) :: Type)

--- a/singletons-th/CHANGES.md
+++ b/singletons-th/CHANGES.md
@@ -3,6 +3,7 @@ Changelog for the `singletons-th` project
 
 3.5 [????.??.??]
 ----------------
+* Require building with GHC 9.12.
 * Require building with `th-desugar-1.18` or later. Notably, `th-desugar-1.18`
   now desugars all lambda, `case`, and `\case` expressions to `\cases`
   expressions, and the same principle applies to the code that `singletons-th`

--- a/singletons-th/CHANGES.md
+++ b/singletons-th/CHANGES.md
@@ -1,8 +1,8 @@
 Changelog for the `singletons-th` project
 =========================================
 
-next [????.??.??]
------------------
+3.5 [????.??.??]
+----------------
 * Require building with `th-desugar-1.18` or later. Notably, `th-desugar-1.18`
   now desugars all lambda, `case`, and `\case` expressions to `\cases`
   expressions, and the same principle applies to the code that `singletons-th`

--- a/singletons-th/README.md
+++ b/singletons-th/README.md
@@ -14,7 +14,7 @@ which describes how promotion works in greater detail.
 
 `singletons-th` generates code that relies on bleeding-edge GHC language
 extensions. As such, `singletons-th` only supports the latest major version
-of GHC (currently GHC 9.10). For more information,
+of GHC (currently GHC 9.12). For more information,
 consult the `singletons`
 [`README`](https://github.com/goldfirere/singletons/blob/master/README.md).
 

--- a/singletons-th/singletons-th.cabal
+++ b/singletons-th/singletons-th.cabal
@@ -8,7 +8,7 @@ author:         Richard Eisenberg <rae@cs.brynmawr.edu>, Jan Stolarek <jan.stola
 maintainer:     Ryan Scott <ryan.gl.scott@gmail.com>
 bug-reports:    https://github.com/goldfirere/singletons/issues
 stability:      experimental
-tested-with:    GHC == 9.10.1
+tested-with:    GHC == 9.12.1
 extra-source-files: README.md, CHANGES.md
 license:        BSD3
 license-file:   LICENSE
@@ -26,7 +26,7 @@ description:
     .
     @singletons-th@ generates code that relies on bleeding-edge GHC language
     extensions. As such, @singletons-th@ only supports the latest major version
-    of GHC (currently GHC 9.10). For more information,
+    of GHC (currently GHC 9.12). For more information,
     consult the @singletons@
     @<https://github.com/goldfirere/singletons/blob/master/README.md README>@.
     .
@@ -52,13 +52,13 @@ source-repository head
 
 library
   hs-source-dirs:     src
-  build-depends:      base             >= 4.20 && < 4.21,
+  build-depends:      base             >= 4.21 && < 4.22,
                       containers       >= 0.5,
                       mtl              >= 2.2.1 && < 2.4,
                       ghc-boot-th,
                       singletons       == 3.0.*,
                       syb              >= 0.4,
-                      template-haskell >= 2.22 && < 2.23,
+                      template-haskell >= 2.23 && < 2.24,
                       th-desugar       >= 1.18 && < 1.19,
                       th-orphans       >= 0.13.11 && < 0.14,
                       transformers     >= 0.5.2

--- a/singletons-th/singletons-th.cabal
+++ b/singletons-th/singletons-th.cabal
@@ -1,5 +1,5 @@
 name:           singletons-th
-version:        3.4
+version:        3.5
 cabal-version:  1.24
 synopsis:       A framework for generating singleton types
 homepage:       http://www.github.com/goldfirere/singletons

--- a/singletons/CHANGES.md
+++ b/singletons/CHANGES.md
@@ -1,8 +1,8 @@
 Changelog for the `singletons` project
 ======================================
 
-next [????.??.??]
------------------
+3.0.4 [????.??.??]
+------------------
 * Define `Sing` instances such that they explicitly match on their types on the
   left-hand sides (e.g., define `type instance Sing @(k1 ~> k2) = SLambda`
   instead of `type instance Sing = SLambda`. Doing so will make `singletons`

--- a/singletons/CHANGES.md
+++ b/singletons/CHANGES.md
@@ -1,6 +1,14 @@
 Changelog for the `singletons` project
 ======================================
 
+next [????.??.??]
+-----------------
+* Define `Sing` instances such that they explicitly match on their types on the
+  left-hand sides (e.g., define `type instance Sing @(k1 ~> k2) = SLambda`
+  instead of `type instance Sing = SLambda`. Doing so will make `singletons`
+  future-proof once
+  [GHC#23515](https://gitlab.haskell.org/ghc/ghc/-/issues/23515) is fixed.
+
 3.0.3 [2024.05.12]
 ------------------
 * Allow building with GHC 9.10.

--- a/singletons/singletons.cabal
+++ b/singletons/singletons.cabal
@@ -17,9 +17,10 @@ tested-with:    GHC == 8.0.2
               , GHC == 9.0.2
               , GHC == 9.2.7
               , GHC == 9.4.8
-              , GHC == 9.6.5
+              , GHC == 9.6.6
               , GHC == 9.8.2
               , GHC == 9.10.1
+              , GHC == 9.12.1
 extra-source-files: README.md, CHANGES.md
 license:        BSD3
 license-file:   LICENSE
@@ -60,7 +61,7 @@ source-repository head
 
 library
   hs-source-dirs:     src
-  build-depends:      base >= 4.9 && < 4.21
+  build-depends:      base >= 4.9 && < 4.22
   default-language:   Haskell2010
   exposed-modules:    Data.Singletons
                       Data.Singletons.Decide
@@ -77,5 +78,5 @@ test-suite singletons-test-suite
   other-modules:      ByHand
                       ByHand2
 
-  build-depends:      base >= 4.9 && < 4.21,
+  build-depends:      base >= 4.9 && < 4.22,
                       singletons

--- a/singletons/singletons.cabal
+++ b/singletons/singletons.cabal
@@ -1,5 +1,5 @@
 name:           singletons
-version:        3.0.3
+version:        3.0.4
 cabal-version:  1.24
 synopsis:       Basic singleton types and definitions
 homepage:       http://www.github.com/goldfirere/singletons


### PR DESCRIPTION
The most notable change is that because GHC 9.12 includes a fix for https://gitlab.haskell.org/ghc/ghc/-/issues/24911, the test suite output now includes explicit namespaces for its fixity declarations. Aside from that, the changes here are mostly bumping upper version bounds.

Checks off one box in https://github.com/goldfirere/singletons/issues/619.