### PR TITLE
Create deterministic names for all identifiers and variables

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -257,7 +257,7 @@ jobs:
           source-repository-package
             type:     git
             location: https://github.com/goldfirere/th-desugar
-            tag:      fb1a3b142d15c8c2bc38372da7c0698ec9a6906d
+            tag:      e44d36282c00aba9214cb94f266d255553637e71
           EOF
           if $HEADHACKAGE; then
           echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project

--- a/cabal.project
+++ b/cabal.project
@@ -6,4 +6,4 @@ packages: ./singletons
 source-repository-package
   type: git
   location: https://github.com/goldfirere/th-desugar
-  tag: fb1a3b142d15c8c2bc38372da7c0698ec9a6906d
+  tag: e44d36282c00aba9214cb94f266d255553637e71

--- a/singletons-base/CHANGES.md
+++ b/singletons-base/CHANGES.md
@@ -1,6 +1,12 @@
 Changelog for the `singletons-base` project
 ===========================================
 
+next [????.??.??]
+-----------------
+* The unique names that `singletons-base` generates are now deterministic. This
+  should not affect the public-facing API portions of the TH-generated code,
+  but the resulting Haddocks should be a bit more compact and readable.
+
 3.5.1 [2026.01.10]
 ------------------
 * Require building with GHC 9.14.

--- a/singletons-base/tests/compile-and-dump/GradingClient/Database.golden
+++ b/singletons-base/tests/compile-and-dump/GradingClient/Database.golden
@@ -14,29 +14,29 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     data SuccSym0 :: (~>) Nat Nat
       where
         SuccSym0KindInference :: SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
-                                 SuccSym0 a0123456789876543210
-    type instance Apply @Nat @Nat SuccSym0 a0123456789876543210 = Succ a0123456789876543210
+                                 SuccSym0 a_GradingClient_Database_4
+    type instance Apply @Nat @Nat SuccSym0 a_GradingClient_Database_4 = Succ a_GradingClient_Database_4
     instance SuppressUnusedWarnings SuccSym0 where
       suppressUnusedWarnings = snd ((,) SuccSym0KindInference ())
     type SuccSym1 :: Nat -> Nat
-    type family SuccSym1 (a0123456789876543210 :: Nat) :: Nat where
-      SuccSym1 a0123456789876543210 = Succ a0123456789876543210
-    type TFHelper_0123456789876543210 :: Nat -> Nat -> Bool
-    type family TFHelper_0123456789876543210 (a :: Nat) (a :: Nat) :: Bool where
-      TFHelper_0123456789876543210 Zero Zero = TrueSym0
-      TFHelper_0123456789876543210 Zero (Succ _) = FalseSym0
-      TFHelper_0123456789876543210 (Succ _) Zero = FalseSym0
-      TFHelper_0123456789876543210 (Succ a_0123456789876543210) (Succ b_0123456789876543210) = Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210
+    type family SuccSym1 (a_GradingClient_Database_4 :: Nat) :: Nat where
+      SuccSym1 a_GradingClient_Database_4 = Succ a_GradingClient_Database_4
+    type TFHelper_GradingClient_Database_5 :: Nat -> Nat -> Bool
+    type family TFHelper_GradingClient_Database_5 (a :: Nat) (a :: Nat) :: Bool where
+      TFHelper_GradingClient_Database_5 Zero Zero = TrueSym0
+      TFHelper_GradingClient_Database_5 Zero (Succ _) = FalseSym0
+      TFHelper_GradingClient_Database_5 (Succ _) Zero = FalseSym0
+      TFHelper_GradingClient_Database_5 (Succ a_GradingClient_Database_0) (Succ b_GradingClient_Database_1) = Apply (Apply (==@#@$) a_GradingClient_Database_0) b_GradingClient_Database_1
     instance PEq Nat where
-      type (==) a a = TFHelper_0123456789876543210 a a
-    type Compare_0123456789876543210 :: Nat -> Nat -> Ordering
-    type family Compare_0123456789876543210 (a :: Nat) (a :: Nat) :: Ordering where
-      Compare_0123456789876543210 Zero Zero = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
-      Compare_0123456789876543210 (Succ a_0123456789876543210) (Succ b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0)
-      Compare_0123456789876543210 Zero (Succ _) = LTSym0
-      Compare_0123456789876543210 (Succ _) Zero = GTSym0
+      type (==) a a = TFHelper_GradingClient_Database_5 a a
+    type Compare_GradingClient_Database_8 :: Nat -> Nat -> Ordering
+    type family Compare_GradingClient_Database_8 (a :: Nat) (a :: Nat) :: Ordering where
+      Compare_GradingClient_Database_8 Zero Zero = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
+      Compare_GradingClient_Database_8 (Succ a_GradingClient_Database_2) (Succ b_GradingClient_Database_3) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_GradingClient_Database_2) b_GradingClient_Database_3)) NilSym0)
+      Compare_GradingClient_Database_8 Zero (Succ _) = LTSym0
+      Compare_GradingClient_Database_8 (Succ _) Zero = GTSym0
     instance POrd Nat where
-      type Compare a a = Compare_0123456789876543210 a a
+      type Compare a a = Compare_GradingClient_Database_8 a a
     data SNat :: Nat -> Type
       where
         SZero :: SNat (Zero :: Nat)
@@ -55,11 +55,11 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       (%==) SZero (SSucc _) = SFalse
       (%==) (SSucc _) SZero = SFalse
       (%==)
-        (SSucc (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SSucc (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SSucc (sA_GradingClient_Database_0 :: Sing a_GradingClient_Database_0))
+        (SSucc (sB_GradingClient_Database_1 :: Sing b_GradingClient_Database_1))
         = applySing
-            (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-            sB_0123456789876543210
+            (applySing (singFun2 @(==@#@$) (%==)) sA_GradingClient_Database_0)
+            sB_GradingClient_Database_1
     instance SOrd Nat => SOrd Nat where
       sCompare SZero SZero
         = applySing
@@ -68,8 +68,8 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
                SEQ)
             SNil
       sCompare
-        (SSucc (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SSucc (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SSucc (sA_GradingClient_Database_2 :: Sing a_GradingClient_Database_2))
+        (SSucc (sB_GradingClient_Database_3 :: Sing b_GradingClient_Database_3))
         = applySing
             (applySing
                (applySing (singFun3 @FoldlSym0 sFoldl) (singFun2 @(<>@#@$) (%<>)))
@@ -78,8 +78,9 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
                (applySing
                   (singFun2 @(:@#@$) SCons)
                   (applySing
-                     (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                     sB_0123456789876543210))
+                     (applySing
+                        (singFun2 @CompareSym0 sCompare) sA_GradingClient_Database_2)
+                     sB_GradingClient_Database_3))
                SNil)
       sCompare SZero (SSucc _) = SLT
       sCompare (SSucc _) SZero = SGT
@@ -231,21 +232,21 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     data VECSym0 :: (~>) U ((~>) Nat U)
       where
         VECSym0KindInference :: SameKind (Apply VECSym0 arg) (VECSym1 arg) =>
-                                VECSym0 a0123456789876543210
-    type instance Apply @U @((~>) Nat U) VECSym0 a0123456789876543210 = VECSym1 a0123456789876543210
+                                VECSym0 a_GradingClient_Database_19
+    type instance Apply @U @((~>) Nat U) VECSym0 a_GradingClient_Database_19 = VECSym1 a_GradingClient_Database_19
     instance SuppressUnusedWarnings VECSym0 where
       suppressUnusedWarnings = snd ((,) VECSym0KindInference ())
     type VECSym1 :: U -> (~>) Nat U
-    data VECSym1 (a0123456789876543210 :: U) :: (~>) Nat U
+    data VECSym1 (a_GradingClient_Database_19 :: U) :: (~>) Nat U
       where
-        VECSym1KindInference :: SameKind (Apply (VECSym1 a0123456789876543210) arg) (VECSym2 a0123456789876543210 arg) =>
-                                VECSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @U (VECSym1 a0123456789876543210) a0123456789876543210 = VEC a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (VECSym1 a0123456789876543210) where
+        VECSym1KindInference :: SameKind (Apply (VECSym1 a_GradingClient_Database_19) arg) (VECSym2 a_GradingClient_Database_19 arg) =>
+                                VECSym1 a_GradingClient_Database_19 a_GradingClient_Database_20
+    type instance Apply @Nat @U (VECSym1 a_GradingClient_Database_19) a_GradingClient_Database_20 = VEC a_GradingClient_Database_19 a_GradingClient_Database_20
+    instance SuppressUnusedWarnings (VECSym1 a_GradingClient_Database_19) where
       suppressUnusedWarnings = snd ((,) VECSym1KindInference ())
     type VECSym2 :: U -> Nat -> U
-    type family VECSym2 (a0123456789876543210 :: U) (a0123456789876543210 :: Nat) :: U where
-      VECSym2 a0123456789876543210 a0123456789876543210 = VEC a0123456789876543210 a0123456789876543210
+    type family VECSym2 (a_GradingClient_Database_19 :: U) (a_GradingClient_Database_20 :: Nat) :: U where
+      VECSym2 a_GradingClient_Database_19 a_GradingClient_Database_20 = VEC a_GradingClient_Database_19 a_GradingClient_Database_20
     type CASym0 :: AChar
     type family CASym0 :: AChar where
       CASym0 = CA
@@ -328,144 +329,144 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     data AttrSym0 :: (~>) [AChar] ((~>) U Attribute)
       where
         AttrSym0KindInference :: SameKind (Apply AttrSym0 arg) (AttrSym1 arg) =>
-                                 AttrSym0 a0123456789876543210
-    type instance Apply @[AChar] @((~>) U Attribute) AttrSym0 a0123456789876543210 = AttrSym1 a0123456789876543210
+                                 AttrSym0 a_GradingClient_Database_21
+    type instance Apply @[AChar] @((~>) U Attribute) AttrSym0 a_GradingClient_Database_21 = AttrSym1 a_GradingClient_Database_21
     instance SuppressUnusedWarnings AttrSym0 where
       suppressUnusedWarnings = snd ((,) AttrSym0KindInference ())
     type AttrSym1 :: [AChar] -> (~>) U Attribute
-    data AttrSym1 (a0123456789876543210 :: [AChar]) :: (~>) U Attribute
+    data AttrSym1 (a_GradingClient_Database_21 :: [AChar]) :: (~>) U Attribute
       where
-        AttrSym1KindInference :: SameKind (Apply (AttrSym1 a0123456789876543210) arg) (AttrSym2 a0123456789876543210 arg) =>
-                                 AttrSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @U @Attribute (AttrSym1 a0123456789876543210) a0123456789876543210 = Attr a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (AttrSym1 a0123456789876543210) where
+        AttrSym1KindInference :: SameKind (Apply (AttrSym1 a_GradingClient_Database_21) arg) (AttrSym2 a_GradingClient_Database_21 arg) =>
+                                 AttrSym1 a_GradingClient_Database_21 a_GradingClient_Database_22
+    type instance Apply @U @Attribute (AttrSym1 a_GradingClient_Database_21) a_GradingClient_Database_22 = Attr a_GradingClient_Database_21 a_GradingClient_Database_22
+    instance SuppressUnusedWarnings (AttrSym1 a_GradingClient_Database_21) where
       suppressUnusedWarnings = snd ((,) AttrSym1KindInference ())
     type AttrSym2 :: [AChar] -> U -> Attribute
-    type family AttrSym2 (a0123456789876543210 :: [AChar]) (a0123456789876543210 :: U) :: Attribute where
-      AttrSym2 a0123456789876543210 a0123456789876543210 = Attr a0123456789876543210 a0123456789876543210
+    type family AttrSym2 (a_GradingClient_Database_21 :: [AChar]) (a_GradingClient_Database_22 :: U) :: Attribute where
+      AttrSym2 a_GradingClient_Database_21 a_GradingClient_Database_22 = Attr a_GradingClient_Database_21 a_GradingClient_Database_22
     type SchSym0 :: (~>) [Attribute] Schema
     data SchSym0 :: (~>) [Attribute] Schema
       where
         SchSym0KindInference :: SameKind (Apply SchSym0 arg) (SchSym1 arg) =>
-                                SchSym0 a0123456789876543210
-    type instance Apply @[Attribute] @Schema SchSym0 a0123456789876543210 = Sch a0123456789876543210
+                                SchSym0 a_GradingClient_Database_23
+    type instance Apply @[Attribute] @Schema SchSym0 a_GradingClient_Database_23 = Sch a_GradingClient_Database_23
     instance SuppressUnusedWarnings SchSym0 where
       suppressUnusedWarnings = snd ((,) SchSym0KindInference ())
     type SchSym1 :: [Attribute] -> Schema
-    type family SchSym1 (a0123456789876543210 :: [Attribute]) :: Schema where
-      SchSym1 a0123456789876543210 = Sch a0123456789876543210
-    type family LamCases_0123456789876543210 (name0123456789876543210 :: [AChar]) name'0123456789876543210 u0123456789876543210 attrs0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 name name' u attrs 'True = u
-      LamCases_0123456789876543210 name name' u attrs 'False = Apply (Apply LookupSym0 name) (Apply SchSym0 attrs)
-    data LamCases_0123456789876543210Sym0 (name0123456789876543210 :: [AChar]) name'0123456789876543210 u0123456789876543210 attrs0123456789876543210 a_01234567898765432100123456789876543210
+    type family SchSym1 (a_GradingClient_Database_23 :: [Attribute]) :: Schema where
+      SchSym1 a_GradingClient_Database_23 = Sch a_GradingClient_Database_23
+    type family LamCases_GradingClient_Database_26 (name0 :: [AChar]) name'1 u2 attrs3 a_GradingClient_Database_27 where
+      LamCases_GradingClient_Database_26 name name' u attrs 'True = u
+      LamCases_GradingClient_Database_26 name name' u attrs 'False = Apply (Apply LookupSym0 name) (Apply SchSym0 attrs)
+    data LamCases_GradingClient_Database_26Sym0 (name0 :: [AChar]) name'1 u2 attrs3 a_GradingClient_Database_27
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 name0123456789876543210 name'0123456789876543210 u0123456789876543210 attrs0123456789876543210) arg) (LamCases_0123456789876543210Sym1 name0123456789876543210 name'0123456789876543210 u0123456789876543210 attrs0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 name0123456789876543210 name'0123456789876543210 u0123456789876543210 attrs0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 name0123456789876543210 name'0123456789876543210 u0123456789876543210 attrs0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 name0123456789876543210 name'0123456789876543210 u0123456789876543210 attrs0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 name0123456789876543210 name'0123456789876543210 u0123456789876543210 attrs0123456789876543210) where
+        LamCases_GradingClient_Database_26Sym0KindInference :: SameKind (Apply (LamCases_GradingClient_Database_26Sym0 name0 name'1 u2 attrs3) arg) (LamCases_GradingClient_Database_26Sym1 name0 name'1 u2 attrs3 arg) =>
+                                                               LamCases_GradingClient_Database_26Sym0 name0 name'1 u2 attrs3 a_GradingClient_Database_27
+    type instance Apply @_ @_ (LamCases_GradingClient_Database_26Sym0 name0 name'1 u2 attrs3) a_GradingClient_Database_27 = LamCases_GradingClient_Database_26 name0 name'1 u2 attrs3 a_GradingClient_Database_27
+    instance SuppressUnusedWarnings (LamCases_GradingClient_Database_26Sym0 name0 name'1 u2 attrs3) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (name0123456789876543210 :: [AChar]) name'0123456789876543210 u0123456789876543210 attrs0123456789876543210 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 name0123456789876543210 name'0123456789876543210 u0123456789876543210 attrs0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 name0123456789876543210 name'0123456789876543210 u0123456789876543210 attrs0123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_GradingClient_Database_26Sym0KindInference ())
+    type family LamCases_GradingClient_Database_26Sym1 (name0 :: [AChar]) name'1 u2 attrs3 a_GradingClient_Database_27 where
+      LamCases_GradingClient_Database_26Sym1 name0 name'1 u2 attrs3 a_GradingClient_Database_27 = LamCases_GradingClient_Database_26 name0 name'1 u2 attrs3 a_GradingClient_Database_27
     type LookupSym0 :: (~>) [AChar] ((~>) Schema U)
     data LookupSym0 :: (~>) [AChar] ((~>) Schema U)
       where
         LookupSym0KindInference :: SameKind (Apply LookupSym0 arg) (LookupSym1 arg) =>
-                                   LookupSym0 a0123456789876543210
-    type instance Apply @[AChar] @((~>) Schema U) LookupSym0 a0123456789876543210 = LookupSym1 a0123456789876543210
+                                   LookupSym0 a_GradingClient_Database_24
+    type instance Apply @[AChar] @((~>) Schema U) LookupSym0 a_GradingClient_Database_24 = LookupSym1 a_GradingClient_Database_24
     instance SuppressUnusedWarnings LookupSym0 where
       suppressUnusedWarnings = snd ((,) LookupSym0KindInference ())
     type LookupSym1 :: [AChar] -> (~>) Schema U
-    data LookupSym1 (a0123456789876543210 :: [AChar]) :: (~>) Schema U
+    data LookupSym1 (a_GradingClient_Database_24 :: [AChar]) :: (~>) Schema U
       where
-        LookupSym1KindInference :: SameKind (Apply (LookupSym1 a0123456789876543210) arg) (LookupSym2 a0123456789876543210 arg) =>
-                                   LookupSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Schema @U (LookupSym1 a0123456789876543210) a0123456789876543210 = Lookup a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (LookupSym1 a0123456789876543210) where
+        LookupSym1KindInference :: SameKind (Apply (LookupSym1 a_GradingClient_Database_24) arg) (LookupSym2 a_GradingClient_Database_24 arg) =>
+                                   LookupSym1 a_GradingClient_Database_24 a_GradingClient_Database_25
+    type instance Apply @Schema @U (LookupSym1 a_GradingClient_Database_24) a_GradingClient_Database_25 = Lookup a_GradingClient_Database_24 a_GradingClient_Database_25
+    instance SuppressUnusedWarnings (LookupSym1 a_GradingClient_Database_24) where
       suppressUnusedWarnings = snd ((,) LookupSym1KindInference ())
     type LookupSym2 :: [AChar] -> Schema -> U
-    type family LookupSym2 (a0123456789876543210 :: [AChar]) (a0123456789876543210 :: Schema) :: U where
-      LookupSym2 a0123456789876543210 a0123456789876543210 = Lookup a0123456789876543210 a0123456789876543210
+    type family LookupSym2 (a_GradingClient_Database_24 :: [AChar]) (a_GradingClient_Database_25 :: Schema) :: U where
+      LookupSym2 a_GradingClient_Database_24 a_GradingClient_Database_25 = Lookup a_GradingClient_Database_24 a_GradingClient_Database_25
     type OccursSym0 :: (~>) [AChar] ((~>) Schema Bool)
     data OccursSym0 :: (~>) [AChar] ((~>) Schema Bool)
       where
         OccursSym0KindInference :: SameKind (Apply OccursSym0 arg) (OccursSym1 arg) =>
-                                   OccursSym0 a0123456789876543210
-    type instance Apply @[AChar] @((~>) Schema Bool) OccursSym0 a0123456789876543210 = OccursSym1 a0123456789876543210
+                                   OccursSym0 a_GradingClient_Database_28
+    type instance Apply @[AChar] @((~>) Schema Bool) OccursSym0 a_GradingClient_Database_28 = OccursSym1 a_GradingClient_Database_28
     instance SuppressUnusedWarnings OccursSym0 where
       suppressUnusedWarnings = snd ((,) OccursSym0KindInference ())
     type OccursSym1 :: [AChar] -> (~>) Schema Bool
-    data OccursSym1 (a0123456789876543210 :: [AChar]) :: (~>) Schema Bool
+    data OccursSym1 (a_GradingClient_Database_28 :: [AChar]) :: (~>) Schema Bool
       where
-        OccursSym1KindInference :: SameKind (Apply (OccursSym1 a0123456789876543210) arg) (OccursSym2 a0123456789876543210 arg) =>
-                                   OccursSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Schema @Bool (OccursSym1 a0123456789876543210) a0123456789876543210 = Occurs a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (OccursSym1 a0123456789876543210) where
+        OccursSym1KindInference :: SameKind (Apply (OccursSym1 a_GradingClient_Database_28) arg) (OccursSym2 a_GradingClient_Database_28 arg) =>
+                                   OccursSym1 a_GradingClient_Database_28 a_GradingClient_Database_29
+    type instance Apply @Schema @Bool (OccursSym1 a_GradingClient_Database_28) a_GradingClient_Database_29 = Occurs a_GradingClient_Database_28 a_GradingClient_Database_29
+    instance SuppressUnusedWarnings (OccursSym1 a_GradingClient_Database_28) where
       suppressUnusedWarnings = snd ((,) OccursSym1KindInference ())
     type OccursSym2 :: [AChar] -> Schema -> Bool
-    type family OccursSym2 (a0123456789876543210 :: [AChar]) (a0123456789876543210 :: Schema) :: Bool where
-      OccursSym2 a0123456789876543210 a0123456789876543210 = Occurs a0123456789876543210 a0123456789876543210
+    type family OccursSym2 (a_GradingClient_Database_28 :: [AChar]) (a_GradingClient_Database_29 :: Schema) :: Bool where
+      OccursSym2 a_GradingClient_Database_28 a_GradingClient_Database_29 = Occurs a_GradingClient_Database_28 a_GradingClient_Database_29
     type DisjointSym0 :: (~>) Schema ((~>) Schema Bool)
     data DisjointSym0 :: (~>) Schema ((~>) Schema Bool)
       where
         DisjointSym0KindInference :: SameKind (Apply DisjointSym0 arg) (DisjointSym1 arg) =>
-                                     DisjointSym0 a0123456789876543210
-    type instance Apply @Schema @((~>) Schema Bool) DisjointSym0 a0123456789876543210 = DisjointSym1 a0123456789876543210
+                                     DisjointSym0 a_GradingClient_Database_30
+    type instance Apply @Schema @((~>) Schema Bool) DisjointSym0 a_GradingClient_Database_30 = DisjointSym1 a_GradingClient_Database_30
     instance SuppressUnusedWarnings DisjointSym0 where
       suppressUnusedWarnings = snd ((,) DisjointSym0KindInference ())
     type DisjointSym1 :: Schema -> (~>) Schema Bool
-    data DisjointSym1 (a0123456789876543210 :: Schema) :: (~>) Schema Bool
+    data DisjointSym1 (a_GradingClient_Database_30 :: Schema) :: (~>) Schema Bool
       where
-        DisjointSym1KindInference :: SameKind (Apply (DisjointSym1 a0123456789876543210) arg) (DisjointSym2 a0123456789876543210 arg) =>
-                                     DisjointSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Schema @Bool (DisjointSym1 a0123456789876543210) a0123456789876543210 = Disjoint a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (DisjointSym1 a0123456789876543210) where
+        DisjointSym1KindInference :: SameKind (Apply (DisjointSym1 a_GradingClient_Database_30) arg) (DisjointSym2 a_GradingClient_Database_30 arg) =>
+                                     DisjointSym1 a_GradingClient_Database_30 a_GradingClient_Database_31
+    type instance Apply @Schema @Bool (DisjointSym1 a_GradingClient_Database_30) a_GradingClient_Database_31 = Disjoint a_GradingClient_Database_30 a_GradingClient_Database_31
+    instance SuppressUnusedWarnings (DisjointSym1 a_GradingClient_Database_30) where
       suppressUnusedWarnings = snd ((,) DisjointSym1KindInference ())
     type DisjointSym2 :: Schema -> Schema -> Bool
-    type family DisjointSym2 (a0123456789876543210 :: Schema) (a0123456789876543210 :: Schema) :: Bool where
-      DisjointSym2 a0123456789876543210 a0123456789876543210 = Disjoint a0123456789876543210 a0123456789876543210
+    type family DisjointSym2 (a_GradingClient_Database_30 :: Schema) (a_GradingClient_Database_31 :: Schema) :: Bool where
+      DisjointSym2 a_GradingClient_Database_30 a_GradingClient_Database_31 = Disjoint a_GradingClient_Database_30 a_GradingClient_Database_31
     type AttrNotInSym0 :: (~>) Attribute ((~>) Schema Bool)
     data AttrNotInSym0 :: (~>) Attribute ((~>) Schema Bool)
       where
         AttrNotInSym0KindInference :: SameKind (Apply AttrNotInSym0 arg) (AttrNotInSym1 arg) =>
-                                      AttrNotInSym0 a0123456789876543210
-    type instance Apply @Attribute @((~>) Schema Bool) AttrNotInSym0 a0123456789876543210 = AttrNotInSym1 a0123456789876543210
+                                      AttrNotInSym0 a_GradingClient_Database_32
+    type instance Apply @Attribute @((~>) Schema Bool) AttrNotInSym0 a_GradingClient_Database_32 = AttrNotInSym1 a_GradingClient_Database_32
     instance SuppressUnusedWarnings AttrNotInSym0 where
       suppressUnusedWarnings = snd ((,) AttrNotInSym0KindInference ())
     type AttrNotInSym1 :: Attribute -> (~>) Schema Bool
-    data AttrNotInSym1 (a0123456789876543210 :: Attribute) :: (~>) Schema Bool
+    data AttrNotInSym1 (a_GradingClient_Database_32 :: Attribute) :: (~>) Schema Bool
       where
-        AttrNotInSym1KindInference :: SameKind (Apply (AttrNotInSym1 a0123456789876543210) arg) (AttrNotInSym2 a0123456789876543210 arg) =>
-                                      AttrNotInSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Schema @Bool (AttrNotInSym1 a0123456789876543210) a0123456789876543210 = AttrNotIn a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (AttrNotInSym1 a0123456789876543210) where
+        AttrNotInSym1KindInference :: SameKind (Apply (AttrNotInSym1 a_GradingClient_Database_32) arg) (AttrNotInSym2 a_GradingClient_Database_32 arg) =>
+                                      AttrNotInSym1 a_GradingClient_Database_32 a_GradingClient_Database_33
+    type instance Apply @Schema @Bool (AttrNotInSym1 a_GradingClient_Database_32) a_GradingClient_Database_33 = AttrNotIn a_GradingClient_Database_32 a_GradingClient_Database_33
+    instance SuppressUnusedWarnings (AttrNotInSym1 a_GradingClient_Database_32) where
       suppressUnusedWarnings = snd ((,) AttrNotInSym1KindInference ())
     type AttrNotInSym2 :: Attribute -> Schema -> Bool
-    type family AttrNotInSym2 (a0123456789876543210 :: Attribute) (a0123456789876543210 :: Schema) :: Bool where
-      AttrNotInSym2 a0123456789876543210 a0123456789876543210 = AttrNotIn a0123456789876543210 a0123456789876543210
+    type family AttrNotInSym2 (a_GradingClient_Database_32 :: Attribute) (a_GradingClient_Database_33 :: Schema) :: Bool where
+      AttrNotInSym2 a_GradingClient_Database_32 a_GradingClient_Database_33 = AttrNotIn a_GradingClient_Database_32 a_GradingClient_Database_33
     type AppendSym0 :: (~>) Schema ((~>) Schema Schema)
     data AppendSym0 :: (~>) Schema ((~>) Schema Schema)
       where
         AppendSym0KindInference :: SameKind (Apply AppendSym0 arg) (AppendSym1 arg) =>
-                                   AppendSym0 a0123456789876543210
-    type instance Apply @Schema @((~>) Schema Schema) AppendSym0 a0123456789876543210 = AppendSym1 a0123456789876543210
+                                   AppendSym0 a_GradingClient_Database_34
+    type instance Apply @Schema @((~>) Schema Schema) AppendSym0 a_GradingClient_Database_34 = AppendSym1 a_GradingClient_Database_34
     instance SuppressUnusedWarnings AppendSym0 where
       suppressUnusedWarnings = snd ((,) AppendSym0KindInference ())
     type AppendSym1 :: Schema -> (~>) Schema Schema
-    data AppendSym1 (a0123456789876543210 :: Schema) :: (~>) Schema Schema
+    data AppendSym1 (a_GradingClient_Database_34 :: Schema) :: (~>) Schema Schema
       where
-        AppendSym1KindInference :: SameKind (Apply (AppendSym1 a0123456789876543210) arg) (AppendSym2 a0123456789876543210 arg) =>
-                                   AppendSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Schema @Schema (AppendSym1 a0123456789876543210) a0123456789876543210 = Append a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (AppendSym1 a0123456789876543210) where
+        AppendSym1KindInference :: SameKind (Apply (AppendSym1 a_GradingClient_Database_34) arg) (AppendSym2 a_GradingClient_Database_34 arg) =>
+                                   AppendSym1 a_GradingClient_Database_34 a_GradingClient_Database_35
+    type instance Apply @Schema @Schema (AppendSym1 a_GradingClient_Database_34) a_GradingClient_Database_35 = Append a_GradingClient_Database_34 a_GradingClient_Database_35
+    instance SuppressUnusedWarnings (AppendSym1 a_GradingClient_Database_34) where
       suppressUnusedWarnings = snd ((,) AppendSym1KindInference ())
     type AppendSym2 :: Schema -> Schema -> Schema
-    type family AppendSym2 (a0123456789876543210 :: Schema) (a0123456789876543210 :: Schema) :: Schema where
-      AppendSym2 a0123456789876543210 a0123456789876543210 = Append a0123456789876543210 a0123456789876543210
+    type family AppendSym2 (a_GradingClient_Database_34 :: Schema) (a_GradingClient_Database_35 :: Schema) :: Schema where
+      AppendSym2 a_GradingClient_Database_34 a_GradingClient_Database_35 = Append a_GradingClient_Database_34 a_GradingClient_Database_35
     type Lookup :: [AChar] -> Schema -> U
     type family Lookup (a :: [AChar]) (a :: Schema) :: U where
       Lookup _ (Sch '[]) = UndefinedSym0
-      Lookup name (Sch ('(:) (Attr name' u) attrs)) = Apply (LamCases_0123456789876543210Sym0 name name' u attrs) (Apply (Apply (==@#@$) name) name')
+      Lookup name (Sch ('(:) (Attr name' u) attrs)) = Apply (LamCases_GradingClient_Database_26Sym0 name name' u attrs) (Apply (Apply (==@#@$) name) name')
     type Occurs :: [AChar] -> Schema -> Bool
     type family Occurs (a :: [AChar]) (a :: Schema) :: Bool where
       Occurs _ (Sch '[]) = FalseSym0
@@ -481,746 +482,746 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
     type Append :: Schema -> Schema -> Schema
     type family Append (a :: Schema) (a :: Schema) :: Schema where
       Append (Sch s1) (Sch s2) = Apply SchSym0 (Apply (Apply (++@#@$) s1) s2)
-    type TFHelper_0123456789876543210 :: U -> U -> Bool
-    type family TFHelper_0123456789876543210 (a :: U) (a :: U) :: Bool where
-      TFHelper_0123456789876543210 BOOL BOOL = TrueSym0
-      TFHelper_0123456789876543210 BOOL STRING = FalseSym0
-      TFHelper_0123456789876543210 BOOL NAT = FalseSym0
-      TFHelper_0123456789876543210 BOOL (VEC _ _) = FalseSym0
-      TFHelper_0123456789876543210 STRING BOOL = FalseSym0
-      TFHelper_0123456789876543210 STRING STRING = TrueSym0
-      TFHelper_0123456789876543210 STRING NAT = FalseSym0
-      TFHelper_0123456789876543210 STRING (VEC _ _) = FalseSym0
-      TFHelper_0123456789876543210 NAT BOOL = FalseSym0
-      TFHelper_0123456789876543210 NAT STRING = FalseSym0
-      TFHelper_0123456789876543210 NAT NAT = TrueSym0
-      TFHelper_0123456789876543210 NAT (VEC _ _) = FalseSym0
-      TFHelper_0123456789876543210 (VEC _ _) BOOL = FalseSym0
-      TFHelper_0123456789876543210 (VEC _ _) STRING = FalseSym0
-      TFHelper_0123456789876543210 (VEC _ _) NAT = FalseSym0
-      TFHelper_0123456789876543210 (VEC a_0123456789876543210 a_0123456789876543210) (VEC b_0123456789876543210 b_0123456789876543210) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)
+    type TFHelper_GradingClient_Database_36 :: U -> U -> Bool
+    type family TFHelper_GradingClient_Database_36 (a :: U) (a :: U) :: Bool where
+      TFHelper_GradingClient_Database_36 BOOL BOOL = TrueSym0
+      TFHelper_GradingClient_Database_36 BOOL STRING = FalseSym0
+      TFHelper_GradingClient_Database_36 BOOL NAT = FalseSym0
+      TFHelper_GradingClient_Database_36 BOOL (VEC _ _) = FalseSym0
+      TFHelper_GradingClient_Database_36 STRING BOOL = FalseSym0
+      TFHelper_GradingClient_Database_36 STRING STRING = TrueSym0
+      TFHelper_GradingClient_Database_36 STRING NAT = FalseSym0
+      TFHelper_GradingClient_Database_36 STRING (VEC _ _) = FalseSym0
+      TFHelper_GradingClient_Database_36 NAT BOOL = FalseSym0
+      TFHelper_GradingClient_Database_36 NAT STRING = FalseSym0
+      TFHelper_GradingClient_Database_36 NAT NAT = TrueSym0
+      TFHelper_GradingClient_Database_36 NAT (VEC _ _) = FalseSym0
+      TFHelper_GradingClient_Database_36 (VEC _ _) BOOL = FalseSym0
+      TFHelper_GradingClient_Database_36 (VEC _ _) STRING = FalseSym0
+      TFHelper_GradingClient_Database_36 (VEC _ _) NAT = FalseSym0
+      TFHelper_GradingClient_Database_36 (VEC a_GradingClient_Database_11 a_GradingClient_Database_12) (VEC b_GradingClient_Database_13 b_GradingClient_Database_14) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_GradingClient_Database_11) b_GradingClient_Database_13)) (Apply (Apply (==@#@$) a_GradingClient_Database_12) b_GradingClient_Database_14)
     instance PEq U where
-      type (==) a a = TFHelper_0123456789876543210 a a
-    type ShowsPrec_0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural
-                                          -> U -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210 (a :: GHC.Internal.Bignum.Natural.Natural) (a :: U) (a :: Symbol) :: Symbol where
-      ShowsPrec_0123456789876543210 _ BOOL a_0123456789876543210 = Apply (Apply ShowStringSym0 "BOOL") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ STRING a_0123456789876543210 = Apply (Apply ShowStringSym0 "STRING") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ NAT a_0123456789876543210 = Apply (Apply ShowStringSym0 "NAT") a_0123456789876543210
-      ShowsPrec_0123456789876543210 p_0123456789876543210 (VEC arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "VEC ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
+      type (==) a a = TFHelper_GradingClient_Database_36 a a
+    type ShowsPrec_GradingClient_Database_39 :: GHC.Internal.Bignum.Natural.Natural
+                                                -> U -> Symbol -> Symbol
+    type family ShowsPrec_GradingClient_Database_39 (a :: GHC.Internal.Bignum.Natural.Natural) (a :: U) (a :: Symbol) :: Symbol where
+      ShowsPrec_GradingClient_Database_39 _ BOOL a_GradingClient_Database_40 = Apply (Apply ShowStringSym0 "BOOL") a_GradingClient_Database_40
+      ShowsPrec_GradingClient_Database_39 _ STRING a_GradingClient_Database_41 = Apply (Apply ShowStringSym0 "STRING") a_GradingClient_Database_41
+      ShowsPrec_GradingClient_Database_39 _ NAT a_GradingClient_Database_42 = Apply (Apply ShowStringSym0 "NAT") a_GradingClient_Database_42
+      ShowsPrec_GradingClient_Database_39 p_GradingClient_Database_15 (VEC arg_GradingClient_Database_16 arg_GradingClient_Database_17) a_GradingClient_Database_43 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_GradingClient_Database_15) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "VEC ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_GradingClient_Database_16)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_GradingClient_Database_17))))) a_GradingClient_Database_43
     instance PShow U where
-      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
-    type ShowsPrec_0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural
-                                          -> AChar -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210 (a :: GHC.Internal.Bignum.Natural.Natural) (a :: AChar) (a :: Symbol) :: Symbol where
-      ShowsPrec_0123456789876543210 _ CA a_0123456789876543210 = Apply (Apply ShowStringSym0 "CA") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ CB a_0123456789876543210 = Apply (Apply ShowStringSym0 "CB") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ CC a_0123456789876543210 = Apply (Apply ShowStringSym0 "CC") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ CD a_0123456789876543210 = Apply (Apply ShowStringSym0 "CD") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ CE a_0123456789876543210 = Apply (Apply ShowStringSym0 "CE") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ CF a_0123456789876543210 = Apply (Apply ShowStringSym0 "CF") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ CG a_0123456789876543210 = Apply (Apply ShowStringSym0 "CG") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ CH a_0123456789876543210 = Apply (Apply ShowStringSym0 "CH") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ CI a_0123456789876543210 = Apply (Apply ShowStringSym0 "CI") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ CJ a_0123456789876543210 = Apply (Apply ShowStringSym0 "CJ") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ CK a_0123456789876543210 = Apply (Apply ShowStringSym0 "CK") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ CL a_0123456789876543210 = Apply (Apply ShowStringSym0 "CL") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ CM a_0123456789876543210 = Apply (Apply ShowStringSym0 "CM") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ CN a_0123456789876543210 = Apply (Apply ShowStringSym0 "CN") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ CO a_0123456789876543210 = Apply (Apply ShowStringSym0 "CO") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ CP a_0123456789876543210 = Apply (Apply ShowStringSym0 "CP") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ CQ a_0123456789876543210 = Apply (Apply ShowStringSym0 "CQ") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ CR a_0123456789876543210 = Apply (Apply ShowStringSym0 "CR") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ CS a_0123456789876543210 = Apply (Apply ShowStringSym0 "CS") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ CT a_0123456789876543210 = Apply (Apply ShowStringSym0 "CT") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ CU a_0123456789876543210 = Apply (Apply ShowStringSym0 "CU") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ CV a_0123456789876543210 = Apply (Apply ShowStringSym0 "CV") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ CW a_0123456789876543210 = Apply (Apply ShowStringSym0 "CW") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ CX a_0123456789876543210 = Apply (Apply ShowStringSym0 "CX") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ CY a_0123456789876543210 = Apply (Apply ShowStringSym0 "CY") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ CZ a_0123456789876543210 = Apply (Apply ShowStringSym0 "CZ") a_0123456789876543210
+      type ShowsPrec a a a = ShowsPrec_GradingClient_Database_39 a a a
+    type ShowsPrec_GradingClient_Database_47 :: GHC.Internal.Bignum.Natural.Natural
+                                                -> AChar -> Symbol -> Symbol
+    type family ShowsPrec_GradingClient_Database_47 (a :: GHC.Internal.Bignum.Natural.Natural) (a :: AChar) (a :: Symbol) :: Symbol where
+      ShowsPrec_GradingClient_Database_47 _ CA a_GradingClient_Database_48 = Apply (Apply ShowStringSym0 "CA") a_GradingClient_Database_48
+      ShowsPrec_GradingClient_Database_47 _ CB a_GradingClient_Database_49 = Apply (Apply ShowStringSym0 "CB") a_GradingClient_Database_49
+      ShowsPrec_GradingClient_Database_47 _ CC a_GradingClient_Database_50 = Apply (Apply ShowStringSym0 "CC") a_GradingClient_Database_50
+      ShowsPrec_GradingClient_Database_47 _ CD a_GradingClient_Database_51 = Apply (Apply ShowStringSym0 "CD") a_GradingClient_Database_51
+      ShowsPrec_GradingClient_Database_47 _ CE a_GradingClient_Database_52 = Apply (Apply ShowStringSym0 "CE") a_GradingClient_Database_52
+      ShowsPrec_GradingClient_Database_47 _ CF a_GradingClient_Database_53 = Apply (Apply ShowStringSym0 "CF") a_GradingClient_Database_53
+      ShowsPrec_GradingClient_Database_47 _ CG a_GradingClient_Database_54 = Apply (Apply ShowStringSym0 "CG") a_GradingClient_Database_54
+      ShowsPrec_GradingClient_Database_47 _ CH a_GradingClient_Database_55 = Apply (Apply ShowStringSym0 "CH") a_GradingClient_Database_55
+      ShowsPrec_GradingClient_Database_47 _ CI a_GradingClient_Database_56 = Apply (Apply ShowStringSym0 "CI") a_GradingClient_Database_56
+      ShowsPrec_GradingClient_Database_47 _ CJ a_GradingClient_Database_57 = Apply (Apply ShowStringSym0 "CJ") a_GradingClient_Database_57
+      ShowsPrec_GradingClient_Database_47 _ CK a_GradingClient_Database_58 = Apply (Apply ShowStringSym0 "CK") a_GradingClient_Database_58
+      ShowsPrec_GradingClient_Database_47 _ CL a_GradingClient_Database_59 = Apply (Apply ShowStringSym0 "CL") a_GradingClient_Database_59
+      ShowsPrec_GradingClient_Database_47 _ CM a_GradingClient_Database_60 = Apply (Apply ShowStringSym0 "CM") a_GradingClient_Database_60
+      ShowsPrec_GradingClient_Database_47 _ CN a_GradingClient_Database_61 = Apply (Apply ShowStringSym0 "CN") a_GradingClient_Database_61
+      ShowsPrec_GradingClient_Database_47 _ CO a_GradingClient_Database_62 = Apply (Apply ShowStringSym0 "CO") a_GradingClient_Database_62
+      ShowsPrec_GradingClient_Database_47 _ CP a_GradingClient_Database_63 = Apply (Apply ShowStringSym0 "CP") a_GradingClient_Database_63
+      ShowsPrec_GradingClient_Database_47 _ CQ a_GradingClient_Database_64 = Apply (Apply ShowStringSym0 "CQ") a_GradingClient_Database_64
+      ShowsPrec_GradingClient_Database_47 _ CR a_GradingClient_Database_65 = Apply (Apply ShowStringSym0 "CR") a_GradingClient_Database_65
+      ShowsPrec_GradingClient_Database_47 _ CS a_GradingClient_Database_66 = Apply (Apply ShowStringSym0 "CS") a_GradingClient_Database_66
+      ShowsPrec_GradingClient_Database_47 _ CT a_GradingClient_Database_67 = Apply (Apply ShowStringSym0 "CT") a_GradingClient_Database_67
+      ShowsPrec_GradingClient_Database_47 _ CU a_GradingClient_Database_68 = Apply (Apply ShowStringSym0 "CU") a_GradingClient_Database_68
+      ShowsPrec_GradingClient_Database_47 _ CV a_GradingClient_Database_69 = Apply (Apply ShowStringSym0 "CV") a_GradingClient_Database_69
+      ShowsPrec_GradingClient_Database_47 _ CW a_GradingClient_Database_70 = Apply (Apply ShowStringSym0 "CW") a_GradingClient_Database_70
+      ShowsPrec_GradingClient_Database_47 _ CX a_GradingClient_Database_71 = Apply (Apply ShowStringSym0 "CX") a_GradingClient_Database_71
+      ShowsPrec_GradingClient_Database_47 _ CY a_GradingClient_Database_72 = Apply (Apply ShowStringSym0 "CY") a_GradingClient_Database_72
+      ShowsPrec_GradingClient_Database_47 _ CZ a_GradingClient_Database_73 = Apply (Apply ShowStringSym0 "CZ") a_GradingClient_Database_73
     instance PShow AChar where
-      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
-    type TFHelper_0123456789876543210 :: AChar -> AChar -> Bool
-    type family TFHelper_0123456789876543210 (a :: AChar) (a :: AChar) :: Bool where
-      TFHelper_0123456789876543210 CA CA = TrueSym0
-      TFHelper_0123456789876543210 CA CB = FalseSym0
-      TFHelper_0123456789876543210 CA CC = FalseSym0
-      TFHelper_0123456789876543210 CA CD = FalseSym0
-      TFHelper_0123456789876543210 CA CE = FalseSym0
-      TFHelper_0123456789876543210 CA CF = FalseSym0
-      TFHelper_0123456789876543210 CA CG = FalseSym0
-      TFHelper_0123456789876543210 CA CH = FalseSym0
-      TFHelper_0123456789876543210 CA CI = FalseSym0
-      TFHelper_0123456789876543210 CA CJ = FalseSym0
-      TFHelper_0123456789876543210 CA CK = FalseSym0
-      TFHelper_0123456789876543210 CA CL = FalseSym0
-      TFHelper_0123456789876543210 CA CM = FalseSym0
-      TFHelper_0123456789876543210 CA CN = FalseSym0
-      TFHelper_0123456789876543210 CA CO = FalseSym0
-      TFHelper_0123456789876543210 CA CP = FalseSym0
-      TFHelper_0123456789876543210 CA CQ = FalseSym0
-      TFHelper_0123456789876543210 CA CR = FalseSym0
-      TFHelper_0123456789876543210 CA CS = FalseSym0
-      TFHelper_0123456789876543210 CA CT = FalseSym0
-      TFHelper_0123456789876543210 CA CU = FalseSym0
-      TFHelper_0123456789876543210 CA CV = FalseSym0
-      TFHelper_0123456789876543210 CA CW = FalseSym0
-      TFHelper_0123456789876543210 CA CX = FalseSym0
-      TFHelper_0123456789876543210 CA CY = FalseSym0
-      TFHelper_0123456789876543210 CA CZ = FalseSym0
-      TFHelper_0123456789876543210 CB CA = FalseSym0
-      TFHelper_0123456789876543210 CB CB = TrueSym0
-      TFHelper_0123456789876543210 CB CC = FalseSym0
-      TFHelper_0123456789876543210 CB CD = FalseSym0
-      TFHelper_0123456789876543210 CB CE = FalseSym0
-      TFHelper_0123456789876543210 CB CF = FalseSym0
-      TFHelper_0123456789876543210 CB CG = FalseSym0
-      TFHelper_0123456789876543210 CB CH = FalseSym0
-      TFHelper_0123456789876543210 CB CI = FalseSym0
-      TFHelper_0123456789876543210 CB CJ = FalseSym0
-      TFHelper_0123456789876543210 CB CK = FalseSym0
-      TFHelper_0123456789876543210 CB CL = FalseSym0
-      TFHelper_0123456789876543210 CB CM = FalseSym0
-      TFHelper_0123456789876543210 CB CN = FalseSym0
-      TFHelper_0123456789876543210 CB CO = FalseSym0
-      TFHelper_0123456789876543210 CB CP = FalseSym0
-      TFHelper_0123456789876543210 CB CQ = FalseSym0
-      TFHelper_0123456789876543210 CB CR = FalseSym0
-      TFHelper_0123456789876543210 CB CS = FalseSym0
-      TFHelper_0123456789876543210 CB CT = FalseSym0
-      TFHelper_0123456789876543210 CB CU = FalseSym0
-      TFHelper_0123456789876543210 CB CV = FalseSym0
-      TFHelper_0123456789876543210 CB CW = FalseSym0
-      TFHelper_0123456789876543210 CB CX = FalseSym0
-      TFHelper_0123456789876543210 CB CY = FalseSym0
-      TFHelper_0123456789876543210 CB CZ = FalseSym0
-      TFHelper_0123456789876543210 CC CA = FalseSym0
-      TFHelper_0123456789876543210 CC CB = FalseSym0
-      TFHelper_0123456789876543210 CC CC = TrueSym0
-      TFHelper_0123456789876543210 CC CD = FalseSym0
-      TFHelper_0123456789876543210 CC CE = FalseSym0
-      TFHelper_0123456789876543210 CC CF = FalseSym0
-      TFHelper_0123456789876543210 CC CG = FalseSym0
-      TFHelper_0123456789876543210 CC CH = FalseSym0
-      TFHelper_0123456789876543210 CC CI = FalseSym0
-      TFHelper_0123456789876543210 CC CJ = FalseSym0
-      TFHelper_0123456789876543210 CC CK = FalseSym0
-      TFHelper_0123456789876543210 CC CL = FalseSym0
-      TFHelper_0123456789876543210 CC CM = FalseSym0
-      TFHelper_0123456789876543210 CC CN = FalseSym0
-      TFHelper_0123456789876543210 CC CO = FalseSym0
-      TFHelper_0123456789876543210 CC CP = FalseSym0
-      TFHelper_0123456789876543210 CC CQ = FalseSym0
-      TFHelper_0123456789876543210 CC CR = FalseSym0
-      TFHelper_0123456789876543210 CC CS = FalseSym0
-      TFHelper_0123456789876543210 CC CT = FalseSym0
-      TFHelper_0123456789876543210 CC CU = FalseSym0
-      TFHelper_0123456789876543210 CC CV = FalseSym0
-      TFHelper_0123456789876543210 CC CW = FalseSym0
-      TFHelper_0123456789876543210 CC CX = FalseSym0
-      TFHelper_0123456789876543210 CC CY = FalseSym0
-      TFHelper_0123456789876543210 CC CZ = FalseSym0
-      TFHelper_0123456789876543210 CD CA = FalseSym0
-      TFHelper_0123456789876543210 CD CB = FalseSym0
-      TFHelper_0123456789876543210 CD CC = FalseSym0
-      TFHelper_0123456789876543210 CD CD = TrueSym0
-      TFHelper_0123456789876543210 CD CE = FalseSym0
-      TFHelper_0123456789876543210 CD CF = FalseSym0
-      TFHelper_0123456789876543210 CD CG = FalseSym0
-      TFHelper_0123456789876543210 CD CH = FalseSym0
-      TFHelper_0123456789876543210 CD CI = FalseSym0
-      TFHelper_0123456789876543210 CD CJ = FalseSym0
-      TFHelper_0123456789876543210 CD CK = FalseSym0
-      TFHelper_0123456789876543210 CD CL = FalseSym0
-      TFHelper_0123456789876543210 CD CM = FalseSym0
-      TFHelper_0123456789876543210 CD CN = FalseSym0
-      TFHelper_0123456789876543210 CD CO = FalseSym0
-      TFHelper_0123456789876543210 CD CP = FalseSym0
-      TFHelper_0123456789876543210 CD CQ = FalseSym0
-      TFHelper_0123456789876543210 CD CR = FalseSym0
-      TFHelper_0123456789876543210 CD CS = FalseSym0
-      TFHelper_0123456789876543210 CD CT = FalseSym0
-      TFHelper_0123456789876543210 CD CU = FalseSym0
-      TFHelper_0123456789876543210 CD CV = FalseSym0
-      TFHelper_0123456789876543210 CD CW = FalseSym0
-      TFHelper_0123456789876543210 CD CX = FalseSym0
-      TFHelper_0123456789876543210 CD CY = FalseSym0
-      TFHelper_0123456789876543210 CD CZ = FalseSym0
-      TFHelper_0123456789876543210 CE CA = FalseSym0
-      TFHelper_0123456789876543210 CE CB = FalseSym0
-      TFHelper_0123456789876543210 CE CC = FalseSym0
-      TFHelper_0123456789876543210 CE CD = FalseSym0
-      TFHelper_0123456789876543210 CE CE = TrueSym0
-      TFHelper_0123456789876543210 CE CF = FalseSym0
-      TFHelper_0123456789876543210 CE CG = FalseSym0
-      TFHelper_0123456789876543210 CE CH = FalseSym0
-      TFHelper_0123456789876543210 CE CI = FalseSym0
-      TFHelper_0123456789876543210 CE CJ = FalseSym0
-      TFHelper_0123456789876543210 CE CK = FalseSym0
-      TFHelper_0123456789876543210 CE CL = FalseSym0
-      TFHelper_0123456789876543210 CE CM = FalseSym0
-      TFHelper_0123456789876543210 CE CN = FalseSym0
-      TFHelper_0123456789876543210 CE CO = FalseSym0
-      TFHelper_0123456789876543210 CE CP = FalseSym0
-      TFHelper_0123456789876543210 CE CQ = FalseSym0
-      TFHelper_0123456789876543210 CE CR = FalseSym0
-      TFHelper_0123456789876543210 CE CS = FalseSym0
-      TFHelper_0123456789876543210 CE CT = FalseSym0
-      TFHelper_0123456789876543210 CE CU = FalseSym0
-      TFHelper_0123456789876543210 CE CV = FalseSym0
-      TFHelper_0123456789876543210 CE CW = FalseSym0
-      TFHelper_0123456789876543210 CE CX = FalseSym0
-      TFHelper_0123456789876543210 CE CY = FalseSym0
-      TFHelper_0123456789876543210 CE CZ = FalseSym0
-      TFHelper_0123456789876543210 CF CA = FalseSym0
-      TFHelper_0123456789876543210 CF CB = FalseSym0
-      TFHelper_0123456789876543210 CF CC = FalseSym0
-      TFHelper_0123456789876543210 CF CD = FalseSym0
-      TFHelper_0123456789876543210 CF CE = FalseSym0
-      TFHelper_0123456789876543210 CF CF = TrueSym0
-      TFHelper_0123456789876543210 CF CG = FalseSym0
-      TFHelper_0123456789876543210 CF CH = FalseSym0
-      TFHelper_0123456789876543210 CF CI = FalseSym0
-      TFHelper_0123456789876543210 CF CJ = FalseSym0
-      TFHelper_0123456789876543210 CF CK = FalseSym0
-      TFHelper_0123456789876543210 CF CL = FalseSym0
-      TFHelper_0123456789876543210 CF CM = FalseSym0
-      TFHelper_0123456789876543210 CF CN = FalseSym0
-      TFHelper_0123456789876543210 CF CO = FalseSym0
-      TFHelper_0123456789876543210 CF CP = FalseSym0
-      TFHelper_0123456789876543210 CF CQ = FalseSym0
-      TFHelper_0123456789876543210 CF CR = FalseSym0
-      TFHelper_0123456789876543210 CF CS = FalseSym0
-      TFHelper_0123456789876543210 CF CT = FalseSym0
-      TFHelper_0123456789876543210 CF CU = FalseSym0
-      TFHelper_0123456789876543210 CF CV = FalseSym0
-      TFHelper_0123456789876543210 CF CW = FalseSym0
-      TFHelper_0123456789876543210 CF CX = FalseSym0
-      TFHelper_0123456789876543210 CF CY = FalseSym0
-      TFHelper_0123456789876543210 CF CZ = FalseSym0
-      TFHelper_0123456789876543210 CG CA = FalseSym0
-      TFHelper_0123456789876543210 CG CB = FalseSym0
-      TFHelper_0123456789876543210 CG CC = FalseSym0
-      TFHelper_0123456789876543210 CG CD = FalseSym0
-      TFHelper_0123456789876543210 CG CE = FalseSym0
-      TFHelper_0123456789876543210 CG CF = FalseSym0
-      TFHelper_0123456789876543210 CG CG = TrueSym0
-      TFHelper_0123456789876543210 CG CH = FalseSym0
-      TFHelper_0123456789876543210 CG CI = FalseSym0
-      TFHelper_0123456789876543210 CG CJ = FalseSym0
-      TFHelper_0123456789876543210 CG CK = FalseSym0
-      TFHelper_0123456789876543210 CG CL = FalseSym0
-      TFHelper_0123456789876543210 CG CM = FalseSym0
-      TFHelper_0123456789876543210 CG CN = FalseSym0
-      TFHelper_0123456789876543210 CG CO = FalseSym0
-      TFHelper_0123456789876543210 CG CP = FalseSym0
-      TFHelper_0123456789876543210 CG CQ = FalseSym0
-      TFHelper_0123456789876543210 CG CR = FalseSym0
-      TFHelper_0123456789876543210 CG CS = FalseSym0
-      TFHelper_0123456789876543210 CG CT = FalseSym0
-      TFHelper_0123456789876543210 CG CU = FalseSym0
-      TFHelper_0123456789876543210 CG CV = FalseSym0
-      TFHelper_0123456789876543210 CG CW = FalseSym0
-      TFHelper_0123456789876543210 CG CX = FalseSym0
-      TFHelper_0123456789876543210 CG CY = FalseSym0
-      TFHelper_0123456789876543210 CG CZ = FalseSym0
-      TFHelper_0123456789876543210 CH CA = FalseSym0
-      TFHelper_0123456789876543210 CH CB = FalseSym0
-      TFHelper_0123456789876543210 CH CC = FalseSym0
-      TFHelper_0123456789876543210 CH CD = FalseSym0
-      TFHelper_0123456789876543210 CH CE = FalseSym0
-      TFHelper_0123456789876543210 CH CF = FalseSym0
-      TFHelper_0123456789876543210 CH CG = FalseSym0
-      TFHelper_0123456789876543210 CH CH = TrueSym0
-      TFHelper_0123456789876543210 CH CI = FalseSym0
-      TFHelper_0123456789876543210 CH CJ = FalseSym0
-      TFHelper_0123456789876543210 CH CK = FalseSym0
-      TFHelper_0123456789876543210 CH CL = FalseSym0
-      TFHelper_0123456789876543210 CH CM = FalseSym0
-      TFHelper_0123456789876543210 CH CN = FalseSym0
-      TFHelper_0123456789876543210 CH CO = FalseSym0
-      TFHelper_0123456789876543210 CH CP = FalseSym0
-      TFHelper_0123456789876543210 CH CQ = FalseSym0
-      TFHelper_0123456789876543210 CH CR = FalseSym0
-      TFHelper_0123456789876543210 CH CS = FalseSym0
-      TFHelper_0123456789876543210 CH CT = FalseSym0
-      TFHelper_0123456789876543210 CH CU = FalseSym0
-      TFHelper_0123456789876543210 CH CV = FalseSym0
-      TFHelper_0123456789876543210 CH CW = FalseSym0
-      TFHelper_0123456789876543210 CH CX = FalseSym0
-      TFHelper_0123456789876543210 CH CY = FalseSym0
-      TFHelper_0123456789876543210 CH CZ = FalseSym0
-      TFHelper_0123456789876543210 CI CA = FalseSym0
-      TFHelper_0123456789876543210 CI CB = FalseSym0
-      TFHelper_0123456789876543210 CI CC = FalseSym0
-      TFHelper_0123456789876543210 CI CD = FalseSym0
-      TFHelper_0123456789876543210 CI CE = FalseSym0
-      TFHelper_0123456789876543210 CI CF = FalseSym0
-      TFHelper_0123456789876543210 CI CG = FalseSym0
-      TFHelper_0123456789876543210 CI CH = FalseSym0
-      TFHelper_0123456789876543210 CI CI = TrueSym0
-      TFHelper_0123456789876543210 CI CJ = FalseSym0
-      TFHelper_0123456789876543210 CI CK = FalseSym0
-      TFHelper_0123456789876543210 CI CL = FalseSym0
-      TFHelper_0123456789876543210 CI CM = FalseSym0
-      TFHelper_0123456789876543210 CI CN = FalseSym0
-      TFHelper_0123456789876543210 CI CO = FalseSym0
-      TFHelper_0123456789876543210 CI CP = FalseSym0
-      TFHelper_0123456789876543210 CI CQ = FalseSym0
-      TFHelper_0123456789876543210 CI CR = FalseSym0
-      TFHelper_0123456789876543210 CI CS = FalseSym0
-      TFHelper_0123456789876543210 CI CT = FalseSym0
-      TFHelper_0123456789876543210 CI CU = FalseSym0
-      TFHelper_0123456789876543210 CI CV = FalseSym0
-      TFHelper_0123456789876543210 CI CW = FalseSym0
-      TFHelper_0123456789876543210 CI CX = FalseSym0
-      TFHelper_0123456789876543210 CI CY = FalseSym0
-      TFHelper_0123456789876543210 CI CZ = FalseSym0
-      TFHelper_0123456789876543210 CJ CA = FalseSym0
-      TFHelper_0123456789876543210 CJ CB = FalseSym0
-      TFHelper_0123456789876543210 CJ CC = FalseSym0
-      TFHelper_0123456789876543210 CJ CD = FalseSym0
-      TFHelper_0123456789876543210 CJ CE = FalseSym0
-      TFHelper_0123456789876543210 CJ CF = FalseSym0
-      TFHelper_0123456789876543210 CJ CG = FalseSym0
-      TFHelper_0123456789876543210 CJ CH = FalseSym0
-      TFHelper_0123456789876543210 CJ CI = FalseSym0
-      TFHelper_0123456789876543210 CJ CJ = TrueSym0
-      TFHelper_0123456789876543210 CJ CK = FalseSym0
-      TFHelper_0123456789876543210 CJ CL = FalseSym0
-      TFHelper_0123456789876543210 CJ CM = FalseSym0
-      TFHelper_0123456789876543210 CJ CN = FalseSym0
-      TFHelper_0123456789876543210 CJ CO = FalseSym0
-      TFHelper_0123456789876543210 CJ CP = FalseSym0
-      TFHelper_0123456789876543210 CJ CQ = FalseSym0
-      TFHelper_0123456789876543210 CJ CR = FalseSym0
-      TFHelper_0123456789876543210 CJ CS = FalseSym0
-      TFHelper_0123456789876543210 CJ CT = FalseSym0
-      TFHelper_0123456789876543210 CJ CU = FalseSym0
-      TFHelper_0123456789876543210 CJ CV = FalseSym0
-      TFHelper_0123456789876543210 CJ CW = FalseSym0
-      TFHelper_0123456789876543210 CJ CX = FalseSym0
-      TFHelper_0123456789876543210 CJ CY = FalseSym0
-      TFHelper_0123456789876543210 CJ CZ = FalseSym0
-      TFHelper_0123456789876543210 CK CA = FalseSym0
-      TFHelper_0123456789876543210 CK CB = FalseSym0
-      TFHelper_0123456789876543210 CK CC = FalseSym0
-      TFHelper_0123456789876543210 CK CD = FalseSym0
-      TFHelper_0123456789876543210 CK CE = FalseSym0
-      TFHelper_0123456789876543210 CK CF = FalseSym0
-      TFHelper_0123456789876543210 CK CG = FalseSym0
-      TFHelper_0123456789876543210 CK CH = FalseSym0
-      TFHelper_0123456789876543210 CK CI = FalseSym0
-      TFHelper_0123456789876543210 CK CJ = FalseSym0
-      TFHelper_0123456789876543210 CK CK = TrueSym0
-      TFHelper_0123456789876543210 CK CL = FalseSym0
-      TFHelper_0123456789876543210 CK CM = FalseSym0
-      TFHelper_0123456789876543210 CK CN = FalseSym0
-      TFHelper_0123456789876543210 CK CO = FalseSym0
-      TFHelper_0123456789876543210 CK CP = FalseSym0
-      TFHelper_0123456789876543210 CK CQ = FalseSym0
-      TFHelper_0123456789876543210 CK CR = FalseSym0
-      TFHelper_0123456789876543210 CK CS = FalseSym0
-      TFHelper_0123456789876543210 CK CT = FalseSym0
-      TFHelper_0123456789876543210 CK CU = FalseSym0
-      TFHelper_0123456789876543210 CK CV = FalseSym0
-      TFHelper_0123456789876543210 CK CW = FalseSym0
-      TFHelper_0123456789876543210 CK CX = FalseSym0
-      TFHelper_0123456789876543210 CK CY = FalseSym0
-      TFHelper_0123456789876543210 CK CZ = FalseSym0
-      TFHelper_0123456789876543210 CL CA = FalseSym0
-      TFHelper_0123456789876543210 CL CB = FalseSym0
-      TFHelper_0123456789876543210 CL CC = FalseSym0
-      TFHelper_0123456789876543210 CL CD = FalseSym0
-      TFHelper_0123456789876543210 CL CE = FalseSym0
-      TFHelper_0123456789876543210 CL CF = FalseSym0
-      TFHelper_0123456789876543210 CL CG = FalseSym0
-      TFHelper_0123456789876543210 CL CH = FalseSym0
-      TFHelper_0123456789876543210 CL CI = FalseSym0
-      TFHelper_0123456789876543210 CL CJ = FalseSym0
-      TFHelper_0123456789876543210 CL CK = FalseSym0
-      TFHelper_0123456789876543210 CL CL = TrueSym0
-      TFHelper_0123456789876543210 CL CM = FalseSym0
-      TFHelper_0123456789876543210 CL CN = FalseSym0
-      TFHelper_0123456789876543210 CL CO = FalseSym0
-      TFHelper_0123456789876543210 CL CP = FalseSym0
-      TFHelper_0123456789876543210 CL CQ = FalseSym0
-      TFHelper_0123456789876543210 CL CR = FalseSym0
-      TFHelper_0123456789876543210 CL CS = FalseSym0
-      TFHelper_0123456789876543210 CL CT = FalseSym0
-      TFHelper_0123456789876543210 CL CU = FalseSym0
-      TFHelper_0123456789876543210 CL CV = FalseSym0
-      TFHelper_0123456789876543210 CL CW = FalseSym0
-      TFHelper_0123456789876543210 CL CX = FalseSym0
-      TFHelper_0123456789876543210 CL CY = FalseSym0
-      TFHelper_0123456789876543210 CL CZ = FalseSym0
-      TFHelper_0123456789876543210 CM CA = FalseSym0
-      TFHelper_0123456789876543210 CM CB = FalseSym0
-      TFHelper_0123456789876543210 CM CC = FalseSym0
-      TFHelper_0123456789876543210 CM CD = FalseSym0
-      TFHelper_0123456789876543210 CM CE = FalseSym0
-      TFHelper_0123456789876543210 CM CF = FalseSym0
-      TFHelper_0123456789876543210 CM CG = FalseSym0
-      TFHelper_0123456789876543210 CM CH = FalseSym0
-      TFHelper_0123456789876543210 CM CI = FalseSym0
-      TFHelper_0123456789876543210 CM CJ = FalseSym0
-      TFHelper_0123456789876543210 CM CK = FalseSym0
-      TFHelper_0123456789876543210 CM CL = FalseSym0
-      TFHelper_0123456789876543210 CM CM = TrueSym0
-      TFHelper_0123456789876543210 CM CN = FalseSym0
-      TFHelper_0123456789876543210 CM CO = FalseSym0
-      TFHelper_0123456789876543210 CM CP = FalseSym0
-      TFHelper_0123456789876543210 CM CQ = FalseSym0
-      TFHelper_0123456789876543210 CM CR = FalseSym0
-      TFHelper_0123456789876543210 CM CS = FalseSym0
-      TFHelper_0123456789876543210 CM CT = FalseSym0
-      TFHelper_0123456789876543210 CM CU = FalseSym0
-      TFHelper_0123456789876543210 CM CV = FalseSym0
-      TFHelper_0123456789876543210 CM CW = FalseSym0
-      TFHelper_0123456789876543210 CM CX = FalseSym0
-      TFHelper_0123456789876543210 CM CY = FalseSym0
-      TFHelper_0123456789876543210 CM CZ = FalseSym0
-      TFHelper_0123456789876543210 CN CA = FalseSym0
-      TFHelper_0123456789876543210 CN CB = FalseSym0
-      TFHelper_0123456789876543210 CN CC = FalseSym0
-      TFHelper_0123456789876543210 CN CD = FalseSym0
-      TFHelper_0123456789876543210 CN CE = FalseSym0
-      TFHelper_0123456789876543210 CN CF = FalseSym0
-      TFHelper_0123456789876543210 CN CG = FalseSym0
-      TFHelper_0123456789876543210 CN CH = FalseSym0
-      TFHelper_0123456789876543210 CN CI = FalseSym0
-      TFHelper_0123456789876543210 CN CJ = FalseSym0
-      TFHelper_0123456789876543210 CN CK = FalseSym0
-      TFHelper_0123456789876543210 CN CL = FalseSym0
-      TFHelper_0123456789876543210 CN CM = FalseSym0
-      TFHelper_0123456789876543210 CN CN = TrueSym0
-      TFHelper_0123456789876543210 CN CO = FalseSym0
-      TFHelper_0123456789876543210 CN CP = FalseSym0
-      TFHelper_0123456789876543210 CN CQ = FalseSym0
-      TFHelper_0123456789876543210 CN CR = FalseSym0
-      TFHelper_0123456789876543210 CN CS = FalseSym0
-      TFHelper_0123456789876543210 CN CT = FalseSym0
-      TFHelper_0123456789876543210 CN CU = FalseSym0
-      TFHelper_0123456789876543210 CN CV = FalseSym0
-      TFHelper_0123456789876543210 CN CW = FalseSym0
-      TFHelper_0123456789876543210 CN CX = FalseSym0
-      TFHelper_0123456789876543210 CN CY = FalseSym0
-      TFHelper_0123456789876543210 CN CZ = FalseSym0
-      TFHelper_0123456789876543210 CO CA = FalseSym0
-      TFHelper_0123456789876543210 CO CB = FalseSym0
-      TFHelper_0123456789876543210 CO CC = FalseSym0
-      TFHelper_0123456789876543210 CO CD = FalseSym0
-      TFHelper_0123456789876543210 CO CE = FalseSym0
-      TFHelper_0123456789876543210 CO CF = FalseSym0
-      TFHelper_0123456789876543210 CO CG = FalseSym0
-      TFHelper_0123456789876543210 CO CH = FalseSym0
-      TFHelper_0123456789876543210 CO CI = FalseSym0
-      TFHelper_0123456789876543210 CO CJ = FalseSym0
-      TFHelper_0123456789876543210 CO CK = FalseSym0
-      TFHelper_0123456789876543210 CO CL = FalseSym0
-      TFHelper_0123456789876543210 CO CM = FalseSym0
-      TFHelper_0123456789876543210 CO CN = FalseSym0
-      TFHelper_0123456789876543210 CO CO = TrueSym0
-      TFHelper_0123456789876543210 CO CP = FalseSym0
-      TFHelper_0123456789876543210 CO CQ = FalseSym0
-      TFHelper_0123456789876543210 CO CR = FalseSym0
-      TFHelper_0123456789876543210 CO CS = FalseSym0
-      TFHelper_0123456789876543210 CO CT = FalseSym0
-      TFHelper_0123456789876543210 CO CU = FalseSym0
-      TFHelper_0123456789876543210 CO CV = FalseSym0
-      TFHelper_0123456789876543210 CO CW = FalseSym0
-      TFHelper_0123456789876543210 CO CX = FalseSym0
-      TFHelper_0123456789876543210 CO CY = FalseSym0
-      TFHelper_0123456789876543210 CO CZ = FalseSym0
-      TFHelper_0123456789876543210 CP CA = FalseSym0
-      TFHelper_0123456789876543210 CP CB = FalseSym0
-      TFHelper_0123456789876543210 CP CC = FalseSym0
-      TFHelper_0123456789876543210 CP CD = FalseSym0
-      TFHelper_0123456789876543210 CP CE = FalseSym0
-      TFHelper_0123456789876543210 CP CF = FalseSym0
-      TFHelper_0123456789876543210 CP CG = FalseSym0
-      TFHelper_0123456789876543210 CP CH = FalseSym0
-      TFHelper_0123456789876543210 CP CI = FalseSym0
-      TFHelper_0123456789876543210 CP CJ = FalseSym0
-      TFHelper_0123456789876543210 CP CK = FalseSym0
-      TFHelper_0123456789876543210 CP CL = FalseSym0
-      TFHelper_0123456789876543210 CP CM = FalseSym0
-      TFHelper_0123456789876543210 CP CN = FalseSym0
-      TFHelper_0123456789876543210 CP CO = FalseSym0
-      TFHelper_0123456789876543210 CP CP = TrueSym0
-      TFHelper_0123456789876543210 CP CQ = FalseSym0
-      TFHelper_0123456789876543210 CP CR = FalseSym0
-      TFHelper_0123456789876543210 CP CS = FalseSym0
-      TFHelper_0123456789876543210 CP CT = FalseSym0
-      TFHelper_0123456789876543210 CP CU = FalseSym0
-      TFHelper_0123456789876543210 CP CV = FalseSym0
-      TFHelper_0123456789876543210 CP CW = FalseSym0
-      TFHelper_0123456789876543210 CP CX = FalseSym0
-      TFHelper_0123456789876543210 CP CY = FalseSym0
-      TFHelper_0123456789876543210 CP CZ = FalseSym0
-      TFHelper_0123456789876543210 CQ CA = FalseSym0
-      TFHelper_0123456789876543210 CQ CB = FalseSym0
-      TFHelper_0123456789876543210 CQ CC = FalseSym0
-      TFHelper_0123456789876543210 CQ CD = FalseSym0
-      TFHelper_0123456789876543210 CQ CE = FalseSym0
-      TFHelper_0123456789876543210 CQ CF = FalseSym0
-      TFHelper_0123456789876543210 CQ CG = FalseSym0
-      TFHelper_0123456789876543210 CQ CH = FalseSym0
-      TFHelper_0123456789876543210 CQ CI = FalseSym0
-      TFHelper_0123456789876543210 CQ CJ = FalseSym0
-      TFHelper_0123456789876543210 CQ CK = FalseSym0
-      TFHelper_0123456789876543210 CQ CL = FalseSym0
-      TFHelper_0123456789876543210 CQ CM = FalseSym0
-      TFHelper_0123456789876543210 CQ CN = FalseSym0
-      TFHelper_0123456789876543210 CQ CO = FalseSym0
-      TFHelper_0123456789876543210 CQ CP = FalseSym0
-      TFHelper_0123456789876543210 CQ CQ = TrueSym0
-      TFHelper_0123456789876543210 CQ CR = FalseSym0
-      TFHelper_0123456789876543210 CQ CS = FalseSym0
-      TFHelper_0123456789876543210 CQ CT = FalseSym0
-      TFHelper_0123456789876543210 CQ CU = FalseSym0
-      TFHelper_0123456789876543210 CQ CV = FalseSym0
-      TFHelper_0123456789876543210 CQ CW = FalseSym0
-      TFHelper_0123456789876543210 CQ CX = FalseSym0
-      TFHelper_0123456789876543210 CQ CY = FalseSym0
-      TFHelper_0123456789876543210 CQ CZ = FalseSym0
-      TFHelper_0123456789876543210 CR CA = FalseSym0
-      TFHelper_0123456789876543210 CR CB = FalseSym0
-      TFHelper_0123456789876543210 CR CC = FalseSym0
-      TFHelper_0123456789876543210 CR CD = FalseSym0
-      TFHelper_0123456789876543210 CR CE = FalseSym0
-      TFHelper_0123456789876543210 CR CF = FalseSym0
-      TFHelper_0123456789876543210 CR CG = FalseSym0
-      TFHelper_0123456789876543210 CR CH = FalseSym0
-      TFHelper_0123456789876543210 CR CI = FalseSym0
-      TFHelper_0123456789876543210 CR CJ = FalseSym0
-      TFHelper_0123456789876543210 CR CK = FalseSym0
-      TFHelper_0123456789876543210 CR CL = FalseSym0
-      TFHelper_0123456789876543210 CR CM = FalseSym0
-      TFHelper_0123456789876543210 CR CN = FalseSym0
-      TFHelper_0123456789876543210 CR CO = FalseSym0
-      TFHelper_0123456789876543210 CR CP = FalseSym0
-      TFHelper_0123456789876543210 CR CQ = FalseSym0
-      TFHelper_0123456789876543210 CR CR = TrueSym0
-      TFHelper_0123456789876543210 CR CS = FalseSym0
-      TFHelper_0123456789876543210 CR CT = FalseSym0
-      TFHelper_0123456789876543210 CR CU = FalseSym0
-      TFHelper_0123456789876543210 CR CV = FalseSym0
-      TFHelper_0123456789876543210 CR CW = FalseSym0
-      TFHelper_0123456789876543210 CR CX = FalseSym0
-      TFHelper_0123456789876543210 CR CY = FalseSym0
-      TFHelper_0123456789876543210 CR CZ = FalseSym0
-      TFHelper_0123456789876543210 CS CA = FalseSym0
-      TFHelper_0123456789876543210 CS CB = FalseSym0
-      TFHelper_0123456789876543210 CS CC = FalseSym0
-      TFHelper_0123456789876543210 CS CD = FalseSym0
-      TFHelper_0123456789876543210 CS CE = FalseSym0
-      TFHelper_0123456789876543210 CS CF = FalseSym0
-      TFHelper_0123456789876543210 CS CG = FalseSym0
-      TFHelper_0123456789876543210 CS CH = FalseSym0
-      TFHelper_0123456789876543210 CS CI = FalseSym0
-      TFHelper_0123456789876543210 CS CJ = FalseSym0
-      TFHelper_0123456789876543210 CS CK = FalseSym0
-      TFHelper_0123456789876543210 CS CL = FalseSym0
-      TFHelper_0123456789876543210 CS CM = FalseSym0
-      TFHelper_0123456789876543210 CS CN = FalseSym0
-      TFHelper_0123456789876543210 CS CO = FalseSym0
-      TFHelper_0123456789876543210 CS CP = FalseSym0
-      TFHelper_0123456789876543210 CS CQ = FalseSym0
-      TFHelper_0123456789876543210 CS CR = FalseSym0
-      TFHelper_0123456789876543210 CS CS = TrueSym0
-      TFHelper_0123456789876543210 CS CT = FalseSym0
-      TFHelper_0123456789876543210 CS CU = FalseSym0
-      TFHelper_0123456789876543210 CS CV = FalseSym0
-      TFHelper_0123456789876543210 CS CW = FalseSym0
-      TFHelper_0123456789876543210 CS CX = FalseSym0
-      TFHelper_0123456789876543210 CS CY = FalseSym0
-      TFHelper_0123456789876543210 CS CZ = FalseSym0
-      TFHelper_0123456789876543210 CT CA = FalseSym0
-      TFHelper_0123456789876543210 CT CB = FalseSym0
-      TFHelper_0123456789876543210 CT CC = FalseSym0
-      TFHelper_0123456789876543210 CT CD = FalseSym0
-      TFHelper_0123456789876543210 CT CE = FalseSym0
-      TFHelper_0123456789876543210 CT CF = FalseSym0
-      TFHelper_0123456789876543210 CT CG = FalseSym0
-      TFHelper_0123456789876543210 CT CH = FalseSym0
-      TFHelper_0123456789876543210 CT CI = FalseSym0
-      TFHelper_0123456789876543210 CT CJ = FalseSym0
-      TFHelper_0123456789876543210 CT CK = FalseSym0
-      TFHelper_0123456789876543210 CT CL = FalseSym0
-      TFHelper_0123456789876543210 CT CM = FalseSym0
-      TFHelper_0123456789876543210 CT CN = FalseSym0
-      TFHelper_0123456789876543210 CT CO = FalseSym0
-      TFHelper_0123456789876543210 CT CP = FalseSym0
-      TFHelper_0123456789876543210 CT CQ = FalseSym0
-      TFHelper_0123456789876543210 CT CR = FalseSym0
-      TFHelper_0123456789876543210 CT CS = FalseSym0
-      TFHelper_0123456789876543210 CT CT = TrueSym0
-      TFHelper_0123456789876543210 CT CU = FalseSym0
-      TFHelper_0123456789876543210 CT CV = FalseSym0
-      TFHelper_0123456789876543210 CT CW = FalseSym0
-      TFHelper_0123456789876543210 CT CX = FalseSym0
-      TFHelper_0123456789876543210 CT CY = FalseSym0
-      TFHelper_0123456789876543210 CT CZ = FalseSym0
-      TFHelper_0123456789876543210 CU CA = FalseSym0
-      TFHelper_0123456789876543210 CU CB = FalseSym0
-      TFHelper_0123456789876543210 CU CC = FalseSym0
-      TFHelper_0123456789876543210 CU CD = FalseSym0
-      TFHelper_0123456789876543210 CU CE = FalseSym0
-      TFHelper_0123456789876543210 CU CF = FalseSym0
-      TFHelper_0123456789876543210 CU CG = FalseSym0
-      TFHelper_0123456789876543210 CU CH = FalseSym0
-      TFHelper_0123456789876543210 CU CI = FalseSym0
-      TFHelper_0123456789876543210 CU CJ = FalseSym0
-      TFHelper_0123456789876543210 CU CK = FalseSym0
-      TFHelper_0123456789876543210 CU CL = FalseSym0
-      TFHelper_0123456789876543210 CU CM = FalseSym0
-      TFHelper_0123456789876543210 CU CN = FalseSym0
-      TFHelper_0123456789876543210 CU CO = FalseSym0
-      TFHelper_0123456789876543210 CU CP = FalseSym0
-      TFHelper_0123456789876543210 CU CQ = FalseSym0
-      TFHelper_0123456789876543210 CU CR = FalseSym0
-      TFHelper_0123456789876543210 CU CS = FalseSym0
-      TFHelper_0123456789876543210 CU CT = FalseSym0
-      TFHelper_0123456789876543210 CU CU = TrueSym0
-      TFHelper_0123456789876543210 CU CV = FalseSym0
-      TFHelper_0123456789876543210 CU CW = FalseSym0
-      TFHelper_0123456789876543210 CU CX = FalseSym0
-      TFHelper_0123456789876543210 CU CY = FalseSym0
-      TFHelper_0123456789876543210 CU CZ = FalseSym0
-      TFHelper_0123456789876543210 CV CA = FalseSym0
-      TFHelper_0123456789876543210 CV CB = FalseSym0
-      TFHelper_0123456789876543210 CV CC = FalseSym0
-      TFHelper_0123456789876543210 CV CD = FalseSym0
-      TFHelper_0123456789876543210 CV CE = FalseSym0
-      TFHelper_0123456789876543210 CV CF = FalseSym0
-      TFHelper_0123456789876543210 CV CG = FalseSym0
-      TFHelper_0123456789876543210 CV CH = FalseSym0
-      TFHelper_0123456789876543210 CV CI = FalseSym0
-      TFHelper_0123456789876543210 CV CJ = FalseSym0
-      TFHelper_0123456789876543210 CV CK = FalseSym0
-      TFHelper_0123456789876543210 CV CL = FalseSym0
-      TFHelper_0123456789876543210 CV CM = FalseSym0
-      TFHelper_0123456789876543210 CV CN = FalseSym0
-      TFHelper_0123456789876543210 CV CO = FalseSym0
-      TFHelper_0123456789876543210 CV CP = FalseSym0
-      TFHelper_0123456789876543210 CV CQ = FalseSym0
-      TFHelper_0123456789876543210 CV CR = FalseSym0
-      TFHelper_0123456789876543210 CV CS = FalseSym0
-      TFHelper_0123456789876543210 CV CT = FalseSym0
-      TFHelper_0123456789876543210 CV CU = FalseSym0
-      TFHelper_0123456789876543210 CV CV = TrueSym0
-      TFHelper_0123456789876543210 CV CW = FalseSym0
-      TFHelper_0123456789876543210 CV CX = FalseSym0
-      TFHelper_0123456789876543210 CV CY = FalseSym0
-      TFHelper_0123456789876543210 CV CZ = FalseSym0
-      TFHelper_0123456789876543210 CW CA = FalseSym0
-      TFHelper_0123456789876543210 CW CB = FalseSym0
-      TFHelper_0123456789876543210 CW CC = FalseSym0
-      TFHelper_0123456789876543210 CW CD = FalseSym0
-      TFHelper_0123456789876543210 CW CE = FalseSym0
-      TFHelper_0123456789876543210 CW CF = FalseSym0
-      TFHelper_0123456789876543210 CW CG = FalseSym0
-      TFHelper_0123456789876543210 CW CH = FalseSym0
-      TFHelper_0123456789876543210 CW CI = FalseSym0
-      TFHelper_0123456789876543210 CW CJ = FalseSym0
-      TFHelper_0123456789876543210 CW CK = FalseSym0
-      TFHelper_0123456789876543210 CW CL = FalseSym0
-      TFHelper_0123456789876543210 CW CM = FalseSym0
-      TFHelper_0123456789876543210 CW CN = FalseSym0
-      TFHelper_0123456789876543210 CW CO = FalseSym0
-      TFHelper_0123456789876543210 CW CP = FalseSym0
-      TFHelper_0123456789876543210 CW CQ = FalseSym0
-      TFHelper_0123456789876543210 CW CR = FalseSym0
-      TFHelper_0123456789876543210 CW CS = FalseSym0
-      TFHelper_0123456789876543210 CW CT = FalseSym0
-      TFHelper_0123456789876543210 CW CU = FalseSym0
-      TFHelper_0123456789876543210 CW CV = FalseSym0
-      TFHelper_0123456789876543210 CW CW = TrueSym0
-      TFHelper_0123456789876543210 CW CX = FalseSym0
-      TFHelper_0123456789876543210 CW CY = FalseSym0
-      TFHelper_0123456789876543210 CW CZ = FalseSym0
-      TFHelper_0123456789876543210 CX CA = FalseSym0
-      TFHelper_0123456789876543210 CX CB = FalseSym0
-      TFHelper_0123456789876543210 CX CC = FalseSym0
-      TFHelper_0123456789876543210 CX CD = FalseSym0
-      TFHelper_0123456789876543210 CX CE = FalseSym0
-      TFHelper_0123456789876543210 CX CF = FalseSym0
-      TFHelper_0123456789876543210 CX CG = FalseSym0
-      TFHelper_0123456789876543210 CX CH = FalseSym0
-      TFHelper_0123456789876543210 CX CI = FalseSym0
-      TFHelper_0123456789876543210 CX CJ = FalseSym0
-      TFHelper_0123456789876543210 CX CK = FalseSym0
-      TFHelper_0123456789876543210 CX CL = FalseSym0
-      TFHelper_0123456789876543210 CX CM = FalseSym0
-      TFHelper_0123456789876543210 CX CN = FalseSym0
-      TFHelper_0123456789876543210 CX CO = FalseSym0
-      TFHelper_0123456789876543210 CX CP = FalseSym0
-      TFHelper_0123456789876543210 CX CQ = FalseSym0
-      TFHelper_0123456789876543210 CX CR = FalseSym0
-      TFHelper_0123456789876543210 CX CS = FalseSym0
-      TFHelper_0123456789876543210 CX CT = FalseSym0
-      TFHelper_0123456789876543210 CX CU = FalseSym0
-      TFHelper_0123456789876543210 CX CV = FalseSym0
-      TFHelper_0123456789876543210 CX CW = FalseSym0
-      TFHelper_0123456789876543210 CX CX = TrueSym0
-      TFHelper_0123456789876543210 CX CY = FalseSym0
-      TFHelper_0123456789876543210 CX CZ = FalseSym0
-      TFHelper_0123456789876543210 CY CA = FalseSym0
-      TFHelper_0123456789876543210 CY CB = FalseSym0
-      TFHelper_0123456789876543210 CY CC = FalseSym0
-      TFHelper_0123456789876543210 CY CD = FalseSym0
-      TFHelper_0123456789876543210 CY CE = FalseSym0
-      TFHelper_0123456789876543210 CY CF = FalseSym0
-      TFHelper_0123456789876543210 CY CG = FalseSym0
-      TFHelper_0123456789876543210 CY CH = FalseSym0
-      TFHelper_0123456789876543210 CY CI = FalseSym0
-      TFHelper_0123456789876543210 CY CJ = FalseSym0
-      TFHelper_0123456789876543210 CY CK = FalseSym0
-      TFHelper_0123456789876543210 CY CL = FalseSym0
-      TFHelper_0123456789876543210 CY CM = FalseSym0
-      TFHelper_0123456789876543210 CY CN = FalseSym0
-      TFHelper_0123456789876543210 CY CO = FalseSym0
-      TFHelper_0123456789876543210 CY CP = FalseSym0
-      TFHelper_0123456789876543210 CY CQ = FalseSym0
-      TFHelper_0123456789876543210 CY CR = FalseSym0
-      TFHelper_0123456789876543210 CY CS = FalseSym0
-      TFHelper_0123456789876543210 CY CT = FalseSym0
-      TFHelper_0123456789876543210 CY CU = FalseSym0
-      TFHelper_0123456789876543210 CY CV = FalseSym0
-      TFHelper_0123456789876543210 CY CW = FalseSym0
-      TFHelper_0123456789876543210 CY CX = FalseSym0
-      TFHelper_0123456789876543210 CY CY = TrueSym0
-      TFHelper_0123456789876543210 CY CZ = FalseSym0
-      TFHelper_0123456789876543210 CZ CA = FalseSym0
-      TFHelper_0123456789876543210 CZ CB = FalseSym0
-      TFHelper_0123456789876543210 CZ CC = FalseSym0
-      TFHelper_0123456789876543210 CZ CD = FalseSym0
-      TFHelper_0123456789876543210 CZ CE = FalseSym0
-      TFHelper_0123456789876543210 CZ CF = FalseSym0
-      TFHelper_0123456789876543210 CZ CG = FalseSym0
-      TFHelper_0123456789876543210 CZ CH = FalseSym0
-      TFHelper_0123456789876543210 CZ CI = FalseSym0
-      TFHelper_0123456789876543210 CZ CJ = FalseSym0
-      TFHelper_0123456789876543210 CZ CK = FalseSym0
-      TFHelper_0123456789876543210 CZ CL = FalseSym0
-      TFHelper_0123456789876543210 CZ CM = FalseSym0
-      TFHelper_0123456789876543210 CZ CN = FalseSym0
-      TFHelper_0123456789876543210 CZ CO = FalseSym0
-      TFHelper_0123456789876543210 CZ CP = FalseSym0
-      TFHelper_0123456789876543210 CZ CQ = FalseSym0
-      TFHelper_0123456789876543210 CZ CR = FalseSym0
-      TFHelper_0123456789876543210 CZ CS = FalseSym0
-      TFHelper_0123456789876543210 CZ CT = FalseSym0
-      TFHelper_0123456789876543210 CZ CU = FalseSym0
-      TFHelper_0123456789876543210 CZ CV = FalseSym0
-      TFHelper_0123456789876543210 CZ CW = FalseSym0
-      TFHelper_0123456789876543210 CZ CX = FalseSym0
-      TFHelper_0123456789876543210 CZ CY = FalseSym0
-      TFHelper_0123456789876543210 CZ CZ = TrueSym0
+      type ShowsPrec a a a = ShowsPrec_GradingClient_Database_47 a a a
+    type TFHelper_GradingClient_Database_77 :: AChar -> AChar -> Bool
+    type family TFHelper_GradingClient_Database_77 (a :: AChar) (a :: AChar) :: Bool where
+      TFHelper_GradingClient_Database_77 CA CA = TrueSym0
+      TFHelper_GradingClient_Database_77 CA CB = FalseSym0
+      TFHelper_GradingClient_Database_77 CA CC = FalseSym0
+      TFHelper_GradingClient_Database_77 CA CD = FalseSym0
+      TFHelper_GradingClient_Database_77 CA CE = FalseSym0
+      TFHelper_GradingClient_Database_77 CA CF = FalseSym0
+      TFHelper_GradingClient_Database_77 CA CG = FalseSym0
+      TFHelper_GradingClient_Database_77 CA CH = FalseSym0
+      TFHelper_GradingClient_Database_77 CA CI = FalseSym0
+      TFHelper_GradingClient_Database_77 CA CJ = FalseSym0
+      TFHelper_GradingClient_Database_77 CA CK = FalseSym0
+      TFHelper_GradingClient_Database_77 CA CL = FalseSym0
+      TFHelper_GradingClient_Database_77 CA CM = FalseSym0
+      TFHelper_GradingClient_Database_77 CA CN = FalseSym0
+      TFHelper_GradingClient_Database_77 CA CO = FalseSym0
+      TFHelper_GradingClient_Database_77 CA CP = FalseSym0
+      TFHelper_GradingClient_Database_77 CA CQ = FalseSym0
+      TFHelper_GradingClient_Database_77 CA CR = FalseSym0
+      TFHelper_GradingClient_Database_77 CA CS = FalseSym0
+      TFHelper_GradingClient_Database_77 CA CT = FalseSym0
+      TFHelper_GradingClient_Database_77 CA CU = FalseSym0
+      TFHelper_GradingClient_Database_77 CA CV = FalseSym0
+      TFHelper_GradingClient_Database_77 CA CW = FalseSym0
+      TFHelper_GradingClient_Database_77 CA CX = FalseSym0
+      TFHelper_GradingClient_Database_77 CA CY = FalseSym0
+      TFHelper_GradingClient_Database_77 CA CZ = FalseSym0
+      TFHelper_GradingClient_Database_77 CB CA = FalseSym0
+      TFHelper_GradingClient_Database_77 CB CB = TrueSym0
+      TFHelper_GradingClient_Database_77 CB CC = FalseSym0
+      TFHelper_GradingClient_Database_77 CB CD = FalseSym0
+      TFHelper_GradingClient_Database_77 CB CE = FalseSym0
+      TFHelper_GradingClient_Database_77 CB CF = FalseSym0
+      TFHelper_GradingClient_Database_77 CB CG = FalseSym0
+      TFHelper_GradingClient_Database_77 CB CH = FalseSym0
+      TFHelper_GradingClient_Database_77 CB CI = FalseSym0
+      TFHelper_GradingClient_Database_77 CB CJ = FalseSym0
+      TFHelper_GradingClient_Database_77 CB CK = FalseSym0
+      TFHelper_GradingClient_Database_77 CB CL = FalseSym0
+      TFHelper_GradingClient_Database_77 CB CM = FalseSym0
+      TFHelper_GradingClient_Database_77 CB CN = FalseSym0
+      TFHelper_GradingClient_Database_77 CB CO = FalseSym0
+      TFHelper_GradingClient_Database_77 CB CP = FalseSym0
+      TFHelper_GradingClient_Database_77 CB CQ = FalseSym0
+      TFHelper_GradingClient_Database_77 CB CR = FalseSym0
+      TFHelper_GradingClient_Database_77 CB CS = FalseSym0
+      TFHelper_GradingClient_Database_77 CB CT = FalseSym0
+      TFHelper_GradingClient_Database_77 CB CU = FalseSym0
+      TFHelper_GradingClient_Database_77 CB CV = FalseSym0
+      TFHelper_GradingClient_Database_77 CB CW = FalseSym0
+      TFHelper_GradingClient_Database_77 CB CX = FalseSym0
+      TFHelper_GradingClient_Database_77 CB CY = FalseSym0
+      TFHelper_GradingClient_Database_77 CB CZ = FalseSym0
+      TFHelper_GradingClient_Database_77 CC CA = FalseSym0
+      TFHelper_GradingClient_Database_77 CC CB = FalseSym0
+      TFHelper_GradingClient_Database_77 CC CC = TrueSym0
+      TFHelper_GradingClient_Database_77 CC CD = FalseSym0
+      TFHelper_GradingClient_Database_77 CC CE = FalseSym0
+      TFHelper_GradingClient_Database_77 CC CF = FalseSym0
+      TFHelper_GradingClient_Database_77 CC CG = FalseSym0
+      TFHelper_GradingClient_Database_77 CC CH = FalseSym0
+      TFHelper_GradingClient_Database_77 CC CI = FalseSym0
+      TFHelper_GradingClient_Database_77 CC CJ = FalseSym0
+      TFHelper_GradingClient_Database_77 CC CK = FalseSym0
+      TFHelper_GradingClient_Database_77 CC CL = FalseSym0
+      TFHelper_GradingClient_Database_77 CC CM = FalseSym0
+      TFHelper_GradingClient_Database_77 CC CN = FalseSym0
+      TFHelper_GradingClient_Database_77 CC CO = FalseSym0
+      TFHelper_GradingClient_Database_77 CC CP = FalseSym0
+      TFHelper_GradingClient_Database_77 CC CQ = FalseSym0
+      TFHelper_GradingClient_Database_77 CC CR = FalseSym0
+      TFHelper_GradingClient_Database_77 CC CS = FalseSym0
+      TFHelper_GradingClient_Database_77 CC CT = FalseSym0
+      TFHelper_GradingClient_Database_77 CC CU = FalseSym0
+      TFHelper_GradingClient_Database_77 CC CV = FalseSym0
+      TFHelper_GradingClient_Database_77 CC CW = FalseSym0
+      TFHelper_GradingClient_Database_77 CC CX = FalseSym0
+      TFHelper_GradingClient_Database_77 CC CY = FalseSym0
+      TFHelper_GradingClient_Database_77 CC CZ = FalseSym0
+      TFHelper_GradingClient_Database_77 CD CA = FalseSym0
+      TFHelper_GradingClient_Database_77 CD CB = FalseSym0
+      TFHelper_GradingClient_Database_77 CD CC = FalseSym0
+      TFHelper_GradingClient_Database_77 CD CD = TrueSym0
+      TFHelper_GradingClient_Database_77 CD CE = FalseSym0
+      TFHelper_GradingClient_Database_77 CD CF = FalseSym0
+      TFHelper_GradingClient_Database_77 CD CG = FalseSym0
+      TFHelper_GradingClient_Database_77 CD CH = FalseSym0
+      TFHelper_GradingClient_Database_77 CD CI = FalseSym0
+      TFHelper_GradingClient_Database_77 CD CJ = FalseSym0
+      TFHelper_GradingClient_Database_77 CD CK = FalseSym0
+      TFHelper_GradingClient_Database_77 CD CL = FalseSym0
+      TFHelper_GradingClient_Database_77 CD CM = FalseSym0
+      TFHelper_GradingClient_Database_77 CD CN = FalseSym0
+      TFHelper_GradingClient_Database_77 CD CO = FalseSym0
+      TFHelper_GradingClient_Database_77 CD CP = FalseSym0
+      TFHelper_GradingClient_Database_77 CD CQ = FalseSym0
+      TFHelper_GradingClient_Database_77 CD CR = FalseSym0
+      TFHelper_GradingClient_Database_77 CD CS = FalseSym0
+      TFHelper_GradingClient_Database_77 CD CT = FalseSym0
+      TFHelper_GradingClient_Database_77 CD CU = FalseSym0
+      TFHelper_GradingClient_Database_77 CD CV = FalseSym0
+      TFHelper_GradingClient_Database_77 CD CW = FalseSym0
+      TFHelper_GradingClient_Database_77 CD CX = FalseSym0
+      TFHelper_GradingClient_Database_77 CD CY = FalseSym0
+      TFHelper_GradingClient_Database_77 CD CZ = FalseSym0
+      TFHelper_GradingClient_Database_77 CE CA = FalseSym0
+      TFHelper_GradingClient_Database_77 CE CB = FalseSym0
+      TFHelper_GradingClient_Database_77 CE CC = FalseSym0
+      TFHelper_GradingClient_Database_77 CE CD = FalseSym0
+      TFHelper_GradingClient_Database_77 CE CE = TrueSym0
+      TFHelper_GradingClient_Database_77 CE CF = FalseSym0
+      TFHelper_GradingClient_Database_77 CE CG = FalseSym0
+      TFHelper_GradingClient_Database_77 CE CH = FalseSym0
+      TFHelper_GradingClient_Database_77 CE CI = FalseSym0
+      TFHelper_GradingClient_Database_77 CE CJ = FalseSym0
+      TFHelper_GradingClient_Database_77 CE CK = FalseSym0
+      TFHelper_GradingClient_Database_77 CE CL = FalseSym0
+      TFHelper_GradingClient_Database_77 CE CM = FalseSym0
+      TFHelper_GradingClient_Database_77 CE CN = FalseSym0
+      TFHelper_GradingClient_Database_77 CE CO = FalseSym0
+      TFHelper_GradingClient_Database_77 CE CP = FalseSym0
+      TFHelper_GradingClient_Database_77 CE CQ = FalseSym0
+      TFHelper_GradingClient_Database_77 CE CR = FalseSym0
+      TFHelper_GradingClient_Database_77 CE CS = FalseSym0
+      TFHelper_GradingClient_Database_77 CE CT = FalseSym0
+      TFHelper_GradingClient_Database_77 CE CU = FalseSym0
+      TFHelper_GradingClient_Database_77 CE CV = FalseSym0
+      TFHelper_GradingClient_Database_77 CE CW = FalseSym0
+      TFHelper_GradingClient_Database_77 CE CX = FalseSym0
+      TFHelper_GradingClient_Database_77 CE CY = FalseSym0
+      TFHelper_GradingClient_Database_77 CE CZ = FalseSym0
+      TFHelper_GradingClient_Database_77 CF CA = FalseSym0
+      TFHelper_GradingClient_Database_77 CF CB = FalseSym0
+      TFHelper_GradingClient_Database_77 CF CC = FalseSym0
+      TFHelper_GradingClient_Database_77 CF CD = FalseSym0
+      TFHelper_GradingClient_Database_77 CF CE = FalseSym0
+      TFHelper_GradingClient_Database_77 CF CF = TrueSym0
+      TFHelper_GradingClient_Database_77 CF CG = FalseSym0
+      TFHelper_GradingClient_Database_77 CF CH = FalseSym0
+      TFHelper_GradingClient_Database_77 CF CI = FalseSym0
+      TFHelper_GradingClient_Database_77 CF CJ = FalseSym0
+      TFHelper_GradingClient_Database_77 CF CK = FalseSym0
+      TFHelper_GradingClient_Database_77 CF CL = FalseSym0
+      TFHelper_GradingClient_Database_77 CF CM = FalseSym0
+      TFHelper_GradingClient_Database_77 CF CN = FalseSym0
+      TFHelper_GradingClient_Database_77 CF CO = FalseSym0
+      TFHelper_GradingClient_Database_77 CF CP = FalseSym0
+      TFHelper_GradingClient_Database_77 CF CQ = FalseSym0
+      TFHelper_GradingClient_Database_77 CF CR = FalseSym0
+      TFHelper_GradingClient_Database_77 CF CS = FalseSym0
+      TFHelper_GradingClient_Database_77 CF CT = FalseSym0
+      TFHelper_GradingClient_Database_77 CF CU = FalseSym0
+      TFHelper_GradingClient_Database_77 CF CV = FalseSym0
+      TFHelper_GradingClient_Database_77 CF CW = FalseSym0
+      TFHelper_GradingClient_Database_77 CF CX = FalseSym0
+      TFHelper_GradingClient_Database_77 CF CY = FalseSym0
+      TFHelper_GradingClient_Database_77 CF CZ = FalseSym0
+      TFHelper_GradingClient_Database_77 CG CA = FalseSym0
+      TFHelper_GradingClient_Database_77 CG CB = FalseSym0
+      TFHelper_GradingClient_Database_77 CG CC = FalseSym0
+      TFHelper_GradingClient_Database_77 CG CD = FalseSym0
+      TFHelper_GradingClient_Database_77 CG CE = FalseSym0
+      TFHelper_GradingClient_Database_77 CG CF = FalseSym0
+      TFHelper_GradingClient_Database_77 CG CG = TrueSym0
+      TFHelper_GradingClient_Database_77 CG CH = FalseSym0
+      TFHelper_GradingClient_Database_77 CG CI = FalseSym0
+      TFHelper_GradingClient_Database_77 CG CJ = FalseSym0
+      TFHelper_GradingClient_Database_77 CG CK = FalseSym0
+      TFHelper_GradingClient_Database_77 CG CL = FalseSym0
+      TFHelper_GradingClient_Database_77 CG CM = FalseSym0
+      TFHelper_GradingClient_Database_77 CG CN = FalseSym0
+      TFHelper_GradingClient_Database_77 CG CO = FalseSym0
+      TFHelper_GradingClient_Database_77 CG CP = FalseSym0
+      TFHelper_GradingClient_Database_77 CG CQ = FalseSym0
+      TFHelper_GradingClient_Database_77 CG CR = FalseSym0
+      TFHelper_GradingClient_Database_77 CG CS = FalseSym0
+      TFHelper_GradingClient_Database_77 CG CT = FalseSym0
+      TFHelper_GradingClient_Database_77 CG CU = FalseSym0
+      TFHelper_GradingClient_Database_77 CG CV = FalseSym0
+      TFHelper_GradingClient_Database_77 CG CW = FalseSym0
+      TFHelper_GradingClient_Database_77 CG CX = FalseSym0
+      TFHelper_GradingClient_Database_77 CG CY = FalseSym0
+      TFHelper_GradingClient_Database_77 CG CZ = FalseSym0
+      TFHelper_GradingClient_Database_77 CH CA = FalseSym0
+      TFHelper_GradingClient_Database_77 CH CB = FalseSym0
+      TFHelper_GradingClient_Database_77 CH CC = FalseSym0
+      TFHelper_GradingClient_Database_77 CH CD = FalseSym0
+      TFHelper_GradingClient_Database_77 CH CE = FalseSym0
+      TFHelper_GradingClient_Database_77 CH CF = FalseSym0
+      TFHelper_GradingClient_Database_77 CH CG = FalseSym0
+      TFHelper_GradingClient_Database_77 CH CH = TrueSym0
+      TFHelper_GradingClient_Database_77 CH CI = FalseSym0
+      TFHelper_GradingClient_Database_77 CH CJ = FalseSym0
+      TFHelper_GradingClient_Database_77 CH CK = FalseSym0
+      TFHelper_GradingClient_Database_77 CH CL = FalseSym0
+      TFHelper_GradingClient_Database_77 CH CM = FalseSym0
+      TFHelper_GradingClient_Database_77 CH CN = FalseSym0
+      TFHelper_GradingClient_Database_77 CH CO = FalseSym0
+      TFHelper_GradingClient_Database_77 CH CP = FalseSym0
+      TFHelper_GradingClient_Database_77 CH CQ = FalseSym0
+      TFHelper_GradingClient_Database_77 CH CR = FalseSym0
+      TFHelper_GradingClient_Database_77 CH CS = FalseSym0
+      TFHelper_GradingClient_Database_77 CH CT = FalseSym0
+      TFHelper_GradingClient_Database_77 CH CU = FalseSym0
+      TFHelper_GradingClient_Database_77 CH CV = FalseSym0
+      TFHelper_GradingClient_Database_77 CH CW = FalseSym0
+      TFHelper_GradingClient_Database_77 CH CX = FalseSym0
+      TFHelper_GradingClient_Database_77 CH CY = FalseSym0
+      TFHelper_GradingClient_Database_77 CH CZ = FalseSym0
+      TFHelper_GradingClient_Database_77 CI CA = FalseSym0
+      TFHelper_GradingClient_Database_77 CI CB = FalseSym0
+      TFHelper_GradingClient_Database_77 CI CC = FalseSym0
+      TFHelper_GradingClient_Database_77 CI CD = FalseSym0
+      TFHelper_GradingClient_Database_77 CI CE = FalseSym0
+      TFHelper_GradingClient_Database_77 CI CF = FalseSym0
+      TFHelper_GradingClient_Database_77 CI CG = FalseSym0
+      TFHelper_GradingClient_Database_77 CI CH = FalseSym0
+      TFHelper_GradingClient_Database_77 CI CI = TrueSym0
+      TFHelper_GradingClient_Database_77 CI CJ = FalseSym0
+      TFHelper_GradingClient_Database_77 CI CK = FalseSym0
+      TFHelper_GradingClient_Database_77 CI CL = FalseSym0
+      TFHelper_GradingClient_Database_77 CI CM = FalseSym0
+      TFHelper_GradingClient_Database_77 CI CN = FalseSym0
+      TFHelper_GradingClient_Database_77 CI CO = FalseSym0
+      TFHelper_GradingClient_Database_77 CI CP = FalseSym0
+      TFHelper_GradingClient_Database_77 CI CQ = FalseSym0
+      TFHelper_GradingClient_Database_77 CI CR = FalseSym0
+      TFHelper_GradingClient_Database_77 CI CS = FalseSym0
+      TFHelper_GradingClient_Database_77 CI CT = FalseSym0
+      TFHelper_GradingClient_Database_77 CI CU = FalseSym0
+      TFHelper_GradingClient_Database_77 CI CV = FalseSym0
+      TFHelper_GradingClient_Database_77 CI CW = FalseSym0
+      TFHelper_GradingClient_Database_77 CI CX = FalseSym0
+      TFHelper_GradingClient_Database_77 CI CY = FalseSym0
+      TFHelper_GradingClient_Database_77 CI CZ = FalseSym0
+      TFHelper_GradingClient_Database_77 CJ CA = FalseSym0
+      TFHelper_GradingClient_Database_77 CJ CB = FalseSym0
+      TFHelper_GradingClient_Database_77 CJ CC = FalseSym0
+      TFHelper_GradingClient_Database_77 CJ CD = FalseSym0
+      TFHelper_GradingClient_Database_77 CJ CE = FalseSym0
+      TFHelper_GradingClient_Database_77 CJ CF = FalseSym0
+      TFHelper_GradingClient_Database_77 CJ CG = FalseSym0
+      TFHelper_GradingClient_Database_77 CJ CH = FalseSym0
+      TFHelper_GradingClient_Database_77 CJ CI = FalseSym0
+      TFHelper_GradingClient_Database_77 CJ CJ = TrueSym0
+      TFHelper_GradingClient_Database_77 CJ CK = FalseSym0
+      TFHelper_GradingClient_Database_77 CJ CL = FalseSym0
+      TFHelper_GradingClient_Database_77 CJ CM = FalseSym0
+      TFHelper_GradingClient_Database_77 CJ CN = FalseSym0
+      TFHelper_GradingClient_Database_77 CJ CO = FalseSym0
+      TFHelper_GradingClient_Database_77 CJ CP = FalseSym0
+      TFHelper_GradingClient_Database_77 CJ CQ = FalseSym0
+      TFHelper_GradingClient_Database_77 CJ CR = FalseSym0
+      TFHelper_GradingClient_Database_77 CJ CS = FalseSym0
+      TFHelper_GradingClient_Database_77 CJ CT = FalseSym0
+      TFHelper_GradingClient_Database_77 CJ CU = FalseSym0
+      TFHelper_GradingClient_Database_77 CJ CV = FalseSym0
+      TFHelper_GradingClient_Database_77 CJ CW = FalseSym0
+      TFHelper_GradingClient_Database_77 CJ CX = FalseSym0
+      TFHelper_GradingClient_Database_77 CJ CY = FalseSym0
+      TFHelper_GradingClient_Database_77 CJ CZ = FalseSym0
+      TFHelper_GradingClient_Database_77 CK CA = FalseSym0
+      TFHelper_GradingClient_Database_77 CK CB = FalseSym0
+      TFHelper_GradingClient_Database_77 CK CC = FalseSym0
+      TFHelper_GradingClient_Database_77 CK CD = FalseSym0
+      TFHelper_GradingClient_Database_77 CK CE = FalseSym0
+      TFHelper_GradingClient_Database_77 CK CF = FalseSym0
+      TFHelper_GradingClient_Database_77 CK CG = FalseSym0
+      TFHelper_GradingClient_Database_77 CK CH = FalseSym0
+      TFHelper_GradingClient_Database_77 CK CI = FalseSym0
+      TFHelper_GradingClient_Database_77 CK CJ = FalseSym0
+      TFHelper_GradingClient_Database_77 CK CK = TrueSym0
+      TFHelper_GradingClient_Database_77 CK CL = FalseSym0
+      TFHelper_GradingClient_Database_77 CK CM = FalseSym0
+      TFHelper_GradingClient_Database_77 CK CN = FalseSym0
+      TFHelper_GradingClient_Database_77 CK CO = FalseSym0
+      TFHelper_GradingClient_Database_77 CK CP = FalseSym0
+      TFHelper_GradingClient_Database_77 CK CQ = FalseSym0
+      TFHelper_GradingClient_Database_77 CK CR = FalseSym0
+      TFHelper_GradingClient_Database_77 CK CS = FalseSym0
+      TFHelper_GradingClient_Database_77 CK CT = FalseSym0
+      TFHelper_GradingClient_Database_77 CK CU = FalseSym0
+      TFHelper_GradingClient_Database_77 CK CV = FalseSym0
+      TFHelper_GradingClient_Database_77 CK CW = FalseSym0
+      TFHelper_GradingClient_Database_77 CK CX = FalseSym0
+      TFHelper_GradingClient_Database_77 CK CY = FalseSym0
+      TFHelper_GradingClient_Database_77 CK CZ = FalseSym0
+      TFHelper_GradingClient_Database_77 CL CA = FalseSym0
+      TFHelper_GradingClient_Database_77 CL CB = FalseSym0
+      TFHelper_GradingClient_Database_77 CL CC = FalseSym0
+      TFHelper_GradingClient_Database_77 CL CD = FalseSym0
+      TFHelper_GradingClient_Database_77 CL CE = FalseSym0
+      TFHelper_GradingClient_Database_77 CL CF = FalseSym0
+      TFHelper_GradingClient_Database_77 CL CG = FalseSym0
+      TFHelper_GradingClient_Database_77 CL CH = FalseSym0
+      TFHelper_GradingClient_Database_77 CL CI = FalseSym0
+      TFHelper_GradingClient_Database_77 CL CJ = FalseSym0
+      TFHelper_GradingClient_Database_77 CL CK = FalseSym0
+      TFHelper_GradingClient_Database_77 CL CL = TrueSym0
+      TFHelper_GradingClient_Database_77 CL CM = FalseSym0
+      TFHelper_GradingClient_Database_77 CL CN = FalseSym0
+      TFHelper_GradingClient_Database_77 CL CO = FalseSym0
+      TFHelper_GradingClient_Database_77 CL CP = FalseSym0
+      TFHelper_GradingClient_Database_77 CL CQ = FalseSym0
+      TFHelper_GradingClient_Database_77 CL CR = FalseSym0
+      TFHelper_GradingClient_Database_77 CL CS = FalseSym0
+      TFHelper_GradingClient_Database_77 CL CT = FalseSym0
+      TFHelper_GradingClient_Database_77 CL CU = FalseSym0
+      TFHelper_GradingClient_Database_77 CL CV = FalseSym0
+      TFHelper_GradingClient_Database_77 CL CW = FalseSym0
+      TFHelper_GradingClient_Database_77 CL CX = FalseSym0
+      TFHelper_GradingClient_Database_77 CL CY = FalseSym0
+      TFHelper_GradingClient_Database_77 CL CZ = FalseSym0
+      TFHelper_GradingClient_Database_77 CM CA = FalseSym0
+      TFHelper_GradingClient_Database_77 CM CB = FalseSym0
+      TFHelper_GradingClient_Database_77 CM CC = FalseSym0
+      TFHelper_GradingClient_Database_77 CM CD = FalseSym0
+      TFHelper_GradingClient_Database_77 CM CE = FalseSym0
+      TFHelper_GradingClient_Database_77 CM CF = FalseSym0
+      TFHelper_GradingClient_Database_77 CM CG = FalseSym0
+      TFHelper_GradingClient_Database_77 CM CH = FalseSym0
+      TFHelper_GradingClient_Database_77 CM CI = FalseSym0
+      TFHelper_GradingClient_Database_77 CM CJ = FalseSym0
+      TFHelper_GradingClient_Database_77 CM CK = FalseSym0
+      TFHelper_GradingClient_Database_77 CM CL = FalseSym0
+      TFHelper_GradingClient_Database_77 CM CM = TrueSym0
+      TFHelper_GradingClient_Database_77 CM CN = FalseSym0
+      TFHelper_GradingClient_Database_77 CM CO = FalseSym0
+      TFHelper_GradingClient_Database_77 CM CP = FalseSym0
+      TFHelper_GradingClient_Database_77 CM CQ = FalseSym0
+      TFHelper_GradingClient_Database_77 CM CR = FalseSym0
+      TFHelper_GradingClient_Database_77 CM CS = FalseSym0
+      TFHelper_GradingClient_Database_77 CM CT = FalseSym0
+      TFHelper_GradingClient_Database_77 CM CU = FalseSym0
+      TFHelper_GradingClient_Database_77 CM CV = FalseSym0
+      TFHelper_GradingClient_Database_77 CM CW = FalseSym0
+      TFHelper_GradingClient_Database_77 CM CX = FalseSym0
+      TFHelper_GradingClient_Database_77 CM CY = FalseSym0
+      TFHelper_GradingClient_Database_77 CM CZ = FalseSym0
+      TFHelper_GradingClient_Database_77 CN CA = FalseSym0
+      TFHelper_GradingClient_Database_77 CN CB = FalseSym0
+      TFHelper_GradingClient_Database_77 CN CC = FalseSym0
+      TFHelper_GradingClient_Database_77 CN CD = FalseSym0
+      TFHelper_GradingClient_Database_77 CN CE = FalseSym0
+      TFHelper_GradingClient_Database_77 CN CF = FalseSym0
+      TFHelper_GradingClient_Database_77 CN CG = FalseSym0
+      TFHelper_GradingClient_Database_77 CN CH = FalseSym0
+      TFHelper_GradingClient_Database_77 CN CI = FalseSym0
+      TFHelper_GradingClient_Database_77 CN CJ = FalseSym0
+      TFHelper_GradingClient_Database_77 CN CK = FalseSym0
+      TFHelper_GradingClient_Database_77 CN CL = FalseSym0
+      TFHelper_GradingClient_Database_77 CN CM = FalseSym0
+      TFHelper_GradingClient_Database_77 CN CN = TrueSym0
+      TFHelper_GradingClient_Database_77 CN CO = FalseSym0
+      TFHelper_GradingClient_Database_77 CN CP = FalseSym0
+      TFHelper_GradingClient_Database_77 CN CQ = FalseSym0
+      TFHelper_GradingClient_Database_77 CN CR = FalseSym0
+      TFHelper_GradingClient_Database_77 CN CS = FalseSym0
+      TFHelper_GradingClient_Database_77 CN CT = FalseSym0
+      TFHelper_GradingClient_Database_77 CN CU = FalseSym0
+      TFHelper_GradingClient_Database_77 CN CV = FalseSym0
+      TFHelper_GradingClient_Database_77 CN CW = FalseSym0
+      TFHelper_GradingClient_Database_77 CN CX = FalseSym0
+      TFHelper_GradingClient_Database_77 CN CY = FalseSym0
+      TFHelper_GradingClient_Database_77 CN CZ = FalseSym0
+      TFHelper_GradingClient_Database_77 CO CA = FalseSym0
+      TFHelper_GradingClient_Database_77 CO CB = FalseSym0
+      TFHelper_GradingClient_Database_77 CO CC = FalseSym0
+      TFHelper_GradingClient_Database_77 CO CD = FalseSym0
+      TFHelper_GradingClient_Database_77 CO CE = FalseSym0
+      TFHelper_GradingClient_Database_77 CO CF = FalseSym0
+      TFHelper_GradingClient_Database_77 CO CG = FalseSym0
+      TFHelper_GradingClient_Database_77 CO CH = FalseSym0
+      TFHelper_GradingClient_Database_77 CO CI = FalseSym0
+      TFHelper_GradingClient_Database_77 CO CJ = FalseSym0
+      TFHelper_GradingClient_Database_77 CO CK = FalseSym0
+      TFHelper_GradingClient_Database_77 CO CL = FalseSym0
+      TFHelper_GradingClient_Database_77 CO CM = FalseSym0
+      TFHelper_GradingClient_Database_77 CO CN = FalseSym0
+      TFHelper_GradingClient_Database_77 CO CO = TrueSym0
+      TFHelper_GradingClient_Database_77 CO CP = FalseSym0
+      TFHelper_GradingClient_Database_77 CO CQ = FalseSym0
+      TFHelper_GradingClient_Database_77 CO CR = FalseSym0
+      TFHelper_GradingClient_Database_77 CO CS = FalseSym0
+      TFHelper_GradingClient_Database_77 CO CT = FalseSym0
+      TFHelper_GradingClient_Database_77 CO CU = FalseSym0
+      TFHelper_GradingClient_Database_77 CO CV = FalseSym0
+      TFHelper_GradingClient_Database_77 CO CW = FalseSym0
+      TFHelper_GradingClient_Database_77 CO CX = FalseSym0
+      TFHelper_GradingClient_Database_77 CO CY = FalseSym0
+      TFHelper_GradingClient_Database_77 CO CZ = FalseSym0
+      TFHelper_GradingClient_Database_77 CP CA = FalseSym0
+      TFHelper_GradingClient_Database_77 CP CB = FalseSym0
+      TFHelper_GradingClient_Database_77 CP CC = FalseSym0
+      TFHelper_GradingClient_Database_77 CP CD = FalseSym0
+      TFHelper_GradingClient_Database_77 CP CE = FalseSym0
+      TFHelper_GradingClient_Database_77 CP CF = FalseSym0
+      TFHelper_GradingClient_Database_77 CP CG = FalseSym0
+      TFHelper_GradingClient_Database_77 CP CH = FalseSym0
+      TFHelper_GradingClient_Database_77 CP CI = FalseSym0
+      TFHelper_GradingClient_Database_77 CP CJ = FalseSym0
+      TFHelper_GradingClient_Database_77 CP CK = FalseSym0
+      TFHelper_GradingClient_Database_77 CP CL = FalseSym0
+      TFHelper_GradingClient_Database_77 CP CM = FalseSym0
+      TFHelper_GradingClient_Database_77 CP CN = FalseSym0
+      TFHelper_GradingClient_Database_77 CP CO = FalseSym0
+      TFHelper_GradingClient_Database_77 CP CP = TrueSym0
+      TFHelper_GradingClient_Database_77 CP CQ = FalseSym0
+      TFHelper_GradingClient_Database_77 CP CR = FalseSym0
+      TFHelper_GradingClient_Database_77 CP CS = FalseSym0
+      TFHelper_GradingClient_Database_77 CP CT = FalseSym0
+      TFHelper_GradingClient_Database_77 CP CU = FalseSym0
+      TFHelper_GradingClient_Database_77 CP CV = FalseSym0
+      TFHelper_GradingClient_Database_77 CP CW = FalseSym0
+      TFHelper_GradingClient_Database_77 CP CX = FalseSym0
+      TFHelper_GradingClient_Database_77 CP CY = FalseSym0
+      TFHelper_GradingClient_Database_77 CP CZ = FalseSym0
+      TFHelper_GradingClient_Database_77 CQ CA = FalseSym0
+      TFHelper_GradingClient_Database_77 CQ CB = FalseSym0
+      TFHelper_GradingClient_Database_77 CQ CC = FalseSym0
+      TFHelper_GradingClient_Database_77 CQ CD = FalseSym0
+      TFHelper_GradingClient_Database_77 CQ CE = FalseSym0
+      TFHelper_GradingClient_Database_77 CQ CF = FalseSym0
+      TFHelper_GradingClient_Database_77 CQ CG = FalseSym0
+      TFHelper_GradingClient_Database_77 CQ CH = FalseSym0
+      TFHelper_GradingClient_Database_77 CQ CI = FalseSym0
+      TFHelper_GradingClient_Database_77 CQ CJ = FalseSym0
+      TFHelper_GradingClient_Database_77 CQ CK = FalseSym0
+      TFHelper_GradingClient_Database_77 CQ CL = FalseSym0
+      TFHelper_GradingClient_Database_77 CQ CM = FalseSym0
+      TFHelper_GradingClient_Database_77 CQ CN = FalseSym0
+      TFHelper_GradingClient_Database_77 CQ CO = FalseSym0
+      TFHelper_GradingClient_Database_77 CQ CP = FalseSym0
+      TFHelper_GradingClient_Database_77 CQ CQ = TrueSym0
+      TFHelper_GradingClient_Database_77 CQ CR = FalseSym0
+      TFHelper_GradingClient_Database_77 CQ CS = FalseSym0
+      TFHelper_GradingClient_Database_77 CQ CT = FalseSym0
+      TFHelper_GradingClient_Database_77 CQ CU = FalseSym0
+      TFHelper_GradingClient_Database_77 CQ CV = FalseSym0
+      TFHelper_GradingClient_Database_77 CQ CW = FalseSym0
+      TFHelper_GradingClient_Database_77 CQ CX = FalseSym0
+      TFHelper_GradingClient_Database_77 CQ CY = FalseSym0
+      TFHelper_GradingClient_Database_77 CQ CZ = FalseSym0
+      TFHelper_GradingClient_Database_77 CR CA = FalseSym0
+      TFHelper_GradingClient_Database_77 CR CB = FalseSym0
+      TFHelper_GradingClient_Database_77 CR CC = FalseSym0
+      TFHelper_GradingClient_Database_77 CR CD = FalseSym0
+      TFHelper_GradingClient_Database_77 CR CE = FalseSym0
+      TFHelper_GradingClient_Database_77 CR CF = FalseSym0
+      TFHelper_GradingClient_Database_77 CR CG = FalseSym0
+      TFHelper_GradingClient_Database_77 CR CH = FalseSym0
+      TFHelper_GradingClient_Database_77 CR CI = FalseSym0
+      TFHelper_GradingClient_Database_77 CR CJ = FalseSym0
+      TFHelper_GradingClient_Database_77 CR CK = FalseSym0
+      TFHelper_GradingClient_Database_77 CR CL = FalseSym0
+      TFHelper_GradingClient_Database_77 CR CM = FalseSym0
+      TFHelper_GradingClient_Database_77 CR CN = FalseSym0
+      TFHelper_GradingClient_Database_77 CR CO = FalseSym0
+      TFHelper_GradingClient_Database_77 CR CP = FalseSym0
+      TFHelper_GradingClient_Database_77 CR CQ = FalseSym0
+      TFHelper_GradingClient_Database_77 CR CR = TrueSym0
+      TFHelper_GradingClient_Database_77 CR CS = FalseSym0
+      TFHelper_GradingClient_Database_77 CR CT = FalseSym0
+      TFHelper_GradingClient_Database_77 CR CU = FalseSym0
+      TFHelper_GradingClient_Database_77 CR CV = FalseSym0
+      TFHelper_GradingClient_Database_77 CR CW = FalseSym0
+      TFHelper_GradingClient_Database_77 CR CX = FalseSym0
+      TFHelper_GradingClient_Database_77 CR CY = FalseSym0
+      TFHelper_GradingClient_Database_77 CR CZ = FalseSym0
+      TFHelper_GradingClient_Database_77 CS CA = FalseSym0
+      TFHelper_GradingClient_Database_77 CS CB = FalseSym0
+      TFHelper_GradingClient_Database_77 CS CC = FalseSym0
+      TFHelper_GradingClient_Database_77 CS CD = FalseSym0
+      TFHelper_GradingClient_Database_77 CS CE = FalseSym0
+      TFHelper_GradingClient_Database_77 CS CF = FalseSym0
+      TFHelper_GradingClient_Database_77 CS CG = FalseSym0
+      TFHelper_GradingClient_Database_77 CS CH = FalseSym0
+      TFHelper_GradingClient_Database_77 CS CI = FalseSym0
+      TFHelper_GradingClient_Database_77 CS CJ = FalseSym0
+      TFHelper_GradingClient_Database_77 CS CK = FalseSym0
+      TFHelper_GradingClient_Database_77 CS CL = FalseSym0
+      TFHelper_GradingClient_Database_77 CS CM = FalseSym0
+      TFHelper_GradingClient_Database_77 CS CN = FalseSym0
+      TFHelper_GradingClient_Database_77 CS CO = FalseSym0
+      TFHelper_GradingClient_Database_77 CS CP = FalseSym0
+      TFHelper_GradingClient_Database_77 CS CQ = FalseSym0
+      TFHelper_GradingClient_Database_77 CS CR = FalseSym0
+      TFHelper_GradingClient_Database_77 CS CS = TrueSym0
+      TFHelper_GradingClient_Database_77 CS CT = FalseSym0
+      TFHelper_GradingClient_Database_77 CS CU = FalseSym0
+      TFHelper_GradingClient_Database_77 CS CV = FalseSym0
+      TFHelper_GradingClient_Database_77 CS CW = FalseSym0
+      TFHelper_GradingClient_Database_77 CS CX = FalseSym0
+      TFHelper_GradingClient_Database_77 CS CY = FalseSym0
+      TFHelper_GradingClient_Database_77 CS CZ = FalseSym0
+      TFHelper_GradingClient_Database_77 CT CA = FalseSym0
+      TFHelper_GradingClient_Database_77 CT CB = FalseSym0
+      TFHelper_GradingClient_Database_77 CT CC = FalseSym0
+      TFHelper_GradingClient_Database_77 CT CD = FalseSym0
+      TFHelper_GradingClient_Database_77 CT CE = FalseSym0
+      TFHelper_GradingClient_Database_77 CT CF = FalseSym0
+      TFHelper_GradingClient_Database_77 CT CG = FalseSym0
+      TFHelper_GradingClient_Database_77 CT CH = FalseSym0
+      TFHelper_GradingClient_Database_77 CT CI = FalseSym0
+      TFHelper_GradingClient_Database_77 CT CJ = FalseSym0
+      TFHelper_GradingClient_Database_77 CT CK = FalseSym0
+      TFHelper_GradingClient_Database_77 CT CL = FalseSym0
+      TFHelper_GradingClient_Database_77 CT CM = FalseSym0
+      TFHelper_GradingClient_Database_77 CT CN = FalseSym0
+      TFHelper_GradingClient_Database_77 CT CO = FalseSym0
+      TFHelper_GradingClient_Database_77 CT CP = FalseSym0
+      TFHelper_GradingClient_Database_77 CT CQ = FalseSym0
+      TFHelper_GradingClient_Database_77 CT CR = FalseSym0
+      TFHelper_GradingClient_Database_77 CT CS = FalseSym0
+      TFHelper_GradingClient_Database_77 CT CT = TrueSym0
+      TFHelper_GradingClient_Database_77 CT CU = FalseSym0
+      TFHelper_GradingClient_Database_77 CT CV = FalseSym0
+      TFHelper_GradingClient_Database_77 CT CW = FalseSym0
+      TFHelper_GradingClient_Database_77 CT CX = FalseSym0
+      TFHelper_GradingClient_Database_77 CT CY = FalseSym0
+      TFHelper_GradingClient_Database_77 CT CZ = FalseSym0
+      TFHelper_GradingClient_Database_77 CU CA = FalseSym0
+      TFHelper_GradingClient_Database_77 CU CB = FalseSym0
+      TFHelper_GradingClient_Database_77 CU CC = FalseSym0
+      TFHelper_GradingClient_Database_77 CU CD = FalseSym0
+      TFHelper_GradingClient_Database_77 CU CE = FalseSym0
+      TFHelper_GradingClient_Database_77 CU CF = FalseSym0
+      TFHelper_GradingClient_Database_77 CU CG = FalseSym0
+      TFHelper_GradingClient_Database_77 CU CH = FalseSym0
+      TFHelper_GradingClient_Database_77 CU CI = FalseSym0
+      TFHelper_GradingClient_Database_77 CU CJ = FalseSym0
+      TFHelper_GradingClient_Database_77 CU CK = FalseSym0
+      TFHelper_GradingClient_Database_77 CU CL = FalseSym0
+      TFHelper_GradingClient_Database_77 CU CM = FalseSym0
+      TFHelper_GradingClient_Database_77 CU CN = FalseSym0
+      TFHelper_GradingClient_Database_77 CU CO = FalseSym0
+      TFHelper_GradingClient_Database_77 CU CP = FalseSym0
+      TFHelper_GradingClient_Database_77 CU CQ = FalseSym0
+      TFHelper_GradingClient_Database_77 CU CR = FalseSym0
+      TFHelper_GradingClient_Database_77 CU CS = FalseSym0
+      TFHelper_GradingClient_Database_77 CU CT = FalseSym0
+      TFHelper_GradingClient_Database_77 CU CU = TrueSym0
+      TFHelper_GradingClient_Database_77 CU CV = FalseSym0
+      TFHelper_GradingClient_Database_77 CU CW = FalseSym0
+      TFHelper_GradingClient_Database_77 CU CX = FalseSym0
+      TFHelper_GradingClient_Database_77 CU CY = FalseSym0
+      TFHelper_GradingClient_Database_77 CU CZ = FalseSym0
+      TFHelper_GradingClient_Database_77 CV CA = FalseSym0
+      TFHelper_GradingClient_Database_77 CV CB = FalseSym0
+      TFHelper_GradingClient_Database_77 CV CC = FalseSym0
+      TFHelper_GradingClient_Database_77 CV CD = FalseSym0
+      TFHelper_GradingClient_Database_77 CV CE = FalseSym0
+      TFHelper_GradingClient_Database_77 CV CF = FalseSym0
+      TFHelper_GradingClient_Database_77 CV CG = FalseSym0
+      TFHelper_GradingClient_Database_77 CV CH = FalseSym0
+      TFHelper_GradingClient_Database_77 CV CI = FalseSym0
+      TFHelper_GradingClient_Database_77 CV CJ = FalseSym0
+      TFHelper_GradingClient_Database_77 CV CK = FalseSym0
+      TFHelper_GradingClient_Database_77 CV CL = FalseSym0
+      TFHelper_GradingClient_Database_77 CV CM = FalseSym0
+      TFHelper_GradingClient_Database_77 CV CN = FalseSym0
+      TFHelper_GradingClient_Database_77 CV CO = FalseSym0
+      TFHelper_GradingClient_Database_77 CV CP = FalseSym0
+      TFHelper_GradingClient_Database_77 CV CQ = FalseSym0
+      TFHelper_GradingClient_Database_77 CV CR = FalseSym0
+      TFHelper_GradingClient_Database_77 CV CS = FalseSym0
+      TFHelper_GradingClient_Database_77 CV CT = FalseSym0
+      TFHelper_GradingClient_Database_77 CV CU = FalseSym0
+      TFHelper_GradingClient_Database_77 CV CV = TrueSym0
+      TFHelper_GradingClient_Database_77 CV CW = FalseSym0
+      TFHelper_GradingClient_Database_77 CV CX = FalseSym0
+      TFHelper_GradingClient_Database_77 CV CY = FalseSym0
+      TFHelper_GradingClient_Database_77 CV CZ = FalseSym0
+      TFHelper_GradingClient_Database_77 CW CA = FalseSym0
+      TFHelper_GradingClient_Database_77 CW CB = FalseSym0
+      TFHelper_GradingClient_Database_77 CW CC = FalseSym0
+      TFHelper_GradingClient_Database_77 CW CD = FalseSym0
+      TFHelper_GradingClient_Database_77 CW CE = FalseSym0
+      TFHelper_GradingClient_Database_77 CW CF = FalseSym0
+      TFHelper_GradingClient_Database_77 CW CG = FalseSym0
+      TFHelper_GradingClient_Database_77 CW CH = FalseSym0
+      TFHelper_GradingClient_Database_77 CW CI = FalseSym0
+      TFHelper_GradingClient_Database_77 CW CJ = FalseSym0
+      TFHelper_GradingClient_Database_77 CW CK = FalseSym0
+      TFHelper_GradingClient_Database_77 CW CL = FalseSym0
+      TFHelper_GradingClient_Database_77 CW CM = FalseSym0
+      TFHelper_GradingClient_Database_77 CW CN = FalseSym0
+      TFHelper_GradingClient_Database_77 CW CO = FalseSym0
+      TFHelper_GradingClient_Database_77 CW CP = FalseSym0
+      TFHelper_GradingClient_Database_77 CW CQ = FalseSym0
+      TFHelper_GradingClient_Database_77 CW CR = FalseSym0
+      TFHelper_GradingClient_Database_77 CW CS = FalseSym0
+      TFHelper_GradingClient_Database_77 CW CT = FalseSym0
+      TFHelper_GradingClient_Database_77 CW CU = FalseSym0
+      TFHelper_GradingClient_Database_77 CW CV = FalseSym0
+      TFHelper_GradingClient_Database_77 CW CW = TrueSym0
+      TFHelper_GradingClient_Database_77 CW CX = FalseSym0
+      TFHelper_GradingClient_Database_77 CW CY = FalseSym0
+      TFHelper_GradingClient_Database_77 CW CZ = FalseSym0
+      TFHelper_GradingClient_Database_77 CX CA = FalseSym0
+      TFHelper_GradingClient_Database_77 CX CB = FalseSym0
+      TFHelper_GradingClient_Database_77 CX CC = FalseSym0
+      TFHelper_GradingClient_Database_77 CX CD = FalseSym0
+      TFHelper_GradingClient_Database_77 CX CE = FalseSym0
+      TFHelper_GradingClient_Database_77 CX CF = FalseSym0
+      TFHelper_GradingClient_Database_77 CX CG = FalseSym0
+      TFHelper_GradingClient_Database_77 CX CH = FalseSym0
+      TFHelper_GradingClient_Database_77 CX CI = FalseSym0
+      TFHelper_GradingClient_Database_77 CX CJ = FalseSym0
+      TFHelper_GradingClient_Database_77 CX CK = FalseSym0
+      TFHelper_GradingClient_Database_77 CX CL = FalseSym0
+      TFHelper_GradingClient_Database_77 CX CM = FalseSym0
+      TFHelper_GradingClient_Database_77 CX CN = FalseSym0
+      TFHelper_GradingClient_Database_77 CX CO = FalseSym0
+      TFHelper_GradingClient_Database_77 CX CP = FalseSym0
+      TFHelper_GradingClient_Database_77 CX CQ = FalseSym0
+      TFHelper_GradingClient_Database_77 CX CR = FalseSym0
+      TFHelper_GradingClient_Database_77 CX CS = FalseSym0
+      TFHelper_GradingClient_Database_77 CX CT = FalseSym0
+      TFHelper_GradingClient_Database_77 CX CU = FalseSym0
+      TFHelper_GradingClient_Database_77 CX CV = FalseSym0
+      TFHelper_GradingClient_Database_77 CX CW = FalseSym0
+      TFHelper_GradingClient_Database_77 CX CX = TrueSym0
+      TFHelper_GradingClient_Database_77 CX CY = FalseSym0
+      TFHelper_GradingClient_Database_77 CX CZ = FalseSym0
+      TFHelper_GradingClient_Database_77 CY CA = FalseSym0
+      TFHelper_GradingClient_Database_77 CY CB = FalseSym0
+      TFHelper_GradingClient_Database_77 CY CC = FalseSym0
+      TFHelper_GradingClient_Database_77 CY CD = FalseSym0
+      TFHelper_GradingClient_Database_77 CY CE = FalseSym0
+      TFHelper_GradingClient_Database_77 CY CF = FalseSym0
+      TFHelper_GradingClient_Database_77 CY CG = FalseSym0
+      TFHelper_GradingClient_Database_77 CY CH = FalseSym0
+      TFHelper_GradingClient_Database_77 CY CI = FalseSym0
+      TFHelper_GradingClient_Database_77 CY CJ = FalseSym0
+      TFHelper_GradingClient_Database_77 CY CK = FalseSym0
+      TFHelper_GradingClient_Database_77 CY CL = FalseSym0
+      TFHelper_GradingClient_Database_77 CY CM = FalseSym0
+      TFHelper_GradingClient_Database_77 CY CN = FalseSym0
+      TFHelper_GradingClient_Database_77 CY CO = FalseSym0
+      TFHelper_GradingClient_Database_77 CY CP = FalseSym0
+      TFHelper_GradingClient_Database_77 CY CQ = FalseSym0
+      TFHelper_GradingClient_Database_77 CY CR = FalseSym0
+      TFHelper_GradingClient_Database_77 CY CS = FalseSym0
+      TFHelper_GradingClient_Database_77 CY CT = FalseSym0
+      TFHelper_GradingClient_Database_77 CY CU = FalseSym0
+      TFHelper_GradingClient_Database_77 CY CV = FalseSym0
+      TFHelper_GradingClient_Database_77 CY CW = FalseSym0
+      TFHelper_GradingClient_Database_77 CY CX = FalseSym0
+      TFHelper_GradingClient_Database_77 CY CY = TrueSym0
+      TFHelper_GradingClient_Database_77 CY CZ = FalseSym0
+      TFHelper_GradingClient_Database_77 CZ CA = FalseSym0
+      TFHelper_GradingClient_Database_77 CZ CB = FalseSym0
+      TFHelper_GradingClient_Database_77 CZ CC = FalseSym0
+      TFHelper_GradingClient_Database_77 CZ CD = FalseSym0
+      TFHelper_GradingClient_Database_77 CZ CE = FalseSym0
+      TFHelper_GradingClient_Database_77 CZ CF = FalseSym0
+      TFHelper_GradingClient_Database_77 CZ CG = FalseSym0
+      TFHelper_GradingClient_Database_77 CZ CH = FalseSym0
+      TFHelper_GradingClient_Database_77 CZ CI = FalseSym0
+      TFHelper_GradingClient_Database_77 CZ CJ = FalseSym0
+      TFHelper_GradingClient_Database_77 CZ CK = FalseSym0
+      TFHelper_GradingClient_Database_77 CZ CL = FalseSym0
+      TFHelper_GradingClient_Database_77 CZ CM = FalseSym0
+      TFHelper_GradingClient_Database_77 CZ CN = FalseSym0
+      TFHelper_GradingClient_Database_77 CZ CO = FalseSym0
+      TFHelper_GradingClient_Database_77 CZ CP = FalseSym0
+      TFHelper_GradingClient_Database_77 CZ CQ = FalseSym0
+      TFHelper_GradingClient_Database_77 CZ CR = FalseSym0
+      TFHelper_GradingClient_Database_77 CZ CS = FalseSym0
+      TFHelper_GradingClient_Database_77 CZ CT = FalseSym0
+      TFHelper_GradingClient_Database_77 CZ CU = FalseSym0
+      TFHelper_GradingClient_Database_77 CZ CV = FalseSym0
+      TFHelper_GradingClient_Database_77 CZ CW = FalseSym0
+      TFHelper_GradingClient_Database_77 CZ CX = FalseSym0
+      TFHelper_GradingClient_Database_77 CZ CY = FalseSym0
+      TFHelper_GradingClient_Database_77 CZ CZ = TrueSym0
     instance PEq AChar where
-      type (==) a a = TFHelper_0123456789876543210 a a
+      type (==) a a = TFHelper_GradingClient_Database_77 a a
     sLookup ::
       (forall (t :: [AChar]) (t :: Schema).
        Sing t -> Sing t -> Sing (Lookup t t :: U) :: Type)
@@ -1243,7 +1244,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
                    (sAttrs :: Sing attrs)))
       = applySing
           (singFun1
-             @(LamCases_0123456789876543210Sym0 name name' u attrs)
+             @(LamCases_GradingClient_Database_26Sym0 name name' u attrs)
              (\cases
                 STrue -> sU
                 SFalse
@@ -1477,55 +1478,55 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
       (%==) (SVEC _ _) SSTRING = SFalse
       (%==) (SVEC _ _) SNAT = SFalse
       (%==)
-        (SVEC (sA_0123456789876543210 :: Sing a_0123456789876543210)
-              (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SVEC (sB_0123456789876543210 :: Sing b_0123456789876543210)
-              (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SVEC (sA_GradingClient_Database_11 :: Sing a_GradingClient_Database_11)
+              (sA_GradingClient_Database_12 :: Sing a_GradingClient_Database_12))
+        (SVEC (sB_GradingClient_Database_13 :: Sing b_GradingClient_Database_13)
+              (sB_GradingClient_Database_14 :: Sing b_GradingClient_Database_14))
         = applySing
             (applySing
                (singFun2 @(&&@#@$) (%&&))
                (applySing
-                  (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                  sB_0123456789876543210))
+                  (applySing (singFun2 @(==@#@$) (%==)) sA_GradingClient_Database_11)
+                  sB_GradingClient_Database_13))
             (applySing
-               (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-               sB_0123456789876543210)
+               (applySing (singFun2 @(==@#@$) (%==)) sA_GradingClient_Database_12)
+               sB_GradingClient_Database_14)
     instance (SShow U, SShow Nat) => SShow U where
       sShowsPrec
         _
         SBOOL
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_40 :: Sing a_GradingClient_Database_40)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "BOOL"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_40
       sShowsPrec
         _
         SSTRING
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_41 :: Sing a_GradingClient_Database_41)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "STRING"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_41
       sShowsPrec
         _
         SNAT
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_42 :: Sing a_GradingClient_Database_42)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "NAT"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_42
       sShowsPrec
-        (sP_0123456789876543210 :: Sing p_0123456789876543210)
-        (SVEC (sArg_0123456789876543210 :: Sing arg_0123456789876543210)
-              (sArg_0123456789876543210 :: Sing arg_0123456789876543210))
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sP_GradingClient_Database_15 :: Sing p_GradingClient_Database_15)
+        (SVEC (sArg_GradingClient_Database_16 :: Sing arg_GradingClient_Database_16)
+              (sArg_GradingClient_Database_17 :: Sing arg_GradingClient_Database_17))
+        (sA_GradingClient_Database_43 :: Sing a_GradingClient_Database_43)
         = applySing
             (applySing
                (applySing
                   (singFun3 @ShowParenSym0 sShowParen)
                   (applySing
-                     (applySing (singFun2 @(>@#@$) (%>)) sP_0123456789876543210)
+                     (applySing (singFun2 @(>@#@$) (%>)) sP_GradingClient_Database_15)
                      (sFromInteger (sing :: Sing 10))))
                (applySing
                   (applySing
@@ -1539,7 +1540,7 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
                            (applySing
                               (singFun3 @ShowsPrecSym0 sShowsPrec)
                               (sFromInteger (sing :: Sing 11)))
-                           sArg_0123456789876543210))
+                           sArg_GradingClient_Database_16))
                      (applySing
                         (applySing
                            (singFun3 @(.@#@$) (%.)) (singFun1 @ShowSpaceSym0 sShowSpace))
@@ -1547,217 +1548,217 @@ GradingClient/Database.hs:(0,0)-(0,0): Splicing declarations
                            (applySing
                               (singFun3 @ShowsPrecSym0 sShowsPrec)
                               (sFromInteger (sing :: Sing 11)))
-                           sArg_0123456789876543210)))))
-            sA_0123456789876543210
+                           sArg_GradingClient_Database_17)))))
+            sA_GradingClient_Database_43
     instance SShow AChar where
       sShowsPrec
         _
         SCA
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_48 :: Sing a_GradingClient_Database_48)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "CA"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_48
       sShowsPrec
         _
         SCB
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_49 :: Sing a_GradingClient_Database_49)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "CB"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_49
       sShowsPrec
         _
         SCC
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_50 :: Sing a_GradingClient_Database_50)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "CC"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_50
       sShowsPrec
         _
         SCD
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_51 :: Sing a_GradingClient_Database_51)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "CD"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_51
       sShowsPrec
         _
         SCE
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_52 :: Sing a_GradingClient_Database_52)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "CE"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_52
       sShowsPrec
         _
         SCF
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_53 :: Sing a_GradingClient_Database_53)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "CF"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_53
       sShowsPrec
         _
         SCG
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_54 :: Sing a_GradingClient_Database_54)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "CG"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_54
       sShowsPrec
         _
         SCH
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_55 :: Sing a_GradingClient_Database_55)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "CH"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_55
       sShowsPrec
         _
         SCI
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_56 :: Sing a_GradingClient_Database_56)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "CI"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_56
       sShowsPrec
         _
         SCJ
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_57 :: Sing a_GradingClient_Database_57)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "CJ"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_57
       sShowsPrec
         _
         SCK
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_58 :: Sing a_GradingClient_Database_58)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "CK"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_58
       sShowsPrec
         _
         SCL
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_59 :: Sing a_GradingClient_Database_59)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "CL"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_59
       sShowsPrec
         _
         SCM
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_60 :: Sing a_GradingClient_Database_60)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "CM"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_60
       sShowsPrec
         _
         SCN
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_61 :: Sing a_GradingClient_Database_61)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "CN"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_61
       sShowsPrec
         _
         SCO
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_62 :: Sing a_GradingClient_Database_62)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "CO"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_62
       sShowsPrec
         _
         SCP
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_63 :: Sing a_GradingClient_Database_63)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "CP"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_63
       sShowsPrec
         _
         SCQ
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_64 :: Sing a_GradingClient_Database_64)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "CQ"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_64
       sShowsPrec
         _
         SCR
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_65 :: Sing a_GradingClient_Database_65)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "CR"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_65
       sShowsPrec
         _
         SCS
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_66 :: Sing a_GradingClient_Database_66)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "CS"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_66
       sShowsPrec
         _
         SCT
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_67 :: Sing a_GradingClient_Database_67)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "CT"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_67
       sShowsPrec
         _
         SCU
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_68 :: Sing a_GradingClient_Database_68)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "CU"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_68
       sShowsPrec
         _
         SCV
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_69 :: Sing a_GradingClient_Database_69)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "CV"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_69
       sShowsPrec
         _
         SCW
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_70 :: Sing a_GradingClient_Database_70)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "CW"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_70
       sShowsPrec
         _
         SCX
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_71 :: Sing a_GradingClient_Database_71)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "CX"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_71
       sShowsPrec
         _
         SCY
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_72 :: Sing a_GradingClient_Database_72)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "CY"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_72
       sShowsPrec
         _
         SCZ
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_GradingClient_Database_73 :: Sing a_GradingClient_Database_73)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "CZ"))
-            sA_0123456789876543210
+            sA_GradingClient_Database_73
     instance SEq AChar where
       (%==) SCA SCA = STrue
       (%==) SCA SCB = SFalse

--- a/singletons-base/tests/compile-and-dump/InsertionSort/InsertionSortImp.golden
+++ b/singletons-base/tests/compile-and-dump/InsertionSort/InsertionSortImp.golden
@@ -9,13 +9,13 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
     data SuccSym0 :: (~>) Nat Nat
       where
         SuccSym0KindInference :: SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
-                                 SuccSym0 a0123456789876543210
-    type instance Apply @Nat @Nat SuccSym0 a0123456789876543210 = Succ a0123456789876543210
+                                 SuccSym0 a_InsertionSort_InsertionSortImp_0
+    type instance Apply @Nat @Nat SuccSym0 a_InsertionSort_InsertionSortImp_0 = Succ a_InsertionSort_InsertionSortImp_0
     instance SuppressUnusedWarnings SuccSym0 where
       suppressUnusedWarnings = snd ((,) SuccSym0KindInference ())
     type SuccSym1 :: Nat -> Nat
-    type family SuccSym1 (a0123456789876543210 :: Nat) :: Nat where
-      SuccSym1 a0123456789876543210 = Succ a0123456789876543210
+    type family SuccSym1 (a_InsertionSort_InsertionSortImp_0 :: Nat) :: Nat where
+      SuccSym1 a_InsertionSort_InsertionSortImp_0 = Succ a_InsertionSort_InsertionSortImp_0
     data SNat :: Nat -> Type
       where
         SZero :: SNat (Zero :: Nat)
@@ -62,69 +62,70 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
     insertionSort :: [Nat] -> [Nat]
     insertionSort [] = []
     insertionSort (h : t) = insert h (insertionSort t)
-    type family LamCases_0123456789876543210 (n0123456789876543210 :: Nat) h0123456789876543210 t0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 n h t 'True = Apply (Apply (:@#@$) n) (Apply (Apply (:@#@$) h) t)
-      LamCases_0123456789876543210 n h t 'False = Apply (Apply (:@#@$) h) (Apply (Apply InsertSym0 n) t)
-    data LamCases_0123456789876543210Sym0 (n0123456789876543210 :: Nat) h0123456789876543210 t0123456789876543210 a_01234567898765432100123456789876543210
+    type family LamCases_InsertionSort_InsertionSortImp_4 (n0 :: Nat) h1 t2 a_InsertionSort_InsertionSortImp_5 where
+      LamCases_InsertionSort_InsertionSortImp_4 n h t 'True = Apply (Apply (:@#@$) n) (Apply (Apply (:@#@$) h) t)
+      LamCases_InsertionSort_InsertionSortImp_4 n h t 'False = Apply (Apply (:@#@$) h) (Apply (Apply InsertSym0 n) t)
+    data LamCases_InsertionSort_InsertionSortImp_4Sym0 (n0 :: Nat) h1 t2 a_InsertionSort_InsertionSortImp_5
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 n0123456789876543210 h0123456789876543210 t0123456789876543210) arg) (LamCases_0123456789876543210Sym1 n0123456789876543210 h0123456789876543210 t0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 n0123456789876543210 h0123456789876543210 t0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 n0123456789876543210 h0123456789876543210 t0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 n0123456789876543210 h0123456789876543210 t0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 n0123456789876543210 h0123456789876543210 t0123456789876543210) where
+        LamCases_InsertionSort_InsertionSortImp_4Sym0KindInference :: SameKind (Apply (LamCases_InsertionSort_InsertionSortImp_4Sym0 n0 h1 t2) arg) (LamCases_InsertionSort_InsertionSortImp_4Sym1 n0 h1 t2 arg) =>
+                                                                      LamCases_InsertionSort_InsertionSortImp_4Sym0 n0 h1 t2 a_InsertionSort_InsertionSortImp_5
+    type instance Apply @_ @_ (LamCases_InsertionSort_InsertionSortImp_4Sym0 n0 h1 t2) a_InsertionSort_InsertionSortImp_5 = LamCases_InsertionSort_InsertionSortImp_4 n0 h1 t2 a_InsertionSort_InsertionSortImp_5
+    instance SuppressUnusedWarnings (LamCases_InsertionSort_InsertionSortImp_4Sym0 n0 h1 t2) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (n0123456789876543210 :: Nat) h0123456789876543210 t0123456789876543210 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 n0123456789876543210 h0123456789876543210 t0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 n0123456789876543210 h0123456789876543210 t0123456789876543210 a_01234567898765432100123456789876543210
+        = snd
+            ((,) LamCases_InsertionSort_InsertionSortImp_4Sym0KindInference ())
+    type family LamCases_InsertionSort_InsertionSortImp_4Sym1 (n0 :: Nat) h1 t2 a_InsertionSort_InsertionSortImp_5 where
+      LamCases_InsertionSort_InsertionSortImp_4Sym1 n0 h1 t2 a_InsertionSort_InsertionSortImp_5 = LamCases_InsertionSort_InsertionSortImp_4 n0 h1 t2 a_InsertionSort_InsertionSortImp_5
     type InsertionSortSym0 :: (~>) [Nat] [Nat]
     data InsertionSortSym0 :: (~>) [Nat] [Nat]
       where
         InsertionSortSym0KindInference :: SameKind (Apply InsertionSortSym0 arg) (InsertionSortSym1 arg) =>
-                                          InsertionSortSym0 a0123456789876543210
-    type instance Apply @[Nat] @[Nat] InsertionSortSym0 a0123456789876543210 = InsertionSort a0123456789876543210
+                                          InsertionSortSym0 a_InsertionSort_InsertionSortImp_1
+    type instance Apply @[Nat] @[Nat] InsertionSortSym0 a_InsertionSort_InsertionSortImp_1 = InsertionSort a_InsertionSort_InsertionSortImp_1
     instance SuppressUnusedWarnings InsertionSortSym0 where
       suppressUnusedWarnings
         = snd ((,) InsertionSortSym0KindInference ())
     type InsertionSortSym1 :: [Nat] -> [Nat]
-    type family InsertionSortSym1 (a0123456789876543210 :: [Nat]) :: [Nat] where
-      InsertionSortSym1 a0123456789876543210 = InsertionSort a0123456789876543210
+    type family InsertionSortSym1 (a_InsertionSort_InsertionSortImp_1 :: [Nat]) :: [Nat] where
+      InsertionSortSym1 a_InsertionSort_InsertionSortImp_1 = InsertionSort a_InsertionSort_InsertionSortImp_1
     type InsertSym0 :: (~>) Nat ((~>) [Nat] [Nat])
     data InsertSym0 :: (~>) Nat ((~>) [Nat] [Nat])
       where
         InsertSym0KindInference :: SameKind (Apply InsertSym0 arg) (InsertSym1 arg) =>
-                                   InsertSym0 a0123456789876543210
-    type instance Apply @Nat @((~>) [Nat] [Nat]) InsertSym0 a0123456789876543210 = InsertSym1 a0123456789876543210
+                                   InsertSym0 a_InsertionSort_InsertionSortImp_2
+    type instance Apply @Nat @((~>) [Nat] [Nat]) InsertSym0 a_InsertionSort_InsertionSortImp_2 = InsertSym1 a_InsertionSort_InsertionSortImp_2
     instance SuppressUnusedWarnings InsertSym0 where
       suppressUnusedWarnings = snd ((,) InsertSym0KindInference ())
     type InsertSym1 :: Nat -> (~>) [Nat] [Nat]
-    data InsertSym1 (a0123456789876543210 :: Nat) :: (~>) [Nat] [Nat]
+    data InsertSym1 (a_InsertionSort_InsertionSortImp_2 :: Nat) :: (~>) [Nat] [Nat]
       where
-        InsertSym1KindInference :: SameKind (Apply (InsertSym1 a0123456789876543210) arg) (InsertSym2 a0123456789876543210 arg) =>
-                                   InsertSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @[Nat] @[Nat] (InsertSym1 a0123456789876543210) a0123456789876543210 = Insert a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (InsertSym1 a0123456789876543210) where
+        InsertSym1KindInference :: SameKind (Apply (InsertSym1 a_InsertionSort_InsertionSortImp_2) arg) (InsertSym2 a_InsertionSort_InsertionSortImp_2 arg) =>
+                                   InsertSym1 a_InsertionSort_InsertionSortImp_2 a_InsertionSort_InsertionSortImp_3
+    type instance Apply @[Nat] @[Nat] (InsertSym1 a_InsertionSort_InsertionSortImp_2) a_InsertionSort_InsertionSortImp_3 = Insert a_InsertionSort_InsertionSortImp_2 a_InsertionSort_InsertionSortImp_3
+    instance SuppressUnusedWarnings (InsertSym1 a_InsertionSort_InsertionSortImp_2) where
       suppressUnusedWarnings = snd ((,) InsertSym1KindInference ())
     type InsertSym2 :: Nat -> [Nat] -> [Nat]
-    type family InsertSym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: [Nat]) :: [Nat] where
-      InsertSym2 a0123456789876543210 a0123456789876543210 = Insert a0123456789876543210 a0123456789876543210
+    type family InsertSym2 (a_InsertionSort_InsertionSortImp_2 :: Nat) (a_InsertionSort_InsertionSortImp_3 :: [Nat]) :: [Nat] where
+      InsertSym2 a_InsertionSort_InsertionSortImp_2 a_InsertionSort_InsertionSortImp_3 = Insert a_InsertionSort_InsertionSortImp_2 a_InsertionSort_InsertionSortImp_3
     type LeqSym0 :: (~>) Nat ((~>) Nat Bool)
     data LeqSym0 :: (~>) Nat ((~>) Nat Bool)
       where
         LeqSym0KindInference :: SameKind (Apply LeqSym0 arg) (LeqSym1 arg) =>
-                                LeqSym0 a0123456789876543210
-    type instance Apply @Nat @((~>) Nat Bool) LeqSym0 a0123456789876543210 = LeqSym1 a0123456789876543210
+                                LeqSym0 a_InsertionSort_InsertionSortImp_6
+    type instance Apply @Nat @((~>) Nat Bool) LeqSym0 a_InsertionSort_InsertionSortImp_6 = LeqSym1 a_InsertionSort_InsertionSortImp_6
     instance SuppressUnusedWarnings LeqSym0 where
       suppressUnusedWarnings = snd ((,) LeqSym0KindInference ())
     type LeqSym1 :: Nat -> (~>) Nat Bool
-    data LeqSym1 (a0123456789876543210 :: Nat) :: (~>) Nat Bool
+    data LeqSym1 (a_InsertionSort_InsertionSortImp_6 :: Nat) :: (~>) Nat Bool
       where
-        LeqSym1KindInference :: SameKind (Apply (LeqSym1 a0123456789876543210) arg) (LeqSym2 a0123456789876543210 arg) =>
-                                LeqSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @Bool (LeqSym1 a0123456789876543210) a0123456789876543210 = Leq a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (LeqSym1 a0123456789876543210) where
+        LeqSym1KindInference :: SameKind (Apply (LeqSym1 a_InsertionSort_InsertionSortImp_6) arg) (LeqSym2 a_InsertionSort_InsertionSortImp_6 arg) =>
+                                LeqSym1 a_InsertionSort_InsertionSortImp_6 a_InsertionSort_InsertionSortImp_7
+    type instance Apply @Nat @Bool (LeqSym1 a_InsertionSort_InsertionSortImp_6) a_InsertionSort_InsertionSortImp_7 = Leq a_InsertionSort_InsertionSortImp_6 a_InsertionSort_InsertionSortImp_7
+    instance SuppressUnusedWarnings (LeqSym1 a_InsertionSort_InsertionSortImp_6) where
       suppressUnusedWarnings = snd ((,) LeqSym1KindInference ())
     type LeqSym2 :: Nat -> Nat -> Bool
-    type family LeqSym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Bool where
-      LeqSym2 a0123456789876543210 a0123456789876543210 = Leq a0123456789876543210 a0123456789876543210
+    type family LeqSym2 (a_InsertionSort_InsertionSortImp_6 :: Nat) (a_InsertionSort_InsertionSortImp_7 :: Nat) :: Bool where
+      LeqSym2 a_InsertionSort_InsertionSortImp_6 a_InsertionSort_InsertionSortImp_7 = Leq a_InsertionSort_InsertionSortImp_6 a_InsertionSort_InsertionSortImp_7
     type InsertionSort :: [Nat] -> [Nat]
     type family InsertionSort (a :: [Nat]) :: [Nat] where
       InsertionSort '[] = NilSym0
@@ -132,7 +133,7 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
     type Insert :: Nat -> [Nat] -> [Nat]
     type family Insert (a :: Nat) (a :: [Nat]) :: [Nat] where
       Insert n '[] = Apply (Apply (:@#@$) n) NilSym0
-      Insert n ('(:) h t) = Apply (LamCases_0123456789876543210Sym0 n h t) (Apply (Apply LeqSym0 n) h)
+      Insert n ('(:) h t) = Apply (LamCases_InsertionSort_InsertionSortImp_4Sym0 n h t) (Apply (Apply LeqSym0 n) h)
     type Leq :: Nat -> Nat -> Bool
     type family Leq (a :: Nat) (a :: Nat) :: Bool where
       Leq 'Zero _ = TrueSym0
@@ -157,7 +158,7 @@ InsertionSort/InsertionSortImp.hs:(0,0)-(0,0): Splicing declarations
     sInsert (sN :: Sing n) (SCons (sH :: Sing h) (sT :: Sing t))
       = applySing
           (singFun1
-             @(LamCases_0123456789876543210Sym0 n h t)
+             @(LamCases_InsertionSort_InsertionSortImp_4Sym0 n h t)
              (\cases
                 STrue
                   -> applySing

--- a/singletons-base/tests/compile-and-dump/Promote/Constructors.golden
+++ b/singletons-base/tests/compile-and-dump/Promote/Constructors.golden
@@ -12,62 +12,62 @@ Promote/Constructors.hs:(0,0)-(0,0): Splicing declarations
     data (:+@#@$) :: (~>) Foo ((~>) Foo Foo)
       where
         (::+@#@$###) :: SameKind (Apply (:+@#@$) arg) ((:+@#@$$) arg) =>
-                        (:+@#@$) a0123456789876543210
-    type instance Apply @Foo @((~>) Foo Foo) (:+@#@$) a0123456789876543210 = (:+@#@$$) a0123456789876543210
+                        (:+@#@$) a_Promote_Constructors_0
+    type instance Apply @Foo @((~>) Foo Foo) (:+@#@$) a_Promote_Constructors_0 = (:+@#@$$) a_Promote_Constructors_0
     instance SuppressUnusedWarnings (:+@#@$) where
       suppressUnusedWarnings = snd ((,) (::+@#@$###) ())
     type (:+@#@$$) :: Foo -> (~>) Foo Foo
-    data (:+@#@$$) (a0123456789876543210 :: Foo) :: (~>) Foo Foo
+    data (:+@#@$$) (a_Promote_Constructors_0 :: Foo) :: (~>) Foo Foo
       where
-        (::+@#@$$###) :: SameKind (Apply ((:+@#@$$) a0123456789876543210) arg) ((:+@#@$$$) a0123456789876543210 arg) =>
-                         (:+@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @Foo @Foo ((:+@#@$$) a0123456789876543210) a0123456789876543210 = (:+) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((:+@#@$$) a0123456789876543210) where
+        (::+@#@$$###) :: SameKind (Apply ((:+@#@$$) a_Promote_Constructors_0) arg) ((:+@#@$$$) a_Promote_Constructors_0 arg) =>
+                         (:+@#@$$) a_Promote_Constructors_0 a_Promote_Constructors_1
+    type instance Apply @Foo @Foo ((:+@#@$$) a_Promote_Constructors_0) a_Promote_Constructors_1 = (:+) a_Promote_Constructors_0 a_Promote_Constructors_1
+    instance SuppressUnusedWarnings ((:+@#@$$) a_Promote_Constructors_0) where
       suppressUnusedWarnings = snd ((,) (::+@#@$$###) ())
     type (:+@#@$$$) :: Foo -> Foo -> Foo
-    type family (:+@#@$$$) (a0123456789876543210 :: Foo) (a0123456789876543210 :: Foo) :: Foo where
-      (:+@#@$$$) a0123456789876543210 a0123456789876543210 = (:+) a0123456789876543210 a0123456789876543210
+    type family (:+@#@$$$) (a_Promote_Constructors_0 :: Foo) (a_Promote_Constructors_1 :: Foo) :: Foo where
+      (:+@#@$$$) a_Promote_Constructors_0 a_Promote_Constructors_1 = (:+) a_Promote_Constructors_0 a_Promote_Constructors_1
     type BarSym0 :: (~>) Bar ((~>) Bar ((~>) Bar ((~>) Bar ((~>) Foo Bar))))
     data BarSym0 :: (~>) Bar ((~>) Bar ((~>) Bar ((~>) Bar ((~>) Foo Bar))))
       where
         BarSym0KindInference :: SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
-                                BarSym0 a0123456789876543210
-    type instance Apply @Bar @((~>) Bar ((~>) Bar ((~>) Bar ((~>) Foo Bar)))) BarSym0 a0123456789876543210 = BarSym1 a0123456789876543210
+                                BarSym0 a_Promote_Constructors_2
+    type instance Apply @Bar @((~>) Bar ((~>) Bar ((~>) Bar ((~>) Foo Bar)))) BarSym0 a_Promote_Constructors_2 = BarSym1 a_Promote_Constructors_2
     instance SuppressUnusedWarnings BarSym0 where
       suppressUnusedWarnings = snd ((,) BarSym0KindInference ())
     type BarSym1 :: Bar
                     -> (~>) Bar ((~>) Bar ((~>) Bar ((~>) Foo Bar)))
-    data BarSym1 (a0123456789876543210 :: Bar) :: (~>) Bar ((~>) Bar ((~>) Bar ((~>) Foo Bar)))
+    data BarSym1 (a_Promote_Constructors_2 :: Bar) :: (~>) Bar ((~>) Bar ((~>) Bar ((~>) Foo Bar)))
       where
-        BarSym1KindInference :: SameKind (Apply (BarSym1 a0123456789876543210) arg) (BarSym2 a0123456789876543210 arg) =>
-                                BarSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Bar @((~>) Bar ((~>) Bar ((~>) Foo Bar))) (BarSym1 a0123456789876543210) a0123456789876543210 = BarSym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (BarSym1 a0123456789876543210) where
+        BarSym1KindInference :: SameKind (Apply (BarSym1 a_Promote_Constructors_2) arg) (BarSym2 a_Promote_Constructors_2 arg) =>
+                                BarSym1 a_Promote_Constructors_2 a_Promote_Constructors_3
+    type instance Apply @Bar @((~>) Bar ((~>) Bar ((~>) Foo Bar))) (BarSym1 a_Promote_Constructors_2) a_Promote_Constructors_3 = BarSym2 a_Promote_Constructors_2 a_Promote_Constructors_3
+    instance SuppressUnusedWarnings (BarSym1 a_Promote_Constructors_2) where
       suppressUnusedWarnings = snd ((,) BarSym1KindInference ())
     type BarSym2 :: Bar -> Bar -> (~>) Bar ((~>) Bar ((~>) Foo Bar))
-    data BarSym2 (a0123456789876543210 :: Bar) (a0123456789876543210 :: Bar) :: (~>) Bar ((~>) Bar ((~>) Foo Bar))
+    data BarSym2 (a_Promote_Constructors_2 :: Bar) (a_Promote_Constructors_3 :: Bar) :: (~>) Bar ((~>) Bar ((~>) Foo Bar))
       where
-        BarSym2KindInference :: SameKind (Apply (BarSym2 a0123456789876543210 a0123456789876543210) arg) (BarSym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                BarSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @Bar @((~>) Bar ((~>) Foo Bar)) (BarSym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = BarSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (BarSym2 a0123456789876543210 a0123456789876543210) where
+        BarSym2KindInference :: SameKind (Apply (BarSym2 a_Promote_Constructors_2 a_Promote_Constructors_3) arg) (BarSym3 a_Promote_Constructors_2 a_Promote_Constructors_3 arg) =>
+                                BarSym2 a_Promote_Constructors_2 a_Promote_Constructors_3 a_Promote_Constructors_4
+    type instance Apply @Bar @((~>) Bar ((~>) Foo Bar)) (BarSym2 a_Promote_Constructors_2 a_Promote_Constructors_3) a_Promote_Constructors_4 = BarSym3 a_Promote_Constructors_2 a_Promote_Constructors_3 a_Promote_Constructors_4
+    instance SuppressUnusedWarnings (BarSym2 a_Promote_Constructors_2 a_Promote_Constructors_3) where
       suppressUnusedWarnings = snd ((,) BarSym2KindInference ())
     type BarSym3 :: Bar -> Bar -> Bar -> (~>) Bar ((~>) Foo Bar)
-    data BarSym3 (a0123456789876543210 :: Bar) (a0123456789876543210 :: Bar) (a0123456789876543210 :: Bar) :: (~>) Bar ((~>) Foo Bar)
+    data BarSym3 (a_Promote_Constructors_2 :: Bar) (a_Promote_Constructors_3 :: Bar) (a_Promote_Constructors_4 :: Bar) :: (~>) Bar ((~>) Foo Bar)
       where
-        BarSym3KindInference :: SameKind (Apply (BarSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) arg) (BarSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 arg) =>
-                                BarSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @Bar @((~>) Foo Bar) (BarSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) a0123456789876543210 = BarSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (BarSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) where
+        BarSym3KindInference :: SameKind (Apply (BarSym3 a_Promote_Constructors_2 a_Promote_Constructors_3 a_Promote_Constructors_4) arg) (BarSym4 a_Promote_Constructors_2 a_Promote_Constructors_3 a_Promote_Constructors_4 arg) =>
+                                BarSym3 a_Promote_Constructors_2 a_Promote_Constructors_3 a_Promote_Constructors_4 a_Promote_Constructors_5
+    type instance Apply @Bar @((~>) Foo Bar) (BarSym3 a_Promote_Constructors_2 a_Promote_Constructors_3 a_Promote_Constructors_4) a_Promote_Constructors_5 = BarSym4 a_Promote_Constructors_2 a_Promote_Constructors_3 a_Promote_Constructors_4 a_Promote_Constructors_5
+    instance SuppressUnusedWarnings (BarSym3 a_Promote_Constructors_2 a_Promote_Constructors_3 a_Promote_Constructors_4) where
       suppressUnusedWarnings = snd ((,) BarSym3KindInference ())
     type BarSym4 :: Bar -> Bar -> Bar -> Bar -> (~>) Foo Bar
-    data BarSym4 (a0123456789876543210 :: Bar) (a0123456789876543210 :: Bar) (a0123456789876543210 :: Bar) (a0123456789876543210 :: Bar) :: (~>) Foo Bar
+    data BarSym4 (a_Promote_Constructors_2 :: Bar) (a_Promote_Constructors_3 :: Bar) (a_Promote_Constructors_4 :: Bar) (a_Promote_Constructors_5 :: Bar) :: (~>) Foo Bar
       where
-        BarSym4KindInference :: SameKind (Apply (BarSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210) arg) (BarSym5 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 arg) =>
-                                BarSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @Foo @Bar (BarSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210) a0123456789876543210 = Bar a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (BarSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210) where
+        BarSym4KindInference :: SameKind (Apply (BarSym4 a_Promote_Constructors_2 a_Promote_Constructors_3 a_Promote_Constructors_4 a_Promote_Constructors_5) arg) (BarSym5 a_Promote_Constructors_2 a_Promote_Constructors_3 a_Promote_Constructors_4 a_Promote_Constructors_5 arg) =>
+                                BarSym4 a_Promote_Constructors_2 a_Promote_Constructors_3 a_Promote_Constructors_4 a_Promote_Constructors_5 a_Promote_Constructors_6
+    type instance Apply @Foo @Bar (BarSym4 a_Promote_Constructors_2 a_Promote_Constructors_3 a_Promote_Constructors_4 a_Promote_Constructors_5) a_Promote_Constructors_6 = Bar a_Promote_Constructors_2 a_Promote_Constructors_3 a_Promote_Constructors_4 a_Promote_Constructors_5 a_Promote_Constructors_6
+    instance SuppressUnusedWarnings (BarSym4 a_Promote_Constructors_2 a_Promote_Constructors_3 a_Promote_Constructors_4 a_Promote_Constructors_5) where
       suppressUnusedWarnings = snd ((,) BarSym4KindInference ())
     type BarSym5 :: Bar -> Bar -> Bar -> Bar -> Foo -> Bar
-    type family BarSym5 (a0123456789876543210 :: Bar) (a0123456789876543210 :: Bar) (a0123456789876543210 :: Bar) (a0123456789876543210 :: Bar) (a0123456789876543210 :: Foo) :: Bar where
-      BarSym5 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 = Bar a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type family BarSym5 (a_Promote_Constructors_2 :: Bar) (a_Promote_Constructors_3 :: Bar) (a_Promote_Constructors_4 :: Bar) (a_Promote_Constructors_5 :: Bar) (a_Promote_Constructors_6 :: Foo) :: Bar where
+      BarSym5 a_Promote_Constructors_2 a_Promote_Constructors_3 a_Promote_Constructors_4 a_Promote_Constructors_5 a_Promote_Constructors_6 = Bar a_Promote_Constructors_2 a_Promote_Constructors_3 a_Promote_Constructors_4 a_Promote_Constructors_5 a_Promote_Constructors_6

--- a/singletons-base/tests/compile-and-dump/Promote/GenDefunSymbols.golden
+++ b/singletons-base/tests/compile-and-dump/Promote/GenDefunSymbols.golden
@@ -6,25 +6,25 @@ Promote/GenDefunSymbols.hs:0:0:: Splicing declarations
     data LiftMaybeSym0 :: (~>) ((~>) a b) ((~>) (Maybe a) (Maybe b))
       where
         LiftMaybeSym0KindInference :: Data.Singletons.SameKind (Apply LiftMaybeSym0 arg) (LiftMaybeSym1 arg) =>
-                                      LiftMaybeSym0 a0123456789876543210
-    type instance Apply @((~>) a b) @((~>) (Maybe a) (Maybe b)) LiftMaybeSym0 a0123456789876543210 = LiftMaybeSym1 a0123456789876543210
+                                      LiftMaybeSym0 a_Promote_GenDefunSymbols_0
+    type instance Apply @((~>) a b) @((~>) (Maybe a) (Maybe b)) LiftMaybeSym0 a_Promote_GenDefunSymbols_0 = LiftMaybeSym1 a_Promote_GenDefunSymbols_0
     instance Data.Singletons.TH.SuppressUnusedWarnings.SuppressUnusedWarnings LiftMaybeSym0 where
       Data.Singletons.TH.SuppressUnusedWarnings.suppressUnusedWarnings
         = snd ((,) LiftMaybeSym0KindInference ())
     type LiftMaybeSym1 :: forall (a :: Type) (b :: Type). (~>) a b
                                                           -> (~>) (Maybe a) (Maybe b)
-    data LiftMaybeSym1 (a0123456789876543210 :: (~>) a b) :: (~>) (Maybe a) (Maybe b)
+    data LiftMaybeSym1 (a_Promote_GenDefunSymbols_0 :: (~>) a b) :: (~>) (Maybe a) (Maybe b)
       where
-        LiftMaybeSym1KindInference :: Data.Singletons.SameKind (Apply (LiftMaybeSym1 a0123456789876543210) arg) (LiftMaybeSym2 a0123456789876543210 arg) =>
-                                      LiftMaybeSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Maybe a) @(Maybe b) (LiftMaybeSym1 a0123456789876543210) a0123456789876543210 = LiftMaybe a0123456789876543210 a0123456789876543210
-    instance Data.Singletons.TH.SuppressUnusedWarnings.SuppressUnusedWarnings (LiftMaybeSym1 a0123456789876543210) where
+        LiftMaybeSym1KindInference :: Data.Singletons.SameKind (Apply (LiftMaybeSym1 a_Promote_GenDefunSymbols_0) arg) (LiftMaybeSym2 a_Promote_GenDefunSymbols_0 arg) =>
+                                      LiftMaybeSym1 a_Promote_GenDefunSymbols_0 a_Promote_GenDefunSymbols_1
+    type instance Apply @(Maybe a) @(Maybe b) (LiftMaybeSym1 a_Promote_GenDefunSymbols_0) a_Promote_GenDefunSymbols_1 = LiftMaybe a_Promote_GenDefunSymbols_0 a_Promote_GenDefunSymbols_1
+    instance Data.Singletons.TH.SuppressUnusedWarnings.SuppressUnusedWarnings (LiftMaybeSym1 a_Promote_GenDefunSymbols_0) where
       Data.Singletons.TH.SuppressUnusedWarnings.suppressUnusedWarnings
         = snd ((,) LiftMaybeSym1KindInference ())
     type LiftMaybeSym2 :: forall (a :: Type) (b :: Type). (~>) a b
                                                           -> Maybe a -> Maybe b
-    type family LiftMaybeSym2 @(a :: Type) @(b :: Type) (a0123456789876543210 :: (~>) a b) (a0123456789876543210 :: Maybe a) :: Maybe b where
-      LiftMaybeSym2 a0123456789876543210 a0123456789876543210 = LiftMaybe a0123456789876543210 a0123456789876543210
+    type family LiftMaybeSym2 @(a :: Type) @(b :: Type) (a_Promote_GenDefunSymbols_0 :: (~>) a b) (a_Promote_GenDefunSymbols_1 :: Maybe a) :: Maybe b where
+      LiftMaybeSym2 a_Promote_GenDefunSymbols_0 a_Promote_GenDefunSymbols_1 = LiftMaybe a_Promote_GenDefunSymbols_0 a_Promote_GenDefunSymbols_1
     type ZeroSym0 :: NatT
     type family ZeroSym0 :: NatT where
       ZeroSym0 = 'Zero
@@ -32,32 +32,32 @@ Promote/GenDefunSymbols.hs:0:0:: Splicing declarations
     data SuccSym0 :: (~>) NatT NatT
       where
         SuccSym0KindInference :: Data.Singletons.SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
-                                 SuccSym0 a0123456789876543210
-    type instance Apply @NatT @NatT SuccSym0 a0123456789876543210 = 'Succ a0123456789876543210
+                                 SuccSym0 a_Promote_GenDefunSymbols_2
+    type instance Apply @NatT @NatT SuccSym0 a_Promote_GenDefunSymbols_2 = 'Succ a_Promote_GenDefunSymbols_2
     instance Data.Singletons.TH.SuppressUnusedWarnings.SuppressUnusedWarnings SuccSym0 where
       Data.Singletons.TH.SuppressUnusedWarnings.suppressUnusedWarnings
         = snd ((,) SuccSym0KindInference ())
     type SuccSym1 :: NatT -> NatT
-    type family SuccSym1 (a0123456789876543210 :: NatT) :: NatT where
-      SuccSym1 a0123456789876543210 = 'Succ a0123456789876543210
+    type family SuccSym1 (a_Promote_GenDefunSymbols_2 :: NatT) :: NatT where
+      SuccSym1 a_Promote_GenDefunSymbols_2 = 'Succ a_Promote_GenDefunSymbols_2
     type (:+@#@$) :: (~>) Natural ((~>) Natural Natural)
     data (:+@#@$) :: (~>) Natural ((~>) Natural Natural)
       where
         (::+@#@$###) :: Data.Singletons.SameKind (Apply (:+@#@$) arg) ((:+@#@$$) arg) =>
-                        (:+@#@$) a0123456789876543210
-    type instance Apply @Natural @((~>) Natural Natural) (:+@#@$) a0123456789876543210 = (:+@#@$$) a0123456789876543210
+                        (:+@#@$) a_Promote_GenDefunSymbols_3
+    type instance Apply @Natural @((~>) Natural Natural) (:+@#@$) a_Promote_GenDefunSymbols_3 = (:+@#@$$) a_Promote_GenDefunSymbols_3
     instance Data.Singletons.TH.SuppressUnusedWarnings.SuppressUnusedWarnings (:+@#@$) where
       Data.Singletons.TH.SuppressUnusedWarnings.suppressUnusedWarnings
         = snd ((,) (::+@#@$###) ())
     type (:+@#@$$) :: Natural -> (~>) Natural Natural
-    data (:+@#@$$) (a0123456789876543210 :: Natural) :: (~>) Natural Natural
+    data (:+@#@$$) (a_Promote_GenDefunSymbols_3 :: Natural) :: (~>) Natural Natural
       where
-        (::+@#@$$###) :: Data.Singletons.SameKind (Apply ((:+@#@$$) a0123456789876543210) arg) ((:+@#@$$$) a0123456789876543210 arg) =>
-                         (:+@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @Natural @Natural ((:+@#@$$) a0123456789876543210) a0123456789876543210 = (:+) a0123456789876543210 a0123456789876543210
-    instance Data.Singletons.TH.SuppressUnusedWarnings.SuppressUnusedWarnings ((:+@#@$$) a0123456789876543210) where
+        (::+@#@$$###) :: Data.Singletons.SameKind (Apply ((:+@#@$$) a_Promote_GenDefunSymbols_3) arg) ((:+@#@$$$) a_Promote_GenDefunSymbols_3 arg) =>
+                         (:+@#@$$) a_Promote_GenDefunSymbols_3 a_Promote_GenDefunSymbols_4
+    type instance Apply @Natural @Natural ((:+@#@$$) a_Promote_GenDefunSymbols_3) a_Promote_GenDefunSymbols_4 = (:+) a_Promote_GenDefunSymbols_3 a_Promote_GenDefunSymbols_4
+    instance Data.Singletons.TH.SuppressUnusedWarnings.SuppressUnusedWarnings ((:+@#@$$) a_Promote_GenDefunSymbols_3) where
       Data.Singletons.TH.SuppressUnusedWarnings.suppressUnusedWarnings
         = snd ((,) (::+@#@$$###) ())
     type (:+@#@$$$) :: Natural -> Natural -> Natural
-    type family (:+@#@$$$) (a0123456789876543210 :: Natural) (a0123456789876543210 :: Natural) :: Natural where
-      (:+@#@$$$) a0123456789876543210 a0123456789876543210 = (:+) a0123456789876543210 a0123456789876543210
+    type family (:+@#@$$$) (a_Promote_GenDefunSymbols_3 :: Natural) (a_Promote_GenDefunSymbols_4 :: Natural) :: Natural where
+      (:+@#@$$$) a_Promote_GenDefunSymbols_3 a_Promote_GenDefunSymbols_4 = (:+) a_Promote_GenDefunSymbols_3 a_Promote_GenDefunSymbols_4

--- a/singletons-base/tests/compile-and-dump/Promote/Newtypes.golden
+++ b/singletons-base/tests/compile-and-dump/Promote/Newtypes.golden
@@ -13,40 +13,40 @@ Promote/Newtypes.hs:(0,0)-(0,0): Splicing declarations
     data FooSym0 :: (~>) Nat Foo
       where
         FooSym0KindInference :: SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
-                                FooSym0 a0123456789876543210
-    type instance Apply @Nat @Foo FooSym0 a0123456789876543210 = Foo a0123456789876543210
+                                FooSym0 a_Promote_Newtypes_2
+    type instance Apply @Nat @Foo FooSym0 a_Promote_Newtypes_2 = Foo a_Promote_Newtypes_2
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings = snd ((,) FooSym0KindInference ())
     type FooSym1 :: Nat -> Foo
-    type family FooSym1 (a0123456789876543210 :: Nat) :: Foo where
-      FooSym1 a0123456789876543210 = Foo a0123456789876543210
+    type family FooSym1 (a_Promote_Newtypes_2 :: Nat) :: Foo where
+      FooSym1 a_Promote_Newtypes_2 = Foo a_Promote_Newtypes_2
     type BarSym0 :: (~>) Nat Bar
     data BarSym0 :: (~>) Nat Bar
       where
         BarSym0KindInference :: SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
-                                BarSym0 a0123456789876543210
-    type instance Apply @Nat @Bar BarSym0 a0123456789876543210 = Bar a0123456789876543210
+                                BarSym0 a_Promote_Newtypes_3
+    type instance Apply @Nat @Bar BarSym0 a_Promote_Newtypes_3 = Bar a_Promote_Newtypes_3
     instance SuppressUnusedWarnings BarSym0 where
       suppressUnusedWarnings = snd ((,) BarSym0KindInference ())
     type BarSym1 :: Nat -> Bar
-    type family BarSym1 (a0123456789876543210 :: Nat) :: Bar where
-      BarSym1 a0123456789876543210 = Bar a0123456789876543210
+    type family BarSym1 (a_Promote_Newtypes_3 :: Nat) :: Bar where
+      BarSym1 a_Promote_Newtypes_3 = Bar a_Promote_Newtypes_3
     type UnBarSym0 :: (~>) Bar Nat
     data UnBarSym0 :: (~>) Bar Nat
       where
         UnBarSym0KindInference :: SameKind (Apply UnBarSym0 arg) (UnBarSym1 arg) =>
-                                  UnBarSym0 a0123456789876543210
-    type instance Apply @Bar @Nat UnBarSym0 a0123456789876543210 = UnBar a0123456789876543210
+                                  UnBarSym0 a_Promote_Newtypes_4
+    type instance Apply @Bar @Nat UnBarSym0 a_Promote_Newtypes_4 = UnBar a_Promote_Newtypes_4
     instance SuppressUnusedWarnings UnBarSym0 where
       suppressUnusedWarnings = snd ((,) UnBarSym0KindInference ())
     type UnBarSym1 :: Bar -> Nat
-    type family UnBarSym1 (a0123456789876543210 :: Bar) :: Nat where
-      UnBarSym1 a0123456789876543210 = UnBar a0123456789876543210
+    type family UnBarSym1 (a_Promote_Newtypes_4 :: Bar) :: Nat where
+      UnBarSym1 a_Promote_Newtypes_4 = UnBar a_Promote_Newtypes_4
     type UnBar :: Bar -> Nat
     type family UnBar (a :: Bar) :: Nat where
       UnBar (Bar field) = field
-    type TFHelper_0123456789876543210 :: Foo -> Foo -> Bool
-    type family TFHelper_0123456789876543210 (a :: Foo) (a :: Foo) :: Bool where
-      TFHelper_0123456789876543210 (Foo a_0123456789876543210) (Foo b_0123456789876543210) = Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210
+    type TFHelper_Promote_Newtypes_5 :: Foo -> Foo -> Bool
+    type family TFHelper_Promote_Newtypes_5 (a :: Foo) (a :: Foo) :: Bool where
+      TFHelper_Promote_Newtypes_5 (Foo a_Promote_Newtypes_0) (Foo b_Promote_Newtypes_1) = Apply (Apply (==@#@$) a_Promote_Newtypes_0) b_Promote_Newtypes_1
     instance PEq Foo where
-      type (==) a a = TFHelper_0123456789876543210 a a
+      type (==) a a = TFHelper_Promote_Newtypes_5 a a

--- a/singletons-base/tests/compile-and-dump/Promote/Prelude.golden
+++ b/singletons-base/tests/compile-and-dump/Promote/Prelude.golden
@@ -8,13 +8,13 @@ Promote/Prelude.hs:(0,0)-(0,0): Splicing declarations
     data OddSym0 :: (~>) Natural Bool
       where
         OddSym0KindInference :: SameKind (Apply OddSym0 arg) (OddSym1 arg) =>
-                                OddSym0 a0123456789876543210
-    type instance Apply @Natural @Bool OddSym0 a0123456789876543210 = Odd a0123456789876543210
+                                OddSym0 a_Promote_Prelude_0
+    type instance Apply @Natural @Bool OddSym0 a_Promote_Prelude_0 = Odd a_Promote_Prelude_0
     instance SuppressUnusedWarnings OddSym0 where
       suppressUnusedWarnings = snd ((,) OddSym0KindInference ())
     type OddSym1 :: Natural -> Bool
-    type family OddSym1 (a0123456789876543210 :: Natural) :: Bool where
-      OddSym1 a0123456789876543210 = Odd a0123456789876543210
+    type family OddSym1 (a_Promote_Prelude_0 :: Natural) :: Bool where
+      OddSym1 a_Promote_Prelude_0 = Odd a_Promote_Prelude_0
     type Odd :: Natural -> Bool
     type family Odd (a :: Natural) :: Bool where
       Odd 0 = FalseSym0

--- a/singletons-base/tests/compile-and-dump/Promote/T180.golden
+++ b/singletons-base/tests/compile-and-dump/Promote/T180.golden
@@ -12,44 +12,44 @@ Promote/T180.hs:(0,0)-(0,0): Splicing declarations
     data X1Sym0 :: (~>) Symbol X
       where
         X1Sym0KindInference :: SameKind (Apply X1Sym0 arg) (X1Sym1 arg) =>
-                               X1Sym0 a0123456789876543210
-    type instance Apply @Symbol @X X1Sym0 a0123456789876543210 = X1 a0123456789876543210
+                               X1Sym0 a_T180_0
+    type instance Apply @Symbol @X X1Sym0 a_T180_0 = X1 a_T180_0
     instance SuppressUnusedWarnings X1Sym0 where
       suppressUnusedWarnings = snd ((,) X1Sym0KindInference ())
     type X1Sym1 :: Symbol -> X
-    type family X1Sym1 (a0123456789876543210 :: Symbol) :: X where
-      X1Sym1 a0123456789876543210 = X1 a0123456789876543210
+    type family X1Sym1 (a_T180_0 :: Symbol) :: X where
+      X1Sym1 a_T180_0 = X1 a_T180_0
     type X2Sym0 :: (~>) Symbol X
     data X2Sym0 :: (~>) Symbol X
       where
         X2Sym0KindInference :: SameKind (Apply X2Sym0 arg) (X2Sym1 arg) =>
-                               X2Sym0 a0123456789876543210
-    type instance Apply @Symbol @X X2Sym0 a0123456789876543210 = X2 a0123456789876543210
+                               X2Sym0 a_T180_1
+    type instance Apply @Symbol @X X2Sym0 a_T180_1 = X2 a_T180_1
     instance SuppressUnusedWarnings X2Sym0 where
       suppressUnusedWarnings = snd ((,) X2Sym0KindInference ())
     type X2Sym1 :: Symbol -> X
-    type family X2Sym1 (a0123456789876543210 :: Symbol) :: X where
-      X2Sym1 a0123456789876543210 = X2 a0123456789876543210
-    data ZSym0 a0123456789876543210
+    type family X2Sym1 (a_T180_1 :: Symbol) :: X where
+      X2Sym1 a_T180_1 = X2 a_T180_1
+    data ZSym0 a0
       where
         ZSym0KindInference :: SameKind (Apply ZSym0 arg) (ZSym1 arg) =>
-                              ZSym0 a0123456789876543210
-    type instance Apply @_ @_ ZSym0 a0123456789876543210 = Z a0123456789876543210
+                              ZSym0 a0
+    type instance Apply @_ @_ ZSym0 a0 = Z a0
     instance SuppressUnusedWarnings ZSym0 where
       suppressUnusedWarnings = snd ((,) ZSym0KindInference ())
-    type family ZSym1 a0123456789876543210 where
-      ZSym1 a0123456789876543210 = Z a0123456789876543210
+    type family ZSym1 a0 where
+      ZSym1 a0 = Z a0
     type YSym0 :: (~>) X Symbol
     data YSym0 :: (~>) X Symbol
       where
         YSym0KindInference :: SameKind (Apply YSym0 arg) (YSym1 arg) =>
-                              YSym0 a0123456789876543210
-    type instance Apply @X @Symbol YSym0 a0123456789876543210 = Y a0123456789876543210
+                              YSym0 a_T180_2
+    type instance Apply @X @Symbol YSym0 a_T180_2 = Y a_T180_2
     instance SuppressUnusedWarnings YSym0 where
       suppressUnusedWarnings = snd ((,) YSym0KindInference ())
     type YSym1 :: X -> Symbol
-    type family YSym1 (a0123456789876543210 :: X) :: Symbol where
-      YSym1 a0123456789876543210 = Y a0123456789876543210
+    type family YSym1 (a_T180_2 :: X) :: Symbol where
+      YSym1 a_T180_2 = Y a_T180_2
     type family Z a where
       Z (X1 x) = x
       Z (X2 x) = x

--- a/singletons-base/tests/compile-and-dump/Promote/T361.golden
+++ b/singletons-base/tests/compile-and-dump/Promote/T361.golden
@@ -15,13 +15,13 @@ Promote/T361.hs:(0,0)-(0,0): Splicing declarations
     data FSym0 :: (~>) (Proxy 1) (Proxy 2)
       where
         FSym0KindInference :: SameKind (Apply FSym0 arg) (FSym1 arg) =>
-                              FSym0 a0123456789876543210
-    type instance Apply @(Proxy 1) @(Proxy 2) FSym0 a0123456789876543210 = F a0123456789876543210
+                              FSym0 a_T361_0
+    type instance Apply @(Proxy 1) @(Proxy 2) FSym0 a_T361_0 = F a_T361_0
     instance SuppressUnusedWarnings FSym0 where
       suppressUnusedWarnings = snd ((,) FSym0KindInference ())
     type FSym1 :: Proxy 1 -> Proxy 2
-    type family FSym1 (a0123456789876543210 :: Proxy 1) :: Proxy 2 where
-      FSym1 a0123456789876543210 = F a0123456789876543210
+    type family FSym1 (a_T361_0 :: Proxy 1) :: Proxy 2 where
+      FSym1 a_T361_0 = F a_T361_0
     type F :: Proxy 1 -> Proxy 2
     type family F (a :: Proxy 1) :: Proxy 2 where
       F 'Proxy = ProxySym0

--- a/singletons-base/tests/compile-and-dump/Promote/T601a.golden
+++ b/singletons-base/tests/compile-and-dump/Promote/T601a.golden
@@ -18,56 +18,55 @@ Promote/T601a.hs:(0,0)-(0,0): Splicing declarations
     data ApSym0 :: (~>) (f ((~>) a b)) ((~>) (f a) (f b))
       where
         ApSym0KindInference :: SameKind (Apply ApSym0 arg) (ApSym1 arg) =>
-                               ApSym0 a0123456789876543210
-    type instance Apply @(f ((~>) a b)) @((~>) (f a) (f b)) ApSym0 a0123456789876543210 = ApSym1 a0123456789876543210
+                               ApSym0 a_T601a_0
+    type instance Apply @(f ((~>) a b)) @((~>) (f a) (f b)) ApSym0 a_T601a_0 = ApSym1 a_T601a_0
     instance SuppressUnusedWarnings ApSym0 where
       suppressUnusedWarnings = snd ((,) ApSym0KindInference ())
     type ApSym1 :: forall (f :: Type -> Type) a b. f ((~>) a b)
                                                    -> (~>) (f a) (f b)
-    data ApSym1 (a0123456789876543210 :: f ((~>) a b)) :: (~>) (f a) (f b)
+    data ApSym1 (a_T601a_0 :: f ((~>) a b)) :: (~>) (f a) (f b)
       where
-        ApSym1KindInference :: SameKind (Apply (ApSym1 a0123456789876543210) arg) (ApSym2 a0123456789876543210 arg) =>
-                               ApSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(f a) @(f b) (ApSym1 a0123456789876543210) a0123456789876543210 = Ap a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ApSym1 a0123456789876543210) where
+        ApSym1KindInference :: SameKind (Apply (ApSym1 a_T601a_0) arg) (ApSym2 a_T601a_0 arg) =>
+                               ApSym1 a_T601a_0 a_T601a_1
+    type instance Apply @(f a) @(f b) (ApSym1 a_T601a_0) a_T601a_1 = Ap a_T601a_0 a_T601a_1
+    instance SuppressUnusedWarnings (ApSym1 a_T601a_0) where
       suppressUnusedWarnings = snd ((,) ApSym1KindInference ())
     type ApSym2 :: forall (f :: Type -> Type) a b. f ((~>) a b)
                                                    -> f a -> f b
     type family ApSym2 @(f :: Type
-                              -> Type) @a @b (a0123456789876543210 :: f ((~>) a b)) (a0123456789876543210 :: f a) :: f b where
-      ApSym2 a0123456789876543210 a0123456789876543210 = Ap a0123456789876543210 a0123456789876543210
+                              -> Type) @a @b (a_T601a_0 :: f ((~>) a b)) (a_T601a_1 :: f a) :: f b where
+      ApSym2 a_T601a_0 a_T601a_1 = Ap a_T601a_0 a_T601a_1
     type RightSparrowSym0 :: forall (f :: Type -> Type)
                                     a
                                     b. (~>) (f a) ((~>) (f b) (f b))
     data RightSparrowSym0 :: (~>) (f a) ((~>) (f b) (f b))
       where
         RightSparrowSym0KindInference :: SameKind (Apply RightSparrowSym0 arg) (RightSparrowSym1 arg) =>
-                                         RightSparrowSym0 a0123456789876543210
-    type instance Apply @(f a) @((~>) (f b) (f b)) RightSparrowSym0 a0123456789876543210 = RightSparrowSym1 a0123456789876543210
+                                         RightSparrowSym0 a_T601a_2
+    type instance Apply @(f a) @((~>) (f b) (f b)) RightSparrowSym0 a_T601a_2 = RightSparrowSym1 a_T601a_2
     instance SuppressUnusedWarnings RightSparrowSym0 where
       suppressUnusedWarnings = snd ((,) RightSparrowSym0KindInference ())
     type RightSparrowSym1 :: forall (f :: Type -> Type) a b. f a
                                                              -> (~>) (f b) (f b)
-    data RightSparrowSym1 (a0123456789876543210 :: f a) :: (~>) (f b) (f b)
+    data RightSparrowSym1 (a_T601a_2 :: f a) :: (~>) (f b) (f b)
       where
-        RightSparrowSym1KindInference :: SameKind (Apply (RightSparrowSym1 a0123456789876543210) arg) (RightSparrowSym2 a0123456789876543210 arg) =>
-                                         RightSparrowSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(f b) @(f b) (RightSparrowSym1 a0123456789876543210) a0123456789876543210 = RightSparrow a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (RightSparrowSym1 a0123456789876543210) where
+        RightSparrowSym1KindInference :: SameKind (Apply (RightSparrowSym1 a_T601a_2) arg) (RightSparrowSym2 a_T601a_2 arg) =>
+                                         RightSparrowSym1 a_T601a_2 a_T601a_3
+    type instance Apply @(f b) @(f b) (RightSparrowSym1 a_T601a_2) a_T601a_3 = RightSparrow a_T601a_2 a_T601a_3
+    instance SuppressUnusedWarnings (RightSparrowSym1 a_T601a_2) where
       suppressUnusedWarnings = snd ((,) RightSparrowSym1KindInference ())
     type RightSparrowSym2 :: forall (f :: Type -> Type) a b. f a
                                                              -> f b -> f b
     type family RightSparrowSym2 @(f :: Type
-                                        -> Type) @a @b (a0123456789876543210 :: f a) (a0123456789876543210 :: f b) :: f b where
-      RightSparrowSym2 a0123456789876543210 a0123456789876543210 = RightSparrow a0123456789876543210 a0123456789876543210
-    type RightSparrow_0123456789876543210 :: forall (f :: Type -> Type)
-                                                    a
-                                                    b. f a -> f b -> f b
-    type family RightSparrow_0123456789876543210 @(f :: Type
-                                                        -> Type) @a @b (a :: f a) (a :: f b) :: f b where
-      RightSparrow_0123456789876543210 @f @a @b (x :: f a) (y :: f b) = Apply (Apply ApSym0 (Apply (Apply (<$@#@$) IdSym0) x)) y
+                                        -> Type) @a @b (a_T601a_2 :: f a) (a_T601a_3 :: f b) :: f b where
+      RightSparrowSym2 a_T601a_2 a_T601a_3 = RightSparrow a_T601a_2 a_T601a_3
+    type RightSparrow_T601a_4 :: forall (f :: Type -> Type) a b. f a
+                                                                 -> f b -> f b
+    type family RightSparrow_T601a_4 @(f :: Type
+                                            -> Type) @a @b (a :: f a) (a :: f b) :: f b where
+      RightSparrow_T601a_4 @f @a @b (x :: f a) (y :: f b) = Apply (Apply ApSym0 (Apply (Apply (<$@#@$) IdSym0) x)) y
     type PMyApplicative :: (Type -> Type) -> Constraint
     class PMyApplicative f where
       type family Ap (arg :: f ((~>) a b)) (arg :: f a) :: f b
       type family RightSparrow (arg :: f a) (arg :: f b) :: f b
-      type RightSparrow a a = RightSparrow_0123456789876543210 a a
+      type RightSparrow a a = RightSparrow_T601a_4 a a

--- a/singletons-base/tests/compile-and-dump/Promote/T605.golden
+++ b/singletons-base/tests/compile-and-dump/Promote/T605.golden
@@ -12,28 +12,28 @@ Promote/T605.hs:(0,0)-(0,0): Splicing declarations
     data Traverse'Sym0 :: (~>) ((~>) a (f b)) ((~>) (t a) (t (f b)))
       where
         Traverse'Sym0KindInference :: SameKind (Apply Traverse'Sym0 arg) (Traverse'Sym1 arg) =>
-                                      Traverse'Sym0 a0123456789876543210
-    type instance Apply @((~>) a (f b)) @((~>) (t a) (t (f b))) Traverse'Sym0 a0123456789876543210 = Traverse'Sym1 a0123456789876543210
+                                      Traverse'Sym0 a_T605_0
+    type instance Apply @((~>) a (f b)) @((~>) (t a) (t (f b))) Traverse'Sym0 a_T605_0 = Traverse'Sym1 a_T605_0
     instance SuppressUnusedWarnings Traverse'Sym0 where
       suppressUnusedWarnings = snd ((,) Traverse'Sym0KindInference ())
     type Traverse'Sym1 :: forall (t :: Type -> Type)
                                  a
                                  f
                                  b. (~>) a (f b) -> (~>) (t a) (t (f b))
-    data Traverse'Sym1 (a0123456789876543210 :: (~>) a (f b)) :: (~>) (t a) (t (f b))
+    data Traverse'Sym1 (a_T605_0 :: (~>) a (f b)) :: (~>) (t a) (t (f b))
       where
-        Traverse'Sym1KindInference :: SameKind (Apply (Traverse'Sym1 a0123456789876543210) arg) (Traverse'Sym2 a0123456789876543210 arg) =>
-                                      Traverse'Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(t a) @(t (f b)) (Traverse'Sym1 a0123456789876543210) a0123456789876543210 = Traverse' a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Traverse'Sym1 a0123456789876543210) where
+        Traverse'Sym1KindInference :: SameKind (Apply (Traverse'Sym1 a_T605_0) arg) (Traverse'Sym2 a_T605_0 arg) =>
+                                      Traverse'Sym1 a_T605_0 a_T605_1
+    type instance Apply @(t a) @(t (f b)) (Traverse'Sym1 a_T605_0) a_T605_1 = Traverse' a_T605_0 a_T605_1
+    instance SuppressUnusedWarnings (Traverse'Sym1 a_T605_0) where
       suppressUnusedWarnings = snd ((,) Traverse'Sym1KindInference ())
     type Traverse'Sym2 :: forall (t :: Type -> Type)
                                  a
                                  f
                                  b. (~>) a (f b) -> t a -> t (f b)
     type family Traverse'Sym2 @(t :: Type
-                                     -> Type) @a @f @b (a0123456789876543210 :: (~>) a (f b)) (a0123456789876543210 :: t a) :: t (f b) where
-      Traverse'Sym2 a0123456789876543210 a0123456789876543210 = Traverse' a0123456789876543210 a0123456789876543210
+                                     -> Type) @a @f @b (a_T605_0 :: (~>) a (f b)) (a_T605_1 :: t a) :: t (f b) where
+      Traverse'Sym2 a_T605_0 a_T605_1 = Traverse' a_T605_0 a_T605_1
     type PTraversable' :: (Type -> Type) -> Constraint
     class PTraversable' t where
       type family Traverse' (arg :: (~>) a (f b)) (arg :: t a) :: t (f b)

--- a/singletons-base/tests/compile-and-dump/Promote/T613.golden
+++ b/singletons-base/tests/compile-and-dump/Promote/T613.golden
@@ -11,21 +11,21 @@ Promote/T613.hs:(0,0)-(0,0): Splicing declarations
       = y
       where
           y = x
-    type family Let0123456789876543210YSym0 k0123456789876543210 (a0123456789876543210 :: k0123456789876543210) (x0123456789876543210 :: Proxy a0123456789876543210) where
-      Let0123456789876543210YSym0 k0123456789876543210 a0123456789876543210 x0123456789876543210 = Let0123456789876543210Y k0123456789876543210 a0123456789876543210 x0123456789876543210
-    type family Let0123456789876543210Y k0123456789876543210 (a0123456789876543210 :: k0123456789876543210) (x0123456789876543210 :: Proxy a0123456789876543210) where
-      Let0123456789876543210Y k a x = x
+    type family Let1YSym0 k0 (a1 :: k0) (x2 :: Proxy a1) where
+      Let1YSym0 k0 a1 x2 = Let1Y k0 a1 x2
+    type family Let1Y k0 (a1 :: k0) (x2 :: Proxy a1) where
+      Let1Y k a x = x
     type FSym0 :: forall k (a :: k). (~>) (Proxy a) (Proxy a)
     data FSym0 :: (~>) (Proxy a) (Proxy a)
       where
         FSym0KindInference :: SameKind (Apply FSym0 arg) (FSym1 arg) =>
-                              FSym0 a0123456789876543210
-    type instance Apply @(Proxy a) @(Proxy a) FSym0 a0123456789876543210 = F a0123456789876543210
+                              FSym0 a_T613_0
+    type instance Apply @(Proxy a) @(Proxy a) FSym0 a_T613_0 = F a_T613_0
     instance SuppressUnusedWarnings FSym0 where
       suppressUnusedWarnings = snd ((,) FSym0KindInference ())
     type FSym1 :: forall k (a :: k). Proxy a -> Proxy a
-    type family FSym1 @k @(a :: k) (a0123456789876543210 :: Proxy a) :: Proxy a where
-      FSym1 a0123456789876543210 = F a0123456789876543210
+    type family FSym1 @k @(a :: k) (a_T613_0 :: Proxy a) :: Proxy a where
+      FSym1 a_T613_0 = F a_T613_0
     type F :: forall k (a :: k). Proxy a -> Proxy a
     type family F @k @(a :: k) (a :: Proxy a) :: Proxy a where
-      F @k @a (x :: Proxy a) = Let0123456789876543210YSym0 k a x
+      F @k @a (x :: Proxy a) = Let1YSym0 k a x

--- a/singletons-base/tests/compile-and-dump/Singletons/AsPattern.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/AsPattern.golden
@@ -38,139 +38,139 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
     data BazSym0 :: (~>) Nat ((~>) Nat ((~>) Nat Baz))
       where
         BazSym0KindInference :: SameKind (Apply BazSym0 arg) (BazSym1 arg) =>
-                                BazSym0 a0123456789876543210
-    type instance Apply @Nat @((~>) Nat ((~>) Nat Baz)) BazSym0 a0123456789876543210 = BazSym1 a0123456789876543210
+                                BazSym0 a_Singletons_AsPattern_10
+    type instance Apply @Nat @((~>) Nat ((~>) Nat Baz)) BazSym0 a_Singletons_AsPattern_10 = BazSym1 a_Singletons_AsPattern_10
     instance SuppressUnusedWarnings BazSym0 where
       suppressUnusedWarnings = snd ((,) BazSym0KindInference ())
     type BazSym1 :: Nat -> (~>) Nat ((~>) Nat Baz)
-    data BazSym1 (a0123456789876543210 :: Nat) :: (~>) Nat ((~>) Nat Baz)
+    data BazSym1 (a_Singletons_AsPattern_10 :: Nat) :: (~>) Nat ((~>) Nat Baz)
       where
-        BazSym1KindInference :: SameKind (Apply (BazSym1 a0123456789876543210) arg) (BazSym2 a0123456789876543210 arg) =>
-                                BazSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @((~>) Nat Baz) (BazSym1 a0123456789876543210) a0123456789876543210 = BazSym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (BazSym1 a0123456789876543210) where
+        BazSym1KindInference :: SameKind (Apply (BazSym1 a_Singletons_AsPattern_10) arg) (BazSym2 a_Singletons_AsPattern_10 arg) =>
+                                BazSym1 a_Singletons_AsPattern_10 a_Singletons_AsPattern_11
+    type instance Apply @Nat @((~>) Nat Baz) (BazSym1 a_Singletons_AsPattern_10) a_Singletons_AsPattern_11 = BazSym2 a_Singletons_AsPattern_10 a_Singletons_AsPattern_11
+    instance SuppressUnusedWarnings (BazSym1 a_Singletons_AsPattern_10) where
       suppressUnusedWarnings = snd ((,) BazSym1KindInference ())
     type BazSym2 :: Nat -> Nat -> (~>) Nat Baz
-    data BazSym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: (~>) Nat Baz
+    data BazSym2 (a_Singletons_AsPattern_10 :: Nat) (a_Singletons_AsPattern_11 :: Nat) :: (~>) Nat Baz
       where
-        BazSym2KindInference :: SameKind (Apply (BazSym2 a0123456789876543210 a0123456789876543210) arg) (BazSym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                BazSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @Baz (BazSym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = Baz a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (BazSym2 a0123456789876543210 a0123456789876543210) where
+        BazSym2KindInference :: SameKind (Apply (BazSym2 a_Singletons_AsPattern_10 a_Singletons_AsPattern_11) arg) (BazSym3 a_Singletons_AsPattern_10 a_Singletons_AsPattern_11 arg) =>
+                                BazSym2 a_Singletons_AsPattern_10 a_Singletons_AsPattern_11 a_Singletons_AsPattern_12
+    type instance Apply @Nat @Baz (BazSym2 a_Singletons_AsPattern_10 a_Singletons_AsPattern_11) a_Singletons_AsPattern_12 = Baz a_Singletons_AsPattern_10 a_Singletons_AsPattern_11 a_Singletons_AsPattern_12
+    instance SuppressUnusedWarnings (BazSym2 a_Singletons_AsPattern_10 a_Singletons_AsPattern_11) where
       suppressUnusedWarnings = snd ((,) BazSym2KindInference ())
     type BazSym3 :: Nat -> Nat -> Nat -> Baz
-    type family BazSym3 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Baz where
-      BazSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = Baz a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type family Let0123456789876543210PSym0 where
-      Let0123456789876543210PSym0 = Let0123456789876543210P
-    type family Let0123456789876543210P where
-      Let0123456789876543210P = NilSym0
-    type family Let0123456789876543210PSym0 wild_01234567898765432100123456789876543210 where
-      Let0123456789876543210PSym0 wild_01234567898765432100123456789876543210 = Let0123456789876543210P wild_01234567898765432100123456789876543210
-    type family Let0123456789876543210P wild_01234567898765432100123456789876543210 where
-      Let0123456789876543210P wild_0123456789876543210 = Apply (Apply (:@#@$) wild_0123456789876543210) NilSym0
-    type family Let0123456789876543210PSym0 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 where
-      Let0123456789876543210PSym0 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 = Let0123456789876543210P wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210
-    type family Let0123456789876543210P wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 where
-      Let0123456789876543210P wild_0123456789876543210 wild_0123456789876543210 wild_0123456789876543210 = Apply (Apply (:@#@$) wild_0123456789876543210) (Apply (Apply (:@#@$) wild_0123456789876543210) wild_0123456789876543210)
-    type family Let0123456789876543210PSym0 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 where
-      Let0123456789876543210PSym0 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 = Let0123456789876543210P wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210
-    type family Let0123456789876543210P wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 where
-      Let0123456789876543210P wild_0123456789876543210 wild_0123456789876543210 = Apply (Apply Tuple2Sym0 wild_0123456789876543210) wild_0123456789876543210
-    type family Let0123456789876543210PSym0 where
-      Let0123456789876543210PSym0 = Let0123456789876543210P
-    type family Let0123456789876543210P where
-      Let0123456789876543210P = NothingSym0
-    type family Let0123456789876543210PSym0 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 where
-      Let0123456789876543210PSym0 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 = Let0123456789876543210P wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210
-    type family Let0123456789876543210P wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 wild_01234567898765432100123456789876543210 where
-      Let0123456789876543210P wild_0123456789876543210 wild_0123456789876543210 wild_0123456789876543210 = Apply JustSym0 (Apply (Apply (Apply BazSym0 wild_0123456789876543210) wild_0123456789876543210) wild_0123456789876543210)
-    type family Let0123456789876543210XSym0 wild_01234567898765432100123456789876543210 where
-      Let0123456789876543210XSym0 wild_01234567898765432100123456789876543210 = Let0123456789876543210X wild_01234567898765432100123456789876543210
-    type family Let0123456789876543210X wild_01234567898765432100123456789876543210 where
-      Let0123456789876543210X wild_0123456789876543210 = Apply JustSym0 wild_0123456789876543210
-    type family Let0123456789876543210PSym0 where
-      Let0123456789876543210PSym0 = Let0123456789876543210P
-    type family Let0123456789876543210P where
-      Let0123456789876543210P = NothingSym0
+    type family BazSym3 (a_Singletons_AsPattern_10 :: Nat) (a_Singletons_AsPattern_11 :: Nat) (a_Singletons_AsPattern_12 :: Nat) :: Baz where
+      BazSym3 a_Singletons_AsPattern_10 a_Singletons_AsPattern_11 a_Singletons_AsPattern_12 = Baz a_Singletons_AsPattern_10 a_Singletons_AsPattern_11 a_Singletons_AsPattern_12
+    type family Let14PSym0 where
+      Let14PSym0 = Let14P
+    type family Let14P where
+      Let14P = NilSym0
+    type family Let15PSym0 wild_Singletons_AsPattern_90 where
+      Let15PSym0 wild_Singletons_AsPattern_90 = Let15P wild_Singletons_AsPattern_90
+    type family Let15P wild_Singletons_AsPattern_90 where
+      Let15P wild_Singletons_AsPattern_9 = Apply (Apply (:@#@$) wild_Singletons_AsPattern_9) NilSym0
+    type family Let16PSym0 wild_Singletons_AsPattern_60 wild_Singletons_AsPattern_71 wild_Singletons_AsPattern_82 where
+      Let16PSym0 wild_Singletons_AsPattern_60 wild_Singletons_AsPattern_71 wild_Singletons_AsPattern_82 = Let16P wild_Singletons_AsPattern_60 wild_Singletons_AsPattern_71 wild_Singletons_AsPattern_82
+    type family Let16P wild_Singletons_AsPattern_60 wild_Singletons_AsPattern_71 wild_Singletons_AsPattern_82 where
+      Let16P wild_Singletons_AsPattern_6 wild_Singletons_AsPattern_7 wild_Singletons_AsPattern_8 = Apply (Apply (:@#@$) wild_Singletons_AsPattern_6) (Apply (Apply (:@#@$) wild_Singletons_AsPattern_7) wild_Singletons_AsPattern_8)
+    type family Let18PSym0 wild_Singletons_AsPattern_40 wild_Singletons_AsPattern_51 where
+      Let18PSym0 wild_Singletons_AsPattern_40 wild_Singletons_AsPattern_51 = Let18P wild_Singletons_AsPattern_40 wild_Singletons_AsPattern_51
+    type family Let18P wild_Singletons_AsPattern_40 wild_Singletons_AsPattern_51 where
+      Let18P wild_Singletons_AsPattern_4 wild_Singletons_AsPattern_5 = Apply (Apply Tuple2Sym0 wild_Singletons_AsPattern_4) wild_Singletons_AsPattern_5
+    type family Let20PSym0 where
+      Let20PSym0 = Let20P
+    type family Let20P where
+      Let20P = NothingSym0
+    type family Let21PSym0 wild_Singletons_AsPattern_10 wild_Singletons_AsPattern_21 wild_Singletons_AsPattern_32 where
+      Let21PSym0 wild_Singletons_AsPattern_10 wild_Singletons_AsPattern_21 wild_Singletons_AsPattern_32 = Let21P wild_Singletons_AsPattern_10 wild_Singletons_AsPattern_21 wild_Singletons_AsPattern_32
+    type family Let21P wild_Singletons_AsPattern_10 wild_Singletons_AsPattern_21 wild_Singletons_AsPattern_32 where
+      Let21P wild_Singletons_AsPattern_1 wild_Singletons_AsPattern_2 wild_Singletons_AsPattern_3 = Apply JustSym0 (Apply (Apply (Apply BazSym0 wild_Singletons_AsPattern_1) wild_Singletons_AsPattern_2) wild_Singletons_AsPattern_3)
+    type family Let23XSym0 wild_Singletons_AsPattern_00 where
+      Let23XSym0 wild_Singletons_AsPattern_00 = Let23X wild_Singletons_AsPattern_00
+    type family Let23X wild_Singletons_AsPattern_00 where
+      Let23X wild_Singletons_AsPattern_0 = Apply JustSym0 wild_Singletons_AsPattern_0
+    type family Let25PSym0 where
+      Let25PSym0 = Let25P
+    type family Let25P where
+      Let25P = NothingSym0
     type FooSym0 :: (~>) [Nat] [Nat]
     data FooSym0 :: (~>) [Nat] [Nat]
       where
         FooSym0KindInference :: SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
-                                FooSym0 a0123456789876543210
-    type instance Apply @[Nat] @[Nat] FooSym0 a0123456789876543210 = Foo a0123456789876543210
+                                FooSym0 a_Singletons_AsPattern_13
+    type instance Apply @[Nat] @[Nat] FooSym0 a_Singletons_AsPattern_13 = Foo a_Singletons_AsPattern_13
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings = snd ((,) FooSym0KindInference ())
     type FooSym1 :: [Nat] -> [Nat]
-    type family FooSym1 (a0123456789876543210 :: [Nat]) :: [Nat] where
-      FooSym1 a0123456789876543210 = Foo a0123456789876543210
+    type family FooSym1 (a_Singletons_AsPattern_13 :: [Nat]) :: [Nat] where
+      FooSym1 a_Singletons_AsPattern_13 = Foo a_Singletons_AsPattern_13
     type TupSym0 :: (~>) (Nat, Nat) (Nat, Nat)
     data TupSym0 :: (~>) (Nat, Nat) (Nat, Nat)
       where
         TupSym0KindInference :: SameKind (Apply TupSym0 arg) (TupSym1 arg) =>
-                                TupSym0 a0123456789876543210
+                                TupSym0 a_Singletons_AsPattern_17
     type instance Apply @(Nat, Nat) @(Nat,
-                                      Nat) TupSym0 a0123456789876543210 = Tup a0123456789876543210
+                                      Nat) TupSym0 a_Singletons_AsPattern_17 = Tup a_Singletons_AsPattern_17
     instance SuppressUnusedWarnings TupSym0 where
       suppressUnusedWarnings = snd ((,) TupSym0KindInference ())
     type TupSym1 :: (Nat, Nat) -> (Nat, Nat)
-    type family TupSym1 (a0123456789876543210 :: (Nat, Nat)) :: (Nat,
-                                                                 Nat) where
-      TupSym1 a0123456789876543210 = Tup a0123456789876543210
+    type family TupSym1 (a_Singletons_AsPattern_17 :: (Nat,
+                                                       Nat)) :: (Nat, Nat) where
+      TupSym1 a_Singletons_AsPattern_17 = Tup a_Singletons_AsPattern_17
     type Baz_Sym0 :: (~>) (Maybe Baz) (Maybe Baz)
     data Baz_Sym0 :: (~>) (Maybe Baz) (Maybe Baz)
       where
         Baz_Sym0KindInference :: SameKind (Apply Baz_Sym0 arg) (Baz_Sym1 arg) =>
-                                 Baz_Sym0 a0123456789876543210
-    type instance Apply @(Maybe Baz) @(Maybe Baz) Baz_Sym0 a0123456789876543210 = Baz_ a0123456789876543210
+                                 Baz_Sym0 a_Singletons_AsPattern_19
+    type instance Apply @(Maybe Baz) @(Maybe Baz) Baz_Sym0 a_Singletons_AsPattern_19 = Baz_ a_Singletons_AsPattern_19
     instance SuppressUnusedWarnings Baz_Sym0 where
       suppressUnusedWarnings = snd ((,) Baz_Sym0KindInference ())
     type Baz_Sym1 :: Maybe Baz -> Maybe Baz
-    type family Baz_Sym1 (a0123456789876543210 :: Maybe Baz) :: Maybe Baz where
-      Baz_Sym1 a0123456789876543210 = Baz_ a0123456789876543210
+    type family Baz_Sym1 (a_Singletons_AsPattern_19 :: Maybe Baz) :: Maybe Baz where
+      Baz_Sym1 a_Singletons_AsPattern_19 = Baz_ a_Singletons_AsPattern_19
     type BarSym0 :: (~>) (Maybe Nat) (Maybe Nat)
     data BarSym0 :: (~>) (Maybe Nat) (Maybe Nat)
       where
         BarSym0KindInference :: SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
-                                BarSym0 a0123456789876543210
-    type instance Apply @(Maybe Nat) @(Maybe Nat) BarSym0 a0123456789876543210 = Bar a0123456789876543210
+                                BarSym0 a_Singletons_AsPattern_22
+    type instance Apply @(Maybe Nat) @(Maybe Nat) BarSym0 a_Singletons_AsPattern_22 = Bar a_Singletons_AsPattern_22
     instance SuppressUnusedWarnings BarSym0 where
       suppressUnusedWarnings = snd ((,) BarSym0KindInference ())
     type BarSym1 :: Maybe Nat -> Maybe Nat
-    type family BarSym1 (a0123456789876543210 :: Maybe Nat) :: Maybe Nat where
-      BarSym1 a0123456789876543210 = Bar a0123456789876543210
+    type family BarSym1 (a_Singletons_AsPattern_22 :: Maybe Nat) :: Maybe Nat where
+      BarSym1 a_Singletons_AsPattern_22 = Bar a_Singletons_AsPattern_22
     type MaybePlusSym0 :: (~>) (Maybe Nat) (Maybe Nat)
     data MaybePlusSym0 :: (~>) (Maybe Nat) (Maybe Nat)
       where
         MaybePlusSym0KindInference :: SameKind (Apply MaybePlusSym0 arg) (MaybePlusSym1 arg) =>
-                                      MaybePlusSym0 a0123456789876543210
-    type instance Apply @(Maybe Nat) @(Maybe Nat) MaybePlusSym0 a0123456789876543210 = MaybePlus a0123456789876543210
+                                      MaybePlusSym0 a_Singletons_AsPattern_24
+    type instance Apply @(Maybe Nat) @(Maybe Nat) MaybePlusSym0 a_Singletons_AsPattern_24 = MaybePlus a_Singletons_AsPattern_24
     instance SuppressUnusedWarnings MaybePlusSym0 where
       suppressUnusedWarnings = snd ((,) MaybePlusSym0KindInference ())
     type MaybePlusSym1 :: Maybe Nat -> Maybe Nat
-    type family MaybePlusSym1 (a0123456789876543210 :: Maybe Nat) :: Maybe Nat where
-      MaybePlusSym1 a0123456789876543210 = MaybePlus a0123456789876543210
+    type family MaybePlusSym1 (a_Singletons_AsPattern_24 :: Maybe Nat) :: Maybe Nat where
+      MaybePlusSym1 a_Singletons_AsPattern_24 = MaybePlus a_Singletons_AsPattern_24
     type Foo :: [Nat] -> [Nat]
     type family Foo (a :: [Nat]) :: [Nat] where
-      Foo '[] = Let0123456789876543210PSym0
-      Foo '[wild_0123456789876543210] = Let0123456789876543210PSym0 wild_0123456789876543210
-      Foo ('(:) wild_0123456789876543210 ('(:) wild_0123456789876543210 wild_0123456789876543210)) = Let0123456789876543210PSym0 wild_0123456789876543210 wild_0123456789876543210 wild_0123456789876543210
+      Foo '[] = Let14PSym0
+      Foo '[wild_Singletons_AsPattern_9] = Let15PSym0 wild_Singletons_AsPattern_9
+      Foo ('(:) wild_Singletons_AsPattern_6 ('(:) wild_Singletons_AsPattern_7 wild_Singletons_AsPattern_8)) = Let16PSym0 wild_Singletons_AsPattern_6 wild_Singletons_AsPattern_7 wild_Singletons_AsPattern_8
     type Tup :: (Nat, Nat) -> (Nat, Nat)
     type family Tup (a :: (Nat, Nat)) :: (Nat, Nat) where
-      Tup '(wild_0123456789876543210,
-            wild_0123456789876543210) = Let0123456789876543210PSym0 wild_0123456789876543210 wild_0123456789876543210
+      Tup '(wild_Singletons_AsPattern_4,
+            wild_Singletons_AsPattern_5) = Let18PSym0 wild_Singletons_AsPattern_4 wild_Singletons_AsPattern_5
     type Baz_ :: Maybe Baz -> Maybe Baz
     type family Baz_ (a :: Maybe Baz) :: Maybe Baz where
-      Baz_ 'Nothing = Let0123456789876543210PSym0
-      Baz_ ('Just (Baz wild_0123456789876543210 wild_0123456789876543210 wild_0123456789876543210)) = Let0123456789876543210PSym0 wild_0123456789876543210 wild_0123456789876543210 wild_0123456789876543210
+      Baz_ 'Nothing = Let20PSym0
+      Baz_ ('Just (Baz wild_Singletons_AsPattern_1 wild_Singletons_AsPattern_2 wild_Singletons_AsPattern_3)) = Let21PSym0 wild_Singletons_AsPattern_1 wild_Singletons_AsPattern_2 wild_Singletons_AsPattern_3
     type Bar :: Maybe Nat -> Maybe Nat
     type family Bar (a :: Maybe Nat) :: Maybe Nat where
-      Bar ('Just wild_0123456789876543210) = Let0123456789876543210XSym0 wild_0123456789876543210
+      Bar ('Just wild_Singletons_AsPattern_0) = Let23XSym0 wild_Singletons_AsPattern_0
       Bar 'Nothing = NothingSym0
     type MaybePlus :: Maybe Nat -> Maybe Nat
     type family MaybePlus (a :: Maybe Nat) :: Maybe Nat where
       MaybePlus ('Just n) = Apply JustSym0 (Apply (Apply PlusSym0 (Apply SuccSym0 ZeroSym0)) n)
-      MaybePlus 'Nothing = Let0123456789876543210PSym0
+      MaybePlus 'Nothing = Let25PSym0
     sFoo ::
       (forall (t :: [Nat]). Sing t -> Sing (Foo t :: [Nat]) :: Type)
     sTup ::
@@ -187,71 +187,72 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
        Sing t -> Sing (MaybePlus t :: Maybe Nat) :: Type)
     sFoo SNil
       = let
-          sP :: Sing @_ Let0123456789876543210P
+          sP :: Sing @_ Let14P
           sP = SNil
         in sP
     sFoo
-      (SCons (sWild_0123456789876543210 :: Sing wild_0123456789876543210)
+      (SCons (sWild_Singletons_AsPattern_9 :: Sing wild_Singletons_AsPattern_9)
              SNil)
       = let
-          sP :: Sing @_ (Let0123456789876543210P wild_0123456789876543210)
+          sP :: Sing @_ (Let15P wild_Singletons_AsPattern_9)
           sP
             = applySing
-                (applySing (singFun2 @(:@#@$) SCons) sWild_0123456789876543210)
+                (applySing (singFun2 @(:@#@$) SCons) sWild_Singletons_AsPattern_9)
                 SNil
         in sP
     sFoo
-      (SCons (sWild_0123456789876543210 :: Sing wild_0123456789876543210)
-             (SCons (sWild_0123456789876543210 :: Sing wild_0123456789876543210)
-                    (sWild_0123456789876543210 :: Sing wild_0123456789876543210)))
+      (SCons (sWild_Singletons_AsPattern_6 :: Sing wild_Singletons_AsPattern_6)
+             (SCons (sWild_Singletons_AsPattern_7 :: Sing wild_Singletons_AsPattern_7)
+                    (sWild_Singletons_AsPattern_8 :: Sing wild_Singletons_AsPattern_8)))
       = let
           sP ::
-            Sing @_ (Let0123456789876543210P wild_0123456789876543210 wild_0123456789876543210 wild_0123456789876543210)
+            Sing @_ (Let16P wild_Singletons_AsPattern_6 wild_Singletons_AsPattern_7 wild_Singletons_AsPattern_8)
           sP
             = applySing
-                (applySing (singFun2 @(:@#@$) SCons) sWild_0123456789876543210)
+                (applySing (singFun2 @(:@#@$) SCons) sWild_Singletons_AsPattern_6)
                 (applySing
-                   (applySing (singFun2 @(:@#@$) SCons) sWild_0123456789876543210)
-                   sWild_0123456789876543210)
+                   (applySing (singFun2 @(:@#@$) SCons) sWild_Singletons_AsPattern_7)
+                   sWild_Singletons_AsPattern_8)
         in sP
     sTup
-      (STuple2 (sWild_0123456789876543210 :: Sing wild_0123456789876543210)
-               (sWild_0123456789876543210 :: Sing wild_0123456789876543210))
+      (STuple2 (sWild_Singletons_AsPattern_4 :: Sing wild_Singletons_AsPattern_4)
+               (sWild_Singletons_AsPattern_5 :: Sing wild_Singletons_AsPattern_5))
       = let
           sP ::
-            Sing @_ (Let0123456789876543210P wild_0123456789876543210 wild_0123456789876543210)
+            Sing @_ (Let18P wild_Singletons_AsPattern_4 wild_Singletons_AsPattern_5)
           sP
             = applySing
                 (applySing
-                   (singFun2 @Tuple2Sym0 STuple2) sWild_0123456789876543210)
-                sWild_0123456789876543210
+                   (singFun2 @Tuple2Sym0 STuple2) sWild_Singletons_AsPattern_4)
+                sWild_Singletons_AsPattern_5
         in sP
     sBaz_ SNothing
       = let
-          sP :: Sing @_ Let0123456789876543210P
+          sP :: Sing @_ Let20P
           sP = SNothing
         in sP
     sBaz_
-      (SJust (SBaz (sWild_0123456789876543210 :: Sing wild_0123456789876543210)
-                   (sWild_0123456789876543210 :: Sing wild_0123456789876543210)
-                   (sWild_0123456789876543210 :: Sing wild_0123456789876543210)))
+      (SJust (SBaz (sWild_Singletons_AsPattern_1 :: Sing wild_Singletons_AsPattern_1)
+                   (sWild_Singletons_AsPattern_2 :: Sing wild_Singletons_AsPattern_2)
+                   (sWild_Singletons_AsPattern_3 :: Sing wild_Singletons_AsPattern_3)))
       = let
           sP ::
-            Sing @_ (Let0123456789876543210P wild_0123456789876543210 wild_0123456789876543210 wild_0123456789876543210)
+            Sing @_ (Let21P wild_Singletons_AsPattern_1 wild_Singletons_AsPattern_2 wild_Singletons_AsPattern_3)
           sP
             = applySing
                 (singFun1 @JustSym0 SJust)
                 (applySing
                    (applySing
-                      (applySing (singFun3 @BazSym0 SBaz) sWild_0123456789876543210)
-                      sWild_0123456789876543210)
-                   sWild_0123456789876543210)
+                      (applySing (singFun3 @BazSym0 SBaz) sWild_Singletons_AsPattern_1)
+                      sWild_Singletons_AsPattern_2)
+                   sWild_Singletons_AsPattern_3)
         in sP
     sBar
-      (SJust (sWild_0123456789876543210 :: Sing wild_0123456789876543210))
+      (SJust (sWild_Singletons_AsPattern_0 :: Sing wild_Singletons_AsPattern_0))
       = let
-          sX :: Sing @_ (Let0123456789876543210X wild_0123456789876543210)
-          sX = applySing (singFun1 @JustSym0 SJust) sWild_0123456789876543210
+          sX :: Sing @_ (Let23X wild_Singletons_AsPattern_0)
+          sX
+            = applySing (singFun1 @JustSym0 SJust) sWild_Singletons_AsPattern_0
         in sX
     sBar SNothing = SNothing
     sMaybePlus (SJust (sN :: Sing n))
@@ -264,7 +265,7 @@ Singletons/AsPattern.hs:(0,0)-(0,0): Splicing declarations
              sN)
     sMaybePlus SNothing
       = let
-          sP :: Sing @_ Let0123456789876543210P
+          sP :: Sing @_ Let25P
           sP = SNothing
         in sP
     instance SingI (FooSym0 :: (~>) [Nat] [Nat]) where

--- a/singletons-base/tests/compile-and-dump/Singletons/BoundedDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/BoundedDeriving.golden
@@ -53,13 +53,13 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
     data Foo3Sym0 :: (~>) a (Foo3 a)
       where
         Foo3Sym0KindInference :: SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
-                                 Foo3Sym0 a0123456789876543210
-    type instance Apply @a @(Foo3 a) Foo3Sym0 a0123456789876543210 = Foo3 a0123456789876543210
+                                 Foo3Sym0 a_Singletons_BoundedDeriving_0
+    type instance Apply @a @(Foo3 a) Foo3Sym0 a_Singletons_BoundedDeriving_0 = Foo3 a_Singletons_BoundedDeriving_0
     instance SuppressUnusedWarnings Foo3Sym0 where
       suppressUnusedWarnings = snd ((,) Foo3Sym0KindInference ())
     type Foo3Sym1 :: forall a. a -> Foo3 a
-    type family Foo3Sym1 @a (a0123456789876543210 :: a) :: Foo3 a where
-      Foo3Sym1 a0123456789876543210 = Foo3 a0123456789876543210
+    type family Foo3Sym1 @a (a_Singletons_BoundedDeriving_0 :: a) :: Foo3 a where
+      Foo3Sym1 a_Singletons_BoundedDeriving_0 = Foo3 a_Singletons_BoundedDeriving_0
     type Foo41Sym0 :: forall (a :: Type) (b :: Type). Foo4 a b
     type family Foo41Sym0 @(a :: Type) @(b :: Type) :: Foo4 a b where
       Foo41Sym0 = Foo41
@@ -70,66 +70,66 @@ Singletons/BoundedDeriving.hs:(0,0)-(0,0): Splicing declarations
     data PairSym0 :: (~>) Bool ((~>) Bool Pair)
       where
         PairSym0KindInference :: SameKind (Apply PairSym0 arg) (PairSym1 arg) =>
-                                 PairSym0 a0123456789876543210
-    type instance Apply @Bool @((~>) Bool Pair) PairSym0 a0123456789876543210 = PairSym1 a0123456789876543210
+                                 PairSym0 a_Singletons_BoundedDeriving_1
+    type instance Apply @Bool @((~>) Bool Pair) PairSym0 a_Singletons_BoundedDeriving_1 = PairSym1 a_Singletons_BoundedDeriving_1
     instance SuppressUnusedWarnings PairSym0 where
       suppressUnusedWarnings = snd ((,) PairSym0KindInference ())
     type PairSym1 :: Bool -> (~>) Bool Pair
-    data PairSym1 (a0123456789876543210 :: Bool) :: (~>) Bool Pair
+    data PairSym1 (a_Singletons_BoundedDeriving_1 :: Bool) :: (~>) Bool Pair
       where
-        PairSym1KindInference :: SameKind (Apply (PairSym1 a0123456789876543210) arg) (PairSym2 a0123456789876543210 arg) =>
-                                 PairSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Bool @Pair (PairSym1 a0123456789876543210) a0123456789876543210 = Pair a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (PairSym1 a0123456789876543210) where
+        PairSym1KindInference :: SameKind (Apply (PairSym1 a_Singletons_BoundedDeriving_1) arg) (PairSym2 a_Singletons_BoundedDeriving_1 arg) =>
+                                 PairSym1 a_Singletons_BoundedDeriving_1 a_Singletons_BoundedDeriving_2
+    type instance Apply @Bool @Pair (PairSym1 a_Singletons_BoundedDeriving_1) a_Singletons_BoundedDeriving_2 = Pair a_Singletons_BoundedDeriving_1 a_Singletons_BoundedDeriving_2
+    instance SuppressUnusedWarnings (PairSym1 a_Singletons_BoundedDeriving_1) where
       suppressUnusedWarnings = snd ((,) PairSym1KindInference ())
     type PairSym2 :: Bool -> Bool -> Pair
-    type family PairSym2 (a0123456789876543210 :: Bool) (a0123456789876543210 :: Bool) :: Pair where
-      PairSym2 a0123456789876543210 a0123456789876543210 = Pair a0123456789876543210 a0123456789876543210
-    type MinBound_0123456789876543210 :: Foo1
-    type family MinBound_0123456789876543210 :: Foo1 where
-      MinBound_0123456789876543210 = Foo1Sym0
-    type MaxBound_0123456789876543210 :: Foo1
-    type family MaxBound_0123456789876543210 :: Foo1 where
-      MaxBound_0123456789876543210 = Foo1Sym0
+    type family PairSym2 (a_Singletons_BoundedDeriving_1 :: Bool) (a_Singletons_BoundedDeriving_2 :: Bool) :: Pair where
+      PairSym2 a_Singletons_BoundedDeriving_1 a_Singletons_BoundedDeriving_2 = Pair a_Singletons_BoundedDeriving_1 a_Singletons_BoundedDeriving_2
+    type MinBound_Singletons_BoundedDeriving_3 :: Foo1
+    type family MinBound_Singletons_BoundedDeriving_3 :: Foo1 where
+      MinBound_Singletons_BoundedDeriving_3 = Foo1Sym0
+    type MaxBound_Singletons_BoundedDeriving_4 :: Foo1
+    type family MaxBound_Singletons_BoundedDeriving_4 :: Foo1 where
+      MaxBound_Singletons_BoundedDeriving_4 = Foo1Sym0
     instance PBounded Foo1 where
-      type MinBound = MinBound_0123456789876543210
-      type MaxBound = MaxBound_0123456789876543210
-    type MinBound_0123456789876543210 :: Foo2
-    type family MinBound_0123456789876543210 :: Foo2 where
-      MinBound_0123456789876543210 = ASym0
-    type MaxBound_0123456789876543210 :: Foo2
-    type family MaxBound_0123456789876543210 :: Foo2 where
-      MaxBound_0123456789876543210 = ESym0
+      type MinBound = MinBound_Singletons_BoundedDeriving_3
+      type MaxBound = MaxBound_Singletons_BoundedDeriving_4
+    type MinBound_Singletons_BoundedDeriving_5 :: Foo2
+    type family MinBound_Singletons_BoundedDeriving_5 :: Foo2 where
+      MinBound_Singletons_BoundedDeriving_5 = ASym0
+    type MaxBound_Singletons_BoundedDeriving_6 :: Foo2
+    type family MaxBound_Singletons_BoundedDeriving_6 :: Foo2 where
+      MaxBound_Singletons_BoundedDeriving_6 = ESym0
     instance PBounded Foo2 where
-      type MinBound = MinBound_0123456789876543210
-      type MaxBound = MaxBound_0123456789876543210
-    type MinBound_0123456789876543210 :: forall a. Foo3 a
-    type family MinBound_0123456789876543210 @a :: Foo3 a where
-      MinBound_0123456789876543210 @a = Apply Foo3Sym0 MinBoundSym0
-    type MaxBound_0123456789876543210 :: forall a. Foo3 a
-    type family MaxBound_0123456789876543210 @a :: Foo3 a where
-      MaxBound_0123456789876543210 @a = Apply Foo3Sym0 MaxBoundSym0
+      type MinBound = MinBound_Singletons_BoundedDeriving_5
+      type MaxBound = MaxBound_Singletons_BoundedDeriving_6
+    type MinBound_Singletons_BoundedDeriving_7 :: forall a. Foo3 a
+    type family MinBound_Singletons_BoundedDeriving_7 @a :: Foo3 a where
+      MinBound_Singletons_BoundedDeriving_7 @a = Apply Foo3Sym0 MinBoundSym0
+    type MaxBound_Singletons_BoundedDeriving_8 :: forall a. Foo3 a
+    type family MaxBound_Singletons_BoundedDeriving_8 @a :: Foo3 a where
+      MaxBound_Singletons_BoundedDeriving_8 @a = Apply Foo3Sym0 MaxBoundSym0
     instance PBounded (Foo3 a) where
-      type MinBound = MinBound_0123456789876543210
-      type MaxBound = MaxBound_0123456789876543210
-    type MinBound_0123456789876543210 :: forall a b. Foo4 a b
-    type family MinBound_0123456789876543210 @a @b :: Foo4 a b where
-      MinBound_0123456789876543210 @a @b = Foo41Sym0
-    type MaxBound_0123456789876543210 :: forall a b. Foo4 a b
-    type family MaxBound_0123456789876543210 @a @b :: Foo4 a b where
-      MaxBound_0123456789876543210 @a @b = Foo42Sym0
+      type MinBound = MinBound_Singletons_BoundedDeriving_7
+      type MaxBound = MaxBound_Singletons_BoundedDeriving_8
+    type MinBound_Singletons_BoundedDeriving_9 :: forall a b. Foo4 a b
+    type family MinBound_Singletons_BoundedDeriving_9 @a @b :: Foo4 a b where
+      MinBound_Singletons_BoundedDeriving_9 @a @b = Foo41Sym0
+    type MaxBound_Singletons_BoundedDeriving_10 :: forall a b. Foo4 a b
+    type family MaxBound_Singletons_BoundedDeriving_10 @a @b :: Foo4 a b where
+      MaxBound_Singletons_BoundedDeriving_10 @a @b = Foo42Sym0
     instance PBounded (Foo4 a b) where
-      type MinBound = MinBound_0123456789876543210
-      type MaxBound = MaxBound_0123456789876543210
-    type MinBound_0123456789876543210 :: Pair
-    type family MinBound_0123456789876543210 :: Pair where
-      MinBound_0123456789876543210 = Apply (Apply PairSym0 MinBoundSym0) MinBoundSym0
-    type MaxBound_0123456789876543210 :: Pair
-    type family MaxBound_0123456789876543210 :: Pair where
-      MaxBound_0123456789876543210 = Apply (Apply PairSym0 MaxBoundSym0) MaxBoundSym0
+      type MinBound = MinBound_Singletons_BoundedDeriving_9
+      type MaxBound = MaxBound_Singletons_BoundedDeriving_10
+    type MinBound_Singletons_BoundedDeriving_11 :: Pair
+    type family MinBound_Singletons_BoundedDeriving_11 :: Pair where
+      MinBound_Singletons_BoundedDeriving_11 = Apply (Apply PairSym0 MinBoundSym0) MinBoundSym0
+    type MaxBound_Singletons_BoundedDeriving_12 :: Pair
+    type family MaxBound_Singletons_BoundedDeriving_12 :: Pair where
+      MaxBound_Singletons_BoundedDeriving_12 = Apply (Apply PairSym0 MaxBoundSym0) MaxBoundSym0
     instance PBounded Pair where
-      type MinBound = MinBound_0123456789876543210
-      type MaxBound = MaxBound_0123456789876543210
+      type MinBound = MinBound_Singletons_BoundedDeriving_11
+      type MaxBound = MaxBound_Singletons_BoundedDeriving_12
     data SFoo1 :: Foo1 -> Type where SFoo1 :: SFoo1 (Foo1 :: Foo1)
     type instance Sing @Foo1 = SFoo1
     instance SingKind Foo1 where

--- a/singletons-base/tests/compile-and-dump/Singletons/BoxUnBox.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/BoxUnBox.golden
@@ -12,24 +12,24 @@ Singletons/BoxUnBox.hs:(0,0)-(0,0): Splicing declarations
     data FBoxSym0 :: (~>) a (Box a)
       where
         FBoxSym0KindInference :: SameKind (Apply FBoxSym0 arg) (FBoxSym1 arg) =>
-                                 FBoxSym0 a0123456789876543210
-    type instance Apply @a @(Box a) FBoxSym0 a0123456789876543210 = FBox a0123456789876543210
+                                 FBoxSym0 a_Singletons_BoxUnBox_0
+    type instance Apply @a @(Box a) FBoxSym0 a_Singletons_BoxUnBox_0 = FBox a_Singletons_BoxUnBox_0
     instance SuppressUnusedWarnings FBoxSym0 where
       suppressUnusedWarnings = snd ((,) FBoxSym0KindInference ())
     type FBoxSym1 :: forall a. a -> Box a
-    type family FBoxSym1 @a (a0123456789876543210 :: a) :: Box a where
-      FBoxSym1 a0123456789876543210 = FBox a0123456789876543210
+    type family FBoxSym1 @a (a_Singletons_BoxUnBox_0 :: a) :: Box a where
+      FBoxSym1 a_Singletons_BoxUnBox_0 = FBox a_Singletons_BoxUnBox_0
     type UnBoxSym0 :: (~>) (Box a) a
     data UnBoxSym0 :: (~>) (Box a) a
       where
         UnBoxSym0KindInference :: SameKind (Apply UnBoxSym0 arg) (UnBoxSym1 arg) =>
-                                  UnBoxSym0 a0123456789876543210
-    type instance Apply @(Box a) @a UnBoxSym0 a0123456789876543210 = UnBox a0123456789876543210
+                                  UnBoxSym0 a_Singletons_BoxUnBox_1
+    type instance Apply @(Box a) @a UnBoxSym0 a_Singletons_BoxUnBox_1 = UnBox a_Singletons_BoxUnBox_1
     instance SuppressUnusedWarnings UnBoxSym0 where
       suppressUnusedWarnings = snd ((,) UnBoxSym0KindInference ())
     type UnBoxSym1 :: Box a -> a
-    type family UnBoxSym1 @a (a0123456789876543210 :: Box a) :: a where
-      UnBoxSym1 a0123456789876543210 = UnBox a0123456789876543210
+    type family UnBoxSym1 @a (a_Singletons_BoxUnBox_1 :: Box a) :: a where
+      UnBoxSym1 a_Singletons_BoxUnBox_1 = UnBox a_Singletons_BoxUnBox_1
     type UnBox :: Box a -> a
     type family UnBox @a (a :: Box a) :: a where
       UnBox (FBox a) = a

--- a/singletons-base/tests/compile-and-dump/Singletons/CaseExpressions.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/CaseExpressions.golden
@@ -37,177 +37,183 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
                in z
     foo5 :: a -> a
     foo5 x = case x of y -> (\ _ -> x) y
-    type family LamCases_0123456789876543210 y0123456789876543210 (x0123456789876543210 :: a0123456789876543210) a_0123456789876543210 where
-      LamCases_0123456789876543210 y x _ = x
-    data LamCases_0123456789876543210Sym0 y0123456789876543210 (x0123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210
+    type family LamCases_Singletons_CaseExpressions_2 y0 (x2 :: a1) a_Singletons_CaseExpressions_3 where
+      LamCases_Singletons_CaseExpressions_2 y x _ = x
+    data LamCases_Singletons_CaseExpressions_2Sym0 y0 (x2 :: a1) a_Singletons_CaseExpressions_3
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 y0123456789876543210 x0123456789876543210) arg) (LamCases_0123456789876543210Sym1 y0123456789876543210 x0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 y0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 y0123456789876543210 x0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 y0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 y0123456789876543210 x0123456789876543210) where
+        LamCases_Singletons_CaseExpressions_2Sym0KindInference :: SameKind (Apply (LamCases_Singletons_CaseExpressions_2Sym0 y0 x2) arg) (LamCases_Singletons_CaseExpressions_2Sym1 y0 x2 arg) =>
+                                                                  LamCases_Singletons_CaseExpressions_2Sym0 y0 x2 a_Singletons_CaseExpressions_3
+    type instance Apply @_ @_ (LamCases_Singletons_CaseExpressions_2Sym0 y0 x2) a_Singletons_CaseExpressions_3 = LamCases_Singletons_CaseExpressions_2 y0 x2 a_Singletons_CaseExpressions_3
+    instance SuppressUnusedWarnings (LamCases_Singletons_CaseExpressions_2Sym0 y0 x2) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 y0123456789876543210 (x0123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 y0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 y0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (x0123456789876543210 :: a0123456789876543210) a_0123456789876543210 where
-      LamCases_0123456789876543210 x y = Apply (LamCases_0123456789876543210Sym0 y x) y
-    data LamCases_0123456789876543210Sym0 (x0123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210
+        = snd
+            ((,) LamCases_Singletons_CaseExpressions_2Sym0KindInference ())
+    type family LamCases_Singletons_CaseExpressions_2Sym1 y0 (x2 :: a1) a_Singletons_CaseExpressions_3 where
+      LamCases_Singletons_CaseExpressions_2Sym1 y0 x2 a_Singletons_CaseExpressions_3 = LamCases_Singletons_CaseExpressions_2 y0 x2 a_Singletons_CaseExpressions_3
+    type family LamCases_Singletons_CaseExpressions_1 (x1 :: a0) a_Singletons_CaseExpressions_4 where
+      LamCases_Singletons_CaseExpressions_1 x y = Apply (LamCases_Singletons_CaseExpressions_2Sym0 y x) y
+    data LamCases_Singletons_CaseExpressions_1Sym0 (x1 :: a0) a_Singletons_CaseExpressions_4
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210) where
+        LamCases_Singletons_CaseExpressions_1Sym0KindInference :: SameKind (Apply (LamCases_Singletons_CaseExpressions_1Sym0 x1) arg) (LamCases_Singletons_CaseExpressions_1Sym1 x1 arg) =>
+                                                                  LamCases_Singletons_CaseExpressions_1Sym0 x1 a_Singletons_CaseExpressions_4
+    type instance Apply @_ @_ (LamCases_Singletons_CaseExpressions_1Sym0 x1) a_Singletons_CaseExpressions_4 = LamCases_Singletons_CaseExpressions_1 x1 a_Singletons_CaseExpressions_4
+    instance SuppressUnusedWarnings (LamCases_Singletons_CaseExpressions_1Sym0 x1) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (x0123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 x0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    type family Let0123456789876543210ZSym0 a0123456789876543210 y0123456789876543210 (x0123456789876543210 :: a0123456789876543210) :: a0123456789876543210 where
-      Let0123456789876543210ZSym0 a0123456789876543210 y0123456789876543210 x0123456789876543210 = Let0123456789876543210Z a0123456789876543210 y0123456789876543210 x0123456789876543210
-    type family Let0123456789876543210Z a0123456789876543210 y0123456789876543210 (x0123456789876543210 :: a0123456789876543210) :: a0123456789876543210 where
-      Let0123456789876543210Z a y x = y
-    type family LamCases_0123456789876543210 a0123456789876543210 (x0123456789876543210 :: a0123456789876543210) a_0123456789876543210 where
-      LamCases_0123456789876543210 a x y = Let0123456789876543210ZSym0 a y x
-    data LamCases_0123456789876543210Sym0 a0123456789876543210 (x0123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210
+        = snd
+            ((,) LamCases_Singletons_CaseExpressions_1Sym0KindInference ())
+    type family LamCases_Singletons_CaseExpressions_1Sym1 (x1 :: a0) a_Singletons_CaseExpressions_4 where
+      LamCases_Singletons_CaseExpressions_1Sym1 x1 a_Singletons_CaseExpressions_4 = LamCases_Singletons_CaseExpressions_1 x1 a_Singletons_CaseExpressions_4
+    type family Let7ZSym0 a0 y1 (x2 :: a0) :: a0 where
+      Let7ZSym0 a0 y1 x2 = Let7Z a0 y1 x2
+    type family Let7Z a0 y1 (x2 :: a0) :: a0 where
+      Let7Z a y x = y
+    type family LamCases_Singletons_CaseExpressions_6 a0 (x1 :: a0) a_Singletons_CaseExpressions_8 where
+      LamCases_Singletons_CaseExpressions_6 a x y = Let7ZSym0 a y x
+    data LamCases_Singletons_CaseExpressions_6Sym0 a0 (x1 :: a0) a_Singletons_CaseExpressions_8
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 a0123456789876543210 x0123456789876543210) arg) (LamCases_0123456789876543210Sym1 a0123456789876543210 x0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 a0123456789876543210 x0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 a0123456789876543210 x0123456789876543210) where
+        LamCases_Singletons_CaseExpressions_6Sym0KindInference :: SameKind (Apply (LamCases_Singletons_CaseExpressions_6Sym0 a0 x1) arg) (LamCases_Singletons_CaseExpressions_6Sym1 a0 x1 arg) =>
+                                                                  LamCases_Singletons_CaseExpressions_6Sym0 a0 x1 a_Singletons_CaseExpressions_8
+    type instance Apply @_ @_ (LamCases_Singletons_CaseExpressions_6Sym0 a0 x1) a_Singletons_CaseExpressions_8 = LamCases_Singletons_CaseExpressions_6 a0 x1 a_Singletons_CaseExpressions_8
+    instance SuppressUnusedWarnings (LamCases_Singletons_CaseExpressions_6Sym0 a0 x1) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 a0123456789876543210 (x0123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (a0123456789876543210 :: a0123456789876543210) (b0123456789876543210 :: b0123456789876543210) a_0123456789876543210 where
-      LamCases_0123456789876543210 a b '(p, _) = p
-    data LamCases_0123456789876543210Sym0 (a0123456789876543210 :: a0123456789876543210) (b0123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210
+        = snd
+            ((,) LamCases_Singletons_CaseExpressions_6Sym0KindInference ())
+    type family LamCases_Singletons_CaseExpressions_6Sym1 a0 (x1 :: a0) a_Singletons_CaseExpressions_8 where
+      LamCases_Singletons_CaseExpressions_6Sym1 a0 x1 a_Singletons_CaseExpressions_8 = LamCases_Singletons_CaseExpressions_6 a0 x1 a_Singletons_CaseExpressions_8
+    type family LamCases_Singletons_CaseExpressions_11 (a1 :: a0) (b3 :: b2) a_Singletons_CaseExpressions_12 where
+      LamCases_Singletons_CaseExpressions_11 a b '(p, _) = p
+    data LamCases_Singletons_CaseExpressions_11Sym0 (a1 :: a0) (b3 :: b2) a_Singletons_CaseExpressions_12
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 a0123456789876543210 b0123456789876543210) arg) (LamCases_0123456789876543210Sym1 a0123456789876543210 b0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 a0123456789876543210 b0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 a0123456789876543210 b0123456789876543210) where
+        LamCases_Singletons_CaseExpressions_11Sym0KindInference :: SameKind (Apply (LamCases_Singletons_CaseExpressions_11Sym0 a1 b3) arg) (LamCases_Singletons_CaseExpressions_11Sym1 a1 b3 arg) =>
+                                                                   LamCases_Singletons_CaseExpressions_11Sym0 a1 b3 a_Singletons_CaseExpressions_12
+    type instance Apply @_ @_ (LamCases_Singletons_CaseExpressions_11Sym0 a1 b3) a_Singletons_CaseExpressions_12 = LamCases_Singletons_CaseExpressions_11 a1 b3 a_Singletons_CaseExpressions_12
+    instance SuppressUnusedWarnings (LamCases_Singletons_CaseExpressions_11Sym0 a1 b3) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (a0123456789876543210 :: a0123456789876543210) (b0123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (d0123456789876543210 :: a0123456789876543210) a_0123456789876543210 where
-      LamCases_0123456789876543210 d ('Just y) = y
-    data LamCases_0123456789876543210Sym0 (d0123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210
+        = snd
+            ((,) LamCases_Singletons_CaseExpressions_11Sym0KindInference ())
+    type family LamCases_Singletons_CaseExpressions_11Sym1 (a1 :: a0) (b3 :: b2) a_Singletons_CaseExpressions_12 where
+      LamCases_Singletons_CaseExpressions_11Sym1 a1 b3 a_Singletons_CaseExpressions_12 = LamCases_Singletons_CaseExpressions_11 a1 b3 a_Singletons_CaseExpressions_12
+    type family LamCases_Singletons_CaseExpressions_15 (d1 :: a0) a_Singletons_CaseExpressions_16 where
+      LamCases_Singletons_CaseExpressions_15 d ('Just y) = y
+    data LamCases_Singletons_CaseExpressions_15Sym0 (d1 :: a0) a_Singletons_CaseExpressions_16
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 d0123456789876543210) arg) (LamCases_0123456789876543210Sym1 d0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 d0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 d0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 d0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 d0123456789876543210) where
+        LamCases_Singletons_CaseExpressions_15Sym0KindInference :: SameKind (Apply (LamCases_Singletons_CaseExpressions_15Sym0 d1) arg) (LamCases_Singletons_CaseExpressions_15Sym1 d1 arg) =>
+                                                                   LamCases_Singletons_CaseExpressions_15Sym0 d1 a_Singletons_CaseExpressions_16
+    type instance Apply @_ @_ (LamCases_Singletons_CaseExpressions_15Sym0 d1) a_Singletons_CaseExpressions_16 = LamCases_Singletons_CaseExpressions_15 d1 a_Singletons_CaseExpressions_16
+    instance SuppressUnusedWarnings (LamCases_Singletons_CaseExpressions_15Sym0 d1) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (d0123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 d0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 d0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (d0123456789876543210 :: a0123456789876543210) (x0123456789876543210 :: Maybe a0123456789876543210) a_0123456789876543210 where
-      LamCases_0123456789876543210 d x ('Just y) = y
-      LamCases_0123456789876543210 d x 'Nothing = d
-    data LamCases_0123456789876543210Sym0 (d0123456789876543210 :: a0123456789876543210) (x0123456789876543210 :: Maybe a0123456789876543210) a_01234567898765432100123456789876543210
+        = snd
+            ((,) LamCases_Singletons_CaseExpressions_15Sym0KindInference ())
+    type family LamCases_Singletons_CaseExpressions_15Sym1 (d1 :: a0) a_Singletons_CaseExpressions_16 where
+      LamCases_Singletons_CaseExpressions_15Sym1 d1 a_Singletons_CaseExpressions_16 = LamCases_Singletons_CaseExpressions_15 d1 a_Singletons_CaseExpressions_16
+    type family LamCases_Singletons_CaseExpressions_19 (d1 :: a0) (x2 :: Maybe a0) a_Singletons_CaseExpressions_20 where
+      LamCases_Singletons_CaseExpressions_19 d x ('Just y) = y
+      LamCases_Singletons_CaseExpressions_19 d x 'Nothing = d
+    data LamCases_Singletons_CaseExpressions_19Sym0 (d1 :: a0) (x2 :: Maybe a0) a_Singletons_CaseExpressions_20
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 d0123456789876543210 x0123456789876543210) arg) (LamCases_0123456789876543210Sym1 d0123456789876543210 x0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 d0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 d0123456789876543210 x0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 d0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 d0123456789876543210 x0123456789876543210) where
+        LamCases_Singletons_CaseExpressions_19Sym0KindInference :: SameKind (Apply (LamCases_Singletons_CaseExpressions_19Sym0 d1 x2) arg) (LamCases_Singletons_CaseExpressions_19Sym1 d1 x2 arg) =>
+                                                                   LamCases_Singletons_CaseExpressions_19Sym0 d1 x2 a_Singletons_CaseExpressions_20
+    type instance Apply @_ @_ (LamCases_Singletons_CaseExpressions_19Sym0 d1 x2) a_Singletons_CaseExpressions_20 = LamCases_Singletons_CaseExpressions_19 d1 x2 a_Singletons_CaseExpressions_20
+    instance SuppressUnusedWarnings (LamCases_Singletons_CaseExpressions_19Sym0 d1 x2) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (d0123456789876543210 :: a0123456789876543210) (x0123456789876543210 :: Maybe a0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 d0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 d0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
+        = snd
+            ((,) LamCases_Singletons_CaseExpressions_19Sym0KindInference ())
+    type family LamCases_Singletons_CaseExpressions_19Sym1 (d1 :: a0) (x2 :: Maybe a0) a_Singletons_CaseExpressions_20 where
+      LamCases_Singletons_CaseExpressions_19Sym1 d1 x2 a_Singletons_CaseExpressions_20 = LamCases_Singletons_CaseExpressions_19 d1 x2 a_Singletons_CaseExpressions_20
     type Foo5Sym0 :: (~>) a a
     data Foo5Sym0 :: (~>) a a
       where
         Foo5Sym0KindInference :: SameKind (Apply Foo5Sym0 arg) (Foo5Sym1 arg) =>
-                                 Foo5Sym0 a0123456789876543210
-    type instance Apply @a @a Foo5Sym0 a0123456789876543210 = Foo5 a0123456789876543210
+                                 Foo5Sym0 a_Singletons_CaseExpressions_0
+    type instance Apply @a @a Foo5Sym0 a_Singletons_CaseExpressions_0 = Foo5 a_Singletons_CaseExpressions_0
     instance SuppressUnusedWarnings Foo5Sym0 where
       suppressUnusedWarnings = snd ((,) Foo5Sym0KindInference ())
     type Foo5Sym1 :: a -> a
-    type family Foo5Sym1 @a (a0123456789876543210 :: a) :: a where
-      Foo5Sym1 a0123456789876543210 = Foo5 a0123456789876543210
+    type family Foo5Sym1 @a (a_Singletons_CaseExpressions_0 :: a) :: a where
+      Foo5Sym1 a_Singletons_CaseExpressions_0 = Foo5 a_Singletons_CaseExpressions_0
     type Foo4Sym0 :: forall a. (~>) a a
     data Foo4Sym0 :: (~>) a a
       where
         Foo4Sym0KindInference :: SameKind (Apply Foo4Sym0 arg) (Foo4Sym1 arg) =>
-                                 Foo4Sym0 a0123456789876543210
-    type instance Apply @a @a Foo4Sym0 a0123456789876543210 = Foo4 a0123456789876543210
+                                 Foo4Sym0 a_Singletons_CaseExpressions_5
+    type instance Apply @a @a Foo4Sym0 a_Singletons_CaseExpressions_5 = Foo4 a_Singletons_CaseExpressions_5
     instance SuppressUnusedWarnings Foo4Sym0 where
       suppressUnusedWarnings = snd ((,) Foo4Sym0KindInference ())
     type Foo4Sym1 :: forall a. a -> a
-    type family Foo4Sym1 @a (a0123456789876543210 :: a) :: a where
-      Foo4Sym1 a0123456789876543210 = Foo4 a0123456789876543210
+    type family Foo4Sym1 @a (a_Singletons_CaseExpressions_5 :: a) :: a where
+      Foo4Sym1 a_Singletons_CaseExpressions_5 = Foo4 a_Singletons_CaseExpressions_5
     type Foo3Sym0 :: (~>) a ((~>) b a)
     data Foo3Sym0 :: (~>) a ((~>) b a)
       where
         Foo3Sym0KindInference :: SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
-                                 Foo3Sym0 a0123456789876543210
-    type instance Apply @a @((~>) b a) Foo3Sym0 a0123456789876543210 = Foo3Sym1 a0123456789876543210
+                                 Foo3Sym0 a_Singletons_CaseExpressions_9
+    type instance Apply @a @((~>) b a) Foo3Sym0 a_Singletons_CaseExpressions_9 = Foo3Sym1 a_Singletons_CaseExpressions_9
     instance SuppressUnusedWarnings Foo3Sym0 where
       suppressUnusedWarnings = snd ((,) Foo3Sym0KindInference ())
     type Foo3Sym1 :: a -> (~>) b a
-    data Foo3Sym1 (a0123456789876543210 :: a) :: (~>) b a
+    data Foo3Sym1 (a_Singletons_CaseExpressions_9 :: a) :: (~>) b a
       where
-        Foo3Sym1KindInference :: SameKind (Apply (Foo3Sym1 a0123456789876543210) arg) (Foo3Sym2 a0123456789876543210 arg) =>
-                                 Foo3Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @a (Foo3Sym1 a0123456789876543210) a0123456789876543210 = Foo3 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Foo3Sym1 a0123456789876543210) where
+        Foo3Sym1KindInference :: SameKind (Apply (Foo3Sym1 a_Singletons_CaseExpressions_9) arg) (Foo3Sym2 a_Singletons_CaseExpressions_9 arg) =>
+                                 Foo3Sym1 a_Singletons_CaseExpressions_9 a_Singletons_CaseExpressions_10
+    type instance Apply @b @a (Foo3Sym1 a_Singletons_CaseExpressions_9) a_Singletons_CaseExpressions_10 = Foo3 a_Singletons_CaseExpressions_9 a_Singletons_CaseExpressions_10
+    instance SuppressUnusedWarnings (Foo3Sym1 a_Singletons_CaseExpressions_9) where
       suppressUnusedWarnings = snd ((,) Foo3Sym1KindInference ())
     type Foo3Sym2 :: a -> b -> a
-    type family Foo3Sym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: a where
-      Foo3Sym2 a0123456789876543210 a0123456789876543210 = Foo3 a0123456789876543210 a0123456789876543210
+    type family Foo3Sym2 @a @b (a_Singletons_CaseExpressions_9 :: a) (a_Singletons_CaseExpressions_10 :: b) :: a where
+      Foo3Sym2 a_Singletons_CaseExpressions_9 a_Singletons_CaseExpressions_10 = Foo3 a_Singletons_CaseExpressions_9 a_Singletons_CaseExpressions_10
     type Foo2Sym0 :: (~>) a ((~>) (Maybe a) a)
     data Foo2Sym0 :: (~>) a ((~>) (Maybe a) a)
       where
         Foo2Sym0KindInference :: SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) =>
-                                 Foo2Sym0 a0123456789876543210
-    type instance Apply @a @((~>) (Maybe a) a) Foo2Sym0 a0123456789876543210 = Foo2Sym1 a0123456789876543210
+                                 Foo2Sym0 a_Singletons_CaseExpressions_13
+    type instance Apply @a @((~>) (Maybe a) a) Foo2Sym0 a_Singletons_CaseExpressions_13 = Foo2Sym1 a_Singletons_CaseExpressions_13
     instance SuppressUnusedWarnings Foo2Sym0 where
       suppressUnusedWarnings = snd ((,) Foo2Sym0KindInference ())
     type Foo2Sym1 :: a -> (~>) (Maybe a) a
-    data Foo2Sym1 (a0123456789876543210 :: a) :: (~>) (Maybe a) a
+    data Foo2Sym1 (a_Singletons_CaseExpressions_13 :: a) :: (~>) (Maybe a) a
       where
-        Foo2Sym1KindInference :: SameKind (Apply (Foo2Sym1 a0123456789876543210) arg) (Foo2Sym2 a0123456789876543210 arg) =>
-                                 Foo2Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Maybe a) @a (Foo2Sym1 a0123456789876543210) a0123456789876543210 = Foo2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Foo2Sym1 a0123456789876543210) where
+        Foo2Sym1KindInference :: SameKind (Apply (Foo2Sym1 a_Singletons_CaseExpressions_13) arg) (Foo2Sym2 a_Singletons_CaseExpressions_13 arg) =>
+                                 Foo2Sym1 a_Singletons_CaseExpressions_13 a_Singletons_CaseExpressions_14
+    type instance Apply @(Maybe a) @a (Foo2Sym1 a_Singletons_CaseExpressions_13) a_Singletons_CaseExpressions_14 = Foo2 a_Singletons_CaseExpressions_13 a_Singletons_CaseExpressions_14
+    instance SuppressUnusedWarnings (Foo2Sym1 a_Singletons_CaseExpressions_13) where
       suppressUnusedWarnings = snd ((,) Foo2Sym1KindInference ())
     type Foo2Sym2 :: a -> Maybe a -> a
-    type family Foo2Sym2 @a (a0123456789876543210 :: a) (a0123456789876543210 :: Maybe a) :: a where
-      Foo2Sym2 a0123456789876543210 a0123456789876543210 = Foo2 a0123456789876543210 a0123456789876543210
+    type family Foo2Sym2 @a (a_Singletons_CaseExpressions_13 :: a) (a_Singletons_CaseExpressions_14 :: Maybe a) :: a where
+      Foo2Sym2 a_Singletons_CaseExpressions_13 a_Singletons_CaseExpressions_14 = Foo2 a_Singletons_CaseExpressions_13 a_Singletons_CaseExpressions_14
     type Foo1Sym0 :: (~>) a ((~>) (Maybe a) a)
     data Foo1Sym0 :: (~>) a ((~>) (Maybe a) a)
       where
         Foo1Sym0KindInference :: SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
-                                 Foo1Sym0 a0123456789876543210
-    type instance Apply @a @((~>) (Maybe a) a) Foo1Sym0 a0123456789876543210 = Foo1Sym1 a0123456789876543210
+                                 Foo1Sym0 a_Singletons_CaseExpressions_17
+    type instance Apply @a @((~>) (Maybe a) a) Foo1Sym0 a_Singletons_CaseExpressions_17 = Foo1Sym1 a_Singletons_CaseExpressions_17
     instance SuppressUnusedWarnings Foo1Sym0 where
       suppressUnusedWarnings = snd ((,) Foo1Sym0KindInference ())
     type Foo1Sym1 :: a -> (~>) (Maybe a) a
-    data Foo1Sym1 (a0123456789876543210 :: a) :: (~>) (Maybe a) a
+    data Foo1Sym1 (a_Singletons_CaseExpressions_17 :: a) :: (~>) (Maybe a) a
       where
-        Foo1Sym1KindInference :: SameKind (Apply (Foo1Sym1 a0123456789876543210) arg) (Foo1Sym2 a0123456789876543210 arg) =>
-                                 Foo1Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Maybe a) @a (Foo1Sym1 a0123456789876543210) a0123456789876543210 = Foo1 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Foo1Sym1 a0123456789876543210) where
+        Foo1Sym1KindInference :: SameKind (Apply (Foo1Sym1 a_Singletons_CaseExpressions_17) arg) (Foo1Sym2 a_Singletons_CaseExpressions_17 arg) =>
+                                 Foo1Sym1 a_Singletons_CaseExpressions_17 a_Singletons_CaseExpressions_18
+    type instance Apply @(Maybe a) @a (Foo1Sym1 a_Singletons_CaseExpressions_17) a_Singletons_CaseExpressions_18 = Foo1 a_Singletons_CaseExpressions_17 a_Singletons_CaseExpressions_18
+    instance SuppressUnusedWarnings (Foo1Sym1 a_Singletons_CaseExpressions_17) where
       suppressUnusedWarnings = snd ((,) Foo1Sym1KindInference ())
     type Foo1Sym2 :: a -> Maybe a -> a
-    type family Foo1Sym2 @a (a0123456789876543210 :: a) (a0123456789876543210 :: Maybe a) :: a where
-      Foo1Sym2 a0123456789876543210 a0123456789876543210 = Foo1 a0123456789876543210 a0123456789876543210
+    type family Foo1Sym2 @a (a_Singletons_CaseExpressions_17 :: a) (a_Singletons_CaseExpressions_18 :: Maybe a) :: a where
+      Foo1Sym2 a_Singletons_CaseExpressions_17 a_Singletons_CaseExpressions_18 = Foo1 a_Singletons_CaseExpressions_17 a_Singletons_CaseExpressions_18
     type Foo5 :: a -> a
     type family Foo5 @a (a :: a) :: a where
-      Foo5 x = Apply (LamCases_0123456789876543210Sym0 x) x
+      Foo5 x = Apply (LamCases_Singletons_CaseExpressions_1Sym0 x) x
     type Foo4 :: forall a. a -> a
     type family Foo4 @a (a :: a) :: a where
-      Foo4 @a (x :: a) = Apply (LamCases_0123456789876543210Sym0 a x) x
+      Foo4 @a (x :: a) = Apply (LamCases_Singletons_CaseExpressions_6Sym0 a x) x
     type Foo3 :: a -> b -> a
     type family Foo3 @a @b (a :: a) (a :: b) :: a where
-      Foo3 a b = Apply (LamCases_0123456789876543210Sym0 a b) (Apply (Apply Tuple2Sym0 a) b)
+      Foo3 a b = Apply (LamCases_Singletons_CaseExpressions_11Sym0 a b) (Apply (Apply Tuple2Sym0 a) b)
     type Foo2 :: a -> Maybe a -> a
     type family Foo2 @a (a :: a) (a :: Maybe a) :: a where
-      Foo2 d _ = Apply (LamCases_0123456789876543210Sym0 d) (Apply JustSym0 d)
+      Foo2 d _ = Apply (LamCases_Singletons_CaseExpressions_15Sym0 d) (Apply JustSym0 d)
     type Foo1 :: a -> Maybe a -> a
     type family Foo1 @a (a :: a) (a :: Maybe a) :: a where
-      Foo1 d x = Apply (LamCases_0123456789876543210Sym0 d x) x
+      Foo1 d x = Apply (LamCases_Singletons_CaseExpressions_19Sym0 d x) x
     sFoo5 :: (forall (t :: a). Sing t -> Sing (Foo5 t :: a) :: Type)
     sFoo4 :: forall a (t :: a). Sing t -> Sing (Foo4 t :: a)
     sFoo3 ::
@@ -222,40 +228,41 @@ Singletons/CaseExpressions.hs:(0,0)-(0,0): Splicing declarations
     sFoo5 (sX :: Sing x)
       = applySing
           (singFun1
-             @(LamCases_0123456789876543210Sym0 x)
+             @(LamCases_Singletons_CaseExpressions_1Sym0 x)
              (\cases
                 (sY :: Sing y)
                   -> applySing
-                       (singFun1 @(LamCases_0123456789876543210Sym0 y x) (\cases _ -> sX))
+                       (singFun1
+                          @(LamCases_Singletons_CaseExpressions_2Sym0 y x) (\cases _ -> sX))
                        sY))
           sX
     sFoo4 (sX :: Sing x)
       = applySing
           (singFun1
-             @(LamCases_0123456789876543210Sym0 a x)
+             @(LamCases_Singletons_CaseExpressions_6Sym0 a x)
              (\cases
                 (sY :: Sing y)
                   -> let
-                       sZ :: (Sing (Let0123456789876543210Z a y x :: a) :: Type)
+                       sZ :: (Sing (Let7Z a y x :: a) :: Type)
                        sZ = sY
                      in sZ))
           sX
     sFoo3 (sA :: Sing a) (sB :: Sing b)
       = applySing
           (singFun1
-             @(LamCases_0123456789876543210Sym0 a b)
+             @(LamCases_Singletons_CaseExpressions_11Sym0 a b)
              (\cases (STuple2 (sP :: Sing p) _) -> sP))
           (applySing (applySing (singFun2 @Tuple2Sym0 STuple2) sA) sB)
     sFoo2 (sD :: Sing d) _
       = applySing
           (singFun1
-             @(LamCases_0123456789876543210Sym0 d)
+             @(LamCases_Singletons_CaseExpressions_15Sym0 d)
              (\cases (SJust (sY :: Sing y)) -> sY))
           (applySing (singFun1 @JustSym0 SJust) sD)
     sFoo1 (sD :: Sing d) (sX :: Sing x)
       = applySing
           (singFun1
-             @(LamCases_0123456789876543210Sym0 d x)
+             @(LamCases_Singletons_CaseExpressions_19Sym0 d x)
              (\cases
                 (SJust (sY :: Sing y)) -> sY
                 SNothing -> sD))

--- a/singletons-base/tests/compile-and-dump/Singletons/Classes.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Classes.golden
@@ -75,40 +75,40 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     data FooCompareSym0 :: (~>) Foo ((~>) Foo Ordering)
       where
         FooCompareSym0KindInference :: SameKind (Apply FooCompareSym0 arg) (FooCompareSym1 arg) =>
-                                       FooCompareSym0 a0123456789876543210
-    type instance Apply @Foo @((~>) Foo Ordering) FooCompareSym0 a0123456789876543210 = FooCompareSym1 a0123456789876543210
+                                       FooCompareSym0 a_Singletons_Classes_0
+    type instance Apply @Foo @((~>) Foo Ordering) FooCompareSym0 a_Singletons_Classes_0 = FooCompareSym1 a_Singletons_Classes_0
     instance SuppressUnusedWarnings FooCompareSym0 where
       suppressUnusedWarnings = snd ((,) FooCompareSym0KindInference ())
     type FooCompareSym1 :: Foo -> (~>) Foo Ordering
-    data FooCompareSym1 (a0123456789876543210 :: Foo) :: (~>) Foo Ordering
+    data FooCompareSym1 (a_Singletons_Classes_0 :: Foo) :: (~>) Foo Ordering
       where
-        FooCompareSym1KindInference :: SameKind (Apply (FooCompareSym1 a0123456789876543210) arg) (FooCompareSym2 a0123456789876543210 arg) =>
-                                       FooCompareSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Foo @Ordering (FooCompareSym1 a0123456789876543210) a0123456789876543210 = FooCompare a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (FooCompareSym1 a0123456789876543210) where
+        FooCompareSym1KindInference :: SameKind (Apply (FooCompareSym1 a_Singletons_Classes_0) arg) (FooCompareSym2 a_Singletons_Classes_0 arg) =>
+                                       FooCompareSym1 a_Singletons_Classes_0 a_Singletons_Classes_1
+    type instance Apply @Foo @Ordering (FooCompareSym1 a_Singletons_Classes_0) a_Singletons_Classes_1 = FooCompare a_Singletons_Classes_0 a_Singletons_Classes_1
+    instance SuppressUnusedWarnings (FooCompareSym1 a_Singletons_Classes_0) where
       suppressUnusedWarnings = snd ((,) FooCompareSym1KindInference ())
     type FooCompareSym2 :: Foo -> Foo -> Ordering
-    type family FooCompareSym2 (a0123456789876543210 :: Foo) (a0123456789876543210 :: Foo) :: Ordering where
-      FooCompareSym2 a0123456789876543210 a0123456789876543210 = FooCompare a0123456789876543210 a0123456789876543210
+    type family FooCompareSym2 (a_Singletons_Classes_0 :: Foo) (a_Singletons_Classes_1 :: Foo) :: Ordering where
+      FooCompareSym2 a_Singletons_Classes_0 a_Singletons_Classes_1 = FooCompare a_Singletons_Classes_0 a_Singletons_Classes_1
     type ConstSym0 :: (~>) a ((~>) b a)
     data ConstSym0 :: (~>) a ((~>) b a)
       where
         ConstSym0KindInference :: SameKind (Apply ConstSym0 arg) (ConstSym1 arg) =>
-                                  ConstSym0 a0123456789876543210
-    type instance Apply @a @((~>) b a) ConstSym0 a0123456789876543210 = ConstSym1 a0123456789876543210
+                                  ConstSym0 a_Singletons_Classes_2
+    type instance Apply @a @((~>) b a) ConstSym0 a_Singletons_Classes_2 = ConstSym1 a_Singletons_Classes_2
     instance SuppressUnusedWarnings ConstSym0 where
       suppressUnusedWarnings = snd ((,) ConstSym0KindInference ())
     type ConstSym1 :: a -> (~>) b a
-    data ConstSym1 (a0123456789876543210 :: a) :: (~>) b a
+    data ConstSym1 (a_Singletons_Classes_2 :: a) :: (~>) b a
       where
-        ConstSym1KindInference :: SameKind (Apply (ConstSym1 a0123456789876543210) arg) (ConstSym2 a0123456789876543210 arg) =>
-                                  ConstSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @a (ConstSym1 a0123456789876543210) a0123456789876543210 = Const a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ConstSym1 a0123456789876543210) where
+        ConstSym1KindInference :: SameKind (Apply (ConstSym1 a_Singletons_Classes_2) arg) (ConstSym2 a_Singletons_Classes_2 arg) =>
+                                  ConstSym1 a_Singletons_Classes_2 a_Singletons_Classes_3
+    type instance Apply @b @a (ConstSym1 a_Singletons_Classes_2) a_Singletons_Classes_3 = Const a_Singletons_Classes_2 a_Singletons_Classes_3
+    instance SuppressUnusedWarnings (ConstSym1 a_Singletons_Classes_2) where
       suppressUnusedWarnings = snd ((,) ConstSym1KindInference ())
     type ConstSym2 :: a -> b -> a
-    type family ConstSym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: a where
-      ConstSym2 a0123456789876543210 a0123456789876543210 = Const a0123456789876543210 a0123456789876543210
+    type family ConstSym2 @a @b (a_Singletons_Classes_2 :: a) (a_Singletons_Classes_3 :: b) :: a where
+      ConstSym2 a_Singletons_Classes_2 a_Singletons_Classes_3 = Const a_Singletons_Classes_2 a_Singletons_Classes_3
     type FooCompare :: Foo -> Foo -> Ordering
     type family FooCompare (a :: Foo) (a :: Foo) :: Ordering where
       FooCompare A A = EQSym0
@@ -122,76 +122,76 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     data MycompareSym0 :: (~>) a ((~>) a Ordering)
       where
         MycompareSym0KindInference :: SameKind (Apply MycompareSym0 arg) (MycompareSym1 arg) =>
-                                      MycompareSym0 a0123456789876543210
-    type instance Apply @a @((~>) a Ordering) MycompareSym0 a0123456789876543210 = MycompareSym1 a0123456789876543210
+                                      MycompareSym0 a_Singletons_Classes_4
+    type instance Apply @a @((~>) a Ordering) MycompareSym0 a_Singletons_Classes_4 = MycompareSym1 a_Singletons_Classes_4
     instance SuppressUnusedWarnings MycompareSym0 where
       suppressUnusedWarnings = snd ((,) MycompareSym0KindInference ())
     type MycompareSym1 :: forall a. a -> (~>) a Ordering
-    data MycompareSym1 (a0123456789876543210 :: a) :: (~>) a Ordering
+    data MycompareSym1 (a_Singletons_Classes_4 :: a) :: (~>) a Ordering
       where
-        MycompareSym1KindInference :: SameKind (Apply (MycompareSym1 a0123456789876543210) arg) (MycompareSym2 a0123456789876543210 arg) =>
-                                      MycompareSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @a @Ordering (MycompareSym1 a0123456789876543210) a0123456789876543210 = Mycompare a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (MycompareSym1 a0123456789876543210) where
+        MycompareSym1KindInference :: SameKind (Apply (MycompareSym1 a_Singletons_Classes_4) arg) (MycompareSym2 a_Singletons_Classes_4 arg) =>
+                                      MycompareSym1 a_Singletons_Classes_4 a_Singletons_Classes_5
+    type instance Apply @a @Ordering (MycompareSym1 a_Singletons_Classes_4) a_Singletons_Classes_5 = Mycompare a_Singletons_Classes_4 a_Singletons_Classes_5
+    instance SuppressUnusedWarnings (MycompareSym1 a_Singletons_Classes_4) where
       suppressUnusedWarnings = snd ((,) MycompareSym1KindInference ())
     type MycompareSym2 :: forall a. a -> a -> Ordering
-    type family MycompareSym2 @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Ordering where
-      MycompareSym2 a0123456789876543210 a0123456789876543210 = Mycompare a0123456789876543210 a0123456789876543210
+    type family MycompareSym2 @a (a_Singletons_Classes_4 :: a) (a_Singletons_Classes_5 :: a) :: Ordering where
+      MycompareSym2 a_Singletons_Classes_4 a_Singletons_Classes_5 = Mycompare a_Singletons_Classes_4 a_Singletons_Classes_5
     type (<=>@#@$) :: forall a. (~>) a ((~>) a Ordering)
     data (<=>@#@$) :: (~>) a ((~>) a Ordering)
       where
         (:<=>@#@$###) :: SameKind (Apply (<=>@#@$) arg) ((<=>@#@$$) arg) =>
-                         (<=>@#@$) a0123456789876543210
-    type instance Apply @a @((~>) a Ordering) (<=>@#@$) a0123456789876543210 = (<=>@#@$$) a0123456789876543210
+                         (<=>@#@$) a_Singletons_Classes_6
+    type instance Apply @a @((~>) a Ordering) (<=>@#@$) a_Singletons_Classes_6 = (<=>@#@$$) a_Singletons_Classes_6
     instance SuppressUnusedWarnings (<=>@#@$) where
       suppressUnusedWarnings = snd ((,) (:<=>@#@$###) ())
     infix 4 type <=>@#@$
     type (<=>@#@$$) :: forall a. a -> (~>) a Ordering
-    data (<=>@#@$$) (a0123456789876543210 :: a) :: (~>) a Ordering
+    data (<=>@#@$$) (a_Singletons_Classes_6 :: a) :: (~>) a Ordering
       where
-        (:<=>@#@$$###) :: SameKind (Apply ((<=>@#@$$) a0123456789876543210) arg) ((<=>@#@$$$) a0123456789876543210 arg) =>
-                          (<=>@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @a @Ordering ((<=>@#@$$) a0123456789876543210) a0123456789876543210 = (<=>) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((<=>@#@$$) a0123456789876543210) where
+        (:<=>@#@$$###) :: SameKind (Apply ((<=>@#@$$) a_Singletons_Classes_6) arg) ((<=>@#@$$$) a_Singletons_Classes_6 arg) =>
+                          (<=>@#@$$) a_Singletons_Classes_6 a_Singletons_Classes_7
+    type instance Apply @a @Ordering ((<=>@#@$$) a_Singletons_Classes_6) a_Singletons_Classes_7 = (<=>) a_Singletons_Classes_6 a_Singletons_Classes_7
+    instance SuppressUnusedWarnings ((<=>@#@$$) a_Singletons_Classes_6) where
       suppressUnusedWarnings = snd ((,) (:<=>@#@$$###) ())
     infix 4 type <=>@#@$$
     type (<=>@#@$$$) :: forall a. a -> a -> Ordering
-    type family (<=>@#@$$$) @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Ordering where
-      (<=>@#@$$$) a0123456789876543210 a0123456789876543210 = (<=>) a0123456789876543210 a0123456789876543210
+    type family (<=>@#@$$$) @a (a_Singletons_Classes_6 :: a) (a_Singletons_Classes_7 :: a) :: Ordering where
+      (<=>@#@$$$) a_Singletons_Classes_6 a_Singletons_Classes_7 = (<=>) a_Singletons_Classes_6 a_Singletons_Classes_7
     infix 4 type <=>@#@$$$
-    type TFHelper_0123456789876543210 :: forall a. a -> a -> Ordering
-    type family TFHelper_0123456789876543210 @a (a :: a) (a :: a) :: Ordering where
-      TFHelper_0123456789876543210 @a (a_0123456789876543210 :: a) (a_0123456789876543210 :: a) = Apply (Apply MycompareSym0 a_0123456789876543210) a_0123456789876543210
+    type TFHelper_Singletons_Classes_8 :: forall a. a -> a -> Ordering
+    type family TFHelper_Singletons_Classes_8 @a (a :: a) (a :: a) :: Ordering where
+      TFHelper_Singletons_Classes_8 @a (a_Singletons_Classes_9 :: a) (a_Singletons_Classes_10 :: a) = Apply (Apply MycompareSym0 a_Singletons_Classes_9) a_Singletons_Classes_10
     class PMyOrd a where
       type family Mycompare (arg :: a) (arg :: a) :: Ordering
       type family (<=>) (arg :: a) (arg :: a) :: Ordering
-      type (<=>) a a = TFHelper_0123456789876543210 a a
-    type Mycompare_0123456789876543210 :: Nat -> Nat -> Ordering
-    type family Mycompare_0123456789876543210 (a :: Nat) (a :: Nat) :: Ordering where
-      Mycompare_0123456789876543210 'Zero 'Zero = EQSym0
-      Mycompare_0123456789876543210 'Zero ('Succ _) = LTSym0
-      Mycompare_0123456789876543210 ('Succ _) 'Zero = GTSym0
-      Mycompare_0123456789876543210 ('Succ n) ('Succ m) = Apply (Apply MycompareSym0 m) n
+      type (<=>) a a = TFHelper_Singletons_Classes_8 a a
+    type Mycompare_Singletons_Classes_13 :: Nat -> Nat -> Ordering
+    type family Mycompare_Singletons_Classes_13 (a :: Nat) (a :: Nat) :: Ordering where
+      Mycompare_Singletons_Classes_13 'Zero 'Zero = EQSym0
+      Mycompare_Singletons_Classes_13 'Zero ('Succ _) = LTSym0
+      Mycompare_Singletons_Classes_13 ('Succ _) 'Zero = GTSym0
+      Mycompare_Singletons_Classes_13 ('Succ n) ('Succ m) = Apply (Apply MycompareSym0 m) n
     instance PMyOrd Nat where
-      type Mycompare a a = Mycompare_0123456789876543210 a a
-    type Mycompare_0123456789876543210 :: () -> () -> Ordering
-    type family Mycompare_0123456789876543210 (a :: ()) (a :: ()) :: Ordering where
-      Mycompare_0123456789876543210 _ a_0123456789876543210 = Apply (Apply ConstSym0 EQSym0) a_0123456789876543210
+      type Mycompare a a = Mycompare_Singletons_Classes_13 a a
+    type Mycompare_Singletons_Classes_16 :: () -> () -> Ordering
+    type family Mycompare_Singletons_Classes_16 (a :: ()) (a :: ()) :: Ordering where
+      Mycompare_Singletons_Classes_16 _ a_Singletons_Classes_17 = Apply (Apply ConstSym0 EQSym0) a_Singletons_Classes_17
     instance PMyOrd () where
-      type Mycompare a a = Mycompare_0123456789876543210 a a
-    type Mycompare_0123456789876543210 :: Foo -> Foo -> Ordering
-    type family Mycompare_0123456789876543210 (a :: Foo) (a :: Foo) :: Ordering where
-      Mycompare_0123456789876543210 a_0123456789876543210 a_0123456789876543210 = Apply (Apply FooCompareSym0 a_0123456789876543210) a_0123456789876543210
+      type Mycompare a a = Mycompare_Singletons_Classes_16 a a
+    type Mycompare_Singletons_Classes_20 :: Foo -> Foo -> Ordering
+    type family Mycompare_Singletons_Classes_20 (a :: Foo) (a :: Foo) :: Ordering where
+      Mycompare_Singletons_Classes_20 a_Singletons_Classes_21 a_Singletons_Classes_22 = Apply (Apply FooCompareSym0 a_Singletons_Classes_21) a_Singletons_Classes_22
     instance PMyOrd Foo where
-      type Mycompare a a = Mycompare_0123456789876543210 a a
-    type TFHelper_0123456789876543210 :: Foo2 -> Foo2 -> Bool
-    type family TFHelper_0123456789876543210 (a :: Foo2) (a :: Foo2) :: Bool where
-      TFHelper_0123456789876543210 F F = TrueSym0
-      TFHelper_0123456789876543210 G G = TrueSym0
-      TFHelper_0123456789876543210 F G = FalseSym0
-      TFHelper_0123456789876543210 G F = FalseSym0
+      type Mycompare a a = Mycompare_Singletons_Classes_20 a a
+    type TFHelper_Singletons_Classes_25 :: Foo2 -> Foo2 -> Bool
+    type family TFHelper_Singletons_Classes_25 (a :: Foo2) (a :: Foo2) :: Bool where
+      TFHelper_Singletons_Classes_25 F F = TrueSym0
+      TFHelper_Singletons_Classes_25 G G = TrueSym0
+      TFHelper_Singletons_Classes_25 F G = FalseSym0
+      TFHelper_Singletons_Classes_25 G F = FalseSym0
     instance PEq Foo2 where
-      type (==) a a = TFHelper_0123456789876543210 a a
+      type (==) a a = TFHelper_Singletons_Classes_25 a a
     sFooCompare ::
       (forall (t :: Foo) (t :: Foo).
        Sing t -> Sing t -> Sing (FooCompare t t :: Ordering) :: Type)
@@ -251,15 +251,15 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       infix 4 data %<=>
       default (%<=>) ::
                 (forall (t :: a) (t :: a).
-                 (((<=>) t t :: Ordering) ~ TFHelper_0123456789876543210 t t) =>
+                 (((<=>) t t :: Ordering) ~ TFHelper_Singletons_Classes_8 t t) =>
                  Sing t -> Sing t -> Sing ((<=>) t t :: Ordering) :: Type)
       (%<=>)
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_Singletons_Classes_9 :: Sing a_Singletons_Classes_9)
+        (sA_Singletons_Classes_10 :: Sing a_Singletons_Classes_10)
         = applySing
             (applySing
-               (singFun2 @MycompareSym0 sMycompare) sA_0123456789876543210)
-            sA_0123456789876543210
+               (singFun2 @MycompareSym0 sMycompare) sA_Singletons_Classes_9)
+            sA_Singletons_Classes_10
     instance SMyOrd Nat where
       sMycompare SZero SZero = SEQ
       sMycompare SZero (SSucc _) = SLT
@@ -267,17 +267,20 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       sMycompare (SSucc (sN :: Sing n)) (SSucc (sM :: Sing m))
         = applySing (applySing (singFun2 @MycompareSym0 sMycompare) sM) sN
     instance SMyOrd () where
-      sMycompare _ (sA_0123456789876543210 :: Sing a_0123456789876543210)
+      sMycompare
+        _
+        (sA_Singletons_Classes_17 :: Sing a_Singletons_Classes_17)
         = applySing
-            (applySing (singFun2 @ConstSym0 sConst) SEQ) sA_0123456789876543210
+            (applySing (singFun2 @ConstSym0 sConst) SEQ)
+            sA_Singletons_Classes_17
     instance SMyOrd Foo where
       sMycompare
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_Singletons_Classes_21 :: Sing a_Singletons_Classes_21)
+        (sA_Singletons_Classes_22 :: Sing a_Singletons_Classes_22)
         = applySing
             (applySing
-               (singFun2 @FooCompareSym0 sFooCompare) sA_0123456789876543210)
-            sA_0123456789876543210
+               (singFun2 @FooCompareSym0 sFooCompare) sA_Singletons_Classes_21)
+            sA_Singletons_Classes_22
     instance SEq Foo2 where
       (%==) SF SF = STrue
       (%==) SG SG = STrue
@@ -330,20 +333,20 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
       compare F F = EQ
       compare F _ = LT
       compare _ _ = GT
-    type Mycompare_0123456789876543210 :: Foo2 -> Foo2 -> Ordering
-    type family Mycompare_0123456789876543210 (a :: Foo2) (a :: Foo2) :: Ordering where
-      Mycompare_0123456789876543210 'F 'F = EQSym0
-      Mycompare_0123456789876543210 'F _ = LTSym0
-      Mycompare_0123456789876543210 _ _ = GTSym0
+    type Mycompare_Singletons_Classes_28 :: Foo2 -> Foo2 -> Ordering
+    type family Mycompare_Singletons_Classes_28 (a :: Foo2) (a :: Foo2) :: Ordering where
+      Mycompare_Singletons_Classes_28 'F 'F = EQSym0
+      Mycompare_Singletons_Classes_28 'F _ = LTSym0
+      Mycompare_Singletons_Classes_28 _ _ = GTSym0
     instance PMyOrd Foo2 where
-      type Mycompare a a = Mycompare_0123456789876543210 a a
-    type Compare_0123456789876543210 :: Foo2 -> Foo2 -> Ordering
-    type family Compare_0123456789876543210 (a :: Foo2) (a :: Foo2) :: Ordering where
-      Compare_0123456789876543210 'F 'F = EQSym0
-      Compare_0123456789876543210 'F _ = LTSym0
-      Compare_0123456789876543210 _ _ = GTSym0
+      type Mycompare a a = Mycompare_Singletons_Classes_28 a a
+    type Compare_Singletons_Classes_31 :: Foo2 -> Foo2 -> Ordering
+    type family Compare_Singletons_Classes_31 (a :: Foo2) (a :: Foo2) :: Ordering where
+      Compare_Singletons_Classes_31 'F 'F = EQSym0
+      Compare_Singletons_Classes_31 'F _ = LTSym0
+      Compare_Singletons_Classes_31 _ _ = GTSym0
     instance POrd Foo2 where
-      type Compare a a = Compare_0123456789876543210 a a
+      type Compare a a = Compare_Singletons_Classes_31 a a
 Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     singletons
       [d| data Nat' = Zero' | Succ' Nat'
@@ -367,21 +370,21 @@ Singletons/Classes.hs:(0,0)-(0,0): Splicing declarations
     data Succ'Sym0 :: (~>) Nat' Nat'
       where
         Succ'Sym0KindInference :: SameKind (Apply Succ'Sym0 arg) (Succ'Sym1 arg) =>
-                                  Succ'Sym0 a0123456789876543210
-    type instance Apply @Nat' @Nat' Succ'Sym0 a0123456789876543210 = Succ' a0123456789876543210
+                                  Succ'Sym0 a_Singletons_Classes_34
+    type instance Apply @Nat' @Nat' Succ'Sym0 a_Singletons_Classes_34 = Succ' a_Singletons_Classes_34
     instance SuppressUnusedWarnings Succ'Sym0 where
       suppressUnusedWarnings = snd ((,) Succ'Sym0KindInference ())
     type Succ'Sym1 :: Nat' -> Nat'
-    type family Succ'Sym1 (a0123456789876543210 :: Nat') :: Nat' where
-      Succ'Sym1 a0123456789876543210 = Succ' a0123456789876543210
-    type Mycompare_0123456789876543210 :: Nat' -> Nat' -> Ordering
-    type family Mycompare_0123456789876543210 (a :: Nat') (a :: Nat') :: Ordering where
-      Mycompare_0123456789876543210 Zero' Zero' = EQSym0
-      Mycompare_0123456789876543210 Zero' (Succ' _) = LTSym0
-      Mycompare_0123456789876543210 (Succ' _) Zero' = GTSym0
-      Mycompare_0123456789876543210 (Succ' n) (Succ' m) = Apply (Apply MycompareSym0 m) n
+    type family Succ'Sym1 (a_Singletons_Classes_34 :: Nat') :: Nat' where
+      Succ'Sym1 a_Singletons_Classes_34 = Succ' a_Singletons_Classes_34
+    type Mycompare_Singletons_Classes_35 :: Nat' -> Nat' -> Ordering
+    type family Mycompare_Singletons_Classes_35 (a :: Nat') (a :: Nat') :: Ordering where
+      Mycompare_Singletons_Classes_35 Zero' Zero' = EQSym0
+      Mycompare_Singletons_Classes_35 Zero' (Succ' _) = LTSym0
+      Mycompare_Singletons_Classes_35 (Succ' _) Zero' = GTSym0
+      Mycompare_Singletons_Classes_35 (Succ' n) (Succ' m) = Apply (Apply MycompareSym0 m) n
     instance PMyOrd Nat' where
-      type Mycompare a a = Mycompare_0123456789876543210 a a
+      type Mycompare a a = Mycompare_Singletons_Classes_35 a a
     data SNat' :: Nat' -> Type
       where
         SZero' :: SNat' (Zero' :: Nat')

--- a/singletons-base/tests/compile-and-dump/Singletons/Classes2.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Classes2.golden
@@ -21,21 +21,22 @@ Singletons/Classes2.hs:(0,0)-(0,0): Splicing declarations
     data SuccFooSym0 :: (~>) NatFoo NatFoo
       where
         SuccFooSym0KindInference :: SameKind (Apply SuccFooSym0 arg) (SuccFooSym1 arg) =>
-                                    SuccFooSym0 a0123456789876543210
-    type instance Apply @NatFoo @NatFoo SuccFooSym0 a0123456789876543210 = SuccFoo a0123456789876543210
+                                    SuccFooSym0 a_Singletons_Classes2_0
+    type instance Apply @NatFoo @NatFoo SuccFooSym0 a_Singletons_Classes2_0 = SuccFoo a_Singletons_Classes2_0
     instance SuppressUnusedWarnings SuccFooSym0 where
       suppressUnusedWarnings = snd ((,) SuccFooSym0KindInference ())
     type SuccFooSym1 :: NatFoo -> NatFoo
-    type family SuccFooSym1 (a0123456789876543210 :: NatFoo) :: NatFoo where
-      SuccFooSym1 a0123456789876543210 = SuccFoo a0123456789876543210
-    type Mycompare_0123456789876543210 :: NatFoo -> NatFoo -> Ordering
-    type family Mycompare_0123456789876543210 (a :: NatFoo) (a :: NatFoo) :: Ordering where
-      Mycompare_0123456789876543210 ZeroFoo ZeroFoo = EQSym0
-      Mycompare_0123456789876543210 ZeroFoo (SuccFoo _) = LTSym0
-      Mycompare_0123456789876543210 (SuccFoo _) ZeroFoo = GTSym0
-      Mycompare_0123456789876543210 (SuccFoo n) (SuccFoo m) = Apply (Apply MycompareSym0 m) n
+    type family SuccFooSym1 (a_Singletons_Classes2_0 :: NatFoo) :: NatFoo where
+      SuccFooSym1 a_Singletons_Classes2_0 = SuccFoo a_Singletons_Classes2_0
+    type Mycompare_Singletons_Classes2_1 :: NatFoo
+                                            -> NatFoo -> Ordering
+    type family Mycompare_Singletons_Classes2_1 (a :: NatFoo) (a :: NatFoo) :: Ordering where
+      Mycompare_Singletons_Classes2_1 ZeroFoo ZeroFoo = EQSym0
+      Mycompare_Singletons_Classes2_1 ZeroFoo (SuccFoo _) = LTSym0
+      Mycompare_Singletons_Classes2_1 (SuccFoo _) ZeroFoo = GTSym0
+      Mycompare_Singletons_Classes2_1 (SuccFoo n) (SuccFoo m) = Apply (Apply MycompareSym0 m) n
     instance PMyOrd NatFoo where
-      type Mycompare a a = Mycompare_0123456789876543210 a a
+      type Mycompare a a = Mycompare_Singletons_Classes2_1 a a
     data SNatFoo :: NatFoo -> Type
       where
         SZeroFoo :: SNatFoo (ZeroFoo :: NatFoo)

--- a/singletons-base/tests/compile-and-dump/Singletons/Contains.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Contains.golden
@@ -11,21 +11,21 @@ Singletons/Contains.hs:(0,0)-(0,0): Splicing declarations
     data ContainsSym0 :: (~>) a ((~>) [a] Bool)
       where
         ContainsSym0KindInference :: SameKind (Apply ContainsSym0 arg) (ContainsSym1 arg) =>
-                                     ContainsSym0 a0123456789876543210
-    type instance Apply @a @((~>) [a] Bool) ContainsSym0 a0123456789876543210 = ContainsSym1 a0123456789876543210
+                                     ContainsSym0 a_Singletons_Contains_0
+    type instance Apply @a @((~>) [a] Bool) ContainsSym0 a_Singletons_Contains_0 = ContainsSym1 a_Singletons_Contains_0
     instance SuppressUnusedWarnings ContainsSym0 where
       suppressUnusedWarnings = snd ((,) ContainsSym0KindInference ())
     type ContainsSym1 :: a -> (~>) [a] Bool
-    data ContainsSym1 (a0123456789876543210 :: a) :: (~>) [a] Bool
+    data ContainsSym1 (a_Singletons_Contains_0 :: a) :: (~>) [a] Bool
       where
-        ContainsSym1KindInference :: SameKind (Apply (ContainsSym1 a0123456789876543210) arg) (ContainsSym2 a0123456789876543210 arg) =>
-                                     ContainsSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @[a] @Bool (ContainsSym1 a0123456789876543210) a0123456789876543210 = Contains a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ContainsSym1 a0123456789876543210) where
+        ContainsSym1KindInference :: SameKind (Apply (ContainsSym1 a_Singletons_Contains_0) arg) (ContainsSym2 a_Singletons_Contains_0 arg) =>
+                                     ContainsSym1 a_Singletons_Contains_0 a_Singletons_Contains_1
+    type instance Apply @[a] @Bool (ContainsSym1 a_Singletons_Contains_0) a_Singletons_Contains_1 = Contains a_Singletons_Contains_0 a_Singletons_Contains_1
+    instance SuppressUnusedWarnings (ContainsSym1 a_Singletons_Contains_0) where
       suppressUnusedWarnings = snd ((,) ContainsSym1KindInference ())
     type ContainsSym2 :: a -> [a] -> Bool
-    type family ContainsSym2 @a (a0123456789876543210 :: a) (a0123456789876543210 :: [a]) :: Bool where
-      ContainsSym2 a0123456789876543210 a0123456789876543210 = Contains a0123456789876543210 a0123456789876543210
+    type family ContainsSym2 @a (a_Singletons_Contains_0 :: a) (a_Singletons_Contains_1 :: [a]) :: Bool where
+      ContainsSym2 a_Singletons_Contains_0 a_Singletons_Contains_1 = Contains a_Singletons_Contains_0 a_Singletons_Contains_1
     type Contains :: a -> [a] -> Bool
     type family Contains @a (a :: a) (a :: [a]) :: Bool where
       Contains _ '[] = FalseSym0

--- a/singletons-base/tests/compile-and-dump/Singletons/DataValues.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/DataValues.golden
@@ -20,21 +20,21 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
     data PairSym0 :: (~>) a ((~>) b (Pair a b))
       where
         PairSym0KindInference :: SameKind (Apply PairSym0 arg) (PairSym1 arg) =>
-                                 PairSym0 a0123456789876543210
-    type instance Apply @a @((~>) b (Pair a b)) PairSym0 a0123456789876543210 = PairSym1 a0123456789876543210
+                                 PairSym0 a_Singletons_DataValues_3
+    type instance Apply @a @((~>) b (Pair a b)) PairSym0 a_Singletons_DataValues_3 = PairSym1 a_Singletons_DataValues_3
     instance SuppressUnusedWarnings PairSym0 where
       suppressUnusedWarnings = snd ((,) PairSym0KindInference ())
     type PairSym1 :: forall a b. a -> (~>) b (Pair a b)
-    data PairSym1 (a0123456789876543210 :: a) :: (~>) b (Pair a b)
+    data PairSym1 (a_Singletons_DataValues_3 :: a) :: (~>) b (Pair a b)
       where
-        PairSym1KindInference :: SameKind (Apply (PairSym1 a0123456789876543210) arg) (PairSym2 a0123456789876543210 arg) =>
-                                 PairSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @(Pair a b) (PairSym1 a0123456789876543210) a0123456789876543210 = Pair a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (PairSym1 a0123456789876543210) where
+        PairSym1KindInference :: SameKind (Apply (PairSym1 a_Singletons_DataValues_3) arg) (PairSym2 a_Singletons_DataValues_3 arg) =>
+                                 PairSym1 a_Singletons_DataValues_3 a_Singletons_DataValues_4
+    type instance Apply @b @(Pair a b) (PairSym1 a_Singletons_DataValues_3) a_Singletons_DataValues_4 = Pair a_Singletons_DataValues_3 a_Singletons_DataValues_4
+    instance SuppressUnusedWarnings (PairSym1 a_Singletons_DataValues_3) where
       suppressUnusedWarnings = snd ((,) PairSym1KindInference ())
     type PairSym2 :: forall a b. a -> b -> Pair a b
-    type family PairSym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: Pair a b where
-      PairSym2 a0123456789876543210 a0123456789876543210 = Pair a0123456789876543210 a0123456789876543210
+    type family PairSym2 @a @b (a_Singletons_DataValues_3 :: a) (a_Singletons_DataValues_4 :: b) :: Pair a b where
+      PairSym2 a_Singletons_DataValues_3 a_Singletons_DataValues_4 = Pair a_Singletons_DataValues_3 a_Singletons_DataValues_4
     type family AListSym0 where
       AListSym0 = AList
     type family TupleSym0 where
@@ -51,13 +51,13 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
       Complex = Apply (Apply PairSym0 (Apply (Apply PairSym0 (Apply JustSym0 ZeroSym0)) ZeroSym0)) FalseSym0
     type family Pr where
       Pr = Apply (Apply PairSym0 (Apply SuccSym0 ZeroSym0)) (Apply (Apply (:@#@$) ZeroSym0) NilSym0)
-    type ShowsPrec_0123456789876543210 :: forall a
-                                                 b. GHC.Internal.Bignum.Natural.Natural
-                                                    -> Pair a b -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210 @a @b (a :: GHC.Internal.Bignum.Natural.Natural) (a :: Pair a b) (a :: Symbol) :: Symbol where
-      ShowsPrec_0123456789876543210 @a @b (p_0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) (Pair arg_0123456789876543210 arg_0123456789876543210 :: Pair a b) (a_0123456789876543210 :: Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Pair ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
+    type ShowsPrec_Singletons_DataValues_5 :: forall a
+                                                     b. GHC.Internal.Bignum.Natural.Natural
+                                                        -> Pair a b -> Symbol -> Symbol
+    type family ShowsPrec_Singletons_DataValues_5 @a @b (a :: GHC.Internal.Bignum.Natural.Natural) (a :: Pair a b) (a :: Symbol) :: Symbol where
+      ShowsPrec_Singletons_DataValues_5 @a @b (p_Singletons_DataValues_0 :: GHC.Internal.Bignum.Natural.Natural) (Pair arg_Singletons_DataValues_1 arg_Singletons_DataValues_2 :: Pair a b) (a_Singletons_DataValues_6 :: Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_Singletons_DataValues_0) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Pair ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_Singletons_DataValues_1)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_Singletons_DataValues_2))))) a_Singletons_DataValues_6
     instance PShow (Pair a b) where
-      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
+      type ShowsPrec a a a = ShowsPrec_Singletons_DataValues_5 a a a
     sAList :: Sing @_ AList
     sTuple :: Sing @_ Tuple
     sComplex :: Sing @_ Complex
@@ -111,16 +111,16 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
             (toSing b :: SomeSing a) (toSing b :: SomeSing b)
     instance (SShow a, SShow b) => SShow (Pair a b) where
       sShowsPrec
-        (sP_0123456789876543210 :: Sing p_0123456789876543210)
-        (SPair (sArg_0123456789876543210 :: Sing arg_0123456789876543210)
-               (sArg_0123456789876543210 :: Sing arg_0123456789876543210))
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sP_Singletons_DataValues_0 :: Sing p_Singletons_DataValues_0)
+        (SPair (sArg_Singletons_DataValues_1 :: Sing arg_Singletons_DataValues_1)
+               (sArg_Singletons_DataValues_2 :: Sing arg_Singletons_DataValues_2))
+        (sA_Singletons_DataValues_6 :: Sing a_Singletons_DataValues_6)
         = applySing
             (applySing
                (applySing
                   (singFun3 @ShowParenSym0 sShowParen)
                   (applySing
-                     (applySing (singFun2 @(>@#@$) (%>)) sP_0123456789876543210)
+                     (applySing (singFun2 @(>@#@$) (%>)) sP_Singletons_DataValues_0)
                      (sFromInteger (sing :: Sing 10))))
                (applySing
                   (applySing
@@ -134,7 +134,7 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
                            (applySing
                               (singFun3 @ShowsPrecSym0 sShowsPrec)
                               (sFromInteger (sing :: Sing 11)))
-                           sArg_0123456789876543210))
+                           sArg_Singletons_DataValues_1))
                      (applySing
                         (applySing
                            (singFun3 @(.@#@$) (%.)) (singFun1 @ShowSpaceSym0 sShowSpace))
@@ -142,8 +142,8 @@ Singletons/DataValues.hs:(0,0)-(0,0): Splicing declarations
                            (applySing
                               (singFun3 @ShowsPrecSym0 sShowsPrec)
                               (sFromInteger (sing :: Sing 11)))
-                           sArg_0123456789876543210)))))
-            sA_0123456789876543210
+                           sArg_Singletons_DataValues_2)))))
+            sA_Singletons_DataValues_6
     deriving instance (Data.Singletons.ShowSing.ShowSing a,
                        Data.Singletons.ShowSing.ShowSing b) =>
                       Show (SPair (z :: Pair a b))

--- a/singletons-base/tests/compile-and-dump/Singletons/EmptyShowDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/EmptyShowDeriving.golden
@@ -6,25 +6,26 @@ Singletons/EmptyShowDeriving.hs:(0,0)-(0,0): Splicing declarations
   ======>
     data Foo
     deriving instance Show Foo
-    type family LamCases_0123456789876543210 (v_01234567898765432100123456789876543210 :: Foo) (a_01234567898765432100123456789876543210 :: GHC.Internal.Types.Symbol) a_0123456789876543210 where
-    data LamCases_0123456789876543210Sym0 (v_01234567898765432100123456789876543210 :: Foo) (a_01234567898765432100123456789876543210 :: GHC.Internal.Types.Symbol) a_01234567898765432100123456789876543210
+    type family LamCases_Singletons_EmptyShowDeriving_7 (v_Singletons_EmptyShowDeriving_10 :: Foo) (a_Singletons_EmptyShowDeriving_31 :: GHC.Internal.Types.Symbol) a_Singletons_EmptyShowDeriving_8 where
+    data LamCases_Singletons_EmptyShowDeriving_7Sym0 (v_Singletons_EmptyShowDeriving_10 :: Foo) (a_Singletons_EmptyShowDeriving_31 :: GHC.Internal.Types.Symbol) a_Singletons_EmptyShowDeriving_8
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 v_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 v_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 v_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 v_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 v_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 v_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
+        LamCases_Singletons_EmptyShowDeriving_7Sym0KindInference :: SameKind (Apply (LamCases_Singletons_EmptyShowDeriving_7Sym0 v_Singletons_EmptyShowDeriving_10 a_Singletons_EmptyShowDeriving_31) arg) (LamCases_Singletons_EmptyShowDeriving_7Sym1 v_Singletons_EmptyShowDeriving_10 a_Singletons_EmptyShowDeriving_31 arg) =>
+                                                                    LamCases_Singletons_EmptyShowDeriving_7Sym0 v_Singletons_EmptyShowDeriving_10 a_Singletons_EmptyShowDeriving_31 a_Singletons_EmptyShowDeriving_8
+    type instance Apply @_ @_ (LamCases_Singletons_EmptyShowDeriving_7Sym0 v_Singletons_EmptyShowDeriving_10 a_Singletons_EmptyShowDeriving_31) a_Singletons_EmptyShowDeriving_8 = LamCases_Singletons_EmptyShowDeriving_7 v_Singletons_EmptyShowDeriving_10 a_Singletons_EmptyShowDeriving_31 a_Singletons_EmptyShowDeriving_8
+    instance SuppressUnusedWarnings (LamCases_Singletons_EmptyShowDeriving_7Sym0 v_Singletons_EmptyShowDeriving_10 a_Singletons_EmptyShowDeriving_31) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (v_01234567898765432100123456789876543210 :: Foo) (a_01234567898765432100123456789876543210 :: GHC.Internal.Types.Symbol) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 v_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 v_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type ShowsPrec_0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural
-                                          -> Foo
-                                             -> GHC.Internal.Types.Symbol
-                                                -> GHC.Internal.Types.Symbol
-    type family ShowsPrec_0123456789876543210 (a :: GHC.Internal.Bignum.Natural.Natural) (a :: Foo) (a :: GHC.Internal.Types.Symbol) :: GHC.Internal.Types.Symbol where
-      ShowsPrec_0123456789876543210 _ v_0123456789876543210 a_0123456789876543210 = Apply (Apply (LamCases_0123456789876543210Sym0 v_0123456789876543210 a_0123456789876543210) v_0123456789876543210) a_0123456789876543210
+        = snd
+            ((,) LamCases_Singletons_EmptyShowDeriving_7Sym0KindInference ())
+    type family LamCases_Singletons_EmptyShowDeriving_7Sym1 (v_Singletons_EmptyShowDeriving_10 :: Foo) (a_Singletons_EmptyShowDeriving_31 :: GHC.Internal.Types.Symbol) a_Singletons_EmptyShowDeriving_8 where
+      LamCases_Singletons_EmptyShowDeriving_7Sym1 v_Singletons_EmptyShowDeriving_10 a_Singletons_EmptyShowDeriving_31 a_Singletons_EmptyShowDeriving_8 = LamCases_Singletons_EmptyShowDeriving_7 v_Singletons_EmptyShowDeriving_10 a_Singletons_EmptyShowDeriving_31 a_Singletons_EmptyShowDeriving_8
+    type ShowsPrec_Singletons_EmptyShowDeriving_2 :: GHC.Internal.Bignum.Natural.Natural
+                                                     -> Foo
+                                                        -> GHC.Internal.Types.Symbol
+                                                           -> GHC.Internal.Types.Symbol
+    type family ShowsPrec_Singletons_EmptyShowDeriving_2 (a :: GHC.Internal.Bignum.Natural.Natural) (a :: Foo) (a :: GHC.Internal.Types.Symbol) :: GHC.Internal.Types.Symbol where
+      ShowsPrec_Singletons_EmptyShowDeriving_2 _ v_Singletons_EmptyShowDeriving_1 a_Singletons_EmptyShowDeriving_3 = Apply (Apply (LamCases_Singletons_EmptyShowDeriving_7Sym0 v_Singletons_EmptyShowDeriving_1 a_Singletons_EmptyShowDeriving_3) v_Singletons_EmptyShowDeriving_1) a_Singletons_EmptyShowDeriving_3
     instance PShow Foo where
-      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
+      type ShowsPrec a a a = ShowsPrec_Singletons_EmptyShowDeriving_2 a a a
     data SFoo :: Foo -> Type
     type instance Sing @Foo = SFoo
     instance SingKind Foo where
@@ -34,13 +35,13 @@ Singletons/EmptyShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     instance SShow Foo where
       sShowsPrec
         _
-        (sV_0123456789876543210 :: Sing v_0123456789876543210)
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sV_Singletons_EmptyShowDeriving_1 :: Sing v_Singletons_EmptyShowDeriving_1)
+        (sA_Singletons_EmptyShowDeriving_3 :: Sing a_Singletons_EmptyShowDeriving_3)
         = applySing
             (applySing
                (singFun1
-                  @(LamCases_0123456789876543210Sym0 v_0123456789876543210 a_0123456789876543210)
+                  @(LamCases_Singletons_EmptyShowDeriving_7Sym0 v_Singletons_EmptyShowDeriving_1 a_Singletons_EmptyShowDeriving_3)
                   (\case))
-               sV_0123456789876543210)
-            sA_0123456789876543210
+               sV_Singletons_EmptyShowDeriving_1)
+            sA_Singletons_EmptyShowDeriving_3
     deriving instance Show (SFoo (z :: Foo))

--- a/singletons-base/tests/compile-and-dump/Singletons/EnumDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/EnumDeriving.golden
@@ -24,58 +24,58 @@ Singletons/EnumDeriving.hs:(0,0)-(0,0): Splicing declarations
     type Q2Sym0 :: Quux
     type family Q2Sym0 :: Quux where
       Q2Sym0 = Q2
-    type family LamCases_0123456789876543210 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_0123456789876543210 where
-      LamCases_0123456789876543210 n 'True = BumSym0
-      LamCases_0123456789876543210 n 'False = Apply ErrorSym0 "toEnum: bad argument"
-    data LamCases_0123456789876543210Sym0 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_01234567898765432100123456789876543210
+    type family LamCases_Singletons_EnumDeriving_4 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_Singletons_EnumDeriving_5 where
+      LamCases_Singletons_EnumDeriving_4 n 'True = BumSym0
+      LamCases_Singletons_EnumDeriving_4 n 'False = Apply ErrorSym0 "toEnum: bad argument"
+    data LamCases_Singletons_EnumDeriving_4Sym0 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_Singletons_EnumDeriving_5
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 n0123456789876543210) arg) (LamCases_0123456789876543210Sym1 n0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 n0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 n0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 n0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 n0123456789876543210) where
+        LamCases_Singletons_EnumDeriving_4Sym0KindInference :: SameKind (Apply (LamCases_Singletons_EnumDeriving_4Sym0 n0) arg) (LamCases_Singletons_EnumDeriving_4Sym1 n0 arg) =>
+                                                               LamCases_Singletons_EnumDeriving_4Sym0 n0 a_Singletons_EnumDeriving_5
+    type instance Apply @_ @_ (LamCases_Singletons_EnumDeriving_4Sym0 n0) a_Singletons_EnumDeriving_5 = LamCases_Singletons_EnumDeriving_4 n0 a_Singletons_EnumDeriving_5
+    instance SuppressUnusedWarnings (LamCases_Singletons_EnumDeriving_4Sym0 n0) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 n0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 n0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_0123456789876543210 where
-      LamCases_0123456789876543210 n 'True = BazSym0
-      LamCases_0123456789876543210 n 'False = Apply (LamCases_0123456789876543210Sym0 n) (Apply (Apply (==@#@$) n) (FromInteger 2))
-    data LamCases_0123456789876543210Sym0 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_EnumDeriving_4Sym0KindInference ())
+    type family LamCases_Singletons_EnumDeriving_4Sym1 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_Singletons_EnumDeriving_5 where
+      LamCases_Singletons_EnumDeriving_4Sym1 n0 a_Singletons_EnumDeriving_5 = LamCases_Singletons_EnumDeriving_4 n0 a_Singletons_EnumDeriving_5
+    type family LamCases_Singletons_EnumDeriving_3 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_Singletons_EnumDeriving_6 where
+      LamCases_Singletons_EnumDeriving_3 n 'True = BazSym0
+      LamCases_Singletons_EnumDeriving_3 n 'False = Apply (LamCases_Singletons_EnumDeriving_4Sym0 n) (Apply (Apply (==@#@$) n) (FromInteger 2))
+    data LamCases_Singletons_EnumDeriving_3Sym0 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_Singletons_EnumDeriving_6
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 n0123456789876543210) arg) (LamCases_0123456789876543210Sym1 n0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 n0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 n0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 n0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 n0123456789876543210) where
+        LamCases_Singletons_EnumDeriving_3Sym0KindInference :: SameKind (Apply (LamCases_Singletons_EnumDeriving_3Sym0 n0) arg) (LamCases_Singletons_EnumDeriving_3Sym1 n0 arg) =>
+                                                               LamCases_Singletons_EnumDeriving_3Sym0 n0 a_Singletons_EnumDeriving_6
+    type instance Apply @_ @_ (LamCases_Singletons_EnumDeriving_3Sym0 n0) a_Singletons_EnumDeriving_6 = LamCases_Singletons_EnumDeriving_3 n0 a_Singletons_EnumDeriving_6
+    instance SuppressUnusedWarnings (LamCases_Singletons_EnumDeriving_3Sym0 n0) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 n0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 n0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_0123456789876543210 where
-      LamCases_0123456789876543210 n 'True = BarSym0
-      LamCases_0123456789876543210 n 'False = Apply (LamCases_0123456789876543210Sym0 n) (Apply (Apply (==@#@$) n) (FromInteger 1))
-    data LamCases_0123456789876543210Sym0 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_EnumDeriving_3Sym0KindInference ())
+    type family LamCases_Singletons_EnumDeriving_3Sym1 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_Singletons_EnumDeriving_6 where
+      LamCases_Singletons_EnumDeriving_3Sym1 n0 a_Singletons_EnumDeriving_6 = LamCases_Singletons_EnumDeriving_3 n0 a_Singletons_EnumDeriving_6
+    type family LamCases_Singletons_EnumDeriving_2 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_Singletons_EnumDeriving_7 where
+      LamCases_Singletons_EnumDeriving_2 n 'True = BarSym0
+      LamCases_Singletons_EnumDeriving_2 n 'False = Apply (LamCases_Singletons_EnumDeriving_3Sym0 n) (Apply (Apply (==@#@$) n) (FromInteger 1))
+    data LamCases_Singletons_EnumDeriving_2Sym0 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_Singletons_EnumDeriving_7
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 n0123456789876543210) arg) (LamCases_0123456789876543210Sym1 n0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 n0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 n0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 n0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 n0123456789876543210) where
+        LamCases_Singletons_EnumDeriving_2Sym0KindInference :: SameKind (Apply (LamCases_Singletons_EnumDeriving_2Sym0 n0) arg) (LamCases_Singletons_EnumDeriving_2Sym1 n0 arg) =>
+                                                               LamCases_Singletons_EnumDeriving_2Sym0 n0 a_Singletons_EnumDeriving_7
+    type instance Apply @_ @_ (LamCases_Singletons_EnumDeriving_2Sym0 n0) a_Singletons_EnumDeriving_7 = LamCases_Singletons_EnumDeriving_2 n0 a_Singletons_EnumDeriving_7
+    instance SuppressUnusedWarnings (LamCases_Singletons_EnumDeriving_2Sym0 n0) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 n0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 n0123456789876543210 a_01234567898765432100123456789876543210
-    type ToEnum_0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural
-                                       -> Foo
-    type family ToEnum_0123456789876543210 (a :: GHC.Internal.Bignum.Natural.Natural) :: Foo where
-      ToEnum_0123456789876543210 n = Apply (LamCases_0123456789876543210Sym0 n) (Apply (Apply (==@#@$) n) (FromInteger 0))
-    type FromEnum_0123456789876543210 :: Foo
-                                         -> GHC.Internal.Bignum.Natural.Natural
-    type family FromEnum_0123456789876543210 (a :: Foo) :: GHC.Internal.Bignum.Natural.Natural where
-      FromEnum_0123456789876543210 Bar = FromInteger 0
-      FromEnum_0123456789876543210 Baz = FromInteger 1
-      FromEnum_0123456789876543210 Bum = FromInteger 2
+        = snd ((,) LamCases_Singletons_EnumDeriving_2Sym0KindInference ())
+    type family LamCases_Singletons_EnumDeriving_2Sym1 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_Singletons_EnumDeriving_7 where
+      LamCases_Singletons_EnumDeriving_2Sym1 n0 a_Singletons_EnumDeriving_7 = LamCases_Singletons_EnumDeriving_2 n0 a_Singletons_EnumDeriving_7
+    type ToEnum_Singletons_EnumDeriving_0 :: GHC.Internal.Bignum.Natural.Natural
+                                             -> Foo
+    type family ToEnum_Singletons_EnumDeriving_0 (a :: GHC.Internal.Bignum.Natural.Natural) :: Foo where
+      ToEnum_Singletons_EnumDeriving_0 n = Apply (LamCases_Singletons_EnumDeriving_2Sym0 n) (Apply (Apply (==@#@$) n) (FromInteger 0))
+    type FromEnum_Singletons_EnumDeriving_8 :: Foo
+                                               -> GHC.Internal.Bignum.Natural.Natural
+    type family FromEnum_Singletons_EnumDeriving_8 (a :: Foo) :: GHC.Internal.Bignum.Natural.Natural where
+      FromEnum_Singletons_EnumDeriving_8 Bar = FromInteger 0
+      FromEnum_Singletons_EnumDeriving_8 Baz = FromInteger 1
+      FromEnum_Singletons_EnumDeriving_8 Bum = FromInteger 2
     instance PEnum Foo where
-      type ToEnum a = ToEnum_0123456789876543210 a
-      type FromEnum a = FromEnum_0123456789876543210 a
+      type ToEnum a = ToEnum_Singletons_EnumDeriving_0 a
+      type FromEnum a = FromEnum_Singletons_EnumDeriving_8 a
     data SFoo :: Foo -> Type
       where
         SBar :: SFoo (Bar :: Foo)
@@ -105,19 +105,19 @@ Singletons/EnumDeriving.hs:(0,0)-(0,0): Splicing declarations
       sToEnum (sN :: Sing n)
         = applySing
             (singFun1
-               @(LamCases_0123456789876543210Sym0 n)
+               @(LamCases_Singletons_EnumDeriving_2Sym0 n)
                (\cases
                   STrue -> SBar
                   SFalse
                     -> applySing
                          (singFun1
-                            @(LamCases_0123456789876543210Sym0 n)
+                            @(LamCases_Singletons_EnumDeriving_3Sym0 n)
                             (\cases
                                STrue -> SBaz
                                SFalse
                                  -> applySing
                                       (singFun1
-                                         @(LamCases_0123456789876543210Sym0 n)
+                                         @(LamCases_Singletons_EnumDeriving_4Sym0 n)
                                          (\cases
                                             STrue -> SBum
                                             SFalse
@@ -149,55 +149,55 @@ Singletons/EnumDeriving.hs:(0,0)-(0,0): Splicing declarations
 Singletons/EnumDeriving.hs:0:0:: Splicing declarations
     singEnumInstance ''Quux
   ======>
-    type family LamCases_0123456789876543210 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_0123456789876543210 where
-      LamCases_0123456789876543210 n 'True = Q2Sym0
-      LamCases_0123456789876543210 n 'False = Apply ErrorSym0 "toEnum: bad argument"
-    data LamCases_0123456789876543210Sym0 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_01234567898765432100123456789876543210
+    type family LamCases_Singletons_EnumDeriving_13 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_Singletons_EnumDeriving_14 where
+      LamCases_Singletons_EnumDeriving_13 n 'True = Q2Sym0
+      LamCases_Singletons_EnumDeriving_13 n 'False = Apply ErrorSym0 "toEnum: bad argument"
+    data LamCases_Singletons_EnumDeriving_13Sym0 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_Singletons_EnumDeriving_14
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 n0123456789876543210) arg) (LamCases_0123456789876543210Sym1 n0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 n0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 n0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 n0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 n0123456789876543210) where
+        LamCases_Singletons_EnumDeriving_13Sym0KindInference :: SameKind (Apply (LamCases_Singletons_EnumDeriving_13Sym0 n0) arg) (LamCases_Singletons_EnumDeriving_13Sym1 n0 arg) =>
+                                                                LamCases_Singletons_EnumDeriving_13Sym0 n0 a_Singletons_EnumDeriving_14
+    type instance Apply @_ @_ (LamCases_Singletons_EnumDeriving_13Sym0 n0) a_Singletons_EnumDeriving_14 = LamCases_Singletons_EnumDeriving_13 n0 a_Singletons_EnumDeriving_14
+    instance SuppressUnusedWarnings (LamCases_Singletons_EnumDeriving_13Sym0 n0) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 n0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 n0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_0123456789876543210 where
-      LamCases_0123456789876543210 n 'True = Q1Sym0
-      LamCases_0123456789876543210 n 'False = Apply (LamCases_0123456789876543210Sym0 n) (Apply (Apply (==@#@$) n) (FromInteger 1))
-    data LamCases_0123456789876543210Sym0 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_EnumDeriving_13Sym0KindInference ())
+    type family LamCases_Singletons_EnumDeriving_13Sym1 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_Singletons_EnumDeriving_14 where
+      LamCases_Singletons_EnumDeriving_13Sym1 n0 a_Singletons_EnumDeriving_14 = LamCases_Singletons_EnumDeriving_13 n0 a_Singletons_EnumDeriving_14
+    type family LamCases_Singletons_EnumDeriving_12 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_Singletons_EnumDeriving_15 where
+      LamCases_Singletons_EnumDeriving_12 n 'True = Q1Sym0
+      LamCases_Singletons_EnumDeriving_12 n 'False = Apply (LamCases_Singletons_EnumDeriving_13Sym0 n) (Apply (Apply (==@#@$) n) (FromInteger 1))
+    data LamCases_Singletons_EnumDeriving_12Sym0 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_Singletons_EnumDeriving_15
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 n0123456789876543210) arg) (LamCases_0123456789876543210Sym1 n0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 n0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 n0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 n0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 n0123456789876543210) where
+        LamCases_Singletons_EnumDeriving_12Sym0KindInference :: SameKind (Apply (LamCases_Singletons_EnumDeriving_12Sym0 n0) arg) (LamCases_Singletons_EnumDeriving_12Sym1 n0 arg) =>
+                                                                LamCases_Singletons_EnumDeriving_12Sym0 n0 a_Singletons_EnumDeriving_15
+    type instance Apply @_ @_ (LamCases_Singletons_EnumDeriving_12Sym0 n0) a_Singletons_EnumDeriving_15 = LamCases_Singletons_EnumDeriving_12 n0 a_Singletons_EnumDeriving_15
+    instance SuppressUnusedWarnings (LamCases_Singletons_EnumDeriving_12Sym0 n0) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 n0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 n0123456789876543210 a_01234567898765432100123456789876543210
-    type ToEnum_0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural
-                                       -> Quux
-    type family ToEnum_0123456789876543210 (a :: GHC.Internal.Bignum.Natural.Natural) :: Quux where
-      ToEnum_0123456789876543210 n = Apply (LamCases_0123456789876543210Sym0 n) (Apply (Apply (==@#@$) n) (FromInteger 0))
-    type FromEnum_0123456789876543210 :: Quux
-                                         -> GHC.Internal.Bignum.Natural.Natural
-    type family FromEnum_0123456789876543210 (a :: Quux) :: GHC.Internal.Bignum.Natural.Natural where
-      FromEnum_0123456789876543210 'Q1 = FromInteger 0
-      FromEnum_0123456789876543210 'Q2 = FromInteger 1
+        = snd ((,) LamCases_Singletons_EnumDeriving_12Sym0KindInference ())
+    type family LamCases_Singletons_EnumDeriving_12Sym1 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_Singletons_EnumDeriving_15 where
+      LamCases_Singletons_EnumDeriving_12Sym1 n0 a_Singletons_EnumDeriving_15 = LamCases_Singletons_EnumDeriving_12 n0 a_Singletons_EnumDeriving_15
+    type ToEnum_Singletons_EnumDeriving_10 :: GHC.Internal.Bignum.Natural.Natural
+                                              -> Quux
+    type family ToEnum_Singletons_EnumDeriving_10 (a :: GHC.Internal.Bignum.Natural.Natural) :: Quux where
+      ToEnum_Singletons_EnumDeriving_10 n = Apply (LamCases_Singletons_EnumDeriving_12Sym0 n) (Apply (Apply (==@#@$) n) (FromInteger 0))
+    type FromEnum_Singletons_EnumDeriving_16 :: Quux
+                                                -> GHC.Internal.Bignum.Natural.Natural
+    type family FromEnum_Singletons_EnumDeriving_16 (a :: Quux) :: GHC.Internal.Bignum.Natural.Natural where
+      FromEnum_Singletons_EnumDeriving_16 'Q1 = FromInteger 0
+      FromEnum_Singletons_EnumDeriving_16 'Q2 = FromInteger 1
     instance PEnum Quux where
-      type ToEnum a = ToEnum_0123456789876543210 a
-      type FromEnum a = FromEnum_0123456789876543210 a
+      type ToEnum a = ToEnum_Singletons_EnumDeriving_10 a
+      type FromEnum a = FromEnum_Singletons_EnumDeriving_16 a
     instance SEnum Quux where
       sToEnum (sN :: Sing n)
         = applySing
             (singFun1
-               @(LamCases_0123456789876543210Sym0 n)
+               @(LamCases_Singletons_EnumDeriving_12Sym0 n)
                (\cases
                   STrue -> SQ1
                   SFalse
                     -> applySing
                          (singFun1
-                            @(LamCases_0123456789876543210Sym0 n)
+                            @(LamCases_Singletons_EnumDeriving_13Sym0 n)
                             (\cases
                                STrue -> SQ2
                                SFalse

--- a/singletons-base/tests/compile-and-dump/Singletons/EqInstances.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/EqInstances.golden
@@ -1,36 +1,36 @@
 Singletons/EqInstances.hs:0:0:: Splicing declarations
     singEqInstances [''Foo, ''Empty]
   ======>
-    type TFHelper_0123456789876543210 :: Foo -> Foo -> Bool
-    type family TFHelper_0123456789876543210 (a :: Foo) (a :: Foo) :: Bool where
-      TFHelper_0123456789876543210 'FLeaf 'FLeaf = TrueSym0
-      TFHelper_0123456789876543210 'FLeaf ('(:+:) _ _) = FalseSym0
-      TFHelper_0123456789876543210 ('(:+:) _ _) 'FLeaf = FalseSym0
-      TFHelper_0123456789876543210 ('(:+:) a_0123456789876543210 a_0123456789876543210) ('(:+:) b_0123456789876543210 b_0123456789876543210) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)
+    type TFHelper_Singletons_EqInstances_4 :: Foo -> Foo -> Bool
+    type family TFHelper_Singletons_EqInstances_4 (a :: Foo) (a :: Foo) :: Bool where
+      TFHelper_Singletons_EqInstances_4 'FLeaf 'FLeaf = TrueSym0
+      TFHelper_Singletons_EqInstances_4 'FLeaf ('(:+:) _ _) = FalseSym0
+      TFHelper_Singletons_EqInstances_4 ('(:+:) _ _) 'FLeaf = FalseSym0
+      TFHelper_Singletons_EqInstances_4 ('(:+:) a_Singletons_EqInstances_0 a_Singletons_EqInstances_1) ('(:+:) b_Singletons_EqInstances_2 b_Singletons_EqInstances_3) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_Singletons_EqInstances_0) b_Singletons_EqInstances_2)) (Apply (Apply (==@#@$) a_Singletons_EqInstances_1) b_Singletons_EqInstances_3)
     instance PEq Foo where
-      type (==) a a = TFHelper_0123456789876543210 a a
+      type (==) a a = TFHelper_Singletons_EqInstances_4 a a
     instance SEq Foo => SEq Foo where
       (%==) SFLeaf SFLeaf = STrue
       (%==) SFLeaf ((:%+:) _ _) = SFalse
       (%==) ((:%+:) _ _) SFLeaf = SFalse
       (%==)
-        ((:%+:) (sA_0123456789876543210 :: Sing a_0123456789876543210)
-                (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        ((:%+:) (sB_0123456789876543210 :: Sing b_0123456789876543210)
-                (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        ((:%+:) (sA_Singletons_EqInstances_0 :: Sing a_Singletons_EqInstances_0)
+                (sA_Singletons_EqInstances_1 :: Sing a_Singletons_EqInstances_1))
+        ((:%+:) (sB_Singletons_EqInstances_2 :: Sing b_Singletons_EqInstances_2)
+                (sB_Singletons_EqInstances_3 :: Sing b_Singletons_EqInstances_3))
         = applySing
             (applySing
                (singFun2 @(&&@#@$) (%&&))
                (applySing
-                  (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                  sB_0123456789876543210))
+                  (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_EqInstances_0)
+                  sB_Singletons_EqInstances_2))
             (applySing
-               (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-               sB_0123456789876543210)
-    type TFHelper_0123456789876543210 :: Empty -> Empty -> Bool
-    type family TFHelper_0123456789876543210 (a :: Empty) (a :: Empty) :: Bool where
-      TFHelper_0123456789876543210 _ _ = TrueSym0
+               (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_EqInstances_1)
+               sB_Singletons_EqInstances_3)
+    type TFHelper_Singletons_EqInstances_7 :: Empty -> Empty -> Bool
+    type family TFHelper_Singletons_EqInstances_7 (a :: Empty) (a :: Empty) :: Bool where
+      TFHelper_Singletons_EqInstances_7 _ _ = TrueSym0
     instance PEq Empty where
-      type (==) a a = TFHelper_0123456789876543210 a a
+      type (==) a a = TFHelper_Singletons_EqInstances_7 a a
     instance SEq Empty where
       (%==) _ _ = STrue

--- a/singletons-base/tests/compile-and-dump/Singletons/Error.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Error.golden
@@ -11,13 +11,13 @@ Singletons/Error.hs:(0,0)-(0,0): Splicing declarations
     data HeadSym0 :: (~>) [a] a
       where
         HeadSym0KindInference :: SameKind (Apply HeadSym0 arg) (HeadSym1 arg) =>
-                                 HeadSym0 a0123456789876543210
-    type instance Apply @[a] @a HeadSym0 a0123456789876543210 = Head a0123456789876543210
+                                 HeadSym0 a_Singletons_Error_0
+    type instance Apply @[a] @a HeadSym0 a_Singletons_Error_0 = Head a_Singletons_Error_0
     instance SuppressUnusedWarnings HeadSym0 where
       suppressUnusedWarnings = snd ((,) HeadSym0KindInference ())
     type HeadSym1 :: [a] -> a
-    type family HeadSym1 @a (a0123456789876543210 :: [a]) :: a where
-      HeadSym1 a0123456789876543210 = Head a0123456789876543210
+    type family HeadSym1 @a (a_Singletons_Error_0 :: [a]) :: a where
+      HeadSym1 a_Singletons_Error_0 = Head a_Singletons_Error_0
     type Head :: [a] -> a
     type family Head @a (a :: [a]) :: a where
       Head ('(:) a _) = a

--- a/singletons-base/tests/compile-and-dump/Singletons/Fixity.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Fixity.golden
@@ -19,23 +19,23 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
     data (====@#@$) :: (~>) a ((~>) a a)
       where
         (:====@#@$###) :: SameKind (Apply (====@#@$) arg) ((====@#@$$) arg) =>
-                          (====@#@$) a0123456789876543210
-    type instance Apply @a @((~>) a a) (====@#@$) a0123456789876543210 = (====@#@$$) a0123456789876543210
+                          (====@#@$) a_Singletons_Fixity_0
+    type instance Apply @a @((~>) a a) (====@#@$) a_Singletons_Fixity_0 = (====@#@$$) a_Singletons_Fixity_0
     instance SuppressUnusedWarnings (====@#@$) where
       suppressUnusedWarnings = snd ((,) (:====@#@$###) ())
     infix 4 type ====@#@$
     type (====@#@$$) :: a -> (~>) a a
-    data (====@#@$$) (a0123456789876543210 :: a) :: (~>) a a
+    data (====@#@$$) (a_Singletons_Fixity_0 :: a) :: (~>) a a
       where
-        (:====@#@$$###) :: SameKind (Apply ((====@#@$$) a0123456789876543210) arg) ((====@#@$$$) a0123456789876543210 arg) =>
-                           (====@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @a @a ((====@#@$$) a0123456789876543210) a0123456789876543210 = (====) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((====@#@$$) a0123456789876543210) where
+        (:====@#@$$###) :: SameKind (Apply ((====@#@$$) a_Singletons_Fixity_0) arg) ((====@#@$$$) a_Singletons_Fixity_0 arg) =>
+                           (====@#@$$) a_Singletons_Fixity_0 a_Singletons_Fixity_1
+    type instance Apply @a @a ((====@#@$$) a_Singletons_Fixity_0) a_Singletons_Fixity_1 = (====) a_Singletons_Fixity_0 a_Singletons_Fixity_1
+    instance SuppressUnusedWarnings ((====@#@$$) a_Singletons_Fixity_0) where
       suppressUnusedWarnings = snd ((,) (:====@#@$$###) ())
     infix 4 type ====@#@$$
     type (====@#@$$$) :: a -> a -> a
-    type family (====@#@$$$) @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: a where
-      (====@#@$$$) a0123456789876543210 a0123456789876543210 = (====) a0123456789876543210 a0123456789876543210
+    type family (====@#@$$$) @a (a_Singletons_Fixity_0 :: a) (a_Singletons_Fixity_1 :: a) :: a where
+      (====@#@$$$) a_Singletons_Fixity_0 a_Singletons_Fixity_1 = (====) a_Singletons_Fixity_0 a_Singletons_Fixity_1
     infix 4 type ====@#@$$$
     type (====) :: a -> a -> a
     type family (====) @a (a :: a) (a :: a) :: a where
@@ -44,23 +44,23 @@ Singletons/Fixity.hs:(0,0)-(0,0): Splicing declarations
     data (<=>@#@$) :: (~>) a ((~>) a Ordering)
       where
         (:<=>@#@$###) :: SameKind (Apply (<=>@#@$) arg) ((<=>@#@$$) arg) =>
-                         (<=>@#@$) a0123456789876543210
-    type instance Apply @a @((~>) a Ordering) (<=>@#@$) a0123456789876543210 = (<=>@#@$$) a0123456789876543210
+                         (<=>@#@$) a_Singletons_Fixity_2
+    type instance Apply @a @((~>) a Ordering) (<=>@#@$) a_Singletons_Fixity_2 = (<=>@#@$$) a_Singletons_Fixity_2
     instance SuppressUnusedWarnings (<=>@#@$) where
       suppressUnusedWarnings = snd ((,) (:<=>@#@$###) ())
     infix 4 type <=>@#@$
     type (<=>@#@$$) :: forall a. a -> (~>) a Ordering
-    data (<=>@#@$$) (a0123456789876543210 :: a) :: (~>) a Ordering
+    data (<=>@#@$$) (a_Singletons_Fixity_2 :: a) :: (~>) a Ordering
       where
-        (:<=>@#@$$###) :: SameKind (Apply ((<=>@#@$$) a0123456789876543210) arg) ((<=>@#@$$$) a0123456789876543210 arg) =>
-                          (<=>@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @a @Ordering ((<=>@#@$$) a0123456789876543210) a0123456789876543210 = (<=>) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((<=>@#@$$) a0123456789876543210) where
+        (:<=>@#@$$###) :: SameKind (Apply ((<=>@#@$$) a_Singletons_Fixity_2) arg) ((<=>@#@$$$) a_Singletons_Fixity_2 arg) =>
+                          (<=>@#@$$) a_Singletons_Fixity_2 a_Singletons_Fixity_3
+    type instance Apply @a @Ordering ((<=>@#@$$) a_Singletons_Fixity_2) a_Singletons_Fixity_3 = (<=>) a_Singletons_Fixity_2 a_Singletons_Fixity_3
+    instance SuppressUnusedWarnings ((<=>@#@$$) a_Singletons_Fixity_2) where
       suppressUnusedWarnings = snd ((,) (:<=>@#@$$###) ())
     infix 4 type <=>@#@$$
     type (<=>@#@$$$) :: forall a. a -> a -> Ordering
-    type family (<=>@#@$$$) @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Ordering where
-      (<=>@#@$$$) a0123456789876543210 a0123456789876543210 = (<=>) a0123456789876543210 a0123456789876543210
+    type family (<=>@#@$$$) @a (a_Singletons_Fixity_2 :: a) (a_Singletons_Fixity_3 :: a) :: Ordering where
+      (<=>@#@$$$) a_Singletons_Fixity_2 a_Singletons_Fixity_3 = (<=>) a_Singletons_Fixity_2 a_Singletons_Fixity_3
     infix 4 type <=>@#@$$$
     class PMyOrd a where
       type family (<=>) (arg :: a) (arg :: a) :: Ordering

--- a/singletons-base/tests/compile-and-dump/Singletons/FunDeps.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/FunDeps.golden
@@ -27,45 +27,45 @@ Singletons/FunDeps.hs:(0,0)-(0,0): Splicing declarations
     data MethSym0 :: (~>) a a
       where
         MethSym0KindInference :: SameKind (Apply MethSym0 arg) (MethSym1 arg) =>
-                                 MethSym0 a0123456789876543210
-    type instance Apply @a @a MethSym0 a0123456789876543210 = Meth a0123456789876543210
+                                 MethSym0 a_Singletons_FunDeps_0
+    type instance Apply @a @a MethSym0 a_Singletons_FunDeps_0 = Meth a_Singletons_FunDeps_0
     instance SuppressUnusedWarnings MethSym0 where
       suppressUnusedWarnings = snd ((,) MethSym0KindInference ())
     type MethSym1 :: forall a. a -> a
-    type family MethSym1 @a (a0123456789876543210 :: a) :: a where
-      MethSym1 a0123456789876543210 = Meth a0123456789876543210
+    type family MethSym1 @a (a_Singletons_FunDeps_0 :: a) :: a where
+      MethSym1 a_Singletons_FunDeps_0 = Meth a_Singletons_FunDeps_0
     type L2rSym0 :: forall a b. (~>) a b
     data L2rSym0 :: (~>) a b
       where
         L2rSym0KindInference :: SameKind (Apply L2rSym0 arg) (L2rSym1 arg) =>
-                                L2rSym0 a0123456789876543210
-    type instance Apply @a @b L2rSym0 a0123456789876543210 = L2r a0123456789876543210
+                                L2rSym0 a_Singletons_FunDeps_1
+    type instance Apply @a @b L2rSym0 a_Singletons_FunDeps_1 = L2r a_Singletons_FunDeps_1
     instance SuppressUnusedWarnings L2rSym0 where
       suppressUnusedWarnings = snd ((,) L2rSym0KindInference ())
     type L2rSym1 :: forall a b. a -> b
-    type family L2rSym1 @a @b (a0123456789876543210 :: a) :: b where
-      L2rSym1 a0123456789876543210 = L2r a0123456789876543210
+    type family L2rSym1 @a @b (a_Singletons_FunDeps_1 :: a) :: b where
+      L2rSym1 a_Singletons_FunDeps_1 = L2r a_Singletons_FunDeps_1
     class PFD a b | a -> b where
       type family Meth (arg :: a) :: a
       type family L2r (arg :: a) :: b
-    type Meth_0123456789876543210 :: Bool -> Bool
-    type family Meth_0123456789876543210 (a :: Bool) :: Bool where
-      Meth_0123456789876543210 a_0123456789876543210 = Apply NotSym0 a_0123456789876543210
-    type L2r_0123456789876543210 :: Bool -> Natural
-    type family L2r_0123456789876543210 (a :: Bool) :: Natural where
-      L2r_0123456789876543210 'False = FromInteger 0
-      L2r_0123456789876543210 'True = FromInteger 1
+    type Meth_Singletons_FunDeps_2 :: Bool -> Bool
+    type family Meth_Singletons_FunDeps_2 (a :: Bool) :: Bool where
+      Meth_Singletons_FunDeps_2 a_Singletons_FunDeps_3 = Apply NotSym0 a_Singletons_FunDeps_3
+    type L2r_Singletons_FunDeps_5 :: Bool -> Natural
+    type family L2r_Singletons_FunDeps_5 (a :: Bool) :: Natural where
+      L2r_Singletons_FunDeps_5 'False = FromInteger 0
+      L2r_Singletons_FunDeps_5 'True = FromInteger 1
     instance PFD Bool Natural where
-      type Meth a = Meth_0123456789876543210 a
-      type L2r a = L2r_0123456789876543210 a
+      type Meth a = Meth_Singletons_FunDeps_2 a
+      type L2r a = L2r_Singletons_FunDeps_5 a
     sT1 :: Sing @_ T1
     sT1 = applySing (singFun1 @MethSym0 sMeth) STrue
     class SFD a b | a -> b where
       sMeth :: (forall (t :: a). Sing t -> Sing (Meth t :: a) :: Type)
       sL2r :: (forall (t :: a). Sing t -> Sing (L2r t :: b) :: Type)
     instance SFD Bool Natural where
-      sMeth (sA_0123456789876543210 :: Sing a_0123456789876543210)
-        = applySing (singFun1 @NotSym0 sNot) sA_0123456789876543210
+      sMeth (sA_Singletons_FunDeps_3 :: Sing a_Singletons_FunDeps_3)
+        = applySing (singFun1 @NotSym0 sNot) sA_Singletons_FunDeps_3
       sL2r SFalse = sFromInteger (sing :: Sing 0)
       sL2r STrue = sFromInteger (sing :: Sing 1)
     instance SFD a b => SingI (MethSym0 :: (~>) a a) where

--- a/singletons-base/tests/compile-and-dump/Singletons/FunctorLikeDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/FunctorLikeDeriving.golden
@@ -14,325 +14,328 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
     data MkT1Sym0 :: (~>) x ((~>) a ((~>) (Maybe a) ((~>) (Maybe (Maybe a)) (T x a))))
       where
         MkT1Sym0KindInference :: SameKind (Apply MkT1Sym0 arg) (MkT1Sym1 arg) =>
-                                 MkT1Sym0 a0123456789876543210
-    type instance Apply @x @((~>) a ((~>) (Maybe a) ((~>) (Maybe (Maybe a)) (T x a)))) MkT1Sym0 a0123456789876543210 = MkT1Sym1 a0123456789876543210
+                                 MkT1Sym0 a_FunctorLikeDeriving_50
+    type instance Apply @x @((~>) a ((~>) (Maybe a) ((~>) (Maybe (Maybe a)) (T x a)))) MkT1Sym0 a_FunctorLikeDeriving_50 = MkT1Sym1 a_FunctorLikeDeriving_50
     instance SuppressUnusedWarnings MkT1Sym0 where
       suppressUnusedWarnings = snd ((,) MkT1Sym0KindInference ())
     type MkT1Sym1 :: forall x a. x
                                  -> (~>) a ((~>) (Maybe a) ((~>) (Maybe (Maybe a)) (T x a)))
-    data MkT1Sym1 (a0123456789876543210 :: x) :: (~>) a ((~>) (Maybe a) ((~>) (Maybe (Maybe a)) (T x a)))
+    data MkT1Sym1 (a_FunctorLikeDeriving_50 :: x) :: (~>) a ((~>) (Maybe a) ((~>) (Maybe (Maybe a)) (T x a)))
       where
-        MkT1Sym1KindInference :: SameKind (Apply (MkT1Sym1 a0123456789876543210) arg) (MkT1Sym2 a0123456789876543210 arg) =>
-                                 MkT1Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @a @((~>) (Maybe a) ((~>) (Maybe (Maybe a)) (T x a))) (MkT1Sym1 a0123456789876543210) a0123456789876543210 = MkT1Sym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (MkT1Sym1 a0123456789876543210) where
+        MkT1Sym1KindInference :: SameKind (Apply (MkT1Sym1 a_FunctorLikeDeriving_50) arg) (MkT1Sym2 a_FunctorLikeDeriving_50 arg) =>
+                                 MkT1Sym1 a_FunctorLikeDeriving_50 a_FunctorLikeDeriving_51
+    type instance Apply @a @((~>) (Maybe a) ((~>) (Maybe (Maybe a)) (T x a))) (MkT1Sym1 a_FunctorLikeDeriving_50) a_FunctorLikeDeriving_51 = MkT1Sym2 a_FunctorLikeDeriving_50 a_FunctorLikeDeriving_51
+    instance SuppressUnusedWarnings (MkT1Sym1 a_FunctorLikeDeriving_50) where
       suppressUnusedWarnings = snd ((,) MkT1Sym1KindInference ())
     type MkT1Sym2 :: forall x a. x
                                  -> a -> (~>) (Maybe a) ((~>) (Maybe (Maybe a)) (T x a))
-    data MkT1Sym2 (a0123456789876543210 :: x) (a0123456789876543210 :: a) :: (~>) (Maybe a) ((~>) (Maybe (Maybe a)) (T x a))
+    data MkT1Sym2 (a_FunctorLikeDeriving_50 :: x) (a_FunctorLikeDeriving_51 :: a) :: (~>) (Maybe a) ((~>) (Maybe (Maybe a)) (T x a))
       where
-        MkT1Sym2KindInference :: SameKind (Apply (MkT1Sym2 a0123456789876543210 a0123456789876543210) arg) (MkT1Sym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                 MkT1Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Maybe a) @((~>) (Maybe (Maybe a)) (T x a)) (MkT1Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = MkT1Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (MkT1Sym2 a0123456789876543210 a0123456789876543210) where
+        MkT1Sym2KindInference :: SameKind (Apply (MkT1Sym2 a_FunctorLikeDeriving_50 a_FunctorLikeDeriving_51) arg) (MkT1Sym3 a_FunctorLikeDeriving_50 a_FunctorLikeDeriving_51 arg) =>
+                                 MkT1Sym2 a_FunctorLikeDeriving_50 a_FunctorLikeDeriving_51 a_FunctorLikeDeriving_52
+    type instance Apply @(Maybe a) @((~>) (Maybe (Maybe a)) (T x a)) (MkT1Sym2 a_FunctorLikeDeriving_50 a_FunctorLikeDeriving_51) a_FunctorLikeDeriving_52 = MkT1Sym3 a_FunctorLikeDeriving_50 a_FunctorLikeDeriving_51 a_FunctorLikeDeriving_52
+    instance SuppressUnusedWarnings (MkT1Sym2 a_FunctorLikeDeriving_50 a_FunctorLikeDeriving_51) where
       suppressUnusedWarnings = snd ((,) MkT1Sym2KindInference ())
     type MkT1Sym3 :: forall x a. x
                                  -> a -> Maybe a -> (~>) (Maybe (Maybe a)) (T x a)
-    data MkT1Sym3 (a0123456789876543210 :: x) (a0123456789876543210 :: a) (a0123456789876543210 :: Maybe a) :: (~>) (Maybe (Maybe a)) (T x a)
+    data MkT1Sym3 (a_FunctorLikeDeriving_50 :: x) (a_FunctorLikeDeriving_51 :: a) (a_FunctorLikeDeriving_52 :: Maybe a) :: (~>) (Maybe (Maybe a)) (T x a)
       where
-        MkT1Sym3KindInference :: SameKind (Apply (MkT1Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) arg) (MkT1Sym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 arg) =>
-                                 MkT1Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Maybe (Maybe a)) @(T x a) (MkT1Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) a0123456789876543210 = MkT1 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (MkT1Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) where
+        MkT1Sym3KindInference :: SameKind (Apply (MkT1Sym3 a_FunctorLikeDeriving_50 a_FunctorLikeDeriving_51 a_FunctorLikeDeriving_52) arg) (MkT1Sym4 a_FunctorLikeDeriving_50 a_FunctorLikeDeriving_51 a_FunctorLikeDeriving_52 arg) =>
+                                 MkT1Sym3 a_FunctorLikeDeriving_50 a_FunctorLikeDeriving_51 a_FunctorLikeDeriving_52 a_FunctorLikeDeriving_53
+    type instance Apply @(Maybe (Maybe a)) @(T x a) (MkT1Sym3 a_FunctorLikeDeriving_50 a_FunctorLikeDeriving_51 a_FunctorLikeDeriving_52) a_FunctorLikeDeriving_53 = MkT1 a_FunctorLikeDeriving_50 a_FunctorLikeDeriving_51 a_FunctorLikeDeriving_52 a_FunctorLikeDeriving_53
+    instance SuppressUnusedWarnings (MkT1Sym3 a_FunctorLikeDeriving_50 a_FunctorLikeDeriving_51 a_FunctorLikeDeriving_52) where
       suppressUnusedWarnings = snd ((,) MkT1Sym3KindInference ())
     type MkT1Sym4 :: forall x a. x
                                  -> a -> Maybe a -> Maybe (Maybe a) -> T x a
-    type family MkT1Sym4 @x @a (a0123456789876543210 :: x) (a0123456789876543210 :: a) (a0123456789876543210 :: Maybe a) (a0123456789876543210 :: Maybe (Maybe a)) :: T x a where
-      MkT1Sym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 = MkT1 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type family MkT1Sym4 @x @a (a_FunctorLikeDeriving_50 :: x) (a_FunctorLikeDeriving_51 :: a) (a_FunctorLikeDeriving_52 :: Maybe a) (a_FunctorLikeDeriving_53 :: Maybe (Maybe a)) :: T x a where
+      MkT1Sym4 a_FunctorLikeDeriving_50 a_FunctorLikeDeriving_51 a_FunctorLikeDeriving_52 a_FunctorLikeDeriving_53 = MkT1 a_FunctorLikeDeriving_50 a_FunctorLikeDeriving_51 a_FunctorLikeDeriving_52 a_FunctorLikeDeriving_53
     type MkT2Sym0 :: forall x a. (~>) (Maybe x) (T x a)
     data MkT2Sym0 :: (~>) (Maybe x) (T x a)
       where
         MkT2Sym0KindInference :: SameKind (Apply MkT2Sym0 arg) (MkT2Sym1 arg) =>
-                                 MkT2Sym0 a0123456789876543210
-    type instance Apply @(Maybe x) @(T x a) MkT2Sym0 a0123456789876543210 = MkT2 a0123456789876543210
+                                 MkT2Sym0 a_FunctorLikeDeriving_54
+    type instance Apply @(Maybe x) @(T x a) MkT2Sym0 a_FunctorLikeDeriving_54 = MkT2 a_FunctorLikeDeriving_54
     instance SuppressUnusedWarnings MkT2Sym0 where
       suppressUnusedWarnings = snd ((,) MkT2Sym0KindInference ())
     type MkT2Sym1 :: forall x a. Maybe x -> T x a
-    type family MkT2Sym1 @x @a (a0123456789876543210 :: Maybe x) :: T x a where
-      MkT2Sym1 a0123456789876543210 = MkT2 a0123456789876543210
-    type family LamCases_0123456789876543210 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 b0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 x _f_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 n_0123456789876543210 = n_0123456789876543210
-    data LamCases_0123456789876543210Sym0 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 b0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+    type family MkT2Sym1 @x @a (a_FunctorLikeDeriving_54 :: Maybe x) :: T x a where
+      MkT2Sym1 a_FunctorLikeDeriving_54 = MkT2 a_FunctorLikeDeriving_54
+    type family LamCases_FunctorLikeDeriving_58 x0 (_f_FunctorLikeDeriving_03 :: (~>) a1 b2) a_FunctorLikeDeriving_34 a_FunctorLikeDeriving_45 a_FunctorLikeDeriving_56 a_FunctorLikeDeriving_67 a_FunctorLikeDeriving_59 where
+      LamCases_FunctorLikeDeriving_58 x _f_FunctorLikeDeriving_0 a_FunctorLikeDeriving_3 a_FunctorLikeDeriving_4 a_FunctorLikeDeriving_5 a_FunctorLikeDeriving_6 n_FunctorLikeDeriving_2 = n_FunctorLikeDeriving_2
+    data LamCases_FunctorLikeDeriving_58Sym0 x0 (_f_FunctorLikeDeriving_03 :: (~>) a1 b2) a_FunctorLikeDeriving_34 a_FunctorLikeDeriving_45 a_FunctorLikeDeriving_56 a_FunctorLikeDeriving_67 a_FunctorLikeDeriving_59
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
+        LamCases_FunctorLikeDeriving_58Sym0KindInference :: SameKind (Apply (LamCases_FunctorLikeDeriving_58Sym0 x0 _f_FunctorLikeDeriving_03 a_FunctorLikeDeriving_34 a_FunctorLikeDeriving_45 a_FunctorLikeDeriving_56 a_FunctorLikeDeriving_67) arg) (LamCases_FunctorLikeDeriving_58Sym1 x0 _f_FunctorLikeDeriving_03 a_FunctorLikeDeriving_34 a_FunctorLikeDeriving_45 a_FunctorLikeDeriving_56 a_FunctorLikeDeriving_67 arg) =>
+                                                            LamCases_FunctorLikeDeriving_58Sym0 x0 _f_FunctorLikeDeriving_03 a_FunctorLikeDeriving_34 a_FunctorLikeDeriving_45 a_FunctorLikeDeriving_56 a_FunctorLikeDeriving_67 a_FunctorLikeDeriving_59
+    type instance Apply @_ @_ (LamCases_FunctorLikeDeriving_58Sym0 x0 _f_FunctorLikeDeriving_03 a_FunctorLikeDeriving_34 a_FunctorLikeDeriving_45 a_FunctorLikeDeriving_56 a_FunctorLikeDeriving_67) a_FunctorLikeDeriving_59 = LamCases_FunctorLikeDeriving_58 x0 _f_FunctorLikeDeriving_03 a_FunctorLikeDeriving_34 a_FunctorLikeDeriving_45 a_FunctorLikeDeriving_56 a_FunctorLikeDeriving_67 a_FunctorLikeDeriving_59
+    instance SuppressUnusedWarnings (LamCases_FunctorLikeDeriving_58Sym0 x0 _f_FunctorLikeDeriving_03 a_FunctorLikeDeriving_34 a_FunctorLikeDeriving_45 a_FunctorLikeDeriving_56 a_FunctorLikeDeriving_67) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 b0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 b0123456789876543210) a_01234567898765432100123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 x _f_0123456789876543210 a_0123456789876543210 n_0123456789876543210 = n_0123456789876543210
-    data LamCases_0123456789876543210Sym0 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 b0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_FunctorLikeDeriving_58Sym0KindInference ())
+    type family LamCases_FunctorLikeDeriving_58Sym1 x0 (_f_FunctorLikeDeriving_03 :: (~>) a1 b2) a_FunctorLikeDeriving_34 a_FunctorLikeDeriving_45 a_FunctorLikeDeriving_56 a_FunctorLikeDeriving_67 a_FunctorLikeDeriving_59 where
+      LamCases_FunctorLikeDeriving_58Sym1 x0 _f_FunctorLikeDeriving_03 a_FunctorLikeDeriving_34 a_FunctorLikeDeriving_45 a_FunctorLikeDeriving_56 a_FunctorLikeDeriving_67 a_FunctorLikeDeriving_59 = LamCases_FunctorLikeDeriving_58 x0 _f_FunctorLikeDeriving_03 a_FunctorLikeDeriving_34 a_FunctorLikeDeriving_45 a_FunctorLikeDeriving_56 a_FunctorLikeDeriving_67 a_FunctorLikeDeriving_59
+    type family LamCases_FunctorLikeDeriving_60 x0 (_f_FunctorLikeDeriving_03 :: (~>) a1 b2) a_FunctorLikeDeriving_84 a_FunctorLikeDeriving_61 where
+      LamCases_FunctorLikeDeriving_60 x _f_FunctorLikeDeriving_0 a_FunctorLikeDeriving_8 n_FunctorLikeDeriving_7 = n_FunctorLikeDeriving_7
+    data LamCases_FunctorLikeDeriving_60Sym0 x0 (_f_FunctorLikeDeriving_03 :: (~>) a1 b2) a_FunctorLikeDeriving_84 a_FunctorLikeDeriving_61
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
+        LamCases_FunctorLikeDeriving_60Sym0KindInference :: SameKind (Apply (LamCases_FunctorLikeDeriving_60Sym0 x0 _f_FunctorLikeDeriving_03 a_FunctorLikeDeriving_84) arg) (LamCases_FunctorLikeDeriving_60Sym1 x0 _f_FunctorLikeDeriving_03 a_FunctorLikeDeriving_84 arg) =>
+                                                            LamCases_FunctorLikeDeriving_60Sym0 x0 _f_FunctorLikeDeriving_03 a_FunctorLikeDeriving_84 a_FunctorLikeDeriving_61
+    type instance Apply @_ @_ (LamCases_FunctorLikeDeriving_60Sym0 x0 _f_FunctorLikeDeriving_03 a_FunctorLikeDeriving_84) a_FunctorLikeDeriving_61 = LamCases_FunctorLikeDeriving_60 x0 _f_FunctorLikeDeriving_03 a_FunctorLikeDeriving_84 a_FunctorLikeDeriving_61
+    instance SuppressUnusedWarnings (LamCases_FunctorLikeDeriving_60Sym0 x0 _f_FunctorLikeDeriving_03 a_FunctorLikeDeriving_84) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 b0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type Fmap_0123456789876543210 :: forall x a b. (~>) a b
-                                                   -> T x a -> T x b
-    type family Fmap_0123456789876543210 @x @a @b (a :: (~>) a b) (a :: T x a) :: T x b where
-      Fmap_0123456789876543210 @x @a @b (_f_0123456789876543210 :: (~>) a b) (MkT1 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 :: T x a) = Apply (Apply (Apply (Apply MkT1Sym0 (Apply (LamCases_0123456789876543210Sym0 x _f_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210) a_0123456789876543210)) (Apply _f_0123456789876543210 a_0123456789876543210)) (Apply (Apply FmapSym0 _f_0123456789876543210) a_0123456789876543210)) (Apply (Apply FmapSym0 (Apply FmapSym0 _f_0123456789876543210)) a_0123456789876543210)
-      Fmap_0123456789876543210 @x @a @b (_f_0123456789876543210 :: (~>) a b) (MkT2 a_0123456789876543210 :: T x a) = Apply MkT2Sym0 (Apply (LamCases_0123456789876543210Sym0 x _f_0123456789876543210 a_0123456789876543210) a_0123456789876543210)
-    type family LamCases_0123456789876543210 x0123456789876543210 (_z_01234567898765432100123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 x _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 n_0123456789876543210 = n_0123456789876543210
-    data LamCases_0123456789876543210Sym0 x0123456789876543210 (_z_01234567898765432100123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_FunctorLikeDeriving_60Sym0KindInference ())
+    type family LamCases_FunctorLikeDeriving_60Sym1 x0 (_f_FunctorLikeDeriving_03 :: (~>) a1 b2) a_FunctorLikeDeriving_84 a_FunctorLikeDeriving_61 where
+      LamCases_FunctorLikeDeriving_60Sym1 x0 _f_FunctorLikeDeriving_03 a_FunctorLikeDeriving_84 a_FunctorLikeDeriving_61 = LamCases_FunctorLikeDeriving_60 x0 _f_FunctorLikeDeriving_03 a_FunctorLikeDeriving_84 a_FunctorLikeDeriving_61
+    type Fmap_FunctorLikeDeriving_55 :: forall x a b. (~>) a b
+                                                      -> T x a -> T x b
+    type family Fmap_FunctorLikeDeriving_55 @x @a @b (a :: (~>) a b) (a :: T x a) :: T x b where
+      Fmap_FunctorLikeDeriving_55 @x @a @b (_f_FunctorLikeDeriving_0 :: (~>) a b) (MkT1 a_FunctorLikeDeriving_3 a_FunctorLikeDeriving_4 a_FunctorLikeDeriving_5 a_FunctorLikeDeriving_6 :: T x a) = Apply (Apply (Apply (Apply MkT1Sym0 (Apply (LamCases_FunctorLikeDeriving_58Sym0 x _f_FunctorLikeDeriving_0 a_FunctorLikeDeriving_3 a_FunctorLikeDeriving_4 a_FunctorLikeDeriving_5 a_FunctorLikeDeriving_6) a_FunctorLikeDeriving_3)) (Apply _f_FunctorLikeDeriving_0 a_FunctorLikeDeriving_4)) (Apply (Apply FmapSym0 _f_FunctorLikeDeriving_0) a_FunctorLikeDeriving_5)) (Apply (Apply FmapSym0 (Apply FmapSym0 _f_FunctorLikeDeriving_0)) a_FunctorLikeDeriving_6)
+      Fmap_FunctorLikeDeriving_55 @x @a @b (_f_FunctorLikeDeriving_0 :: (~>) a b) (MkT2 a_FunctorLikeDeriving_8 :: T x a) = Apply MkT2Sym0 (Apply (LamCases_FunctorLikeDeriving_60Sym0 x _f_FunctorLikeDeriving_0 a_FunctorLikeDeriving_8) a_FunctorLikeDeriving_8)
+    type family LamCases_FunctorLikeDeriving_65 x0 (_z_FunctorLikeDeriving_12 :: a1) a_FunctorLikeDeriving_103 a_FunctorLikeDeriving_114 a_FunctorLikeDeriving_125 a_FunctorLikeDeriving_136 a_FunctorLikeDeriving_66 where
+      LamCases_FunctorLikeDeriving_65 x _z_FunctorLikeDeriving_1 a_FunctorLikeDeriving_10 a_FunctorLikeDeriving_11 a_FunctorLikeDeriving_12 a_FunctorLikeDeriving_13 n_FunctorLikeDeriving_9 = n_FunctorLikeDeriving_9
+    data LamCases_FunctorLikeDeriving_65Sym0 x0 (_z_FunctorLikeDeriving_12 :: a1) a_FunctorLikeDeriving_103 a_FunctorLikeDeriving_114 a_FunctorLikeDeriving_125 a_FunctorLikeDeriving_136 a_FunctorLikeDeriving_66
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
+        LamCases_FunctorLikeDeriving_65Sym0KindInference :: SameKind (Apply (LamCases_FunctorLikeDeriving_65Sym0 x0 _z_FunctorLikeDeriving_12 a_FunctorLikeDeriving_103 a_FunctorLikeDeriving_114 a_FunctorLikeDeriving_125 a_FunctorLikeDeriving_136) arg) (LamCases_FunctorLikeDeriving_65Sym1 x0 _z_FunctorLikeDeriving_12 a_FunctorLikeDeriving_103 a_FunctorLikeDeriving_114 a_FunctorLikeDeriving_125 a_FunctorLikeDeriving_136 arg) =>
+                                                            LamCases_FunctorLikeDeriving_65Sym0 x0 _z_FunctorLikeDeriving_12 a_FunctorLikeDeriving_103 a_FunctorLikeDeriving_114 a_FunctorLikeDeriving_125 a_FunctorLikeDeriving_136 a_FunctorLikeDeriving_66
+    type instance Apply @_ @_ (LamCases_FunctorLikeDeriving_65Sym0 x0 _z_FunctorLikeDeriving_12 a_FunctorLikeDeriving_103 a_FunctorLikeDeriving_114 a_FunctorLikeDeriving_125 a_FunctorLikeDeriving_136) a_FunctorLikeDeriving_66 = LamCases_FunctorLikeDeriving_65 x0 _z_FunctorLikeDeriving_12 a_FunctorLikeDeriving_103 a_FunctorLikeDeriving_114 a_FunctorLikeDeriving_125 a_FunctorLikeDeriving_136 a_FunctorLikeDeriving_66
+    instance SuppressUnusedWarnings (LamCases_FunctorLikeDeriving_65Sym0 x0 _z_FunctorLikeDeriving_12 a_FunctorLikeDeriving_103 a_FunctorLikeDeriving_114 a_FunctorLikeDeriving_125 a_FunctorLikeDeriving_136) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 x0123456789876543210 (_z_01234567898765432100123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 x0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 x0123456789876543210 (_z_01234567898765432100123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 x _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 _ = _z_0123456789876543210
-    data LamCases_0123456789876543210Sym0 x0123456789876543210 (_z_01234567898765432100123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_FunctorLikeDeriving_65Sym0KindInference ())
+    type family LamCases_FunctorLikeDeriving_65Sym1 x0 (_z_FunctorLikeDeriving_12 :: a1) a_FunctorLikeDeriving_103 a_FunctorLikeDeriving_114 a_FunctorLikeDeriving_125 a_FunctorLikeDeriving_136 a_FunctorLikeDeriving_66 where
+      LamCases_FunctorLikeDeriving_65Sym1 x0 _z_FunctorLikeDeriving_12 a_FunctorLikeDeriving_103 a_FunctorLikeDeriving_114 a_FunctorLikeDeriving_125 a_FunctorLikeDeriving_136 a_FunctorLikeDeriving_66 = LamCases_FunctorLikeDeriving_65 x0 _z_FunctorLikeDeriving_12 a_FunctorLikeDeriving_103 a_FunctorLikeDeriving_114 a_FunctorLikeDeriving_125 a_FunctorLikeDeriving_136 a_FunctorLikeDeriving_66
+    type family LamCases_FunctorLikeDeriving_67 x0 (_z_FunctorLikeDeriving_12 :: a1) a_FunctorLikeDeriving_103 a_FunctorLikeDeriving_114 a_FunctorLikeDeriving_125 a_FunctorLikeDeriving_136 a_FunctorLikeDeriving_68 where
+      LamCases_FunctorLikeDeriving_67 x _z_FunctorLikeDeriving_1 a_FunctorLikeDeriving_10 a_FunctorLikeDeriving_11 a_FunctorLikeDeriving_12 a_FunctorLikeDeriving_13 _ = _z_FunctorLikeDeriving_1
+    data LamCases_FunctorLikeDeriving_67Sym0 x0 (_z_FunctorLikeDeriving_12 :: a1) a_FunctorLikeDeriving_103 a_FunctorLikeDeriving_114 a_FunctorLikeDeriving_125 a_FunctorLikeDeriving_136 a_FunctorLikeDeriving_68
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
+        LamCases_FunctorLikeDeriving_67Sym0KindInference :: SameKind (Apply (LamCases_FunctorLikeDeriving_67Sym0 x0 _z_FunctorLikeDeriving_12 a_FunctorLikeDeriving_103 a_FunctorLikeDeriving_114 a_FunctorLikeDeriving_125 a_FunctorLikeDeriving_136) arg) (LamCases_FunctorLikeDeriving_67Sym1 x0 _z_FunctorLikeDeriving_12 a_FunctorLikeDeriving_103 a_FunctorLikeDeriving_114 a_FunctorLikeDeriving_125 a_FunctorLikeDeriving_136 arg) =>
+                                                            LamCases_FunctorLikeDeriving_67Sym0 x0 _z_FunctorLikeDeriving_12 a_FunctorLikeDeriving_103 a_FunctorLikeDeriving_114 a_FunctorLikeDeriving_125 a_FunctorLikeDeriving_136 a_FunctorLikeDeriving_68
+    type instance Apply @_ @_ (LamCases_FunctorLikeDeriving_67Sym0 x0 _z_FunctorLikeDeriving_12 a_FunctorLikeDeriving_103 a_FunctorLikeDeriving_114 a_FunctorLikeDeriving_125 a_FunctorLikeDeriving_136) a_FunctorLikeDeriving_68 = LamCases_FunctorLikeDeriving_67 x0 _z_FunctorLikeDeriving_12 a_FunctorLikeDeriving_103 a_FunctorLikeDeriving_114 a_FunctorLikeDeriving_125 a_FunctorLikeDeriving_136 a_FunctorLikeDeriving_68
+    instance SuppressUnusedWarnings (LamCases_FunctorLikeDeriving_67Sym0 x0 _z_FunctorLikeDeriving_12 a_FunctorLikeDeriving_103 a_FunctorLikeDeriving_114 a_FunctorLikeDeriving_125 a_FunctorLikeDeriving_136) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 x0123456789876543210 (_z_01234567898765432100123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 x0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 x0123456789876543210 (_z_01234567898765432100123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 x _z_0123456789876543210 a_0123456789876543210 n_0123456789876543210 = n_0123456789876543210
-    data LamCases_0123456789876543210Sym0 x0123456789876543210 (_z_01234567898765432100123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_FunctorLikeDeriving_67Sym0KindInference ())
+    type family LamCases_FunctorLikeDeriving_67Sym1 x0 (_z_FunctorLikeDeriving_12 :: a1) a_FunctorLikeDeriving_103 a_FunctorLikeDeriving_114 a_FunctorLikeDeriving_125 a_FunctorLikeDeriving_136 a_FunctorLikeDeriving_68 where
+      LamCases_FunctorLikeDeriving_67Sym1 x0 _z_FunctorLikeDeriving_12 a_FunctorLikeDeriving_103 a_FunctorLikeDeriving_114 a_FunctorLikeDeriving_125 a_FunctorLikeDeriving_136 a_FunctorLikeDeriving_68 = LamCases_FunctorLikeDeriving_67 x0 _z_FunctorLikeDeriving_12 a_FunctorLikeDeriving_103 a_FunctorLikeDeriving_114 a_FunctorLikeDeriving_125 a_FunctorLikeDeriving_136 a_FunctorLikeDeriving_68
+    type family LamCases_FunctorLikeDeriving_69 x0 (_z_FunctorLikeDeriving_12 :: a1) a_FunctorLikeDeriving_153 a_FunctorLikeDeriving_70 where
+      LamCases_FunctorLikeDeriving_69 x _z_FunctorLikeDeriving_1 a_FunctorLikeDeriving_15 n_FunctorLikeDeriving_14 = n_FunctorLikeDeriving_14
+    data LamCases_FunctorLikeDeriving_69Sym0 x0 (_z_FunctorLikeDeriving_12 :: a1) a_FunctorLikeDeriving_153 a_FunctorLikeDeriving_70
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
+        LamCases_FunctorLikeDeriving_69Sym0KindInference :: SameKind (Apply (LamCases_FunctorLikeDeriving_69Sym0 x0 _z_FunctorLikeDeriving_12 a_FunctorLikeDeriving_153) arg) (LamCases_FunctorLikeDeriving_69Sym1 x0 _z_FunctorLikeDeriving_12 a_FunctorLikeDeriving_153 arg) =>
+                                                            LamCases_FunctorLikeDeriving_69Sym0 x0 _z_FunctorLikeDeriving_12 a_FunctorLikeDeriving_153 a_FunctorLikeDeriving_70
+    type instance Apply @_ @_ (LamCases_FunctorLikeDeriving_69Sym0 x0 _z_FunctorLikeDeriving_12 a_FunctorLikeDeriving_153) a_FunctorLikeDeriving_70 = LamCases_FunctorLikeDeriving_69 x0 _z_FunctorLikeDeriving_12 a_FunctorLikeDeriving_153 a_FunctorLikeDeriving_70
+    instance SuppressUnusedWarnings (LamCases_FunctorLikeDeriving_69Sym0 x0 _z_FunctorLikeDeriving_12 a_FunctorLikeDeriving_153) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 x0123456789876543210 (_z_01234567898765432100123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 x0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type TFHelper_0123456789876543210 :: forall x a b. a
-                                                       -> T x b -> T x a
-    type family TFHelper_0123456789876543210 @x @a @b (a :: a) (a :: T x b) :: T x a where
-      TFHelper_0123456789876543210 @x @a @b (_z_0123456789876543210 :: a) (MkT1 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 :: T x b) = Apply (Apply (Apply (Apply MkT1Sym0 (Apply (LamCases_0123456789876543210Sym0 x _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210) a_0123456789876543210)) (Apply (LamCases_0123456789876543210Sym0 x _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210) a_0123456789876543210)) (Apply (Apply (<$@#@$) _z_0123456789876543210) a_0123456789876543210)) (Apply (Apply FmapSym0 (Apply (<$@#@$) _z_0123456789876543210)) a_0123456789876543210)
-      TFHelper_0123456789876543210 @x @a @b (_z_0123456789876543210 :: a) (MkT2 a_0123456789876543210 :: T x b) = Apply MkT2Sym0 (Apply (LamCases_0123456789876543210Sym0 x _z_0123456789876543210 a_0123456789876543210) a_0123456789876543210)
+        = snd ((,) LamCases_FunctorLikeDeriving_69Sym0KindInference ())
+    type family LamCases_FunctorLikeDeriving_69Sym1 x0 (_z_FunctorLikeDeriving_12 :: a1) a_FunctorLikeDeriving_153 a_FunctorLikeDeriving_70 where
+      LamCases_FunctorLikeDeriving_69Sym1 x0 _z_FunctorLikeDeriving_12 a_FunctorLikeDeriving_153 a_FunctorLikeDeriving_70 = LamCases_FunctorLikeDeriving_69 x0 _z_FunctorLikeDeriving_12 a_FunctorLikeDeriving_153 a_FunctorLikeDeriving_70
+    type TFHelper_FunctorLikeDeriving_62 :: forall x a b. a
+                                                          -> T x b -> T x a
+    type family TFHelper_FunctorLikeDeriving_62 @x @a @b (a :: a) (a :: T x b) :: T x a where
+      TFHelper_FunctorLikeDeriving_62 @x @a @b (_z_FunctorLikeDeriving_1 :: a) (MkT1 a_FunctorLikeDeriving_10 a_FunctorLikeDeriving_11 a_FunctorLikeDeriving_12 a_FunctorLikeDeriving_13 :: T x b) = Apply (Apply (Apply (Apply MkT1Sym0 (Apply (LamCases_FunctorLikeDeriving_65Sym0 x _z_FunctorLikeDeriving_1 a_FunctorLikeDeriving_10 a_FunctorLikeDeriving_11 a_FunctorLikeDeriving_12 a_FunctorLikeDeriving_13) a_FunctorLikeDeriving_10)) (Apply (LamCases_FunctorLikeDeriving_67Sym0 x _z_FunctorLikeDeriving_1 a_FunctorLikeDeriving_10 a_FunctorLikeDeriving_11 a_FunctorLikeDeriving_12 a_FunctorLikeDeriving_13) a_FunctorLikeDeriving_11)) (Apply (Apply (<$@#@$) _z_FunctorLikeDeriving_1) a_FunctorLikeDeriving_12)) (Apply (Apply FmapSym0 (Apply (<$@#@$) _z_FunctorLikeDeriving_1)) a_FunctorLikeDeriving_13)
+      TFHelper_FunctorLikeDeriving_62 @x @a @b (_z_FunctorLikeDeriving_1 :: a) (MkT2 a_FunctorLikeDeriving_15 :: T x b) = Apply MkT2Sym0 (Apply (LamCases_FunctorLikeDeriving_69Sym0 x _z_FunctorLikeDeriving_1 a_FunctorLikeDeriving_15) a_FunctorLikeDeriving_15)
     instance PFunctor (T x) where
-      type Fmap a a = Fmap_0123456789876543210 a a
-      type (<$) a a = TFHelper_0123456789876543210 a a
-    type family LamCases_0123456789876543210 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 m0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 x _f_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 _ = MemptySym0
-    data LamCases_0123456789876543210Sym0 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 m0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+      type Fmap a a = Fmap_FunctorLikeDeriving_55 a a
+      type (<$) a a = TFHelper_FunctorLikeDeriving_62 a a
+    type family LamCases_FunctorLikeDeriving_74 x0 (_f_FunctorLikeDeriving_163 :: (~>) a1 m2) a_FunctorLikeDeriving_184 a_FunctorLikeDeriving_195 a_FunctorLikeDeriving_206 a_FunctorLikeDeriving_217 a_FunctorLikeDeriving_75 where
+      LamCases_FunctorLikeDeriving_74 x _f_FunctorLikeDeriving_16 a_FunctorLikeDeriving_18 a_FunctorLikeDeriving_19 a_FunctorLikeDeriving_20 a_FunctorLikeDeriving_21 _ = MemptySym0
+    data LamCases_FunctorLikeDeriving_74Sym0 x0 (_f_FunctorLikeDeriving_163 :: (~>) a1 m2) a_FunctorLikeDeriving_184 a_FunctorLikeDeriving_195 a_FunctorLikeDeriving_206 a_FunctorLikeDeriving_217 a_FunctorLikeDeriving_75
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
+        LamCases_FunctorLikeDeriving_74Sym0KindInference :: SameKind (Apply (LamCases_FunctorLikeDeriving_74Sym0 x0 _f_FunctorLikeDeriving_163 a_FunctorLikeDeriving_184 a_FunctorLikeDeriving_195 a_FunctorLikeDeriving_206 a_FunctorLikeDeriving_217) arg) (LamCases_FunctorLikeDeriving_74Sym1 x0 _f_FunctorLikeDeriving_163 a_FunctorLikeDeriving_184 a_FunctorLikeDeriving_195 a_FunctorLikeDeriving_206 a_FunctorLikeDeriving_217 arg) =>
+                                                            LamCases_FunctorLikeDeriving_74Sym0 x0 _f_FunctorLikeDeriving_163 a_FunctorLikeDeriving_184 a_FunctorLikeDeriving_195 a_FunctorLikeDeriving_206 a_FunctorLikeDeriving_217 a_FunctorLikeDeriving_75
+    type instance Apply @_ @_ (LamCases_FunctorLikeDeriving_74Sym0 x0 _f_FunctorLikeDeriving_163 a_FunctorLikeDeriving_184 a_FunctorLikeDeriving_195 a_FunctorLikeDeriving_206 a_FunctorLikeDeriving_217) a_FunctorLikeDeriving_75 = LamCases_FunctorLikeDeriving_74 x0 _f_FunctorLikeDeriving_163 a_FunctorLikeDeriving_184 a_FunctorLikeDeriving_195 a_FunctorLikeDeriving_206 a_FunctorLikeDeriving_217 a_FunctorLikeDeriving_75
+    instance SuppressUnusedWarnings (LamCases_FunctorLikeDeriving_74Sym0 x0 _f_FunctorLikeDeriving_163 a_FunctorLikeDeriving_184 a_FunctorLikeDeriving_195 a_FunctorLikeDeriving_206 a_FunctorLikeDeriving_217) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 m0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 m0123456789876543210) a_01234567898765432100123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 x _f_0123456789876543210 a_0123456789876543210 _ = MemptySym0
-    data LamCases_0123456789876543210Sym0 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 m0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_FunctorLikeDeriving_74Sym0KindInference ())
+    type family LamCases_FunctorLikeDeriving_74Sym1 x0 (_f_FunctorLikeDeriving_163 :: (~>) a1 m2) a_FunctorLikeDeriving_184 a_FunctorLikeDeriving_195 a_FunctorLikeDeriving_206 a_FunctorLikeDeriving_217 a_FunctorLikeDeriving_75 where
+      LamCases_FunctorLikeDeriving_74Sym1 x0 _f_FunctorLikeDeriving_163 a_FunctorLikeDeriving_184 a_FunctorLikeDeriving_195 a_FunctorLikeDeriving_206 a_FunctorLikeDeriving_217 a_FunctorLikeDeriving_75 = LamCases_FunctorLikeDeriving_74 x0 _f_FunctorLikeDeriving_163 a_FunctorLikeDeriving_184 a_FunctorLikeDeriving_195 a_FunctorLikeDeriving_206 a_FunctorLikeDeriving_217 a_FunctorLikeDeriving_75
+    type family LamCases_FunctorLikeDeriving_76 x0 (_f_FunctorLikeDeriving_163 :: (~>) a1 m2) a_FunctorLikeDeriving_224 a_FunctorLikeDeriving_77 where
+      LamCases_FunctorLikeDeriving_76 x _f_FunctorLikeDeriving_16 a_FunctorLikeDeriving_22 _ = MemptySym0
+    data LamCases_FunctorLikeDeriving_76Sym0 x0 (_f_FunctorLikeDeriving_163 :: (~>) a1 m2) a_FunctorLikeDeriving_224 a_FunctorLikeDeriving_77
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
+        LamCases_FunctorLikeDeriving_76Sym0KindInference :: SameKind (Apply (LamCases_FunctorLikeDeriving_76Sym0 x0 _f_FunctorLikeDeriving_163 a_FunctorLikeDeriving_224) arg) (LamCases_FunctorLikeDeriving_76Sym1 x0 _f_FunctorLikeDeriving_163 a_FunctorLikeDeriving_224 arg) =>
+                                                            LamCases_FunctorLikeDeriving_76Sym0 x0 _f_FunctorLikeDeriving_163 a_FunctorLikeDeriving_224 a_FunctorLikeDeriving_77
+    type instance Apply @_ @_ (LamCases_FunctorLikeDeriving_76Sym0 x0 _f_FunctorLikeDeriving_163 a_FunctorLikeDeriving_224) a_FunctorLikeDeriving_77 = LamCases_FunctorLikeDeriving_76 x0 _f_FunctorLikeDeriving_163 a_FunctorLikeDeriving_224 a_FunctorLikeDeriving_77
+    instance SuppressUnusedWarnings (LamCases_FunctorLikeDeriving_76Sym0 x0 _f_FunctorLikeDeriving_163 a_FunctorLikeDeriving_224) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 m0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 _f_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type FoldMap_0123456789876543210 :: forall x a m. (~>) a m
-                                                      -> T x a -> m
-    type family FoldMap_0123456789876543210 @x @a @m (a :: (~>) a m) (a :: T x a) :: m where
-      FoldMap_0123456789876543210 @x @a @m (_f_0123456789876543210 :: (~>) a m) (MkT1 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 :: T x a) = Apply (Apply MappendSym0 (Apply (LamCases_0123456789876543210Sym0 x _f_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210) a_0123456789876543210)) (Apply (Apply MappendSym0 (Apply _f_0123456789876543210 a_0123456789876543210)) (Apply (Apply MappendSym0 (Apply (Apply FoldMapSym0 _f_0123456789876543210) a_0123456789876543210)) (Apply (Apply FoldMapSym0 (Apply FoldMapSym0 _f_0123456789876543210)) a_0123456789876543210)))
-      FoldMap_0123456789876543210 @x @a @m (_f_0123456789876543210 :: (~>) a m) (MkT2 a_0123456789876543210 :: T x a) = Apply (LamCases_0123456789876543210Sym0 x _f_0123456789876543210 a_0123456789876543210) a_0123456789876543210
-    type family LamCases_0123456789876543210 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)) (_z_01234567898765432100123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 x _f_0123456789876543210 _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 _ n_0123456789876543210 = n_0123456789876543210
-    data LamCases_0123456789876543210Sym0 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)) (_z_01234567898765432100123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_FunctorLikeDeriving_76Sym0KindInference ())
+    type family LamCases_FunctorLikeDeriving_76Sym1 x0 (_f_FunctorLikeDeriving_163 :: (~>) a1 m2) a_FunctorLikeDeriving_224 a_FunctorLikeDeriving_77 where
+      LamCases_FunctorLikeDeriving_76Sym1 x0 _f_FunctorLikeDeriving_163 a_FunctorLikeDeriving_224 a_FunctorLikeDeriving_77 = LamCases_FunctorLikeDeriving_76 x0 _f_FunctorLikeDeriving_163 a_FunctorLikeDeriving_224 a_FunctorLikeDeriving_77
+    type FoldMap_FunctorLikeDeriving_71 :: forall x a m. (~>) a m
+                                                         -> T x a -> m
+    type family FoldMap_FunctorLikeDeriving_71 @x @a @m (a :: (~>) a m) (a :: T x a) :: m where
+      FoldMap_FunctorLikeDeriving_71 @x @a @m (_f_FunctorLikeDeriving_16 :: (~>) a m) (MkT1 a_FunctorLikeDeriving_18 a_FunctorLikeDeriving_19 a_FunctorLikeDeriving_20 a_FunctorLikeDeriving_21 :: T x a) = Apply (Apply MappendSym0 (Apply (LamCases_FunctorLikeDeriving_74Sym0 x _f_FunctorLikeDeriving_16 a_FunctorLikeDeriving_18 a_FunctorLikeDeriving_19 a_FunctorLikeDeriving_20 a_FunctorLikeDeriving_21) a_FunctorLikeDeriving_18)) (Apply (Apply MappendSym0 (Apply _f_FunctorLikeDeriving_16 a_FunctorLikeDeriving_19)) (Apply (Apply MappendSym0 (Apply (Apply FoldMapSym0 _f_FunctorLikeDeriving_16) a_FunctorLikeDeriving_20)) (Apply (Apply FoldMapSym0 (Apply FoldMapSym0 _f_FunctorLikeDeriving_16)) a_FunctorLikeDeriving_21)))
+      FoldMap_FunctorLikeDeriving_71 @x @a @m (_f_FunctorLikeDeriving_16 :: (~>) a m) (MkT2 a_FunctorLikeDeriving_22 :: T x a) = Apply (LamCases_FunctorLikeDeriving_76Sym0 x _f_FunctorLikeDeriving_16 a_FunctorLikeDeriving_22) a_FunctorLikeDeriving_22
+    type family LamCases_FunctorLikeDeriving_82 x0 (_f_FunctorLikeDeriving_163 :: (~>) a1 ((~>) b2 b2)) (_z_FunctorLikeDeriving_174 :: b2) a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_83 a_FunctorLikeDeriving_84 where
+      LamCases_FunctorLikeDeriving_82 x _f_FunctorLikeDeriving_16 _z_FunctorLikeDeriving_17 a_FunctorLikeDeriving_30 a_FunctorLikeDeriving_31 a_FunctorLikeDeriving_32 a_FunctorLikeDeriving_33 _ n_FunctorLikeDeriving_23 = n_FunctorLikeDeriving_23
+    data LamCases_FunctorLikeDeriving_82Sym0 x0 (_f_FunctorLikeDeriving_163 :: (~>) a1 ((~>) b2 b2)) (_z_FunctorLikeDeriving_174 :: b2) a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_83
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
+        LamCases_FunctorLikeDeriving_82Sym0KindInference :: SameKind (Apply (LamCases_FunctorLikeDeriving_82Sym0 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338) arg) (LamCases_FunctorLikeDeriving_82Sym1 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 arg) =>
+                                                            LamCases_FunctorLikeDeriving_82Sym0 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_83
+    type instance Apply @_ @_ (LamCases_FunctorLikeDeriving_82Sym0 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338) a_FunctorLikeDeriving_83 = LamCases_FunctorLikeDeriving_82Sym1 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_83
+    instance SuppressUnusedWarnings (LamCases_FunctorLikeDeriving_82Sym0 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    data LamCases_0123456789876543210Sym1 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)) (_z_01234567898765432100123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_FunctorLikeDeriving_82Sym0KindInference ())
+    data LamCases_FunctorLikeDeriving_82Sym1 x0 (_f_FunctorLikeDeriving_163 :: (~>) a1 ((~>) b2 b2)) (_z_FunctorLikeDeriving_174 :: b2) a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_83 a_FunctorLikeDeriving_84
       where
-        LamCases_0123456789876543210Sym1KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym2 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
+        LamCases_FunctorLikeDeriving_82Sym1KindInference :: SameKind (Apply (LamCases_FunctorLikeDeriving_82Sym1 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_83) arg) (LamCases_FunctorLikeDeriving_82Sym2 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_83 arg) =>
+                                                            LamCases_FunctorLikeDeriving_82Sym1 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_83 a_FunctorLikeDeriving_84
+    type instance Apply @_ @_ (LamCases_FunctorLikeDeriving_82Sym1 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_83) a_FunctorLikeDeriving_84 = LamCases_FunctorLikeDeriving_82 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_83 a_FunctorLikeDeriving_84
+    instance SuppressUnusedWarnings (LamCases_FunctorLikeDeriving_82Sym1 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_83) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym1KindInference ())
-    type family LamCases_0123456789876543210Sym2 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)) (_z_01234567898765432100123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym2 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)) (_z_01234567898765432100123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 x _f_0123456789876543210 _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 n1_0123456789876543210 n2_0123456789876543210 = Apply (Apply (Apply FoldrSym0 _f_0123456789876543210) n2_0123456789876543210) n1_0123456789876543210
-    data LamCases_0123456789876543210Sym0 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)) (_z_01234567898765432100123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_FunctorLikeDeriving_82Sym1KindInference ())
+    type family LamCases_FunctorLikeDeriving_82Sym2 x0 (_f_FunctorLikeDeriving_163 :: (~>) a1 ((~>) b2 b2)) (_z_FunctorLikeDeriving_174 :: b2) a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_83 a_FunctorLikeDeriving_84 where
+      LamCases_FunctorLikeDeriving_82Sym2 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_83 a_FunctorLikeDeriving_84 = LamCases_FunctorLikeDeriving_82 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_83 a_FunctorLikeDeriving_84
+    type family LamCases_FunctorLikeDeriving_85 x0 (_f_FunctorLikeDeriving_163 :: (~>) a1 ((~>) b2 b2)) (_z_FunctorLikeDeriving_174 :: b2) a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_86 a_FunctorLikeDeriving_87 where
+      LamCases_FunctorLikeDeriving_85 x _f_FunctorLikeDeriving_16 _z_FunctorLikeDeriving_17 a_FunctorLikeDeriving_30 a_FunctorLikeDeriving_31 a_FunctorLikeDeriving_32 a_FunctorLikeDeriving_33 n1_FunctorLikeDeriving_24 n2_FunctorLikeDeriving_25 = Apply (Apply (Apply FoldrSym0 _f_FunctorLikeDeriving_16) n2_FunctorLikeDeriving_25) n1_FunctorLikeDeriving_24
+    data LamCases_FunctorLikeDeriving_85Sym0 x0 (_f_FunctorLikeDeriving_163 :: (~>) a1 ((~>) b2 b2)) (_z_FunctorLikeDeriving_174 :: b2) a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_86
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
+        LamCases_FunctorLikeDeriving_85Sym0KindInference :: SameKind (Apply (LamCases_FunctorLikeDeriving_85Sym0 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338) arg) (LamCases_FunctorLikeDeriving_85Sym1 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 arg) =>
+                                                            LamCases_FunctorLikeDeriving_85Sym0 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_86
+    type instance Apply @_ @_ (LamCases_FunctorLikeDeriving_85Sym0 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338) a_FunctorLikeDeriving_86 = LamCases_FunctorLikeDeriving_85Sym1 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_86
+    instance SuppressUnusedWarnings (LamCases_FunctorLikeDeriving_85Sym0 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    data LamCases_0123456789876543210Sym1 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)) (_z_01234567898765432100123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_FunctorLikeDeriving_85Sym0KindInference ())
+    data LamCases_FunctorLikeDeriving_85Sym1 x0 (_f_FunctorLikeDeriving_163 :: (~>) a1 ((~>) b2 b2)) (_z_FunctorLikeDeriving_174 :: b2) a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_86 a_FunctorLikeDeriving_87
       where
-        LamCases_0123456789876543210Sym1KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym2 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
+        LamCases_FunctorLikeDeriving_85Sym1KindInference :: SameKind (Apply (LamCases_FunctorLikeDeriving_85Sym1 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_86) arg) (LamCases_FunctorLikeDeriving_85Sym2 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_86 arg) =>
+                                                            LamCases_FunctorLikeDeriving_85Sym1 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_86 a_FunctorLikeDeriving_87
+    type instance Apply @_ @_ (LamCases_FunctorLikeDeriving_85Sym1 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_86) a_FunctorLikeDeriving_87 = LamCases_FunctorLikeDeriving_85 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_86 a_FunctorLikeDeriving_87
+    instance SuppressUnusedWarnings (LamCases_FunctorLikeDeriving_85Sym1 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_86) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym1KindInference ())
-    type family LamCases_0123456789876543210Sym2 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)) (_z_01234567898765432100123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym2 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 x0123456789876543210 n1_01234567898765432100123456789876543210 n2_01234567898765432100123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)) (_z_01234567898765432100123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 x n1_0123456789876543210 n2_0123456789876543210 _f_0123456789876543210 _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 n1_0123456789876543210 n2_0123456789876543210 = Apply (Apply (Apply FoldrSym0 _f_0123456789876543210) n2_0123456789876543210) n1_0123456789876543210
-    data LamCases_0123456789876543210Sym0 x0123456789876543210 n1_01234567898765432100123456789876543210 n2_01234567898765432100123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)) (_z_01234567898765432100123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_FunctorLikeDeriving_85Sym1KindInference ())
+    type family LamCases_FunctorLikeDeriving_85Sym2 x0 (_f_FunctorLikeDeriving_163 :: (~>) a1 ((~>) b2 b2)) (_z_FunctorLikeDeriving_174 :: b2) a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_86 a_FunctorLikeDeriving_87 where
+      LamCases_FunctorLikeDeriving_85Sym2 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_86 a_FunctorLikeDeriving_87 = LamCases_FunctorLikeDeriving_85 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_86 a_FunctorLikeDeriving_87
+    type family LamCases_FunctorLikeDeriving_89 x0 n1_FunctorLikeDeriving_281 n2_FunctorLikeDeriving_292 (_f_FunctorLikeDeriving_165 :: (~>) a3 ((~>) b4 b4)) (_z_FunctorLikeDeriving_176 :: b4) a_FunctorLikeDeriving_307 a_FunctorLikeDeriving_318 a_FunctorLikeDeriving_329 a_FunctorLikeDeriving_3310 a_FunctorLikeDeriving_90 a_FunctorLikeDeriving_91 where
+      LamCases_FunctorLikeDeriving_89 x n1_FunctorLikeDeriving_28 n2_FunctorLikeDeriving_29 _f_FunctorLikeDeriving_16 _z_FunctorLikeDeriving_17 a_FunctorLikeDeriving_30 a_FunctorLikeDeriving_31 a_FunctorLikeDeriving_32 a_FunctorLikeDeriving_33 n1_FunctorLikeDeriving_26 n2_FunctorLikeDeriving_27 = Apply (Apply (Apply FoldrSym0 _f_FunctorLikeDeriving_16) n2_FunctorLikeDeriving_27) n1_FunctorLikeDeriving_26
+    data LamCases_FunctorLikeDeriving_89Sym0 x0 n1_FunctorLikeDeriving_281 n2_FunctorLikeDeriving_292 (_f_FunctorLikeDeriving_165 :: (~>) a3 ((~>) b4 b4)) (_z_FunctorLikeDeriving_176 :: b4) a_FunctorLikeDeriving_307 a_FunctorLikeDeriving_318 a_FunctorLikeDeriving_329 a_FunctorLikeDeriving_3310 a_FunctorLikeDeriving_90
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210 n1_01234567898765432100123456789876543210 n2_01234567898765432100123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 n1_01234567898765432100123456789876543210 n2_01234567898765432100123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 n1_01234567898765432100123456789876543210 n2_01234567898765432100123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210 n1_01234567898765432100123456789876543210 n2_01234567898765432100123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210Sym1 x0123456789876543210 n1_01234567898765432100123456789876543210 n2_01234567898765432100123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210 n1_01234567898765432100123456789876543210 n2_01234567898765432100123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
+        LamCases_FunctorLikeDeriving_89Sym0KindInference :: SameKind (Apply (LamCases_FunctorLikeDeriving_89Sym0 x0 n1_FunctorLikeDeriving_281 n2_FunctorLikeDeriving_292 _f_FunctorLikeDeriving_165 _z_FunctorLikeDeriving_176 a_FunctorLikeDeriving_307 a_FunctorLikeDeriving_318 a_FunctorLikeDeriving_329 a_FunctorLikeDeriving_3310) arg) (LamCases_FunctorLikeDeriving_89Sym1 x0 n1_FunctorLikeDeriving_281 n2_FunctorLikeDeriving_292 _f_FunctorLikeDeriving_165 _z_FunctorLikeDeriving_176 a_FunctorLikeDeriving_307 a_FunctorLikeDeriving_318 a_FunctorLikeDeriving_329 a_FunctorLikeDeriving_3310 arg) =>
+                                                            LamCases_FunctorLikeDeriving_89Sym0 x0 n1_FunctorLikeDeriving_281 n2_FunctorLikeDeriving_292 _f_FunctorLikeDeriving_165 _z_FunctorLikeDeriving_176 a_FunctorLikeDeriving_307 a_FunctorLikeDeriving_318 a_FunctorLikeDeriving_329 a_FunctorLikeDeriving_3310 a_FunctorLikeDeriving_90
+    type instance Apply @_ @_ (LamCases_FunctorLikeDeriving_89Sym0 x0 n1_FunctorLikeDeriving_281 n2_FunctorLikeDeriving_292 _f_FunctorLikeDeriving_165 _z_FunctorLikeDeriving_176 a_FunctorLikeDeriving_307 a_FunctorLikeDeriving_318 a_FunctorLikeDeriving_329 a_FunctorLikeDeriving_3310) a_FunctorLikeDeriving_90 = LamCases_FunctorLikeDeriving_89Sym1 x0 n1_FunctorLikeDeriving_281 n2_FunctorLikeDeriving_292 _f_FunctorLikeDeriving_165 _z_FunctorLikeDeriving_176 a_FunctorLikeDeriving_307 a_FunctorLikeDeriving_318 a_FunctorLikeDeriving_329 a_FunctorLikeDeriving_3310 a_FunctorLikeDeriving_90
+    instance SuppressUnusedWarnings (LamCases_FunctorLikeDeriving_89Sym0 x0 n1_FunctorLikeDeriving_281 n2_FunctorLikeDeriving_292 _f_FunctorLikeDeriving_165 _z_FunctorLikeDeriving_176 a_FunctorLikeDeriving_307 a_FunctorLikeDeriving_318 a_FunctorLikeDeriving_329 a_FunctorLikeDeriving_3310) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    data LamCases_0123456789876543210Sym1 x0123456789876543210 n1_01234567898765432100123456789876543210 n2_01234567898765432100123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)) (_z_01234567898765432100123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_FunctorLikeDeriving_89Sym0KindInference ())
+    data LamCases_FunctorLikeDeriving_89Sym1 x0 n1_FunctorLikeDeriving_281 n2_FunctorLikeDeriving_292 (_f_FunctorLikeDeriving_165 :: (~>) a3 ((~>) b4 b4)) (_z_FunctorLikeDeriving_176 :: b4) a_FunctorLikeDeriving_307 a_FunctorLikeDeriving_318 a_FunctorLikeDeriving_329 a_FunctorLikeDeriving_3310 a_FunctorLikeDeriving_90 a_FunctorLikeDeriving_91
       where
-        LamCases_0123456789876543210Sym1KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym1 x0123456789876543210 n1_01234567898765432100123456789876543210 n2_01234567898765432100123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym2 x0123456789876543210 n1_01234567898765432100123456789876543210 n2_01234567898765432100123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym1 x0123456789876543210 n1_01234567898765432100123456789876543210 n2_01234567898765432100123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym1 x0123456789876543210 n1_01234567898765432100123456789876543210 n2_01234567898765432100123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 n1_01234567898765432100123456789876543210 n2_01234567898765432100123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym1 x0123456789876543210 n1_01234567898765432100123456789876543210 n2_01234567898765432100123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
+        LamCases_FunctorLikeDeriving_89Sym1KindInference :: SameKind (Apply (LamCases_FunctorLikeDeriving_89Sym1 x0 n1_FunctorLikeDeriving_281 n2_FunctorLikeDeriving_292 _f_FunctorLikeDeriving_165 _z_FunctorLikeDeriving_176 a_FunctorLikeDeriving_307 a_FunctorLikeDeriving_318 a_FunctorLikeDeriving_329 a_FunctorLikeDeriving_3310 a_FunctorLikeDeriving_90) arg) (LamCases_FunctorLikeDeriving_89Sym2 x0 n1_FunctorLikeDeriving_281 n2_FunctorLikeDeriving_292 _f_FunctorLikeDeriving_165 _z_FunctorLikeDeriving_176 a_FunctorLikeDeriving_307 a_FunctorLikeDeriving_318 a_FunctorLikeDeriving_329 a_FunctorLikeDeriving_3310 a_FunctorLikeDeriving_90 arg) =>
+                                                            LamCases_FunctorLikeDeriving_89Sym1 x0 n1_FunctorLikeDeriving_281 n2_FunctorLikeDeriving_292 _f_FunctorLikeDeriving_165 _z_FunctorLikeDeriving_176 a_FunctorLikeDeriving_307 a_FunctorLikeDeriving_318 a_FunctorLikeDeriving_329 a_FunctorLikeDeriving_3310 a_FunctorLikeDeriving_90 a_FunctorLikeDeriving_91
+    type instance Apply @_ @_ (LamCases_FunctorLikeDeriving_89Sym1 x0 n1_FunctorLikeDeriving_281 n2_FunctorLikeDeriving_292 _f_FunctorLikeDeriving_165 _z_FunctorLikeDeriving_176 a_FunctorLikeDeriving_307 a_FunctorLikeDeriving_318 a_FunctorLikeDeriving_329 a_FunctorLikeDeriving_3310 a_FunctorLikeDeriving_90) a_FunctorLikeDeriving_91 = LamCases_FunctorLikeDeriving_89 x0 n1_FunctorLikeDeriving_281 n2_FunctorLikeDeriving_292 _f_FunctorLikeDeriving_165 _z_FunctorLikeDeriving_176 a_FunctorLikeDeriving_307 a_FunctorLikeDeriving_318 a_FunctorLikeDeriving_329 a_FunctorLikeDeriving_3310 a_FunctorLikeDeriving_90 a_FunctorLikeDeriving_91
+    instance SuppressUnusedWarnings (LamCases_FunctorLikeDeriving_89Sym1 x0 n1_FunctorLikeDeriving_281 n2_FunctorLikeDeriving_292 _f_FunctorLikeDeriving_165 _z_FunctorLikeDeriving_176 a_FunctorLikeDeriving_307 a_FunctorLikeDeriving_318 a_FunctorLikeDeriving_329 a_FunctorLikeDeriving_3310 a_FunctorLikeDeriving_90) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym1KindInference ())
-    type family LamCases_0123456789876543210Sym2 x0123456789876543210 n1_01234567898765432100123456789876543210 n2_01234567898765432100123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)) (_z_01234567898765432100123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym2 x0123456789876543210 n1_01234567898765432100123456789876543210 n2_01234567898765432100123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 n1_01234567898765432100123456789876543210 n2_01234567898765432100123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)) (_z_01234567898765432100123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 x _f_0123456789876543210 _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 n1_0123456789876543210 n2_0123456789876543210 = Apply (Apply (Apply FoldrSym0 (LamCases_0123456789876543210Sym0 x n1_0123456789876543210 n2_0123456789876543210 _f_0123456789876543210 _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210)) n2_0123456789876543210) n1_0123456789876543210
-    data LamCases_0123456789876543210Sym0 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)) (_z_01234567898765432100123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_FunctorLikeDeriving_89Sym1KindInference ())
+    type family LamCases_FunctorLikeDeriving_89Sym2 x0 n1_FunctorLikeDeriving_281 n2_FunctorLikeDeriving_292 (_f_FunctorLikeDeriving_165 :: (~>) a3 ((~>) b4 b4)) (_z_FunctorLikeDeriving_176 :: b4) a_FunctorLikeDeriving_307 a_FunctorLikeDeriving_318 a_FunctorLikeDeriving_329 a_FunctorLikeDeriving_3310 a_FunctorLikeDeriving_90 a_FunctorLikeDeriving_91 where
+      LamCases_FunctorLikeDeriving_89Sym2 x0 n1_FunctorLikeDeriving_281 n2_FunctorLikeDeriving_292 _f_FunctorLikeDeriving_165 _z_FunctorLikeDeriving_176 a_FunctorLikeDeriving_307 a_FunctorLikeDeriving_318 a_FunctorLikeDeriving_329 a_FunctorLikeDeriving_3310 a_FunctorLikeDeriving_90 a_FunctorLikeDeriving_91 = LamCases_FunctorLikeDeriving_89 x0 n1_FunctorLikeDeriving_281 n2_FunctorLikeDeriving_292 _f_FunctorLikeDeriving_165 _z_FunctorLikeDeriving_176 a_FunctorLikeDeriving_307 a_FunctorLikeDeriving_318 a_FunctorLikeDeriving_329 a_FunctorLikeDeriving_3310 a_FunctorLikeDeriving_90 a_FunctorLikeDeriving_91
+    type family LamCases_FunctorLikeDeriving_88 x0 (_f_FunctorLikeDeriving_163 :: (~>) a1 ((~>) b2 b2)) (_z_FunctorLikeDeriving_174 :: b2) a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_92 a_FunctorLikeDeriving_93 where
+      LamCases_FunctorLikeDeriving_88 x _f_FunctorLikeDeriving_16 _z_FunctorLikeDeriving_17 a_FunctorLikeDeriving_30 a_FunctorLikeDeriving_31 a_FunctorLikeDeriving_32 a_FunctorLikeDeriving_33 n1_FunctorLikeDeriving_28 n2_FunctorLikeDeriving_29 = Apply (Apply (Apply FoldrSym0 (LamCases_FunctorLikeDeriving_89Sym0 x n1_FunctorLikeDeriving_28 n2_FunctorLikeDeriving_29 _f_FunctorLikeDeriving_16 _z_FunctorLikeDeriving_17 a_FunctorLikeDeriving_30 a_FunctorLikeDeriving_31 a_FunctorLikeDeriving_32 a_FunctorLikeDeriving_33)) n2_FunctorLikeDeriving_29) n1_FunctorLikeDeriving_28
+    data LamCases_FunctorLikeDeriving_88Sym0 x0 (_f_FunctorLikeDeriving_163 :: (~>) a1 ((~>) b2 b2)) (_z_FunctorLikeDeriving_174 :: b2) a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_92
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
+        LamCases_FunctorLikeDeriving_88Sym0KindInference :: SameKind (Apply (LamCases_FunctorLikeDeriving_88Sym0 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338) arg) (LamCases_FunctorLikeDeriving_88Sym1 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 arg) =>
+                                                            LamCases_FunctorLikeDeriving_88Sym0 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_92
+    type instance Apply @_ @_ (LamCases_FunctorLikeDeriving_88Sym0 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338) a_FunctorLikeDeriving_92 = LamCases_FunctorLikeDeriving_88Sym1 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_92
+    instance SuppressUnusedWarnings (LamCases_FunctorLikeDeriving_88Sym0 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    data LamCases_0123456789876543210Sym1 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)) (_z_01234567898765432100123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_FunctorLikeDeriving_88Sym0KindInference ())
+    data LamCases_FunctorLikeDeriving_88Sym1 x0 (_f_FunctorLikeDeriving_163 :: (~>) a1 ((~>) b2 b2)) (_z_FunctorLikeDeriving_174 :: b2) a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_92 a_FunctorLikeDeriving_93
       where
-        LamCases_0123456789876543210Sym1KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym2 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
+        LamCases_FunctorLikeDeriving_88Sym1KindInference :: SameKind (Apply (LamCases_FunctorLikeDeriving_88Sym1 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_92) arg) (LamCases_FunctorLikeDeriving_88Sym2 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_92 arg) =>
+                                                            LamCases_FunctorLikeDeriving_88Sym1 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_92 a_FunctorLikeDeriving_93
+    type instance Apply @_ @_ (LamCases_FunctorLikeDeriving_88Sym1 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_92) a_FunctorLikeDeriving_93 = LamCases_FunctorLikeDeriving_88 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_92 a_FunctorLikeDeriving_93
+    instance SuppressUnusedWarnings (LamCases_FunctorLikeDeriving_88Sym1 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_92) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym1KindInference ())
-    type family LamCases_0123456789876543210Sym2 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)) (_z_01234567898765432100123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym2 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)) (_z_01234567898765432100123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 a_0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 x _f_0123456789876543210 _z_0123456789876543210 a_0123456789876543210 _ n_0123456789876543210 = n_0123456789876543210
-    data LamCases_0123456789876543210Sym0 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)) (_z_01234567898765432100123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_FunctorLikeDeriving_88Sym1KindInference ())
+    type family LamCases_FunctorLikeDeriving_88Sym2 x0 (_f_FunctorLikeDeriving_163 :: (~>) a1 ((~>) b2 b2)) (_z_FunctorLikeDeriving_174 :: b2) a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_92 a_FunctorLikeDeriving_93 where
+      LamCases_FunctorLikeDeriving_88Sym2 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_92 a_FunctorLikeDeriving_93 = LamCases_FunctorLikeDeriving_88 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_305 a_FunctorLikeDeriving_316 a_FunctorLikeDeriving_327 a_FunctorLikeDeriving_338 a_FunctorLikeDeriving_92 a_FunctorLikeDeriving_93
+    type family LamCases_FunctorLikeDeriving_94 x0 (_f_FunctorLikeDeriving_163 :: (~>) a1 ((~>) b2 b2)) (_z_FunctorLikeDeriving_174 :: b2) a_FunctorLikeDeriving_355 a_FunctorLikeDeriving_95 a_FunctorLikeDeriving_96 where
+      LamCases_FunctorLikeDeriving_94 x _f_FunctorLikeDeriving_16 _z_FunctorLikeDeriving_17 a_FunctorLikeDeriving_35 _ n_FunctorLikeDeriving_34 = n_FunctorLikeDeriving_34
+    data LamCases_FunctorLikeDeriving_94Sym0 x0 (_f_FunctorLikeDeriving_163 :: (~>) a1 ((~>) b2 b2)) (_z_FunctorLikeDeriving_174 :: b2) a_FunctorLikeDeriving_355 a_FunctorLikeDeriving_95
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
+        LamCases_FunctorLikeDeriving_94Sym0KindInference :: SameKind (Apply (LamCases_FunctorLikeDeriving_94Sym0 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_355) arg) (LamCases_FunctorLikeDeriving_94Sym1 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_355 arg) =>
+                                                            LamCases_FunctorLikeDeriving_94Sym0 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_355 a_FunctorLikeDeriving_95
+    type instance Apply @_ @_ (LamCases_FunctorLikeDeriving_94Sym0 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_355) a_FunctorLikeDeriving_95 = LamCases_FunctorLikeDeriving_94Sym1 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_355 a_FunctorLikeDeriving_95
+    instance SuppressUnusedWarnings (LamCases_FunctorLikeDeriving_94Sym0 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_355) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    data LamCases_0123456789876543210Sym1 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)) (_z_01234567898765432100123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_FunctorLikeDeriving_94Sym0KindInference ())
+    data LamCases_FunctorLikeDeriving_94Sym1 x0 (_f_FunctorLikeDeriving_163 :: (~>) a1 ((~>) b2 b2)) (_z_FunctorLikeDeriving_174 :: b2) a_FunctorLikeDeriving_355 a_FunctorLikeDeriving_95 a_FunctorLikeDeriving_96
       where
-        LamCases_0123456789876543210Sym1KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym2 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym1 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
+        LamCases_FunctorLikeDeriving_94Sym1KindInference :: SameKind (Apply (LamCases_FunctorLikeDeriving_94Sym1 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_355 a_FunctorLikeDeriving_95) arg) (LamCases_FunctorLikeDeriving_94Sym2 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_355 a_FunctorLikeDeriving_95 arg) =>
+                                                            LamCases_FunctorLikeDeriving_94Sym1 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_355 a_FunctorLikeDeriving_95 a_FunctorLikeDeriving_96
+    type instance Apply @_ @_ (LamCases_FunctorLikeDeriving_94Sym1 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_355 a_FunctorLikeDeriving_95) a_FunctorLikeDeriving_96 = LamCases_FunctorLikeDeriving_94 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_355 a_FunctorLikeDeriving_95 a_FunctorLikeDeriving_96
+    instance SuppressUnusedWarnings (LamCases_FunctorLikeDeriving_94Sym1 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_355 a_FunctorLikeDeriving_95) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym1KindInference ())
-    type family LamCases_0123456789876543210Sym2 x0123456789876543210 (_f_01234567898765432100123456789876543210 :: (~>) a0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)) (_z_01234567898765432100123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym2 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 _f_01234567898765432100123456789876543210 _z_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type Foldr_0123456789876543210 :: forall x a b. (~>) a ((~>) b b)
-                                                    -> b -> T x a -> b
-    type family Foldr_0123456789876543210 @x @a @b (a :: (~>) a ((~>) b b)) (a :: b) (a :: T x a) :: b where
-      Foldr_0123456789876543210 @x @a @b (_f_0123456789876543210 :: (~>) a ((~>) b b)) (_z_0123456789876543210 :: b) (MkT1 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 :: T x a) = Apply (Apply (LamCases_0123456789876543210Sym0 x _f_0123456789876543210 _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210) a_0123456789876543210) (Apply (Apply _f_0123456789876543210 a_0123456789876543210) (Apply (Apply (LamCases_0123456789876543210Sym0 x _f_0123456789876543210 _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210) a_0123456789876543210) (Apply (Apply (LamCases_0123456789876543210Sym0 x _f_0123456789876543210 _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210) a_0123456789876543210) _z_0123456789876543210)))
-      Foldr_0123456789876543210 @x @a @b (_f_0123456789876543210 :: (~>) a ((~>) b b)) (_z_0123456789876543210 :: b) (MkT2 a_0123456789876543210 :: T x a) = Apply (Apply (LamCases_0123456789876543210Sym0 x _f_0123456789876543210 _z_0123456789876543210 a_0123456789876543210) a_0123456789876543210) _z_0123456789876543210
+        = snd ((,) LamCases_FunctorLikeDeriving_94Sym1KindInference ())
+    type family LamCases_FunctorLikeDeriving_94Sym2 x0 (_f_FunctorLikeDeriving_163 :: (~>) a1 ((~>) b2 b2)) (_z_FunctorLikeDeriving_174 :: b2) a_FunctorLikeDeriving_355 a_FunctorLikeDeriving_95 a_FunctorLikeDeriving_96 where
+      LamCases_FunctorLikeDeriving_94Sym2 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_355 a_FunctorLikeDeriving_95 a_FunctorLikeDeriving_96 = LamCases_FunctorLikeDeriving_94 x0 _f_FunctorLikeDeriving_163 _z_FunctorLikeDeriving_174 a_FunctorLikeDeriving_355 a_FunctorLikeDeriving_95 a_FunctorLikeDeriving_96
+    type Foldr_FunctorLikeDeriving_78 :: forall x
+                                                a
+                                                b. (~>) a ((~>) b b) -> b -> T x a -> b
+    type family Foldr_FunctorLikeDeriving_78 @x @a @b (a :: (~>) a ((~>) b b)) (a :: b) (a :: T x a) :: b where
+      Foldr_FunctorLikeDeriving_78 @x @a @b (_f_FunctorLikeDeriving_16 :: (~>) a ((~>) b b)) (_z_FunctorLikeDeriving_17 :: b) (MkT1 a_FunctorLikeDeriving_30 a_FunctorLikeDeriving_31 a_FunctorLikeDeriving_32 a_FunctorLikeDeriving_33 :: T x a) = Apply (Apply (LamCases_FunctorLikeDeriving_82Sym0 x _f_FunctorLikeDeriving_16 _z_FunctorLikeDeriving_17 a_FunctorLikeDeriving_30 a_FunctorLikeDeriving_31 a_FunctorLikeDeriving_32 a_FunctorLikeDeriving_33) a_FunctorLikeDeriving_30) (Apply (Apply _f_FunctorLikeDeriving_16 a_FunctorLikeDeriving_31) (Apply (Apply (LamCases_FunctorLikeDeriving_85Sym0 x _f_FunctorLikeDeriving_16 _z_FunctorLikeDeriving_17 a_FunctorLikeDeriving_30 a_FunctorLikeDeriving_31 a_FunctorLikeDeriving_32 a_FunctorLikeDeriving_33) a_FunctorLikeDeriving_32) (Apply (Apply (LamCases_FunctorLikeDeriving_88Sym0 x _f_FunctorLikeDeriving_16 _z_FunctorLikeDeriving_17 a_FunctorLikeDeriving_30 a_FunctorLikeDeriving_31 a_FunctorLikeDeriving_32 a_FunctorLikeDeriving_33) a_FunctorLikeDeriving_33) _z_FunctorLikeDeriving_17)))
+      Foldr_FunctorLikeDeriving_78 @x @a @b (_f_FunctorLikeDeriving_16 :: (~>) a ((~>) b b)) (_z_FunctorLikeDeriving_17 :: b) (MkT2 a_FunctorLikeDeriving_35 :: T x a) = Apply (Apply (LamCases_FunctorLikeDeriving_94Sym0 x _f_FunctorLikeDeriving_16 _z_FunctorLikeDeriving_17 a_FunctorLikeDeriving_35) a_FunctorLikeDeriving_35) _z_FunctorLikeDeriving_17
     instance PFoldable (T x) where
-      type FoldMap a a = FoldMap_0123456789876543210 a a
-      type Foldr a a a = Foldr_0123456789876543210 a a a
-    type Traverse_0123456789876543210 :: forall x a f b. (~>) a (f b)
-                                                         -> T x a -> f (T x b)
-    type family Traverse_0123456789876543210 @x @a @f @b (a :: (~>) a (f b)) (a :: T x a) :: f (T x b) where
-      Traverse_0123456789876543210 @x @a @f @b (_f_0123456789876543210 :: (~>) a (f b)) (MkT1 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 :: T x a) = Apply (Apply (<*>@#@$) (Apply (Apply (<*>@#@$) (Apply (Apply (Apply LiftA2Sym0 MkT1Sym0) (Apply PureSym0 a_0123456789876543210)) (Apply _f_0123456789876543210 a_0123456789876543210))) (Apply (Apply TraverseSym0 _f_0123456789876543210) a_0123456789876543210))) (Apply (Apply TraverseSym0 (Apply TraverseSym0 _f_0123456789876543210)) a_0123456789876543210)
-      Traverse_0123456789876543210 @x @a @f @b (_f_0123456789876543210 :: (~>) a (f b)) (MkT2 a_0123456789876543210 :: T x a) = Apply (Apply FmapSym0 MkT2Sym0) (Apply PureSym0 a_0123456789876543210)
+      type FoldMap a a = FoldMap_FunctorLikeDeriving_71 a a
+      type Foldr a a a = Foldr_FunctorLikeDeriving_78 a a a
+    type Traverse_FunctorLikeDeriving_97 :: forall x
+                                                   a
+                                                   f
+                                                   b. (~>) a (f b) -> T x a -> f (T x b)
+    type family Traverse_FunctorLikeDeriving_97 @x @a @f @b (a :: (~>) a (f b)) (a :: T x a) :: f (T x b) where
+      Traverse_FunctorLikeDeriving_97 @x @a @f @b (_f_FunctorLikeDeriving_36 :: (~>) a (f b)) (MkT1 a_FunctorLikeDeriving_37 a_FunctorLikeDeriving_38 a_FunctorLikeDeriving_39 a_FunctorLikeDeriving_40 :: T x a) = Apply (Apply (<*>@#@$) (Apply (Apply (<*>@#@$) (Apply (Apply (Apply LiftA2Sym0 MkT1Sym0) (Apply PureSym0 a_FunctorLikeDeriving_37)) (Apply _f_FunctorLikeDeriving_36 a_FunctorLikeDeriving_38))) (Apply (Apply TraverseSym0 _f_FunctorLikeDeriving_36) a_FunctorLikeDeriving_39))) (Apply (Apply TraverseSym0 (Apply TraverseSym0 _f_FunctorLikeDeriving_36)) a_FunctorLikeDeriving_40)
+      Traverse_FunctorLikeDeriving_97 @x @a @f @b (_f_FunctorLikeDeriving_36 :: (~>) a (f b)) (MkT2 a_FunctorLikeDeriving_41 :: T x a) = Apply (Apply FmapSym0 MkT2Sym0) (Apply PureSym0 a_FunctorLikeDeriving_41)
     instance PTraversable (T x) where
-      type Traverse a a = Traverse_0123456789876543210 a a
-    type family LamCases_0123456789876543210 (v_01234567898765432100123456789876543210 :: Empty a0123456789876543210) a_0123456789876543210 where
-    data LamCases_0123456789876543210Sym0 (v_01234567898765432100123456789876543210 :: Empty a0123456789876543210) a_01234567898765432100123456789876543210
+      type Traverse a a = Traverse_FunctorLikeDeriving_97 a a
+    type family LamCases_FunctorLikeDeriving_103 (v_FunctorLikeDeriving_441 :: Empty a0) a_FunctorLikeDeriving_104 where
+    data LamCases_FunctorLikeDeriving_103Sym0 (v_FunctorLikeDeriving_441 :: Empty a0) a_FunctorLikeDeriving_104
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 v_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 v_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 v_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 v_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 v_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 v_01234567898765432100123456789876543210) where
+        LamCases_FunctorLikeDeriving_103Sym0KindInference :: SameKind (Apply (LamCases_FunctorLikeDeriving_103Sym0 v_FunctorLikeDeriving_441) arg) (LamCases_FunctorLikeDeriving_103Sym1 v_FunctorLikeDeriving_441 arg) =>
+                                                             LamCases_FunctorLikeDeriving_103Sym0 v_FunctorLikeDeriving_441 a_FunctorLikeDeriving_104
+    type instance Apply @_ @_ (LamCases_FunctorLikeDeriving_103Sym0 v_FunctorLikeDeriving_441) a_FunctorLikeDeriving_104 = LamCases_FunctorLikeDeriving_103 v_FunctorLikeDeriving_441 a_FunctorLikeDeriving_104
+    instance SuppressUnusedWarnings (LamCases_FunctorLikeDeriving_103Sym0 v_FunctorLikeDeriving_441) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (v_01234567898765432100123456789876543210 :: Empty a0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 v_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 v_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type Fmap_0123456789876543210 :: forall a b. (~>) a b
-                                                 -> Empty a -> Empty b
-    type family Fmap_0123456789876543210 @a @b (a :: (~>) a b) (a :: Empty a) :: Empty b where
-      Fmap_0123456789876543210 @a @b _ v_0123456789876543210 = Apply (LamCases_0123456789876543210Sym0 v_0123456789876543210) v_0123456789876543210
-    type family LamCases_0123456789876543210 (v_01234567898765432100123456789876543210 :: Empty b0123456789876543210) a_0123456789876543210 where
-    data LamCases_0123456789876543210Sym0 (v_01234567898765432100123456789876543210 :: Empty b0123456789876543210) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_FunctorLikeDeriving_103Sym0KindInference ())
+    type family LamCases_FunctorLikeDeriving_103Sym1 (v_FunctorLikeDeriving_441 :: Empty a0) a_FunctorLikeDeriving_104 where
+      LamCases_FunctorLikeDeriving_103Sym1 v_FunctorLikeDeriving_441 a_FunctorLikeDeriving_104 = LamCases_FunctorLikeDeriving_103 v_FunctorLikeDeriving_441 a_FunctorLikeDeriving_104
+    type Fmap_FunctorLikeDeriving_100 :: forall a b. (~>) a b
+                                                     -> Empty a -> Empty b
+    type family Fmap_FunctorLikeDeriving_100 @a @b (a :: (~>) a b) (a :: Empty a) :: Empty b where
+      Fmap_FunctorLikeDeriving_100 @a @b _ v_FunctorLikeDeriving_44 = Apply (LamCases_FunctorLikeDeriving_103Sym0 v_FunctorLikeDeriving_44) v_FunctorLikeDeriving_44
+    type family LamCases_FunctorLikeDeriving_108 (v_FunctorLikeDeriving_451 :: Empty b0) a_FunctorLikeDeriving_109 where
+    data LamCases_FunctorLikeDeriving_108Sym0 (v_FunctorLikeDeriving_451 :: Empty b0) a_FunctorLikeDeriving_109
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 v_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 v_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 v_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 v_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 v_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 v_01234567898765432100123456789876543210) where
+        LamCases_FunctorLikeDeriving_108Sym0KindInference :: SameKind (Apply (LamCases_FunctorLikeDeriving_108Sym0 v_FunctorLikeDeriving_451) arg) (LamCases_FunctorLikeDeriving_108Sym1 v_FunctorLikeDeriving_451 arg) =>
+                                                             LamCases_FunctorLikeDeriving_108Sym0 v_FunctorLikeDeriving_451 a_FunctorLikeDeriving_109
+    type instance Apply @_ @_ (LamCases_FunctorLikeDeriving_108Sym0 v_FunctorLikeDeriving_451) a_FunctorLikeDeriving_109 = LamCases_FunctorLikeDeriving_108 v_FunctorLikeDeriving_451 a_FunctorLikeDeriving_109
+    instance SuppressUnusedWarnings (LamCases_FunctorLikeDeriving_108Sym0 v_FunctorLikeDeriving_451) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (v_01234567898765432100123456789876543210 :: Empty b0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 v_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 v_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type TFHelper_0123456789876543210 :: forall a b. a
-                                                     -> Empty b -> Empty a
-    type family TFHelper_0123456789876543210 @a @b (a :: a) (a :: Empty b) :: Empty a where
-      TFHelper_0123456789876543210 @a @b _ v_0123456789876543210 = Apply (LamCases_0123456789876543210Sym0 v_0123456789876543210) v_0123456789876543210
+        = snd ((,) LamCases_FunctorLikeDeriving_108Sym0KindInference ())
+    type family LamCases_FunctorLikeDeriving_108Sym1 (v_FunctorLikeDeriving_451 :: Empty b0) a_FunctorLikeDeriving_109 where
+      LamCases_FunctorLikeDeriving_108Sym1 v_FunctorLikeDeriving_451 a_FunctorLikeDeriving_109 = LamCases_FunctorLikeDeriving_108 v_FunctorLikeDeriving_451 a_FunctorLikeDeriving_109
+    type TFHelper_FunctorLikeDeriving_105 :: forall a b. a
+                                                         -> Empty b -> Empty a
+    type family TFHelper_FunctorLikeDeriving_105 @a @b (a :: a) (a :: Empty b) :: Empty a where
+      TFHelper_FunctorLikeDeriving_105 @a @b _ v_FunctorLikeDeriving_45 = Apply (LamCases_FunctorLikeDeriving_108Sym0 v_FunctorLikeDeriving_45) v_FunctorLikeDeriving_45
     instance PFunctor Empty where
-      type Fmap a a = Fmap_0123456789876543210 a a
-      type (<$) a a = TFHelper_0123456789876543210 a a
-    type FoldMap_0123456789876543210 :: forall a m. (~>) a m
-                                                    -> Empty a -> m
-    type family FoldMap_0123456789876543210 @a @m (a :: (~>) a m) (a :: Empty a) :: m where
-      FoldMap_0123456789876543210 @a @m _ _ = MemptySym0
+      type Fmap a a = Fmap_FunctorLikeDeriving_100 a a
+      type (<$) a a = TFHelper_FunctorLikeDeriving_105 a a
+    type FoldMap_FunctorLikeDeriving_110 :: forall a m. (~>) a m
+                                                        -> Empty a -> m
+    type family FoldMap_FunctorLikeDeriving_110 @a @m (a :: (~>) a m) (a :: Empty a) :: m where
+      FoldMap_FunctorLikeDeriving_110 @a @m _ _ = MemptySym0
     instance PFoldable Empty where
-      type FoldMap a a = FoldMap_0123456789876543210 a a
-    type family LamCases_0123456789876543210 (v_01234567898765432100123456789876543210 :: Empty a0123456789876543210) a_0123456789876543210 where
-    data LamCases_0123456789876543210Sym0 (v_01234567898765432100123456789876543210 :: Empty a0123456789876543210) a_01234567898765432100123456789876543210
+      type FoldMap a a = FoldMap_FunctorLikeDeriving_110 a a
+    type family LamCases_FunctorLikeDeriving_116 (v_FunctorLikeDeriving_491 :: Empty a0) a_FunctorLikeDeriving_117 where
+    data LamCases_FunctorLikeDeriving_116Sym0 (v_FunctorLikeDeriving_491 :: Empty a0) a_FunctorLikeDeriving_117
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 v_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 v_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 v_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 v_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 v_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 v_01234567898765432100123456789876543210) where
+        LamCases_FunctorLikeDeriving_116Sym0KindInference :: SameKind (Apply (LamCases_FunctorLikeDeriving_116Sym0 v_FunctorLikeDeriving_491) arg) (LamCases_FunctorLikeDeriving_116Sym1 v_FunctorLikeDeriving_491 arg) =>
+                                                             LamCases_FunctorLikeDeriving_116Sym0 v_FunctorLikeDeriving_491 a_FunctorLikeDeriving_117
+    type instance Apply @_ @_ (LamCases_FunctorLikeDeriving_116Sym0 v_FunctorLikeDeriving_491) a_FunctorLikeDeriving_117 = LamCases_FunctorLikeDeriving_116 v_FunctorLikeDeriving_491 a_FunctorLikeDeriving_117
+    instance SuppressUnusedWarnings (LamCases_FunctorLikeDeriving_116Sym0 v_FunctorLikeDeriving_491) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (v_01234567898765432100123456789876543210 :: Empty a0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 v_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 v_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type Traverse_0123456789876543210 :: forall a f b. (~>) a (f b)
-                                                       -> Empty a -> f (Empty b)
-    type family Traverse_0123456789876543210 @a @f @b (a :: (~>) a (f b)) (a :: Empty a) :: f (Empty b) where
-      Traverse_0123456789876543210 @a @f @b _ v_0123456789876543210 = Apply PureSym0 (Apply (LamCases_0123456789876543210Sym0 v_0123456789876543210) v_0123456789876543210)
+        = snd ((,) LamCases_FunctorLikeDeriving_116Sym0KindInference ())
+    type family LamCases_FunctorLikeDeriving_116Sym1 (v_FunctorLikeDeriving_491 :: Empty a0) a_FunctorLikeDeriving_117 where
+      LamCases_FunctorLikeDeriving_116Sym1 v_FunctorLikeDeriving_491 a_FunctorLikeDeriving_117 = LamCases_FunctorLikeDeriving_116 v_FunctorLikeDeriving_491 a_FunctorLikeDeriving_117
+    type Traverse_FunctorLikeDeriving_113 :: forall a f b. (~>) a (f b)
+                                                           -> Empty a -> f (Empty b)
+    type family Traverse_FunctorLikeDeriving_113 @a @f @b (a :: (~>) a (f b)) (a :: Empty a) :: f (Empty b) where
+      Traverse_FunctorLikeDeriving_113 @a @f @b _ v_FunctorLikeDeriving_49 = Apply PureSym0 (Apply (LamCases_FunctorLikeDeriving_116Sym0 v_FunctorLikeDeriving_49) v_FunctorLikeDeriving_49)
     instance PTraversable Empty where
-      type Traverse a a = Traverse_0123456789876543210 a a
+      type Traverse a a = Traverse_FunctorLikeDeriving_113 a a
     data ST :: forall x a. T x a -> Type
       where
         SMkT1 :: forall x
@@ -374,11 +377,11 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
       toSing x = SomeSing ((\case) x)
     instance SFunctor (T x) where
       sFmap
-        (_sf_0123456789876543210 :: Sing _f_0123456789876543210)
-        (SMkT1 (sA_0123456789876543210 :: Sing a_0123456789876543210)
-               (sA_0123456789876543210 :: Sing a_0123456789876543210)
-               (sA_0123456789876543210 :: Sing a_0123456789876543210)
-               (sA_0123456789876543210 :: Sing a_0123456789876543210))
+        (_sf_FunctorLikeDeriving_0 :: Sing _f_FunctorLikeDeriving_0)
+        (SMkT1 (sA_FunctorLikeDeriving_3 :: Sing a_FunctorLikeDeriving_3)
+               (sA_FunctorLikeDeriving_4 :: Sing a_FunctorLikeDeriving_4)
+               (sA_FunctorLikeDeriving_5 :: Sing a_FunctorLikeDeriving_5)
+               (sA_FunctorLikeDeriving_6 :: Sing a_FunctorLikeDeriving_6))
         = applySing
             (applySing
                (applySing
@@ -386,38 +389,38 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
                      (singFun4 @MkT1Sym0 SMkT1)
                      (applySing
                         (singFun1
-                           @(LamCases_0123456789876543210Sym0 x _f_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210)
+                           @(LamCases_FunctorLikeDeriving_58Sym0 x _f_FunctorLikeDeriving_0 a_FunctorLikeDeriving_3 a_FunctorLikeDeriving_4 a_FunctorLikeDeriving_5 a_FunctorLikeDeriving_6)
                            (\cases
-                              (sN_0123456789876543210 :: Sing n_0123456789876543210)
-                                -> sN_0123456789876543210))
-                        sA_0123456789876543210))
-                  (applySing _sf_0123456789876543210 sA_0123456789876543210))
+                              (sN_FunctorLikeDeriving_2 :: Sing n_FunctorLikeDeriving_2)
+                                -> sN_FunctorLikeDeriving_2))
+                        sA_FunctorLikeDeriving_3))
+                  (applySing _sf_FunctorLikeDeriving_0 sA_FunctorLikeDeriving_4))
                (applySing
-                  (applySing (singFun2 @FmapSym0 sFmap) _sf_0123456789876543210)
-                  sA_0123456789876543210))
+                  (applySing (singFun2 @FmapSym0 sFmap) _sf_FunctorLikeDeriving_0)
+                  sA_FunctorLikeDeriving_5))
             (applySing
                (applySing
                   (singFun2 @FmapSym0 sFmap)
-                  (applySing (singFun2 @FmapSym0 sFmap) _sf_0123456789876543210))
-               sA_0123456789876543210)
+                  (applySing (singFun2 @FmapSym0 sFmap) _sf_FunctorLikeDeriving_0))
+               sA_FunctorLikeDeriving_6)
       sFmap
-        (_sf_0123456789876543210 :: Sing _f_0123456789876543210)
-        (SMkT2 (sA_0123456789876543210 :: Sing a_0123456789876543210))
+        (_sf_FunctorLikeDeriving_0 :: Sing _f_FunctorLikeDeriving_0)
+        (SMkT2 (sA_FunctorLikeDeriving_8 :: Sing a_FunctorLikeDeriving_8))
         = applySing
             (singFun1 @MkT2Sym0 SMkT2)
             (applySing
                (singFun1
-                  @(LamCases_0123456789876543210Sym0 x _f_0123456789876543210 a_0123456789876543210)
+                  @(LamCases_FunctorLikeDeriving_60Sym0 x _f_FunctorLikeDeriving_0 a_FunctorLikeDeriving_8)
                   (\cases
-                     (sN_0123456789876543210 :: Sing n_0123456789876543210)
-                       -> sN_0123456789876543210))
-               sA_0123456789876543210)
+                     (sN_FunctorLikeDeriving_7 :: Sing n_FunctorLikeDeriving_7)
+                       -> sN_FunctorLikeDeriving_7))
+               sA_FunctorLikeDeriving_8)
       (%<$)
-        (_sz_0123456789876543210 :: Sing _z_0123456789876543210)
-        (SMkT1 (sA_0123456789876543210 :: Sing a_0123456789876543210)
-               (sA_0123456789876543210 :: Sing a_0123456789876543210)
-               (sA_0123456789876543210 :: Sing a_0123456789876543210)
-               (sA_0123456789876543210 :: Sing a_0123456789876543210))
+        (_sz_FunctorLikeDeriving_1 :: Sing _z_FunctorLikeDeriving_1)
+        (SMkT1 (sA_FunctorLikeDeriving_10 :: Sing a_FunctorLikeDeriving_10)
+               (sA_FunctorLikeDeriving_11 :: Sing a_FunctorLikeDeriving_11)
+               (sA_FunctorLikeDeriving_12 :: Sing a_FunctorLikeDeriving_12)
+               (sA_FunctorLikeDeriving_13 :: Sing a_FunctorLikeDeriving_13))
         = applySing
             (applySing
                (applySing
@@ -425,154 +428,154 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
                      (singFun4 @MkT1Sym0 SMkT1)
                      (applySing
                         (singFun1
-                           @(LamCases_0123456789876543210Sym0 x _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210)
+                           @(LamCases_FunctorLikeDeriving_65Sym0 x _z_FunctorLikeDeriving_1 a_FunctorLikeDeriving_10 a_FunctorLikeDeriving_11 a_FunctorLikeDeriving_12 a_FunctorLikeDeriving_13)
                            (\cases
-                              (sN_0123456789876543210 :: Sing n_0123456789876543210)
-                                -> sN_0123456789876543210))
-                        sA_0123456789876543210))
+                              (sN_FunctorLikeDeriving_9 :: Sing n_FunctorLikeDeriving_9)
+                                -> sN_FunctorLikeDeriving_9))
+                        sA_FunctorLikeDeriving_10))
                   (applySing
                      (singFun1
-                        @(LamCases_0123456789876543210Sym0 x _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210)
-                        (\cases _ -> _sz_0123456789876543210))
-                     sA_0123456789876543210))
+                        @(LamCases_FunctorLikeDeriving_67Sym0 x _z_FunctorLikeDeriving_1 a_FunctorLikeDeriving_10 a_FunctorLikeDeriving_11 a_FunctorLikeDeriving_12 a_FunctorLikeDeriving_13)
+                        (\cases _ -> _sz_FunctorLikeDeriving_1))
+                     sA_FunctorLikeDeriving_11))
                (applySing
-                  (applySing (singFun2 @(<$@#@$) (%<$)) _sz_0123456789876543210)
-                  sA_0123456789876543210))
+                  (applySing (singFun2 @(<$@#@$) (%<$)) _sz_FunctorLikeDeriving_1)
+                  sA_FunctorLikeDeriving_12))
             (applySing
                (applySing
                   (singFun2 @FmapSym0 sFmap)
-                  (applySing (singFun2 @(<$@#@$) (%<$)) _sz_0123456789876543210))
-               sA_0123456789876543210)
+                  (applySing (singFun2 @(<$@#@$) (%<$)) _sz_FunctorLikeDeriving_1))
+               sA_FunctorLikeDeriving_13)
       (%<$)
-        (_sz_0123456789876543210 :: Sing _z_0123456789876543210)
-        (SMkT2 (sA_0123456789876543210 :: Sing a_0123456789876543210))
+        (_sz_FunctorLikeDeriving_1 :: Sing _z_FunctorLikeDeriving_1)
+        (SMkT2 (sA_FunctorLikeDeriving_15 :: Sing a_FunctorLikeDeriving_15))
         = applySing
             (singFun1 @MkT2Sym0 SMkT2)
             (applySing
                (singFun1
-                  @(LamCases_0123456789876543210Sym0 x _z_0123456789876543210 a_0123456789876543210)
+                  @(LamCases_FunctorLikeDeriving_69Sym0 x _z_FunctorLikeDeriving_1 a_FunctorLikeDeriving_15)
                   (\cases
-                     (sN_0123456789876543210 :: Sing n_0123456789876543210)
-                       -> sN_0123456789876543210))
-               sA_0123456789876543210)
+                     (sN_FunctorLikeDeriving_14 :: Sing n_FunctorLikeDeriving_14)
+                       -> sN_FunctorLikeDeriving_14))
+               sA_FunctorLikeDeriving_15)
     instance SFoldable (T x) where
       sFoldMap
-        (_sf_0123456789876543210 :: Sing _f_0123456789876543210)
-        (SMkT1 (sA_0123456789876543210 :: Sing a_0123456789876543210)
-               (sA_0123456789876543210 :: Sing a_0123456789876543210)
-               (sA_0123456789876543210 :: Sing a_0123456789876543210)
-               (sA_0123456789876543210 :: Sing a_0123456789876543210))
+        (_sf_FunctorLikeDeriving_16 :: Sing _f_FunctorLikeDeriving_16)
+        (SMkT1 (sA_FunctorLikeDeriving_18 :: Sing a_FunctorLikeDeriving_18)
+               (sA_FunctorLikeDeriving_19 :: Sing a_FunctorLikeDeriving_19)
+               (sA_FunctorLikeDeriving_20 :: Sing a_FunctorLikeDeriving_20)
+               (sA_FunctorLikeDeriving_21 :: Sing a_FunctorLikeDeriving_21))
         = applySing
             (applySing
                (singFun2 @MappendSym0 sMappend)
                (applySing
                   (singFun1
-                     @(LamCases_0123456789876543210Sym0 x _f_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210)
+                     @(LamCases_FunctorLikeDeriving_74Sym0 x _f_FunctorLikeDeriving_16 a_FunctorLikeDeriving_18 a_FunctorLikeDeriving_19 a_FunctorLikeDeriving_20 a_FunctorLikeDeriving_21)
                      (\cases _ -> sMempty))
-                  sA_0123456789876543210))
+                  sA_FunctorLikeDeriving_18))
             (applySing
                (applySing
                   (singFun2 @MappendSym0 sMappend)
-                  (applySing _sf_0123456789876543210 sA_0123456789876543210))
+                  (applySing _sf_FunctorLikeDeriving_16 sA_FunctorLikeDeriving_19))
                (applySing
                   (applySing
                      (singFun2 @MappendSym0 sMappend)
                      (applySing
                         (applySing
-                           (singFun2 @FoldMapSym0 sFoldMap) _sf_0123456789876543210)
-                        sA_0123456789876543210))
+                           (singFun2 @FoldMapSym0 sFoldMap) _sf_FunctorLikeDeriving_16)
+                        sA_FunctorLikeDeriving_20))
                   (applySing
                      (applySing
                         (singFun2 @FoldMapSym0 sFoldMap)
                         (applySing
-                           (singFun2 @FoldMapSym0 sFoldMap) _sf_0123456789876543210))
-                     sA_0123456789876543210)))
+                           (singFun2 @FoldMapSym0 sFoldMap) _sf_FunctorLikeDeriving_16))
+                     sA_FunctorLikeDeriving_21)))
       sFoldMap
-        (_sf_0123456789876543210 :: Sing _f_0123456789876543210)
-        (SMkT2 (sA_0123456789876543210 :: Sing a_0123456789876543210))
+        (_sf_FunctorLikeDeriving_16 :: Sing _f_FunctorLikeDeriving_16)
+        (SMkT2 (sA_FunctorLikeDeriving_22 :: Sing a_FunctorLikeDeriving_22))
         = applySing
             (singFun1
-               @(LamCases_0123456789876543210Sym0 x _f_0123456789876543210 a_0123456789876543210)
+               @(LamCases_FunctorLikeDeriving_76Sym0 x _f_FunctorLikeDeriving_16 a_FunctorLikeDeriving_22)
                (\cases _ -> sMempty))
-            sA_0123456789876543210
+            sA_FunctorLikeDeriving_22
       sFoldr
-        (_sf_0123456789876543210 :: Sing _f_0123456789876543210)
-        (_sz_0123456789876543210 :: Sing _z_0123456789876543210)
-        (SMkT1 (sA_0123456789876543210 :: Sing a_0123456789876543210)
-               (sA_0123456789876543210 :: Sing a_0123456789876543210)
-               (sA_0123456789876543210 :: Sing a_0123456789876543210)
-               (sA_0123456789876543210 :: Sing a_0123456789876543210))
+        (_sf_FunctorLikeDeriving_16 :: Sing _f_FunctorLikeDeriving_16)
+        (_sz_FunctorLikeDeriving_17 :: Sing _z_FunctorLikeDeriving_17)
+        (SMkT1 (sA_FunctorLikeDeriving_30 :: Sing a_FunctorLikeDeriving_30)
+               (sA_FunctorLikeDeriving_31 :: Sing a_FunctorLikeDeriving_31)
+               (sA_FunctorLikeDeriving_32 :: Sing a_FunctorLikeDeriving_32)
+               (sA_FunctorLikeDeriving_33 :: Sing a_FunctorLikeDeriving_33))
         = applySing
             (applySing
                (singFun2
-                  @(LamCases_0123456789876543210Sym0 x _f_0123456789876543210 _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210)
+                  @(LamCases_FunctorLikeDeriving_82Sym0 x _f_FunctorLikeDeriving_16 _z_FunctorLikeDeriving_17 a_FunctorLikeDeriving_30 a_FunctorLikeDeriving_31 a_FunctorLikeDeriving_32 a_FunctorLikeDeriving_33)
                   (\cases
-                     _ (sN_0123456789876543210 :: Sing n_0123456789876543210)
-                       -> sN_0123456789876543210))
-               sA_0123456789876543210)
+                     _ (sN_FunctorLikeDeriving_23 :: Sing n_FunctorLikeDeriving_23)
+                       -> sN_FunctorLikeDeriving_23))
+               sA_FunctorLikeDeriving_30)
             (applySing
-               (applySing _sf_0123456789876543210 sA_0123456789876543210)
+               (applySing _sf_FunctorLikeDeriving_16 sA_FunctorLikeDeriving_31)
                (applySing
                   (applySing
                      (singFun2
-                        @(LamCases_0123456789876543210Sym0 x _f_0123456789876543210 _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210)
+                        @(LamCases_FunctorLikeDeriving_85Sym0 x _f_FunctorLikeDeriving_16 _z_FunctorLikeDeriving_17 a_FunctorLikeDeriving_30 a_FunctorLikeDeriving_31 a_FunctorLikeDeriving_32 a_FunctorLikeDeriving_33)
                         (\cases
-                           (sN1_0123456789876543210 :: Sing n1_0123456789876543210)
-                             (sN2_0123456789876543210 :: Sing n2_0123456789876543210)
+                           (sN1_FunctorLikeDeriving_24 :: Sing n1_FunctorLikeDeriving_24)
+                             (sN2_FunctorLikeDeriving_25 :: Sing n2_FunctorLikeDeriving_25)
                              -> applySing
                                   (applySing
                                      (applySing
-                                        (singFun3 @FoldrSym0 sFoldr) _sf_0123456789876543210)
-                                     sN2_0123456789876543210)
-                                  sN1_0123456789876543210))
-                     sA_0123456789876543210)
+                                        (singFun3 @FoldrSym0 sFoldr) _sf_FunctorLikeDeriving_16)
+                                     sN2_FunctorLikeDeriving_25)
+                                  sN1_FunctorLikeDeriving_24))
+                     sA_FunctorLikeDeriving_32)
                   (applySing
                      (applySing
                         (singFun2
-                           @(LamCases_0123456789876543210Sym0 x _f_0123456789876543210 _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210)
+                           @(LamCases_FunctorLikeDeriving_88Sym0 x _f_FunctorLikeDeriving_16 _z_FunctorLikeDeriving_17 a_FunctorLikeDeriving_30 a_FunctorLikeDeriving_31 a_FunctorLikeDeriving_32 a_FunctorLikeDeriving_33)
                            (\cases
-                              (sN1_0123456789876543210 :: Sing n1_0123456789876543210)
-                                (sN2_0123456789876543210 :: Sing n2_0123456789876543210)
+                              (sN1_FunctorLikeDeriving_28 :: Sing n1_FunctorLikeDeriving_28)
+                                (sN2_FunctorLikeDeriving_29 :: Sing n2_FunctorLikeDeriving_29)
                                 -> applySing
                                      (applySing
                                         (applySing
                                            (singFun3 @FoldrSym0 sFoldr)
                                            (singFun2
-                                              @(LamCases_0123456789876543210Sym0 x n1_0123456789876543210 n2_0123456789876543210 _f_0123456789876543210 _z_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210)
+                                              @(LamCases_FunctorLikeDeriving_89Sym0 x n1_FunctorLikeDeriving_28 n2_FunctorLikeDeriving_29 _f_FunctorLikeDeriving_16 _z_FunctorLikeDeriving_17 a_FunctorLikeDeriving_30 a_FunctorLikeDeriving_31 a_FunctorLikeDeriving_32 a_FunctorLikeDeriving_33)
                                               (\cases
-                                                 (sN1_0123456789876543210 :: Sing n1_0123456789876543210)
-                                                   (sN2_0123456789876543210 :: Sing n2_0123456789876543210)
+                                                 (sN1_FunctorLikeDeriving_26 :: Sing n1_FunctorLikeDeriving_26)
+                                                   (sN2_FunctorLikeDeriving_27 :: Sing n2_FunctorLikeDeriving_27)
                                                    -> applySing
                                                         (applySing
                                                            (applySing
                                                               (singFun3 @FoldrSym0 sFoldr)
-                                                              _sf_0123456789876543210)
-                                                           sN2_0123456789876543210)
-                                                        sN1_0123456789876543210)))
-                                        sN2_0123456789876543210)
-                                     sN1_0123456789876543210))
-                        sA_0123456789876543210)
-                     _sz_0123456789876543210)))
+                                                              _sf_FunctorLikeDeriving_16)
+                                                           sN2_FunctorLikeDeriving_27)
+                                                        sN1_FunctorLikeDeriving_26)))
+                                        sN2_FunctorLikeDeriving_29)
+                                     sN1_FunctorLikeDeriving_28))
+                        sA_FunctorLikeDeriving_33)
+                     _sz_FunctorLikeDeriving_17)))
       sFoldr
-        (_sf_0123456789876543210 :: Sing _f_0123456789876543210)
-        (_sz_0123456789876543210 :: Sing _z_0123456789876543210)
-        (SMkT2 (sA_0123456789876543210 :: Sing a_0123456789876543210))
+        (_sf_FunctorLikeDeriving_16 :: Sing _f_FunctorLikeDeriving_16)
+        (_sz_FunctorLikeDeriving_17 :: Sing _z_FunctorLikeDeriving_17)
+        (SMkT2 (sA_FunctorLikeDeriving_35 :: Sing a_FunctorLikeDeriving_35))
         = applySing
             (applySing
                (singFun2
-                  @(LamCases_0123456789876543210Sym0 x _f_0123456789876543210 _z_0123456789876543210 a_0123456789876543210)
+                  @(LamCases_FunctorLikeDeriving_94Sym0 x _f_FunctorLikeDeriving_16 _z_FunctorLikeDeriving_17 a_FunctorLikeDeriving_35)
                   (\cases
-                     _ (sN_0123456789876543210 :: Sing n_0123456789876543210)
-                       -> sN_0123456789876543210))
-               sA_0123456789876543210)
-            _sz_0123456789876543210
+                     _ (sN_FunctorLikeDeriving_34 :: Sing n_FunctorLikeDeriving_34)
+                       -> sN_FunctorLikeDeriving_34))
+               sA_FunctorLikeDeriving_35)
+            _sz_FunctorLikeDeriving_17
     instance STraversable (T x) where
       sTraverse
-        (_sf_0123456789876543210 :: Sing _f_0123456789876543210)
-        (SMkT1 (sA_0123456789876543210 :: Sing a_0123456789876543210)
-               (sA_0123456789876543210 :: Sing a_0123456789876543210)
-               (sA_0123456789876543210 :: Sing a_0123456789876543210)
-               (sA_0123456789876543210 :: Sing a_0123456789876543210))
+        (_sf_FunctorLikeDeriving_36 :: Sing _f_FunctorLikeDeriving_36)
+        (SMkT1 (sA_FunctorLikeDeriving_37 :: Sing a_FunctorLikeDeriving_37)
+               (sA_FunctorLikeDeriving_38 :: Sing a_FunctorLikeDeriving_38)
+               (sA_FunctorLikeDeriving_39 :: Sing a_FunctorLikeDeriving_39)
+               (sA_FunctorLikeDeriving_40 :: Sing a_FunctorLikeDeriving_40))
         = applySing
             (applySing
                (singFun2 @(<*>@#@$) (%<*>))
@@ -583,45 +586,54 @@ Singletons/FunctorLikeDeriving.hs:(0,0)-(0,0): Splicing declarations
                         (applySing
                            (applySing
                               (singFun3 @LiftA2Sym0 sLiftA2) (singFun4 @MkT1Sym0 SMkT1))
-                           (applySing (singFun1 @PureSym0 sPure) sA_0123456789876543210))
-                        (applySing _sf_0123456789876543210 sA_0123456789876543210)))
+                           (applySing (singFun1 @PureSym0 sPure) sA_FunctorLikeDeriving_37))
+                        (applySing _sf_FunctorLikeDeriving_36 sA_FunctorLikeDeriving_38)))
                   (applySing
                      (applySing
-                        (singFun2 @TraverseSym0 sTraverse) _sf_0123456789876543210)
-                     sA_0123456789876543210)))
+                        (singFun2 @TraverseSym0 sTraverse) _sf_FunctorLikeDeriving_36)
+                     sA_FunctorLikeDeriving_39)))
             (applySing
                (applySing
                   (singFun2 @TraverseSym0 sTraverse)
                   (applySing
-                     (singFun2 @TraverseSym0 sTraverse) _sf_0123456789876543210))
-               sA_0123456789876543210)
+                     (singFun2 @TraverseSym0 sTraverse) _sf_FunctorLikeDeriving_36))
+               sA_FunctorLikeDeriving_40)
       sTraverse
-        (_sf_0123456789876543210 :: Sing _f_0123456789876543210)
-        (SMkT2 (sA_0123456789876543210 :: Sing a_0123456789876543210))
+        (_sf_FunctorLikeDeriving_36 :: Sing _f_FunctorLikeDeriving_36)
+        (SMkT2 (sA_FunctorLikeDeriving_41 :: Sing a_FunctorLikeDeriving_41))
         = applySing
             (applySing (singFun2 @FmapSym0 sFmap) (singFun1 @MkT2Sym0 SMkT2))
-            (applySing (singFun1 @PureSym0 sPure) sA_0123456789876543210)
+            (applySing (singFun1 @PureSym0 sPure) sA_FunctorLikeDeriving_41)
     instance SFunctor Empty where
-      sFmap _ (sV_0123456789876543210 :: Sing v_0123456789876543210)
+      sFmap
+        _
+        (sV_FunctorLikeDeriving_44 :: Sing v_FunctorLikeDeriving_44)
         = applySing
             (singFun1
-               @(LamCases_0123456789876543210Sym0 v_0123456789876543210) (\case))
-            sV_0123456789876543210
-      (%<$) _ (sV_0123456789876543210 :: Sing v_0123456789876543210)
+               @(LamCases_FunctorLikeDeriving_103Sym0 v_FunctorLikeDeriving_44)
+               (\case))
+            sV_FunctorLikeDeriving_44
+      (%<$)
+        _
+        (sV_FunctorLikeDeriving_45 :: Sing v_FunctorLikeDeriving_45)
         = applySing
             (singFun1
-               @(LamCases_0123456789876543210Sym0 v_0123456789876543210) (\case))
-            sV_0123456789876543210
+               @(LamCases_FunctorLikeDeriving_108Sym0 v_FunctorLikeDeriving_45)
+               (\case))
+            sV_FunctorLikeDeriving_45
     instance SFoldable Empty where
       sFoldMap _ _ = sMempty
     instance STraversable Empty where
-      sTraverse _ (sV_0123456789876543210 :: Sing v_0123456789876543210)
+      sTraverse
+        _
+        (sV_FunctorLikeDeriving_49 :: Sing v_FunctorLikeDeriving_49)
         = applySing
             (singFun1 @PureSym0 sPure)
             (applySing
                (singFun1
-                  @(LamCases_0123456789876543210Sym0 v_0123456789876543210) (\case))
-               sV_0123456789876543210)
+                  @(LamCases_FunctorLikeDeriving_116Sym0 v_FunctorLikeDeriving_49)
+                  (\case))
+               sV_FunctorLikeDeriving_49)
     instance (SingI n, SingI n, SingI n, SingI n) =>
              SingI (MkT1 (n :: x) (n :: a) (n :: Maybe a) (n :: Maybe (Maybe a))) where
       sing = SMkT1 sing sing sing sing

--- a/singletons-base/tests/compile-and-dump/Singletons/HigherOrder.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/HigherOrder.golden
@@ -44,227 +44,227 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
     data LeftSym0 :: (~>) a (Either a b)
       where
         LeftSym0KindInference :: SameKind (Apply LeftSym0 arg) (LeftSym1 arg) =>
-                                 LeftSym0 a0123456789876543210
-    type instance Apply @a @(Either a b) LeftSym0 a0123456789876543210 = Left a0123456789876543210
+                                 LeftSym0 a_Singletons_HigherOrder_0
+    type instance Apply @a @(Either a b) LeftSym0 a_Singletons_HigherOrder_0 = Left a_Singletons_HigherOrder_0
     instance SuppressUnusedWarnings LeftSym0 where
       suppressUnusedWarnings = snd ((,) LeftSym0KindInference ())
     type LeftSym1 :: forall a b. a -> Either a b
-    type family LeftSym1 @a @b (a0123456789876543210 :: a) :: Either a b where
-      LeftSym1 a0123456789876543210 = Left a0123456789876543210
+    type family LeftSym1 @a @b (a_Singletons_HigherOrder_0 :: a) :: Either a b where
+      LeftSym1 a_Singletons_HigherOrder_0 = Left a_Singletons_HigherOrder_0
     type RightSym0 :: forall a b. (~>) b (Either a b)
     data RightSym0 :: (~>) b (Either a b)
       where
         RightSym0KindInference :: SameKind (Apply RightSym0 arg) (RightSym1 arg) =>
-                                  RightSym0 a0123456789876543210
-    type instance Apply @b @(Either a b) RightSym0 a0123456789876543210 = Right a0123456789876543210
+                                  RightSym0 a_Singletons_HigherOrder_1
+    type instance Apply @b @(Either a b) RightSym0 a_Singletons_HigherOrder_1 = Right a_Singletons_HigherOrder_1
     instance SuppressUnusedWarnings RightSym0 where
       suppressUnusedWarnings = snd ((,) RightSym0KindInference ())
     type RightSym1 :: forall a b. b -> Either a b
-    type family RightSym1 @a @b (a0123456789876543210 :: b) :: Either a b where
-      RightSym1 a0123456789876543210 = Right a0123456789876543210
-    type family LamCases_0123456789876543210 n0123456789876543210 b0123456789876543210 (a_01234567898765432100123456789876543210 :: [Nat]) (a_01234567898765432100123456789876543210 :: [Bool]) a_0123456789876543210 where
-      LamCases_0123456789876543210 n b a_0123456789876543210 a_0123456789876543210 'True = Apply SuccSym0 (Apply SuccSym0 n)
-      LamCases_0123456789876543210 n b a_0123456789876543210 a_0123456789876543210 'False = n
-    data LamCases_0123456789876543210Sym0 n0123456789876543210 b0123456789876543210 (a_01234567898765432100123456789876543210 :: [Nat]) (a_01234567898765432100123456789876543210 :: [Bool]) a_01234567898765432100123456789876543210
+    type family RightSym1 @a @b (a_Singletons_HigherOrder_1 :: b) :: Either a b where
+      RightSym1 a_Singletons_HigherOrder_1 = Right a_Singletons_HigherOrder_1
+    type family LamCases_Singletons_HigherOrder_7 n0 b1 (a_Singletons_HigherOrder_22 :: [Nat]) (a_Singletons_HigherOrder_33 :: [Bool]) a_Singletons_HigherOrder_8 where
+      LamCases_Singletons_HigherOrder_7 n b a_Singletons_HigherOrder_2 a_Singletons_HigherOrder_3 'True = Apply SuccSym0 (Apply SuccSym0 n)
+      LamCases_Singletons_HigherOrder_7 n b a_Singletons_HigherOrder_2 a_Singletons_HigherOrder_3 'False = n
+    data LamCases_Singletons_HigherOrder_7Sym0 n0 b1 (a_Singletons_HigherOrder_22 :: [Nat]) (a_Singletons_HigherOrder_33 :: [Bool]) a_Singletons_HigherOrder_8
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 n0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 n0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 n0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 n0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 n0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 n0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
+        LamCases_Singletons_HigherOrder_7Sym0KindInference :: SameKind (Apply (LamCases_Singletons_HigherOrder_7Sym0 n0 b1 a_Singletons_HigherOrder_22 a_Singletons_HigherOrder_33) arg) (LamCases_Singletons_HigherOrder_7Sym1 n0 b1 a_Singletons_HigherOrder_22 a_Singletons_HigherOrder_33 arg) =>
+                                                              LamCases_Singletons_HigherOrder_7Sym0 n0 b1 a_Singletons_HigherOrder_22 a_Singletons_HigherOrder_33 a_Singletons_HigherOrder_8
+    type instance Apply @_ @_ (LamCases_Singletons_HigherOrder_7Sym0 n0 b1 a_Singletons_HigherOrder_22 a_Singletons_HigherOrder_33) a_Singletons_HigherOrder_8 = LamCases_Singletons_HigherOrder_7 n0 b1 a_Singletons_HigherOrder_22 a_Singletons_HigherOrder_33 a_Singletons_HigherOrder_8
+    instance SuppressUnusedWarnings (LamCases_Singletons_HigherOrder_7Sym0 n0 b1 a_Singletons_HigherOrder_22 a_Singletons_HigherOrder_33) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 n0123456789876543210 b0123456789876543210 (a_01234567898765432100123456789876543210 :: [Nat]) (a_01234567898765432100123456789876543210 :: [Bool]) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 n0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 n0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (a_01234567898765432100123456789876543210 :: [Nat]) (a_01234567898765432100123456789876543210 :: [Bool]) a_0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 a_0123456789876543210 a_0123456789876543210 n b = Apply (LamCases_0123456789876543210Sym0 n b a_0123456789876543210 a_0123456789876543210) b
-    data LamCases_0123456789876543210Sym0 (a_01234567898765432100123456789876543210 :: [Nat]) (a_01234567898765432100123456789876543210 :: [Bool]) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_HigherOrder_7Sym0KindInference ())
+    type family LamCases_Singletons_HigherOrder_7Sym1 n0 b1 (a_Singletons_HigherOrder_22 :: [Nat]) (a_Singletons_HigherOrder_33 :: [Bool]) a_Singletons_HigherOrder_8 where
+      LamCases_Singletons_HigherOrder_7Sym1 n0 b1 a_Singletons_HigherOrder_22 a_Singletons_HigherOrder_33 a_Singletons_HigherOrder_8 = LamCases_Singletons_HigherOrder_7 n0 b1 a_Singletons_HigherOrder_22 a_Singletons_HigherOrder_33 a_Singletons_HigherOrder_8
+    type family LamCases_Singletons_HigherOrder_6 (a_Singletons_HigherOrder_20 :: [Nat]) (a_Singletons_HigherOrder_31 :: [Bool]) a_Singletons_HigherOrder_9 a_Singletons_HigherOrder_10 where
+      LamCases_Singletons_HigherOrder_6 a_Singletons_HigherOrder_2 a_Singletons_HigherOrder_3 n b = Apply (LamCases_Singletons_HigherOrder_7Sym0 n b a_Singletons_HigherOrder_2 a_Singletons_HigherOrder_3) b
+    data LamCases_Singletons_HigherOrder_6Sym0 (a_Singletons_HigherOrder_20 :: [Nat]) (a_Singletons_HigherOrder_31 :: [Bool]) a_Singletons_HigherOrder_9
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
+        LamCases_Singletons_HigherOrder_6Sym0KindInference :: SameKind (Apply (LamCases_Singletons_HigherOrder_6Sym0 a_Singletons_HigherOrder_20 a_Singletons_HigherOrder_31) arg) (LamCases_Singletons_HigherOrder_6Sym1 a_Singletons_HigherOrder_20 a_Singletons_HigherOrder_31 arg) =>
+                                                              LamCases_Singletons_HigherOrder_6Sym0 a_Singletons_HigherOrder_20 a_Singletons_HigherOrder_31 a_Singletons_HigherOrder_9
+    type instance Apply @_ @_ (LamCases_Singletons_HigherOrder_6Sym0 a_Singletons_HigherOrder_20 a_Singletons_HigherOrder_31) a_Singletons_HigherOrder_9 = LamCases_Singletons_HigherOrder_6Sym1 a_Singletons_HigherOrder_20 a_Singletons_HigherOrder_31 a_Singletons_HigherOrder_9
+    instance SuppressUnusedWarnings (LamCases_Singletons_HigherOrder_6Sym0 a_Singletons_HigherOrder_20 a_Singletons_HigherOrder_31) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    data LamCases_0123456789876543210Sym1 (a_01234567898765432100123456789876543210 :: [Nat]) (a_01234567898765432100123456789876543210 :: [Bool]) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_HigherOrder_6Sym0KindInference ())
+    data LamCases_Singletons_HigherOrder_6Sym1 (a_Singletons_HigherOrder_20 :: [Nat]) (a_Singletons_HigherOrder_31 :: [Bool]) a_Singletons_HigherOrder_9 a_Singletons_HigherOrder_10
       where
-        LamCases_0123456789876543210Sym1KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym2 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
+        LamCases_Singletons_HigherOrder_6Sym1KindInference :: SameKind (Apply (LamCases_Singletons_HigherOrder_6Sym1 a_Singletons_HigherOrder_20 a_Singletons_HigherOrder_31 a_Singletons_HigherOrder_9) arg) (LamCases_Singletons_HigherOrder_6Sym2 a_Singletons_HigherOrder_20 a_Singletons_HigherOrder_31 a_Singletons_HigherOrder_9 arg) =>
+                                                              LamCases_Singletons_HigherOrder_6Sym1 a_Singletons_HigherOrder_20 a_Singletons_HigherOrder_31 a_Singletons_HigherOrder_9 a_Singletons_HigherOrder_10
+    type instance Apply @_ @_ (LamCases_Singletons_HigherOrder_6Sym1 a_Singletons_HigherOrder_20 a_Singletons_HigherOrder_31 a_Singletons_HigherOrder_9) a_Singletons_HigherOrder_10 = LamCases_Singletons_HigherOrder_6 a_Singletons_HigherOrder_20 a_Singletons_HigherOrder_31 a_Singletons_HigherOrder_9 a_Singletons_HigherOrder_10
+    instance SuppressUnusedWarnings (LamCases_Singletons_HigherOrder_6Sym1 a_Singletons_HigherOrder_20 a_Singletons_HigherOrder_31 a_Singletons_HigherOrder_9) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym1KindInference ())
-    type family LamCases_0123456789876543210Sym2 (a_01234567898765432100123456789876543210 :: [Nat]) (a_01234567898765432100123456789876543210 :: [Bool]) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym2 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 n0123456789876543210 b0123456789876543210 (ns0123456789876543210 :: [Nat]) (bs0123456789876543210 :: [Bool]) a_0123456789876543210 where
-      LamCases_0123456789876543210 n b ns bs 'True = Apply SuccSym0 (Apply SuccSym0 n)
-      LamCases_0123456789876543210 n b ns bs 'False = n
-    data LamCases_0123456789876543210Sym0 n0123456789876543210 b0123456789876543210 (ns0123456789876543210 :: [Nat]) (bs0123456789876543210 :: [Bool]) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_HigherOrder_6Sym1KindInference ())
+    type family LamCases_Singletons_HigherOrder_6Sym2 (a_Singletons_HigherOrder_20 :: [Nat]) (a_Singletons_HigherOrder_31 :: [Bool]) a_Singletons_HigherOrder_9 a_Singletons_HigherOrder_10 where
+      LamCases_Singletons_HigherOrder_6Sym2 a_Singletons_HigherOrder_20 a_Singletons_HigherOrder_31 a_Singletons_HigherOrder_9 a_Singletons_HigherOrder_10 = LamCases_Singletons_HigherOrder_6 a_Singletons_HigherOrder_20 a_Singletons_HigherOrder_31 a_Singletons_HigherOrder_9 a_Singletons_HigherOrder_10
+    type family LamCases_Singletons_HigherOrder_14 n0 b1 (ns2 :: [Nat]) (bs3 :: [Bool]) a_Singletons_HigherOrder_15 where
+      LamCases_Singletons_HigherOrder_14 n b ns bs 'True = Apply SuccSym0 (Apply SuccSym0 n)
+      LamCases_Singletons_HigherOrder_14 n b ns bs 'False = n
+    data LamCases_Singletons_HigherOrder_14Sym0 n0 b1 (ns2 :: [Nat]) (bs3 :: [Bool]) a_Singletons_HigherOrder_15
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 n0123456789876543210 b0123456789876543210 ns0123456789876543210 bs0123456789876543210) arg) (LamCases_0123456789876543210Sym1 n0123456789876543210 b0123456789876543210 ns0123456789876543210 bs0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 n0123456789876543210 b0123456789876543210 ns0123456789876543210 bs0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 n0123456789876543210 b0123456789876543210 ns0123456789876543210 bs0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 n0123456789876543210 b0123456789876543210 ns0123456789876543210 bs0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 n0123456789876543210 b0123456789876543210 ns0123456789876543210 bs0123456789876543210) where
+        LamCases_Singletons_HigherOrder_14Sym0KindInference :: SameKind (Apply (LamCases_Singletons_HigherOrder_14Sym0 n0 b1 ns2 bs3) arg) (LamCases_Singletons_HigherOrder_14Sym1 n0 b1 ns2 bs3 arg) =>
+                                                               LamCases_Singletons_HigherOrder_14Sym0 n0 b1 ns2 bs3 a_Singletons_HigherOrder_15
+    type instance Apply @_ @_ (LamCases_Singletons_HigherOrder_14Sym0 n0 b1 ns2 bs3) a_Singletons_HigherOrder_15 = LamCases_Singletons_HigherOrder_14 n0 b1 ns2 bs3 a_Singletons_HigherOrder_15
+    instance SuppressUnusedWarnings (LamCases_Singletons_HigherOrder_14Sym0 n0 b1 ns2 bs3) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 n0123456789876543210 b0123456789876543210 (ns0123456789876543210 :: [Nat]) (bs0123456789876543210 :: [Bool]) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 n0123456789876543210 b0123456789876543210 ns0123456789876543210 bs0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 n0123456789876543210 b0123456789876543210 ns0123456789876543210 bs0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (ns0123456789876543210 :: [Nat]) (bs0123456789876543210 :: [Bool]) a_0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 ns bs n b = Apply (LamCases_0123456789876543210Sym0 n b ns bs) b
-    data LamCases_0123456789876543210Sym0 (ns0123456789876543210 :: [Nat]) (bs0123456789876543210 :: [Bool]) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_HigherOrder_14Sym0KindInference ())
+    type family LamCases_Singletons_HigherOrder_14Sym1 n0 b1 (ns2 :: [Nat]) (bs3 :: [Bool]) a_Singletons_HigherOrder_15 where
+      LamCases_Singletons_HigherOrder_14Sym1 n0 b1 ns2 bs3 a_Singletons_HigherOrder_15 = LamCases_Singletons_HigherOrder_14 n0 b1 ns2 bs3 a_Singletons_HigherOrder_15
+    type family LamCases_Singletons_HigherOrder_13 (ns0 :: [Nat]) (bs1 :: [Bool]) a_Singletons_HigherOrder_16 a_Singletons_HigherOrder_17 where
+      LamCases_Singletons_HigherOrder_13 ns bs n b = Apply (LamCases_Singletons_HigherOrder_14Sym0 n b ns bs) b
+    data LamCases_Singletons_HigherOrder_13Sym0 (ns0 :: [Nat]) (bs1 :: [Bool]) a_Singletons_HigherOrder_16
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 ns0123456789876543210 bs0123456789876543210) arg) (LamCases_0123456789876543210Sym1 ns0123456789876543210 bs0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 ns0123456789876543210 bs0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 ns0123456789876543210 bs0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210Sym1 ns0123456789876543210 bs0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 ns0123456789876543210 bs0123456789876543210) where
+        LamCases_Singletons_HigherOrder_13Sym0KindInference :: SameKind (Apply (LamCases_Singletons_HigherOrder_13Sym0 ns0 bs1) arg) (LamCases_Singletons_HigherOrder_13Sym1 ns0 bs1 arg) =>
+                                                               LamCases_Singletons_HigherOrder_13Sym0 ns0 bs1 a_Singletons_HigherOrder_16
+    type instance Apply @_ @_ (LamCases_Singletons_HigherOrder_13Sym0 ns0 bs1) a_Singletons_HigherOrder_16 = LamCases_Singletons_HigherOrder_13Sym1 ns0 bs1 a_Singletons_HigherOrder_16
+    instance SuppressUnusedWarnings (LamCases_Singletons_HigherOrder_13Sym0 ns0 bs1) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    data LamCases_0123456789876543210Sym1 (ns0123456789876543210 :: [Nat]) (bs0123456789876543210 :: [Bool]) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_HigherOrder_13Sym0KindInference ())
+    data LamCases_Singletons_HigherOrder_13Sym1 (ns0 :: [Nat]) (bs1 :: [Bool]) a_Singletons_HigherOrder_16 a_Singletons_HigherOrder_17
       where
-        LamCases_0123456789876543210Sym1KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym1 ns0123456789876543210 bs0123456789876543210 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym2 ns0123456789876543210 bs0123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym1 ns0123456789876543210 bs0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym1 ns0123456789876543210 bs0123456789876543210 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 ns0123456789876543210 bs0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym1 ns0123456789876543210 bs0123456789876543210 a_01234567898765432100123456789876543210) where
+        LamCases_Singletons_HigherOrder_13Sym1KindInference :: SameKind (Apply (LamCases_Singletons_HigherOrder_13Sym1 ns0 bs1 a_Singletons_HigherOrder_16) arg) (LamCases_Singletons_HigherOrder_13Sym2 ns0 bs1 a_Singletons_HigherOrder_16 arg) =>
+                                                               LamCases_Singletons_HigherOrder_13Sym1 ns0 bs1 a_Singletons_HigherOrder_16 a_Singletons_HigherOrder_17
+    type instance Apply @_ @_ (LamCases_Singletons_HigherOrder_13Sym1 ns0 bs1 a_Singletons_HigherOrder_16) a_Singletons_HigherOrder_17 = LamCases_Singletons_HigherOrder_13 ns0 bs1 a_Singletons_HigherOrder_16 a_Singletons_HigherOrder_17
+    instance SuppressUnusedWarnings (LamCases_Singletons_HigherOrder_13Sym1 ns0 bs1 a_Singletons_HigherOrder_16) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym1KindInference ())
-    type family LamCases_0123456789876543210Sym2 (ns0123456789876543210 :: [Nat]) (bs0123456789876543210 :: [Bool]) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym2 ns0123456789876543210 bs0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 ns0123456789876543210 bs0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_HigherOrder_13Sym1KindInference ())
+    type family LamCases_Singletons_HigherOrder_13Sym2 (ns0 :: [Nat]) (bs1 :: [Bool]) a_Singletons_HigherOrder_16 a_Singletons_HigherOrder_17 where
+      LamCases_Singletons_HigherOrder_13Sym2 ns0 bs1 a_Singletons_HigherOrder_16 a_Singletons_HigherOrder_17 = LamCases_Singletons_HigherOrder_13 ns0 bs1 a_Singletons_HigherOrder_16 a_Singletons_HigherOrder_17
     type EtadSym0 :: (~>) [Nat] ((~>) [Bool] [Nat])
     data EtadSym0 :: (~>) [Nat] ((~>) [Bool] [Nat])
       where
         EtadSym0KindInference :: SameKind (Apply EtadSym0 arg) (EtadSym1 arg) =>
-                                 EtadSym0 a0123456789876543210
-    type instance Apply @[Nat] @((~>) [Bool] [Nat]) EtadSym0 a0123456789876543210 = EtadSym1 a0123456789876543210
+                                 EtadSym0 a_Singletons_HigherOrder_4
+    type instance Apply @[Nat] @((~>) [Bool] [Nat]) EtadSym0 a_Singletons_HigherOrder_4 = EtadSym1 a_Singletons_HigherOrder_4
     instance SuppressUnusedWarnings EtadSym0 where
       suppressUnusedWarnings = snd ((,) EtadSym0KindInference ())
     type EtadSym1 :: [Nat] -> (~>) [Bool] [Nat]
-    data EtadSym1 (a0123456789876543210 :: [Nat]) :: (~>) [Bool] [Nat]
+    data EtadSym1 (a_Singletons_HigherOrder_4 :: [Nat]) :: (~>) [Bool] [Nat]
       where
-        EtadSym1KindInference :: SameKind (Apply (EtadSym1 a0123456789876543210) arg) (EtadSym2 a0123456789876543210 arg) =>
-                                 EtadSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @[Bool] @[Nat] (EtadSym1 a0123456789876543210) a0123456789876543210 = Etad a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (EtadSym1 a0123456789876543210) where
+        EtadSym1KindInference :: SameKind (Apply (EtadSym1 a_Singletons_HigherOrder_4) arg) (EtadSym2 a_Singletons_HigherOrder_4 arg) =>
+                                 EtadSym1 a_Singletons_HigherOrder_4 a_Singletons_HigherOrder_5
+    type instance Apply @[Bool] @[Nat] (EtadSym1 a_Singletons_HigherOrder_4) a_Singletons_HigherOrder_5 = Etad a_Singletons_HigherOrder_4 a_Singletons_HigherOrder_5
+    instance SuppressUnusedWarnings (EtadSym1 a_Singletons_HigherOrder_4) where
       suppressUnusedWarnings = snd ((,) EtadSym1KindInference ())
     type EtadSym2 :: [Nat] -> [Bool] -> [Nat]
-    type family EtadSym2 (a0123456789876543210 :: [Nat]) (a0123456789876543210 :: [Bool]) :: [Nat] where
-      EtadSym2 a0123456789876543210 a0123456789876543210 = Etad a0123456789876543210 a0123456789876543210
+    type family EtadSym2 (a_Singletons_HigherOrder_4 :: [Nat]) (a_Singletons_HigherOrder_5 :: [Bool]) :: [Nat] where
+      EtadSym2 a_Singletons_HigherOrder_4 a_Singletons_HigherOrder_5 = Etad a_Singletons_HigherOrder_4 a_Singletons_HigherOrder_5
     type SplungeSym0 :: (~>) [Nat] ((~>) [Bool] [Nat])
     data SplungeSym0 :: (~>) [Nat] ((~>) [Bool] [Nat])
       where
         SplungeSym0KindInference :: SameKind (Apply SplungeSym0 arg) (SplungeSym1 arg) =>
-                                    SplungeSym0 a0123456789876543210
-    type instance Apply @[Nat] @((~>) [Bool] [Nat]) SplungeSym0 a0123456789876543210 = SplungeSym1 a0123456789876543210
+                                    SplungeSym0 a_Singletons_HigherOrder_11
+    type instance Apply @[Nat] @((~>) [Bool] [Nat]) SplungeSym0 a_Singletons_HigherOrder_11 = SplungeSym1 a_Singletons_HigherOrder_11
     instance SuppressUnusedWarnings SplungeSym0 where
       suppressUnusedWarnings = snd ((,) SplungeSym0KindInference ())
     type SplungeSym1 :: [Nat] -> (~>) [Bool] [Nat]
-    data SplungeSym1 (a0123456789876543210 :: [Nat]) :: (~>) [Bool] [Nat]
+    data SplungeSym1 (a_Singletons_HigherOrder_11 :: [Nat]) :: (~>) [Bool] [Nat]
       where
-        SplungeSym1KindInference :: SameKind (Apply (SplungeSym1 a0123456789876543210) arg) (SplungeSym2 a0123456789876543210 arg) =>
-                                    SplungeSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @[Bool] @[Nat] (SplungeSym1 a0123456789876543210) a0123456789876543210 = Splunge a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (SplungeSym1 a0123456789876543210) where
+        SplungeSym1KindInference :: SameKind (Apply (SplungeSym1 a_Singletons_HigherOrder_11) arg) (SplungeSym2 a_Singletons_HigherOrder_11 arg) =>
+                                    SplungeSym1 a_Singletons_HigherOrder_11 a_Singletons_HigherOrder_12
+    type instance Apply @[Bool] @[Nat] (SplungeSym1 a_Singletons_HigherOrder_11) a_Singletons_HigherOrder_12 = Splunge a_Singletons_HigherOrder_11 a_Singletons_HigherOrder_12
+    instance SuppressUnusedWarnings (SplungeSym1 a_Singletons_HigherOrder_11) where
       suppressUnusedWarnings = snd ((,) SplungeSym1KindInference ())
     type SplungeSym2 :: [Nat] -> [Bool] -> [Nat]
-    type family SplungeSym2 (a0123456789876543210 :: [Nat]) (a0123456789876543210 :: [Bool]) :: [Nat] where
-      SplungeSym2 a0123456789876543210 a0123456789876543210 = Splunge a0123456789876543210 a0123456789876543210
+    type family SplungeSym2 (a_Singletons_HigherOrder_11 :: [Nat]) (a_Singletons_HigherOrder_12 :: [Bool]) :: [Nat] where
+      SplungeSym2 a_Singletons_HigherOrder_11 a_Singletons_HigherOrder_12 = Splunge a_Singletons_HigherOrder_11 a_Singletons_HigherOrder_12
     type FooSym0 :: (~>) ((~>) ((~>) a b) ((~>) a b)) ((~>) ((~>) a b) ((~>) a b))
     data FooSym0 :: (~>) ((~>) ((~>) a b) ((~>) a b)) ((~>) ((~>) a b) ((~>) a b))
       where
         FooSym0KindInference :: SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
-                                FooSym0 a0123456789876543210
-    type instance Apply @((~>) ((~>) a b) ((~>) a b)) @((~>) ((~>) a b) ((~>) a b)) FooSym0 a0123456789876543210 = FooSym1 a0123456789876543210
+                                FooSym0 a_Singletons_HigherOrder_18
+    type instance Apply @((~>) ((~>) a b) ((~>) a b)) @((~>) ((~>) a b) ((~>) a b)) FooSym0 a_Singletons_HigherOrder_18 = FooSym1 a_Singletons_HigherOrder_18
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings = snd ((,) FooSym0KindInference ())
     type FooSym1 :: (~>) ((~>) a b) ((~>) a b)
                     -> (~>) ((~>) a b) ((~>) a b)
-    data FooSym1 (a0123456789876543210 :: (~>) ((~>) a b) ((~>) a b)) :: (~>) ((~>) a b) ((~>) a b)
+    data FooSym1 (a_Singletons_HigherOrder_18 :: (~>) ((~>) a b) ((~>) a b)) :: (~>) ((~>) a b) ((~>) a b)
       where
-        FooSym1KindInference :: SameKind (Apply (FooSym1 a0123456789876543210) arg) (FooSym2 a0123456789876543210 arg) =>
-                                FooSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @((~>) a b) @((~>) a b) (FooSym1 a0123456789876543210) a0123456789876543210 = FooSym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (FooSym1 a0123456789876543210) where
+        FooSym1KindInference :: SameKind (Apply (FooSym1 a_Singletons_HigherOrder_18) arg) (FooSym2 a_Singletons_HigherOrder_18 arg) =>
+                                FooSym1 a_Singletons_HigherOrder_18 a_Singletons_HigherOrder_19
+    type instance Apply @((~>) a b) @((~>) a b) (FooSym1 a_Singletons_HigherOrder_18) a_Singletons_HigherOrder_19 = FooSym2 a_Singletons_HigherOrder_18 a_Singletons_HigherOrder_19
+    instance SuppressUnusedWarnings (FooSym1 a_Singletons_HigherOrder_18) where
       suppressUnusedWarnings = snd ((,) FooSym1KindInference ())
     type FooSym2 :: (~>) ((~>) a b) ((~>) a b) -> (~>) a b -> (~>) a b
-    data FooSym2 (a0123456789876543210 :: (~>) ((~>) a b) ((~>) a b)) (a0123456789876543210 :: (~>) a b) :: (~>) a b
+    data FooSym2 (a_Singletons_HigherOrder_18 :: (~>) ((~>) a b) ((~>) a b)) (a_Singletons_HigherOrder_19 :: (~>) a b) :: (~>) a b
       where
-        FooSym2KindInference :: SameKind (Apply (FooSym2 a0123456789876543210 a0123456789876543210) arg) (FooSym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                FooSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @a @b (FooSym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = Foo a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (FooSym2 a0123456789876543210 a0123456789876543210) where
+        FooSym2KindInference :: SameKind (Apply (FooSym2 a_Singletons_HigherOrder_18 a_Singletons_HigherOrder_19) arg) (FooSym3 a_Singletons_HigherOrder_18 a_Singletons_HigherOrder_19 arg) =>
+                                FooSym2 a_Singletons_HigherOrder_18 a_Singletons_HigherOrder_19 a_Singletons_HigherOrder_20
+    type instance Apply @a @b (FooSym2 a_Singletons_HigherOrder_18 a_Singletons_HigherOrder_19) a_Singletons_HigherOrder_20 = Foo a_Singletons_HigherOrder_18 a_Singletons_HigherOrder_19 a_Singletons_HigherOrder_20
+    instance SuppressUnusedWarnings (FooSym2 a_Singletons_HigherOrder_18 a_Singletons_HigherOrder_19) where
       suppressUnusedWarnings = snd ((,) FooSym2KindInference ())
     type FooSym3 :: (~>) ((~>) a b) ((~>) a b) -> (~>) a b -> a -> b
-    type family FooSym3 @a @b (a0123456789876543210 :: (~>) ((~>) a b) ((~>) a b)) (a0123456789876543210 :: (~>) a b) (a0123456789876543210 :: a) :: b where
-      FooSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = Foo a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type family FooSym3 @a @b (a_Singletons_HigherOrder_18 :: (~>) ((~>) a b) ((~>) a b)) (a_Singletons_HigherOrder_19 :: (~>) a b) (a_Singletons_HigherOrder_20 :: a) :: b where
+      FooSym3 a_Singletons_HigherOrder_18 a_Singletons_HigherOrder_19 a_Singletons_HigherOrder_20 = Foo a_Singletons_HigherOrder_18 a_Singletons_HigherOrder_19 a_Singletons_HigherOrder_20
     type ZipWithSym0 :: (~>) ((~>) a ((~>) b c)) ((~>) [a] ((~>) [b] [c]))
     data ZipWithSym0 :: (~>) ((~>) a ((~>) b c)) ((~>) [a] ((~>) [b] [c]))
       where
         ZipWithSym0KindInference :: SameKind (Apply ZipWithSym0 arg) (ZipWithSym1 arg) =>
-                                    ZipWithSym0 a0123456789876543210
-    type instance Apply @((~>) a ((~>) b c)) @((~>) [a] ((~>) [b] [c])) ZipWithSym0 a0123456789876543210 = ZipWithSym1 a0123456789876543210
+                                    ZipWithSym0 a_Singletons_HigherOrder_21
+    type instance Apply @((~>) a ((~>) b c)) @((~>) [a] ((~>) [b] [c])) ZipWithSym0 a_Singletons_HigherOrder_21 = ZipWithSym1 a_Singletons_HigherOrder_21
     instance SuppressUnusedWarnings ZipWithSym0 where
       suppressUnusedWarnings = snd ((,) ZipWithSym0KindInference ())
     type ZipWithSym1 :: (~>) a ((~>) b c) -> (~>) [a] ((~>) [b] [c])
-    data ZipWithSym1 (a0123456789876543210 :: (~>) a ((~>) b c)) :: (~>) [a] ((~>) [b] [c])
+    data ZipWithSym1 (a_Singletons_HigherOrder_21 :: (~>) a ((~>) b c)) :: (~>) [a] ((~>) [b] [c])
       where
-        ZipWithSym1KindInference :: SameKind (Apply (ZipWithSym1 a0123456789876543210) arg) (ZipWithSym2 a0123456789876543210 arg) =>
-                                    ZipWithSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @[a] @((~>) [b] [c]) (ZipWithSym1 a0123456789876543210) a0123456789876543210 = ZipWithSym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ZipWithSym1 a0123456789876543210) where
+        ZipWithSym1KindInference :: SameKind (Apply (ZipWithSym1 a_Singletons_HigherOrder_21) arg) (ZipWithSym2 a_Singletons_HigherOrder_21 arg) =>
+                                    ZipWithSym1 a_Singletons_HigherOrder_21 a_Singletons_HigherOrder_22
+    type instance Apply @[a] @((~>) [b] [c]) (ZipWithSym1 a_Singletons_HigherOrder_21) a_Singletons_HigherOrder_22 = ZipWithSym2 a_Singletons_HigherOrder_21 a_Singletons_HigherOrder_22
+    instance SuppressUnusedWarnings (ZipWithSym1 a_Singletons_HigherOrder_21) where
       suppressUnusedWarnings = snd ((,) ZipWithSym1KindInference ())
     type ZipWithSym2 :: (~>) a ((~>) b c) -> [a] -> (~>) [b] [c]
-    data ZipWithSym2 (a0123456789876543210 :: (~>) a ((~>) b c)) (a0123456789876543210 :: [a]) :: (~>) [b] [c]
+    data ZipWithSym2 (a_Singletons_HigherOrder_21 :: (~>) a ((~>) b c)) (a_Singletons_HigherOrder_22 :: [a]) :: (~>) [b] [c]
       where
-        ZipWithSym2KindInference :: SameKind (Apply (ZipWithSym2 a0123456789876543210 a0123456789876543210) arg) (ZipWithSym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                    ZipWithSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @[b] @[c] (ZipWithSym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ZipWith a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ZipWithSym2 a0123456789876543210 a0123456789876543210) where
+        ZipWithSym2KindInference :: SameKind (Apply (ZipWithSym2 a_Singletons_HigherOrder_21 a_Singletons_HigherOrder_22) arg) (ZipWithSym3 a_Singletons_HigherOrder_21 a_Singletons_HigherOrder_22 arg) =>
+                                    ZipWithSym2 a_Singletons_HigherOrder_21 a_Singletons_HigherOrder_22 a_Singletons_HigherOrder_23
+    type instance Apply @[b] @[c] (ZipWithSym2 a_Singletons_HigherOrder_21 a_Singletons_HigherOrder_22) a_Singletons_HigherOrder_23 = ZipWith a_Singletons_HigherOrder_21 a_Singletons_HigherOrder_22 a_Singletons_HigherOrder_23
+    instance SuppressUnusedWarnings (ZipWithSym2 a_Singletons_HigherOrder_21 a_Singletons_HigherOrder_22) where
       suppressUnusedWarnings = snd ((,) ZipWithSym2KindInference ())
     type ZipWithSym3 :: (~>) a ((~>) b c) -> [a] -> [b] -> [c]
-    type family ZipWithSym3 @a @b @c (a0123456789876543210 :: (~>) a ((~>) b c)) (a0123456789876543210 :: [a]) (a0123456789876543210 :: [b]) :: [c] where
-      ZipWithSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ZipWith a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type family ZipWithSym3 @a @b @c (a_Singletons_HigherOrder_21 :: (~>) a ((~>) b c)) (a_Singletons_HigherOrder_22 :: [a]) (a_Singletons_HigherOrder_23 :: [b]) :: [c] where
+      ZipWithSym3 a_Singletons_HigherOrder_21 a_Singletons_HigherOrder_22 a_Singletons_HigherOrder_23 = ZipWith a_Singletons_HigherOrder_21 a_Singletons_HigherOrder_22 a_Singletons_HigherOrder_23
     type LiftMaybeSym0 :: (~>) ((~>) a b) ((~>) (Maybe a) (Maybe b))
     data LiftMaybeSym0 :: (~>) ((~>) a b) ((~>) (Maybe a) (Maybe b))
       where
         LiftMaybeSym0KindInference :: SameKind (Apply LiftMaybeSym0 arg) (LiftMaybeSym1 arg) =>
-                                      LiftMaybeSym0 a0123456789876543210
-    type instance Apply @((~>) a b) @((~>) (Maybe a) (Maybe b)) LiftMaybeSym0 a0123456789876543210 = LiftMaybeSym1 a0123456789876543210
+                                      LiftMaybeSym0 a_Singletons_HigherOrder_24
+    type instance Apply @((~>) a b) @((~>) (Maybe a) (Maybe b)) LiftMaybeSym0 a_Singletons_HigherOrder_24 = LiftMaybeSym1 a_Singletons_HigherOrder_24
     instance SuppressUnusedWarnings LiftMaybeSym0 where
       suppressUnusedWarnings = snd ((,) LiftMaybeSym0KindInference ())
     type LiftMaybeSym1 :: (~>) a b -> (~>) (Maybe a) (Maybe b)
-    data LiftMaybeSym1 (a0123456789876543210 :: (~>) a b) :: (~>) (Maybe a) (Maybe b)
+    data LiftMaybeSym1 (a_Singletons_HigherOrder_24 :: (~>) a b) :: (~>) (Maybe a) (Maybe b)
       where
-        LiftMaybeSym1KindInference :: SameKind (Apply (LiftMaybeSym1 a0123456789876543210) arg) (LiftMaybeSym2 a0123456789876543210 arg) =>
-                                      LiftMaybeSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Maybe a) @(Maybe b) (LiftMaybeSym1 a0123456789876543210) a0123456789876543210 = LiftMaybe a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (LiftMaybeSym1 a0123456789876543210) where
+        LiftMaybeSym1KindInference :: SameKind (Apply (LiftMaybeSym1 a_Singletons_HigherOrder_24) arg) (LiftMaybeSym2 a_Singletons_HigherOrder_24 arg) =>
+                                      LiftMaybeSym1 a_Singletons_HigherOrder_24 a_Singletons_HigherOrder_25
+    type instance Apply @(Maybe a) @(Maybe b) (LiftMaybeSym1 a_Singletons_HigherOrder_24) a_Singletons_HigherOrder_25 = LiftMaybe a_Singletons_HigherOrder_24 a_Singletons_HigherOrder_25
+    instance SuppressUnusedWarnings (LiftMaybeSym1 a_Singletons_HigherOrder_24) where
       suppressUnusedWarnings = snd ((,) LiftMaybeSym1KindInference ())
     type LiftMaybeSym2 :: (~>) a b -> Maybe a -> Maybe b
-    type family LiftMaybeSym2 @a @b (a0123456789876543210 :: (~>) a b) (a0123456789876543210 :: Maybe a) :: Maybe b where
-      LiftMaybeSym2 a0123456789876543210 a0123456789876543210 = LiftMaybe a0123456789876543210 a0123456789876543210
+    type family LiftMaybeSym2 @a @b (a_Singletons_HigherOrder_24 :: (~>) a b) (a_Singletons_HigherOrder_25 :: Maybe a) :: Maybe b where
+      LiftMaybeSym2 a_Singletons_HigherOrder_24 a_Singletons_HigherOrder_25 = LiftMaybe a_Singletons_HigherOrder_24 a_Singletons_HigherOrder_25
     type MapSym0 :: (~>) ((~>) a b) ((~>) [a] [b])
     data MapSym0 :: (~>) ((~>) a b) ((~>) [a] [b])
       where
         MapSym0KindInference :: SameKind (Apply MapSym0 arg) (MapSym1 arg) =>
-                                MapSym0 a0123456789876543210
-    type instance Apply @((~>) a b) @((~>) [a] [b]) MapSym0 a0123456789876543210 = MapSym1 a0123456789876543210
+                                MapSym0 a_Singletons_HigherOrder_26
+    type instance Apply @((~>) a b) @((~>) [a] [b]) MapSym0 a_Singletons_HigherOrder_26 = MapSym1 a_Singletons_HigherOrder_26
     instance SuppressUnusedWarnings MapSym0 where
       suppressUnusedWarnings = snd ((,) MapSym0KindInference ())
     type MapSym1 :: (~>) a b -> (~>) [a] [b]
-    data MapSym1 (a0123456789876543210 :: (~>) a b) :: (~>) [a] [b]
+    data MapSym1 (a_Singletons_HigherOrder_26 :: (~>) a b) :: (~>) [a] [b]
       where
-        MapSym1KindInference :: SameKind (Apply (MapSym1 a0123456789876543210) arg) (MapSym2 a0123456789876543210 arg) =>
-                                MapSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @[a] @[b] (MapSym1 a0123456789876543210) a0123456789876543210 = Map a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (MapSym1 a0123456789876543210) where
+        MapSym1KindInference :: SameKind (Apply (MapSym1 a_Singletons_HigherOrder_26) arg) (MapSym2 a_Singletons_HigherOrder_26 arg) =>
+                                MapSym1 a_Singletons_HigherOrder_26 a_Singletons_HigherOrder_27
+    type instance Apply @[a] @[b] (MapSym1 a_Singletons_HigherOrder_26) a_Singletons_HigherOrder_27 = Map a_Singletons_HigherOrder_26 a_Singletons_HigherOrder_27
+    instance SuppressUnusedWarnings (MapSym1 a_Singletons_HigherOrder_26) where
       suppressUnusedWarnings = snd ((,) MapSym1KindInference ())
     type MapSym2 :: (~>) a b -> [a] -> [b]
-    type family MapSym2 @a @b (a0123456789876543210 :: (~>) a b) (a0123456789876543210 :: [a]) :: [b] where
-      MapSym2 a0123456789876543210 a0123456789876543210 = Map a0123456789876543210 a0123456789876543210
+    type family MapSym2 @a @b (a_Singletons_HigherOrder_26 :: (~>) a b) (a_Singletons_HigherOrder_27 :: [a]) :: [b] where
+      MapSym2 a_Singletons_HigherOrder_26 a_Singletons_HigherOrder_27 = Map a_Singletons_HigherOrder_26 a_Singletons_HigherOrder_27
     type Etad :: [Nat] -> [Bool] -> [Nat]
     type family Etad (a :: [Nat]) (a :: [Bool]) :: [Nat] where
-      Etad a_0123456789876543210 a_0123456789876543210 = Apply (Apply (Apply ZipWithSym0 (LamCases_0123456789876543210Sym0 a_0123456789876543210 a_0123456789876543210)) a_0123456789876543210) a_0123456789876543210
+      Etad a_Singletons_HigherOrder_2 a_Singletons_HigherOrder_3 = Apply (Apply (Apply ZipWithSym0 (LamCases_Singletons_HigherOrder_6Sym0 a_Singletons_HigherOrder_2 a_Singletons_HigherOrder_3)) a_Singletons_HigherOrder_2) a_Singletons_HigherOrder_3
     type Splunge :: [Nat] -> [Bool] -> [Nat]
     type family Splunge (a :: [Nat]) (a :: [Bool]) :: [Nat] where
-      Splunge ns bs = Apply (Apply (Apply ZipWithSym0 (LamCases_0123456789876543210Sym0 ns bs)) ns) bs
+      Splunge ns bs = Apply (Apply (Apply ZipWithSym0 (LamCases_Singletons_HigherOrder_13Sym0 ns bs)) ns) bs
     type Foo :: (~>) ((~>) a b) ((~>) a b) -> (~>) a b -> a -> b
     type family Foo @a @b (a :: (~>) ((~>) a b) ((~>) a b)) (a :: (~>) a b) (a :: a) :: b where
       Foo f g a = Apply (Apply f g) a
@@ -301,19 +301,19 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
       (forall (t :: (~>) a b) (t :: [a]).
        Sing t -> Sing t -> Sing (Map t t :: [b]) :: Type)
     sEtad
-      (sA_0123456789876543210 :: Sing a_0123456789876543210)
-      (sA_0123456789876543210 :: Sing a_0123456789876543210)
+      (sA_Singletons_HigherOrder_2 :: Sing a_Singletons_HigherOrder_2)
+      (sA_Singletons_HigherOrder_3 :: Sing a_Singletons_HigherOrder_3)
       = applySing
           (applySing
              (applySing
                 (singFun3 @ZipWithSym0 sZipWith)
                 (singFun2
-                   @(LamCases_0123456789876543210Sym0 a_0123456789876543210 a_0123456789876543210)
+                   @(LamCases_Singletons_HigherOrder_6Sym0 a_Singletons_HigherOrder_2 a_Singletons_HigherOrder_3)
                    (\cases
                       (sN :: Sing n) (sB :: Sing b)
                         -> applySing
                              (singFun1
-                                @(LamCases_0123456789876543210Sym0 n b a_0123456789876543210 a_0123456789876543210)
+                                @(LamCases_Singletons_HigherOrder_7Sym0 n b a_Singletons_HigherOrder_2 a_Singletons_HigherOrder_3)
                                 (\cases
                                    STrue
                                      -> applySing
@@ -321,20 +321,20 @@ Singletons/HigherOrder.hs:(0,0)-(0,0): Splicing declarations
                                           (applySing (singFun1 @SuccSym0 SSucc) sN)
                                    SFalse -> sN))
                              sB)))
-             sA_0123456789876543210)
-          sA_0123456789876543210
+             sA_Singletons_HigherOrder_2)
+          sA_Singletons_HigherOrder_3
     sSplunge (sNs :: Sing ns) (sBs :: Sing bs)
       = applySing
           (applySing
              (applySing
                 (singFun3 @ZipWithSym0 sZipWith)
                 (singFun2
-                   @(LamCases_0123456789876543210Sym0 ns bs)
+                   @(LamCases_Singletons_HigherOrder_13Sym0 ns bs)
                    (\cases
                       (sN :: Sing n) (sB :: Sing b)
                         -> applySing
                              (singFun1
-                                @(LamCases_0123456789876543210Sym0 n b ns bs)
+                                @(LamCases_Singletons_HigherOrder_14Sym0 n b ns bs)
                                 (\cases
                                    STrue
                                      -> applySing

--- a/singletons-base/tests/compile-and-dump/Singletons/LambdaCase.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/LambdaCase.golden
@@ -29,110 +29,110 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
           (Just d)
     foo3 :: a -> b -> a
     foo3 a b = (\case (p, _) -> p) (a, b)
-    type family LamCases_0123456789876543210 (a0123456789876543210 :: a0123456789876543210) (b0123456789876543210 :: b0123456789876543210) a_0123456789876543210 where
-      LamCases_0123456789876543210 a b '(p, _) = p
-    data LamCases_0123456789876543210Sym0 (a0123456789876543210 :: a0123456789876543210) (b0123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210
+    type family LamCases_Singletons_LambdaCase_2 (a1 :: a0) (b3 :: b2) a_Singletons_LambdaCase_3 where
+      LamCases_Singletons_LambdaCase_2 a b '(p, _) = p
+    data LamCases_Singletons_LambdaCase_2Sym0 (a1 :: a0) (b3 :: b2) a_Singletons_LambdaCase_3
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 a0123456789876543210 b0123456789876543210) arg) (LamCases_0123456789876543210Sym1 a0123456789876543210 b0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 a0123456789876543210 b0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 a0123456789876543210 b0123456789876543210) where
+        LamCases_Singletons_LambdaCase_2Sym0KindInference :: SameKind (Apply (LamCases_Singletons_LambdaCase_2Sym0 a1 b3) arg) (LamCases_Singletons_LambdaCase_2Sym1 a1 b3 arg) =>
+                                                             LamCases_Singletons_LambdaCase_2Sym0 a1 b3 a_Singletons_LambdaCase_3
+    type instance Apply @_ @_ (LamCases_Singletons_LambdaCase_2Sym0 a1 b3) a_Singletons_LambdaCase_3 = LamCases_Singletons_LambdaCase_2 a1 b3 a_Singletons_LambdaCase_3
+    instance SuppressUnusedWarnings (LamCases_Singletons_LambdaCase_2Sym0 a1 b3) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (a0123456789876543210 :: a0123456789876543210) (b0123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (d0123456789876543210 :: a0123456789876543210) a_0123456789876543210 where
-      LamCases_0123456789876543210 d ('Just y) = y
-      LamCases_0123456789876543210 d 'Nothing = d
-    data LamCases_0123456789876543210Sym0 (d0123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_LambdaCase_2Sym0KindInference ())
+    type family LamCases_Singletons_LambdaCase_2Sym1 (a1 :: a0) (b3 :: b2) a_Singletons_LambdaCase_3 where
+      LamCases_Singletons_LambdaCase_2Sym1 a1 b3 a_Singletons_LambdaCase_3 = LamCases_Singletons_LambdaCase_2 a1 b3 a_Singletons_LambdaCase_3
+    type family LamCases_Singletons_LambdaCase_6 (d1 :: a0) a_Singletons_LambdaCase_7 where
+      LamCases_Singletons_LambdaCase_6 d ('Just y) = y
+      LamCases_Singletons_LambdaCase_6 d 'Nothing = d
+    data LamCases_Singletons_LambdaCase_6Sym0 (d1 :: a0) a_Singletons_LambdaCase_7
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 d0123456789876543210) arg) (LamCases_0123456789876543210Sym1 d0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 d0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 d0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 d0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 d0123456789876543210) where
+        LamCases_Singletons_LambdaCase_6Sym0KindInference :: SameKind (Apply (LamCases_Singletons_LambdaCase_6Sym0 d1) arg) (LamCases_Singletons_LambdaCase_6Sym1 d1 arg) =>
+                                                             LamCases_Singletons_LambdaCase_6Sym0 d1 a_Singletons_LambdaCase_7
+    type instance Apply @_ @_ (LamCases_Singletons_LambdaCase_6Sym0 d1) a_Singletons_LambdaCase_7 = LamCases_Singletons_LambdaCase_6 d1 a_Singletons_LambdaCase_7
+    instance SuppressUnusedWarnings (LamCases_Singletons_LambdaCase_6Sym0 d1) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (d0123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 d0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 d0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (d0123456789876543210 :: a0123456789876543210) (x0123456789876543210 :: Maybe a0123456789876543210) a_0123456789876543210 where
-      LamCases_0123456789876543210 d x ('Just y) = y
-      LamCases_0123456789876543210 d x 'Nothing = d
-    data LamCases_0123456789876543210Sym0 (d0123456789876543210 :: a0123456789876543210) (x0123456789876543210 :: Maybe a0123456789876543210) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_LambdaCase_6Sym0KindInference ())
+    type family LamCases_Singletons_LambdaCase_6Sym1 (d1 :: a0) a_Singletons_LambdaCase_7 where
+      LamCases_Singletons_LambdaCase_6Sym1 d1 a_Singletons_LambdaCase_7 = LamCases_Singletons_LambdaCase_6 d1 a_Singletons_LambdaCase_7
+    type family LamCases_Singletons_LambdaCase_10 (d1 :: a0) (x2 :: Maybe a0) a_Singletons_LambdaCase_11 where
+      LamCases_Singletons_LambdaCase_10 d x ('Just y) = y
+      LamCases_Singletons_LambdaCase_10 d x 'Nothing = d
+    data LamCases_Singletons_LambdaCase_10Sym0 (d1 :: a0) (x2 :: Maybe a0) a_Singletons_LambdaCase_11
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 d0123456789876543210 x0123456789876543210) arg) (LamCases_0123456789876543210Sym1 d0123456789876543210 x0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 d0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 d0123456789876543210 x0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 d0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 d0123456789876543210 x0123456789876543210) where
+        LamCases_Singletons_LambdaCase_10Sym0KindInference :: SameKind (Apply (LamCases_Singletons_LambdaCase_10Sym0 d1 x2) arg) (LamCases_Singletons_LambdaCase_10Sym1 d1 x2 arg) =>
+                                                              LamCases_Singletons_LambdaCase_10Sym0 d1 x2 a_Singletons_LambdaCase_11
+    type instance Apply @_ @_ (LamCases_Singletons_LambdaCase_10Sym0 d1 x2) a_Singletons_LambdaCase_11 = LamCases_Singletons_LambdaCase_10 d1 x2 a_Singletons_LambdaCase_11
+    instance SuppressUnusedWarnings (LamCases_Singletons_LambdaCase_10Sym0 d1 x2) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (d0123456789876543210 :: a0123456789876543210) (x0123456789876543210 :: Maybe a0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 d0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 d0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_LambdaCase_10Sym0KindInference ())
+    type family LamCases_Singletons_LambdaCase_10Sym1 (d1 :: a0) (x2 :: Maybe a0) a_Singletons_LambdaCase_11 where
+      LamCases_Singletons_LambdaCase_10Sym1 d1 x2 a_Singletons_LambdaCase_11 = LamCases_Singletons_LambdaCase_10 d1 x2 a_Singletons_LambdaCase_11
     type Foo3Sym0 :: (~>) a ((~>) b a)
     data Foo3Sym0 :: (~>) a ((~>) b a)
       where
         Foo3Sym0KindInference :: SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
-                                 Foo3Sym0 a0123456789876543210
-    type instance Apply @a @((~>) b a) Foo3Sym0 a0123456789876543210 = Foo3Sym1 a0123456789876543210
+                                 Foo3Sym0 a_Singletons_LambdaCase_0
+    type instance Apply @a @((~>) b a) Foo3Sym0 a_Singletons_LambdaCase_0 = Foo3Sym1 a_Singletons_LambdaCase_0
     instance SuppressUnusedWarnings Foo3Sym0 where
       suppressUnusedWarnings = snd ((,) Foo3Sym0KindInference ())
     type Foo3Sym1 :: a -> (~>) b a
-    data Foo3Sym1 (a0123456789876543210 :: a) :: (~>) b a
+    data Foo3Sym1 (a_Singletons_LambdaCase_0 :: a) :: (~>) b a
       where
-        Foo3Sym1KindInference :: SameKind (Apply (Foo3Sym1 a0123456789876543210) arg) (Foo3Sym2 a0123456789876543210 arg) =>
-                                 Foo3Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @a (Foo3Sym1 a0123456789876543210) a0123456789876543210 = Foo3 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Foo3Sym1 a0123456789876543210) where
+        Foo3Sym1KindInference :: SameKind (Apply (Foo3Sym1 a_Singletons_LambdaCase_0) arg) (Foo3Sym2 a_Singletons_LambdaCase_0 arg) =>
+                                 Foo3Sym1 a_Singletons_LambdaCase_0 a_Singletons_LambdaCase_1
+    type instance Apply @b @a (Foo3Sym1 a_Singletons_LambdaCase_0) a_Singletons_LambdaCase_1 = Foo3 a_Singletons_LambdaCase_0 a_Singletons_LambdaCase_1
+    instance SuppressUnusedWarnings (Foo3Sym1 a_Singletons_LambdaCase_0) where
       suppressUnusedWarnings = snd ((,) Foo3Sym1KindInference ())
     type Foo3Sym2 :: a -> b -> a
-    type family Foo3Sym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: a where
-      Foo3Sym2 a0123456789876543210 a0123456789876543210 = Foo3 a0123456789876543210 a0123456789876543210
+    type family Foo3Sym2 @a @b (a_Singletons_LambdaCase_0 :: a) (a_Singletons_LambdaCase_1 :: b) :: a where
+      Foo3Sym2 a_Singletons_LambdaCase_0 a_Singletons_LambdaCase_1 = Foo3 a_Singletons_LambdaCase_0 a_Singletons_LambdaCase_1
     type Foo2Sym0 :: (~>) a ((~>) (Maybe a) a)
     data Foo2Sym0 :: (~>) a ((~>) (Maybe a) a)
       where
         Foo2Sym0KindInference :: SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) =>
-                                 Foo2Sym0 a0123456789876543210
-    type instance Apply @a @((~>) (Maybe a) a) Foo2Sym0 a0123456789876543210 = Foo2Sym1 a0123456789876543210
+                                 Foo2Sym0 a_Singletons_LambdaCase_4
+    type instance Apply @a @((~>) (Maybe a) a) Foo2Sym0 a_Singletons_LambdaCase_4 = Foo2Sym1 a_Singletons_LambdaCase_4
     instance SuppressUnusedWarnings Foo2Sym0 where
       suppressUnusedWarnings = snd ((,) Foo2Sym0KindInference ())
     type Foo2Sym1 :: a -> (~>) (Maybe a) a
-    data Foo2Sym1 (a0123456789876543210 :: a) :: (~>) (Maybe a) a
+    data Foo2Sym1 (a_Singletons_LambdaCase_4 :: a) :: (~>) (Maybe a) a
       where
-        Foo2Sym1KindInference :: SameKind (Apply (Foo2Sym1 a0123456789876543210) arg) (Foo2Sym2 a0123456789876543210 arg) =>
-                                 Foo2Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Maybe a) @a (Foo2Sym1 a0123456789876543210) a0123456789876543210 = Foo2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Foo2Sym1 a0123456789876543210) where
+        Foo2Sym1KindInference :: SameKind (Apply (Foo2Sym1 a_Singletons_LambdaCase_4) arg) (Foo2Sym2 a_Singletons_LambdaCase_4 arg) =>
+                                 Foo2Sym1 a_Singletons_LambdaCase_4 a_Singletons_LambdaCase_5
+    type instance Apply @(Maybe a) @a (Foo2Sym1 a_Singletons_LambdaCase_4) a_Singletons_LambdaCase_5 = Foo2 a_Singletons_LambdaCase_4 a_Singletons_LambdaCase_5
+    instance SuppressUnusedWarnings (Foo2Sym1 a_Singletons_LambdaCase_4) where
       suppressUnusedWarnings = snd ((,) Foo2Sym1KindInference ())
     type Foo2Sym2 :: a -> Maybe a -> a
-    type family Foo2Sym2 @a (a0123456789876543210 :: a) (a0123456789876543210 :: Maybe a) :: a where
-      Foo2Sym2 a0123456789876543210 a0123456789876543210 = Foo2 a0123456789876543210 a0123456789876543210
+    type family Foo2Sym2 @a (a_Singletons_LambdaCase_4 :: a) (a_Singletons_LambdaCase_5 :: Maybe a) :: a where
+      Foo2Sym2 a_Singletons_LambdaCase_4 a_Singletons_LambdaCase_5 = Foo2 a_Singletons_LambdaCase_4 a_Singletons_LambdaCase_5
     type Foo1Sym0 :: (~>) a ((~>) (Maybe a) a)
     data Foo1Sym0 :: (~>) a ((~>) (Maybe a) a)
       where
         Foo1Sym0KindInference :: SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
-                                 Foo1Sym0 a0123456789876543210
-    type instance Apply @a @((~>) (Maybe a) a) Foo1Sym0 a0123456789876543210 = Foo1Sym1 a0123456789876543210
+                                 Foo1Sym0 a_Singletons_LambdaCase_8
+    type instance Apply @a @((~>) (Maybe a) a) Foo1Sym0 a_Singletons_LambdaCase_8 = Foo1Sym1 a_Singletons_LambdaCase_8
     instance SuppressUnusedWarnings Foo1Sym0 where
       suppressUnusedWarnings = snd ((,) Foo1Sym0KindInference ())
     type Foo1Sym1 :: a -> (~>) (Maybe a) a
-    data Foo1Sym1 (a0123456789876543210 :: a) :: (~>) (Maybe a) a
+    data Foo1Sym1 (a_Singletons_LambdaCase_8 :: a) :: (~>) (Maybe a) a
       where
-        Foo1Sym1KindInference :: SameKind (Apply (Foo1Sym1 a0123456789876543210) arg) (Foo1Sym2 a0123456789876543210 arg) =>
-                                 Foo1Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Maybe a) @a (Foo1Sym1 a0123456789876543210) a0123456789876543210 = Foo1 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Foo1Sym1 a0123456789876543210) where
+        Foo1Sym1KindInference :: SameKind (Apply (Foo1Sym1 a_Singletons_LambdaCase_8) arg) (Foo1Sym2 a_Singletons_LambdaCase_8 arg) =>
+                                 Foo1Sym1 a_Singletons_LambdaCase_8 a_Singletons_LambdaCase_9
+    type instance Apply @(Maybe a) @a (Foo1Sym1 a_Singletons_LambdaCase_8) a_Singletons_LambdaCase_9 = Foo1 a_Singletons_LambdaCase_8 a_Singletons_LambdaCase_9
+    instance SuppressUnusedWarnings (Foo1Sym1 a_Singletons_LambdaCase_8) where
       suppressUnusedWarnings = snd ((,) Foo1Sym1KindInference ())
     type Foo1Sym2 :: a -> Maybe a -> a
-    type family Foo1Sym2 @a (a0123456789876543210 :: a) (a0123456789876543210 :: Maybe a) :: a where
-      Foo1Sym2 a0123456789876543210 a0123456789876543210 = Foo1 a0123456789876543210 a0123456789876543210
+    type family Foo1Sym2 @a (a_Singletons_LambdaCase_8 :: a) (a_Singletons_LambdaCase_9 :: Maybe a) :: a where
+      Foo1Sym2 a_Singletons_LambdaCase_8 a_Singletons_LambdaCase_9 = Foo1 a_Singletons_LambdaCase_8 a_Singletons_LambdaCase_9
     type Foo3 :: a -> b -> a
     type family Foo3 @a @b (a :: a) (a :: b) :: a where
-      Foo3 a b = Apply (LamCases_0123456789876543210Sym0 a b) (Apply (Apply Tuple2Sym0 a) b)
+      Foo3 a b = Apply (LamCases_Singletons_LambdaCase_2Sym0 a b) (Apply (Apply Tuple2Sym0 a) b)
     type Foo2 :: a -> Maybe a -> a
     type family Foo2 @a (a :: a) (a :: Maybe a) :: a where
-      Foo2 d _ = Apply (LamCases_0123456789876543210Sym0 d) (Apply JustSym0 d)
+      Foo2 d _ = Apply (LamCases_Singletons_LambdaCase_6Sym0 d) (Apply JustSym0 d)
     type Foo1 :: a -> Maybe a -> a
     type family Foo1 @a (a :: a) (a :: Maybe a) :: a where
-      Foo1 d x = Apply (LamCases_0123456789876543210Sym0 d x) x
+      Foo1 d x = Apply (LamCases_Singletons_LambdaCase_10Sym0 d x) x
     sFoo3 ::
       (forall (t :: a) (t :: b).
        Sing t -> Sing t -> Sing (Foo3 t t :: a) :: Type)
@@ -145,13 +145,13 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
     sFoo3 (sA :: Sing a) (sB :: Sing b)
       = applySing
           (singFun1
-             @(LamCases_0123456789876543210Sym0 a b)
+             @(LamCases_Singletons_LambdaCase_2Sym0 a b)
              (\cases (STuple2 (sP :: Sing p) _) -> sP))
           (applySing (applySing (singFun2 @Tuple2Sym0 STuple2) sA) sB)
     sFoo2 (sD :: Sing d) _
       = applySing
           (singFun1
-             @(LamCases_0123456789876543210Sym0 d)
+             @(LamCases_Singletons_LambdaCase_6Sym0 d)
              (\cases
                 (SJust (sY :: Sing y)) -> sY
                 SNothing -> sD))
@@ -159,7 +159,7 @@ Singletons/LambdaCase.hs:(0,0)-(0,0): Splicing declarations
     sFoo1 (sD :: Sing d) (sX :: Sing x)
       = applySing
           (singFun1
-             @(LamCases_0123456789876543210Sym0 d x)
+             @(LamCases_Singletons_LambdaCase_10Sym0 d x)
              (\cases
                 (SJust (sY :: Sing y)) -> sY
                 SNothing -> sD))

--- a/singletons-base/tests/compile-and-dump/Singletons/Lambdas.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Lambdas.golden
@@ -44,347 +44,347 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     data FooSym0 :: (~>) a ((~>) b (Foo a b))
       where
         FooSym0KindInference :: SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
-                                FooSym0 a0123456789876543210
-    type instance Apply @a @((~>) b (Foo a b)) FooSym0 a0123456789876543210 = FooSym1 a0123456789876543210
+                                FooSym0 a_Singletons_Lambdas_0
+    type instance Apply @a @((~>) b (Foo a b)) FooSym0 a_Singletons_Lambdas_0 = FooSym1 a_Singletons_Lambdas_0
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings = snd ((,) FooSym0KindInference ())
     type FooSym1 :: forall a b. a -> (~>) b (Foo a b)
-    data FooSym1 (a0123456789876543210 :: a) :: (~>) b (Foo a b)
+    data FooSym1 (a_Singletons_Lambdas_0 :: a) :: (~>) b (Foo a b)
       where
-        FooSym1KindInference :: SameKind (Apply (FooSym1 a0123456789876543210) arg) (FooSym2 a0123456789876543210 arg) =>
-                                FooSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @(Foo a b) (FooSym1 a0123456789876543210) a0123456789876543210 = Foo a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (FooSym1 a0123456789876543210) where
+        FooSym1KindInference :: SameKind (Apply (FooSym1 a_Singletons_Lambdas_0) arg) (FooSym2 a_Singletons_Lambdas_0 arg) =>
+                                FooSym1 a_Singletons_Lambdas_0 a_Singletons_Lambdas_1
+    type instance Apply @b @(Foo a b) (FooSym1 a_Singletons_Lambdas_0) a_Singletons_Lambdas_1 = Foo a_Singletons_Lambdas_0 a_Singletons_Lambdas_1
+    instance SuppressUnusedWarnings (FooSym1 a_Singletons_Lambdas_0) where
       suppressUnusedWarnings = snd ((,) FooSym1KindInference ())
     type FooSym2 :: forall a b. a -> b -> Foo a b
-    type family FooSym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: Foo a b where
-      FooSym2 a0123456789876543210 a0123456789876543210 = Foo a0123456789876543210 a0123456789876543210
-    type family LamCases_0123456789876543210 (x0123456789876543210 :: Foo a0123456789876543210 b0123456789876543210) a_0123456789876543210 where
-      LamCases_0123456789876543210 x (Foo a _) = a
-    data LamCases_0123456789876543210Sym0 (x0123456789876543210 :: Foo a0123456789876543210 b0123456789876543210) a_01234567898765432100123456789876543210
+    type family FooSym2 @a @b (a_Singletons_Lambdas_0 :: a) (a_Singletons_Lambdas_1 :: b) :: Foo a b where
+      FooSym2 a_Singletons_Lambdas_0 a_Singletons_Lambdas_1 = Foo a_Singletons_Lambdas_0 a_Singletons_Lambdas_1
+    type family LamCases_Singletons_Lambdas_3 (x2 :: Foo a0 b1) a_Singletons_Lambdas_4 where
+      LamCases_Singletons_Lambdas_3 x (Foo a _) = a
+    data LamCases_Singletons_Lambdas_3Sym0 (x2 :: Foo a0 b1) a_Singletons_Lambdas_4
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210) where
+        LamCases_Singletons_Lambdas_3Sym0KindInference :: SameKind (Apply (LamCases_Singletons_Lambdas_3Sym0 x2) arg) (LamCases_Singletons_Lambdas_3Sym1 x2 arg) =>
+                                                          LamCases_Singletons_Lambdas_3Sym0 x2 a_Singletons_Lambdas_4
+    type instance Apply @_ @_ (LamCases_Singletons_Lambdas_3Sym0 x2) a_Singletons_Lambdas_4 = LamCases_Singletons_Lambdas_3 x2 a_Singletons_Lambdas_4
+    instance SuppressUnusedWarnings (LamCases_Singletons_Lambdas_3Sym0 x2) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (x0123456789876543210 :: Foo a0123456789876543210 b0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 x0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (x0123456789876543210 :: a0123456789876543210) (y0123456789876543210 :: b0123456789876543210) a_0123456789876543210 where
-      LamCases_0123456789876543210 x y '(_, b) = b
-    data LamCases_0123456789876543210Sym0 (x0123456789876543210 :: a0123456789876543210) (y0123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_Lambdas_3Sym0KindInference ())
+    type family LamCases_Singletons_Lambdas_3Sym1 (x2 :: Foo a0 b1) a_Singletons_Lambdas_4 where
+      LamCases_Singletons_Lambdas_3Sym1 x2 a_Singletons_Lambdas_4 = LamCases_Singletons_Lambdas_3 x2 a_Singletons_Lambdas_4
+    type family LamCases_Singletons_Lambdas_7 (x1 :: a0) (y3 :: b2) a_Singletons_Lambdas_8 where
+      LamCases_Singletons_Lambdas_7 x y '(_, b) = b
+    data LamCases_Singletons_Lambdas_7Sym0 (x1 :: a0) (y3 :: b2) a_Singletons_Lambdas_8
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210 y0123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210 y0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210 y0123456789876543210) where
+        LamCases_Singletons_Lambdas_7Sym0KindInference :: SameKind (Apply (LamCases_Singletons_Lambdas_7Sym0 x1 y3) arg) (LamCases_Singletons_Lambdas_7Sym1 x1 y3 arg) =>
+                                                          LamCases_Singletons_Lambdas_7Sym0 x1 y3 a_Singletons_Lambdas_8
+    type instance Apply @_ @_ (LamCases_Singletons_Lambdas_7Sym0 x1 y3) a_Singletons_Lambdas_8 = LamCases_Singletons_Lambdas_7 x1 y3 a_Singletons_Lambdas_8
+    instance SuppressUnusedWarnings (LamCases_Singletons_Lambdas_7Sym0 x1 y3) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (x0123456789876543210 :: a0123456789876543210) (y0123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 x0123456789876543210 (a0123456789876543210 :: a0123456789876543210) (b0123456789876543210 :: b0123456789876543210) a_0123456789876543210 where
-      LamCases_0123456789876543210 x a b _ = x
-    data LamCases_0123456789876543210Sym0 x0123456789876543210 (a0123456789876543210 :: a0123456789876543210) (b0123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_Lambdas_7Sym0KindInference ())
+    type family LamCases_Singletons_Lambdas_7Sym1 (x1 :: a0) (y3 :: b2) a_Singletons_Lambdas_8 where
+      LamCases_Singletons_Lambdas_7Sym1 x1 y3 a_Singletons_Lambdas_8 = LamCases_Singletons_Lambdas_7 x1 y3 a_Singletons_Lambdas_8
+    type family LamCases_Singletons_Lambdas_12 x0 (a2 :: a1) (b4 :: b3) a_Singletons_Lambdas_13 where
+      LamCases_Singletons_Lambdas_12 x a b _ = x
+    data LamCases_Singletons_Lambdas_12Sym0 x0 (a2 :: a1) (b4 :: b3) a_Singletons_Lambdas_13
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210 a0123456789876543210 b0123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 a0123456789876543210 b0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210 a0123456789876543210 b0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210 a0123456789876543210 b0123456789876543210) where
+        LamCases_Singletons_Lambdas_12Sym0KindInference :: SameKind (Apply (LamCases_Singletons_Lambdas_12Sym0 x0 a2 b4) arg) (LamCases_Singletons_Lambdas_12Sym1 x0 a2 b4 arg) =>
+                                                           LamCases_Singletons_Lambdas_12Sym0 x0 a2 b4 a_Singletons_Lambdas_13
+    type instance Apply @_ @_ (LamCases_Singletons_Lambdas_12Sym0 x0 a2 b4) a_Singletons_Lambdas_13 = LamCases_Singletons_Lambdas_12 x0 a2 b4 a_Singletons_Lambdas_13
+    instance SuppressUnusedWarnings (LamCases_Singletons_Lambdas_12Sym0 x0 a2 b4) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 x0123456789876543210 (a0123456789876543210 :: a0123456789876543210) (b0123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 x0123456789876543210 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (a0123456789876543210 :: a0123456789876543210) (b0123456789876543210 :: b0123456789876543210) a_0123456789876543210 where
-      LamCases_0123456789876543210 a b x = LamCases_0123456789876543210Sym0 x a b
-    data LamCases_0123456789876543210Sym0 (a0123456789876543210 :: a0123456789876543210) (b0123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_Lambdas_12Sym0KindInference ())
+    type family LamCases_Singletons_Lambdas_12Sym1 x0 (a2 :: a1) (b4 :: b3) a_Singletons_Lambdas_13 where
+      LamCases_Singletons_Lambdas_12Sym1 x0 a2 b4 a_Singletons_Lambdas_13 = LamCases_Singletons_Lambdas_12 x0 a2 b4 a_Singletons_Lambdas_13
+    type family LamCases_Singletons_Lambdas_11 (a1 :: a0) (b3 :: b2) a_Singletons_Lambdas_14 where
+      LamCases_Singletons_Lambdas_11 a b x = LamCases_Singletons_Lambdas_12Sym0 x a b
+    data LamCases_Singletons_Lambdas_11Sym0 (a1 :: a0) (b3 :: b2) a_Singletons_Lambdas_14
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 a0123456789876543210 b0123456789876543210) arg) (LamCases_0123456789876543210Sym1 a0123456789876543210 b0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 a0123456789876543210 b0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 a0123456789876543210 b0123456789876543210) where
+        LamCases_Singletons_Lambdas_11Sym0KindInference :: SameKind (Apply (LamCases_Singletons_Lambdas_11Sym0 a1 b3) arg) (LamCases_Singletons_Lambdas_11Sym1 a1 b3 arg) =>
+                                                           LamCases_Singletons_Lambdas_11Sym0 a1 b3 a_Singletons_Lambdas_14
+    type instance Apply @_ @_ (LamCases_Singletons_Lambdas_11Sym0 a1 b3) a_Singletons_Lambdas_14 = LamCases_Singletons_Lambdas_11 a1 b3 a_Singletons_Lambdas_14
+    instance SuppressUnusedWarnings (LamCases_Singletons_Lambdas_11Sym0 a1 b3) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (a0123456789876543210 :: a0123456789876543210) (b0123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (x0123456789876543210 :: a0123456789876543210) (y0123456789876543210 :: b0123456789876543210) a_0123456789876543210 where
-      LamCases_0123456789876543210 x y x = x
-    data LamCases_0123456789876543210Sym0 (x0123456789876543210 :: a0123456789876543210) (y0123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_Lambdas_11Sym0KindInference ())
+    type family LamCases_Singletons_Lambdas_11Sym1 (a1 :: a0) (b3 :: b2) a_Singletons_Lambdas_14 where
+      LamCases_Singletons_Lambdas_11Sym1 a1 b3 a_Singletons_Lambdas_14 = LamCases_Singletons_Lambdas_11 a1 b3 a_Singletons_Lambdas_14
+    type family LamCases_Singletons_Lambdas_17 (x1 :: a0) (y3 :: b2) a_Singletons_Lambdas_18 where
+      LamCases_Singletons_Lambdas_17 x y x = x
+    data LamCases_Singletons_Lambdas_17Sym0 (x1 :: a0) (y3 :: b2) a_Singletons_Lambdas_18
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210 y0123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210 y0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210 y0123456789876543210) where
+        LamCases_Singletons_Lambdas_17Sym0KindInference :: SameKind (Apply (LamCases_Singletons_Lambdas_17Sym0 x1 y3) arg) (LamCases_Singletons_Lambdas_17Sym1 x1 y3 arg) =>
+                                                           LamCases_Singletons_Lambdas_17Sym0 x1 y3 a_Singletons_Lambdas_18
+    type instance Apply @_ @_ (LamCases_Singletons_Lambdas_17Sym0 x1 y3) a_Singletons_Lambdas_18 = LamCases_Singletons_Lambdas_17 x1 y3 a_Singletons_Lambdas_18
+    instance SuppressUnusedWarnings (LamCases_Singletons_Lambdas_17Sym0 x1 y3) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (x0123456789876543210 :: a0123456789876543210) (y0123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (x0123456789876543210 :: a0123456789876543210) (y0123456789876543210 :: b0123456789876543210) (z0123456789876543210 :: c0123456789876543210) a_0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 x y z _ _ = x
-    data LamCases_0123456789876543210Sym0 (x0123456789876543210 :: a0123456789876543210) (y0123456789876543210 :: b0123456789876543210) (z0123456789876543210 :: c0123456789876543210) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_Lambdas_17Sym0KindInference ())
+    type family LamCases_Singletons_Lambdas_17Sym1 (x1 :: a0) (y3 :: b2) a_Singletons_Lambdas_18 where
+      LamCases_Singletons_Lambdas_17Sym1 x1 y3 a_Singletons_Lambdas_18 = LamCases_Singletons_Lambdas_17 x1 y3 a_Singletons_Lambdas_18
+    type family LamCases_Singletons_Lambdas_22 (x1 :: a0) (y3 :: b2) (z5 :: c4) a_Singletons_Lambdas_23 a_Singletons_Lambdas_24 where
+      LamCases_Singletons_Lambdas_22 x y z _ _ = x
+    data LamCases_Singletons_Lambdas_22Sym0 (x1 :: a0) (y3 :: b2) (z5 :: c4) a_Singletons_Lambdas_23
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210 y0123456789876543210 z0123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210 z0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 y0123456789876543210 z0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210 y0123456789876543210 z0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210 z0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210 y0123456789876543210 z0123456789876543210) where
+        LamCases_Singletons_Lambdas_22Sym0KindInference :: SameKind (Apply (LamCases_Singletons_Lambdas_22Sym0 x1 y3 z5) arg) (LamCases_Singletons_Lambdas_22Sym1 x1 y3 z5 arg) =>
+                                                           LamCases_Singletons_Lambdas_22Sym0 x1 y3 z5 a_Singletons_Lambdas_23
+    type instance Apply @_ @_ (LamCases_Singletons_Lambdas_22Sym0 x1 y3 z5) a_Singletons_Lambdas_23 = LamCases_Singletons_Lambdas_22Sym1 x1 y3 z5 a_Singletons_Lambdas_23
+    instance SuppressUnusedWarnings (LamCases_Singletons_Lambdas_22Sym0 x1 y3 z5) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    data LamCases_0123456789876543210Sym1 (x0123456789876543210 :: a0123456789876543210) (y0123456789876543210 :: b0123456789876543210) (z0123456789876543210 :: c0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_Lambdas_22Sym0KindInference ())
+    data LamCases_Singletons_Lambdas_22Sym1 (x1 :: a0) (y3 :: b2) (z5 :: c4) a_Singletons_Lambdas_23 a_Singletons_Lambdas_24
       where
-        LamCases_0123456789876543210Sym1KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210 z0123456789876543210 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210 z0123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210 z0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210 z0123456789876543210 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 y0123456789876543210 z0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210 z0123456789876543210 a_01234567898765432100123456789876543210) where
+        LamCases_Singletons_Lambdas_22Sym1KindInference :: SameKind (Apply (LamCases_Singletons_Lambdas_22Sym1 x1 y3 z5 a_Singletons_Lambdas_23) arg) (LamCases_Singletons_Lambdas_22Sym2 x1 y3 z5 a_Singletons_Lambdas_23 arg) =>
+                                                           LamCases_Singletons_Lambdas_22Sym1 x1 y3 z5 a_Singletons_Lambdas_23 a_Singletons_Lambdas_24
+    type instance Apply @_ @_ (LamCases_Singletons_Lambdas_22Sym1 x1 y3 z5 a_Singletons_Lambdas_23) a_Singletons_Lambdas_24 = LamCases_Singletons_Lambdas_22 x1 y3 z5 a_Singletons_Lambdas_23 a_Singletons_Lambdas_24
+    instance SuppressUnusedWarnings (LamCases_Singletons_Lambdas_22Sym1 x1 y3 z5 a_Singletons_Lambdas_23) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym1KindInference ())
-    type family LamCases_0123456789876543210Sym2 (x0123456789876543210 :: a0123456789876543210) (y0123456789876543210 :: b0123456789876543210) (z0123456789876543210 :: c0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym2 x0123456789876543210 y0123456789876543210 z0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 y0123456789876543210 z0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (x0123456789876543210 :: a0123456789876543210) a_0123456789876543210 where
-      LamCases_0123456789876543210 x y = y
-    data LamCases_0123456789876543210Sym0 (x0123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_Lambdas_22Sym1KindInference ())
+    type family LamCases_Singletons_Lambdas_22Sym2 (x1 :: a0) (y3 :: b2) (z5 :: c4) a_Singletons_Lambdas_23 a_Singletons_Lambdas_24 where
+      LamCases_Singletons_Lambdas_22Sym2 x1 y3 z5 a_Singletons_Lambdas_23 a_Singletons_Lambdas_24 = LamCases_Singletons_Lambdas_22 x1 y3 z5 a_Singletons_Lambdas_23 a_Singletons_Lambdas_24
+    type family LamCases_Singletons_Lambdas_26 (x1 :: a0) a_Singletons_Lambdas_27 where
+      LamCases_Singletons_Lambdas_26 x y = y
+    data LamCases_Singletons_Lambdas_26Sym0 (x1 :: a0) a_Singletons_Lambdas_27
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210) where
+        LamCases_Singletons_Lambdas_26Sym0KindInference :: SameKind (Apply (LamCases_Singletons_Lambdas_26Sym0 x1) arg) (LamCases_Singletons_Lambdas_26Sym1 x1 arg) =>
+                                                           LamCases_Singletons_Lambdas_26Sym0 x1 a_Singletons_Lambdas_27
+    type instance Apply @_ @_ (LamCases_Singletons_Lambdas_26Sym0 x1) a_Singletons_Lambdas_27 = LamCases_Singletons_Lambdas_26 x1 a_Singletons_Lambdas_27
+    instance SuppressUnusedWarnings (LamCases_Singletons_Lambdas_26Sym0 x1) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (x0123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 x0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (x0123456789876543210 :: a0123456789876543210) (y0123456789876543210 :: b0123456789876543210) a_0123456789876543210 where
-      LamCases_0123456789876543210 x y _ = x
-    data LamCases_0123456789876543210Sym0 (x0123456789876543210 :: a0123456789876543210) (y0123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_Lambdas_26Sym0KindInference ())
+    type family LamCases_Singletons_Lambdas_26Sym1 (x1 :: a0) a_Singletons_Lambdas_27 where
+      LamCases_Singletons_Lambdas_26Sym1 x1 a_Singletons_Lambdas_27 = LamCases_Singletons_Lambdas_26 x1 a_Singletons_Lambdas_27
+    type family LamCases_Singletons_Lambdas_30 (x1 :: a0) (y3 :: b2) a_Singletons_Lambdas_31 where
+      LamCases_Singletons_Lambdas_30 x y _ = x
+    data LamCases_Singletons_Lambdas_30Sym0 (x1 :: a0) (y3 :: b2) a_Singletons_Lambdas_31
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210 y0123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210 y0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210 y0123456789876543210) where
+        LamCases_Singletons_Lambdas_30Sym0KindInference :: SameKind (Apply (LamCases_Singletons_Lambdas_30Sym0 x1 y3) arg) (LamCases_Singletons_Lambdas_30Sym1 x1 y3 arg) =>
+                                                           LamCases_Singletons_Lambdas_30Sym0 x1 y3 a_Singletons_Lambdas_31
+    type instance Apply @_ @_ (LamCases_Singletons_Lambdas_30Sym0 x1 y3) a_Singletons_Lambdas_31 = LamCases_Singletons_Lambdas_30 x1 y3 a_Singletons_Lambdas_31
+    instance SuppressUnusedWarnings (LamCases_Singletons_Lambdas_30Sym0 x1 y3) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (x0123456789876543210 :: a0123456789876543210) (y0123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (x0123456789876543210 :: a0123456789876543210) (a_01234567898765432100123456789876543210 :: b0123456789876543210) a_0123456789876543210 where
-      LamCases_0123456789876543210 x a_0123456789876543210 _ = x
-    data LamCases_0123456789876543210Sym0 (x0123456789876543210 :: a0123456789876543210) (a_01234567898765432100123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_Lambdas_30Sym0KindInference ())
+    type family LamCases_Singletons_Lambdas_30Sym1 (x1 :: a0) (y3 :: b2) a_Singletons_Lambdas_31 where
+      LamCases_Singletons_Lambdas_30Sym1 x1 y3 a_Singletons_Lambdas_31 = LamCases_Singletons_Lambdas_30 x1 y3 a_Singletons_Lambdas_31
+    type family LamCases_Singletons_Lambdas_35 (x1 :: a0) (a_Singletons_Lambdas_323 :: b2) a_Singletons_Lambdas_36 where
+      LamCases_Singletons_Lambdas_35 x a_Singletons_Lambdas_32 _ = x
+    data LamCases_Singletons_Lambdas_35Sym0 (x1 :: a0) (a_Singletons_Lambdas_323 :: b2) a_Singletons_Lambdas_36
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210 a_01234567898765432100123456789876543210) where
+        LamCases_Singletons_Lambdas_35Sym0KindInference :: SameKind (Apply (LamCases_Singletons_Lambdas_35Sym0 x1 a_Singletons_Lambdas_323) arg) (LamCases_Singletons_Lambdas_35Sym1 x1 a_Singletons_Lambdas_323 arg) =>
+                                                           LamCases_Singletons_Lambdas_35Sym0 x1 a_Singletons_Lambdas_323 a_Singletons_Lambdas_36
+    type instance Apply @_ @_ (LamCases_Singletons_Lambdas_35Sym0 x1 a_Singletons_Lambdas_323) a_Singletons_Lambdas_36 = LamCases_Singletons_Lambdas_35 x1 a_Singletons_Lambdas_323 a_Singletons_Lambdas_36
+    instance SuppressUnusedWarnings (LamCases_Singletons_Lambdas_35Sym0 x1 a_Singletons_Lambdas_323) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (x0123456789876543210 :: a0123456789876543210) (a_01234567898765432100123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 x0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (a_01234567898765432100123456789876543210 :: a0123456789876543210) (a_01234567898765432100123456789876543210 :: b0123456789876543210) a_0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 a_0123456789876543210 a_0123456789876543210 x y = x
-    data LamCases_0123456789876543210Sym0 (a_01234567898765432100123456789876543210 :: a0123456789876543210) (a_01234567898765432100123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_Lambdas_35Sym0KindInference ())
+    type family LamCases_Singletons_Lambdas_35Sym1 (x1 :: a0) (a_Singletons_Lambdas_323 :: b2) a_Singletons_Lambdas_36 where
+      LamCases_Singletons_Lambdas_35Sym1 x1 a_Singletons_Lambdas_323 a_Singletons_Lambdas_36 = LamCases_Singletons_Lambdas_35 x1 a_Singletons_Lambdas_323 a_Singletons_Lambdas_36
+    type family LamCases_Singletons_Lambdas_41 (a_Singletons_Lambdas_371 :: a0) (a_Singletons_Lambdas_383 :: b2) a_Singletons_Lambdas_42 a_Singletons_Lambdas_43 where
+      LamCases_Singletons_Lambdas_41 a_Singletons_Lambdas_37 a_Singletons_Lambdas_38 x y = x
+    data LamCases_Singletons_Lambdas_41Sym0 (a_Singletons_Lambdas_371 :: a0) (a_Singletons_Lambdas_383 :: b2) a_Singletons_Lambdas_42
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
+        LamCases_Singletons_Lambdas_41Sym0KindInference :: SameKind (Apply (LamCases_Singletons_Lambdas_41Sym0 a_Singletons_Lambdas_371 a_Singletons_Lambdas_383) arg) (LamCases_Singletons_Lambdas_41Sym1 a_Singletons_Lambdas_371 a_Singletons_Lambdas_383 arg) =>
+                                                           LamCases_Singletons_Lambdas_41Sym0 a_Singletons_Lambdas_371 a_Singletons_Lambdas_383 a_Singletons_Lambdas_42
+    type instance Apply @_ @_ (LamCases_Singletons_Lambdas_41Sym0 a_Singletons_Lambdas_371 a_Singletons_Lambdas_383) a_Singletons_Lambdas_42 = LamCases_Singletons_Lambdas_41Sym1 a_Singletons_Lambdas_371 a_Singletons_Lambdas_383 a_Singletons_Lambdas_42
+    instance SuppressUnusedWarnings (LamCases_Singletons_Lambdas_41Sym0 a_Singletons_Lambdas_371 a_Singletons_Lambdas_383) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    data LamCases_0123456789876543210Sym1 (a_01234567898765432100123456789876543210 :: a0123456789876543210) (a_01234567898765432100123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_Lambdas_41Sym0KindInference ())
+    data LamCases_Singletons_Lambdas_41Sym1 (a_Singletons_Lambdas_371 :: a0) (a_Singletons_Lambdas_383 :: b2) a_Singletons_Lambdas_42 a_Singletons_Lambdas_43
       where
-        LamCases_0123456789876543210Sym1KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym2 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
+        LamCases_Singletons_Lambdas_41Sym1KindInference :: SameKind (Apply (LamCases_Singletons_Lambdas_41Sym1 a_Singletons_Lambdas_371 a_Singletons_Lambdas_383 a_Singletons_Lambdas_42) arg) (LamCases_Singletons_Lambdas_41Sym2 a_Singletons_Lambdas_371 a_Singletons_Lambdas_383 a_Singletons_Lambdas_42 arg) =>
+                                                           LamCases_Singletons_Lambdas_41Sym1 a_Singletons_Lambdas_371 a_Singletons_Lambdas_383 a_Singletons_Lambdas_42 a_Singletons_Lambdas_43
+    type instance Apply @_ @_ (LamCases_Singletons_Lambdas_41Sym1 a_Singletons_Lambdas_371 a_Singletons_Lambdas_383 a_Singletons_Lambdas_42) a_Singletons_Lambdas_43 = LamCases_Singletons_Lambdas_41 a_Singletons_Lambdas_371 a_Singletons_Lambdas_383 a_Singletons_Lambdas_42 a_Singletons_Lambdas_43
+    instance SuppressUnusedWarnings (LamCases_Singletons_Lambdas_41Sym1 a_Singletons_Lambdas_371 a_Singletons_Lambdas_383 a_Singletons_Lambdas_42) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym1KindInference ())
-    type family LamCases_0123456789876543210Sym2 (a_01234567898765432100123456789876543210 :: a0123456789876543210) (a_01234567898765432100123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym2 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_Lambdas_41Sym1KindInference ())
+    type family LamCases_Singletons_Lambdas_41Sym2 (a_Singletons_Lambdas_371 :: a0) (a_Singletons_Lambdas_383 :: b2) a_Singletons_Lambdas_42 a_Singletons_Lambdas_43 where
+      LamCases_Singletons_Lambdas_41Sym2 a_Singletons_Lambdas_371 a_Singletons_Lambdas_383 a_Singletons_Lambdas_42 a_Singletons_Lambdas_43 = LamCases_Singletons_Lambdas_41 a_Singletons_Lambdas_371 a_Singletons_Lambdas_383 a_Singletons_Lambdas_42 a_Singletons_Lambdas_43
     type Foo8Sym0 :: (~>) (Foo a b) a
     data Foo8Sym0 :: (~>) (Foo a b) a
       where
         Foo8Sym0KindInference :: SameKind (Apply Foo8Sym0 arg) (Foo8Sym1 arg) =>
-                                 Foo8Sym0 a0123456789876543210
-    type instance Apply @(Foo a b) @a Foo8Sym0 a0123456789876543210 = Foo8 a0123456789876543210
+                                 Foo8Sym0 a_Singletons_Lambdas_2
+    type instance Apply @(Foo a b) @a Foo8Sym0 a_Singletons_Lambdas_2 = Foo8 a_Singletons_Lambdas_2
     instance SuppressUnusedWarnings Foo8Sym0 where
       suppressUnusedWarnings = snd ((,) Foo8Sym0KindInference ())
     type Foo8Sym1 :: Foo a b -> a
-    type family Foo8Sym1 @a @b (a0123456789876543210 :: Foo a b) :: a where
-      Foo8Sym1 a0123456789876543210 = Foo8 a0123456789876543210
+    type family Foo8Sym1 @a @b (a_Singletons_Lambdas_2 :: Foo a b) :: a where
+      Foo8Sym1 a_Singletons_Lambdas_2 = Foo8 a_Singletons_Lambdas_2
     type Foo7Sym0 :: (~>) a ((~>) b b)
     data Foo7Sym0 :: (~>) a ((~>) b b)
       where
         Foo7Sym0KindInference :: SameKind (Apply Foo7Sym0 arg) (Foo7Sym1 arg) =>
-                                 Foo7Sym0 a0123456789876543210
-    type instance Apply @a @((~>) b b) Foo7Sym0 a0123456789876543210 = Foo7Sym1 a0123456789876543210
+                                 Foo7Sym0 a_Singletons_Lambdas_5
+    type instance Apply @a @((~>) b b) Foo7Sym0 a_Singletons_Lambdas_5 = Foo7Sym1 a_Singletons_Lambdas_5
     instance SuppressUnusedWarnings Foo7Sym0 where
       suppressUnusedWarnings = snd ((,) Foo7Sym0KindInference ())
     type Foo7Sym1 :: a -> (~>) b b
-    data Foo7Sym1 (a0123456789876543210 :: a) :: (~>) b b
+    data Foo7Sym1 (a_Singletons_Lambdas_5 :: a) :: (~>) b b
       where
-        Foo7Sym1KindInference :: SameKind (Apply (Foo7Sym1 a0123456789876543210) arg) (Foo7Sym2 a0123456789876543210 arg) =>
-                                 Foo7Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @b (Foo7Sym1 a0123456789876543210) a0123456789876543210 = Foo7 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Foo7Sym1 a0123456789876543210) where
+        Foo7Sym1KindInference :: SameKind (Apply (Foo7Sym1 a_Singletons_Lambdas_5) arg) (Foo7Sym2 a_Singletons_Lambdas_5 arg) =>
+                                 Foo7Sym1 a_Singletons_Lambdas_5 a_Singletons_Lambdas_6
+    type instance Apply @b @b (Foo7Sym1 a_Singletons_Lambdas_5) a_Singletons_Lambdas_6 = Foo7 a_Singletons_Lambdas_5 a_Singletons_Lambdas_6
+    instance SuppressUnusedWarnings (Foo7Sym1 a_Singletons_Lambdas_5) where
       suppressUnusedWarnings = snd ((,) Foo7Sym1KindInference ())
     type Foo7Sym2 :: a -> b -> b
-    type family Foo7Sym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: b where
-      Foo7Sym2 a0123456789876543210 a0123456789876543210 = Foo7 a0123456789876543210 a0123456789876543210
+    type family Foo7Sym2 @a @b (a_Singletons_Lambdas_5 :: a) (a_Singletons_Lambdas_6 :: b) :: b where
+      Foo7Sym2 a_Singletons_Lambdas_5 a_Singletons_Lambdas_6 = Foo7 a_Singletons_Lambdas_5 a_Singletons_Lambdas_6
     type Foo6Sym0 :: (~>) a ((~>) b a)
     data Foo6Sym0 :: (~>) a ((~>) b a)
       where
         Foo6Sym0KindInference :: SameKind (Apply Foo6Sym0 arg) (Foo6Sym1 arg) =>
-                                 Foo6Sym0 a0123456789876543210
-    type instance Apply @a @((~>) b a) Foo6Sym0 a0123456789876543210 = Foo6Sym1 a0123456789876543210
+                                 Foo6Sym0 a_Singletons_Lambdas_9
+    type instance Apply @a @((~>) b a) Foo6Sym0 a_Singletons_Lambdas_9 = Foo6Sym1 a_Singletons_Lambdas_9
     instance SuppressUnusedWarnings Foo6Sym0 where
       suppressUnusedWarnings = snd ((,) Foo6Sym0KindInference ())
     type Foo6Sym1 :: a -> (~>) b a
-    data Foo6Sym1 (a0123456789876543210 :: a) :: (~>) b a
+    data Foo6Sym1 (a_Singletons_Lambdas_9 :: a) :: (~>) b a
       where
-        Foo6Sym1KindInference :: SameKind (Apply (Foo6Sym1 a0123456789876543210) arg) (Foo6Sym2 a0123456789876543210 arg) =>
-                                 Foo6Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @a (Foo6Sym1 a0123456789876543210) a0123456789876543210 = Foo6 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Foo6Sym1 a0123456789876543210) where
+        Foo6Sym1KindInference :: SameKind (Apply (Foo6Sym1 a_Singletons_Lambdas_9) arg) (Foo6Sym2 a_Singletons_Lambdas_9 arg) =>
+                                 Foo6Sym1 a_Singletons_Lambdas_9 a_Singletons_Lambdas_10
+    type instance Apply @b @a (Foo6Sym1 a_Singletons_Lambdas_9) a_Singletons_Lambdas_10 = Foo6 a_Singletons_Lambdas_9 a_Singletons_Lambdas_10
+    instance SuppressUnusedWarnings (Foo6Sym1 a_Singletons_Lambdas_9) where
       suppressUnusedWarnings = snd ((,) Foo6Sym1KindInference ())
     type Foo6Sym2 :: a -> b -> a
-    type family Foo6Sym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: a where
-      Foo6Sym2 a0123456789876543210 a0123456789876543210 = Foo6 a0123456789876543210 a0123456789876543210
+    type family Foo6Sym2 @a @b (a_Singletons_Lambdas_9 :: a) (a_Singletons_Lambdas_10 :: b) :: a where
+      Foo6Sym2 a_Singletons_Lambdas_9 a_Singletons_Lambdas_10 = Foo6 a_Singletons_Lambdas_9 a_Singletons_Lambdas_10
     type Foo5Sym0 :: (~>) a ((~>) b b)
     data Foo5Sym0 :: (~>) a ((~>) b b)
       where
         Foo5Sym0KindInference :: SameKind (Apply Foo5Sym0 arg) (Foo5Sym1 arg) =>
-                                 Foo5Sym0 a0123456789876543210
-    type instance Apply @a @((~>) b b) Foo5Sym0 a0123456789876543210 = Foo5Sym1 a0123456789876543210
+                                 Foo5Sym0 a_Singletons_Lambdas_15
+    type instance Apply @a @((~>) b b) Foo5Sym0 a_Singletons_Lambdas_15 = Foo5Sym1 a_Singletons_Lambdas_15
     instance SuppressUnusedWarnings Foo5Sym0 where
       suppressUnusedWarnings = snd ((,) Foo5Sym0KindInference ())
     type Foo5Sym1 :: a -> (~>) b b
-    data Foo5Sym1 (a0123456789876543210 :: a) :: (~>) b b
+    data Foo5Sym1 (a_Singletons_Lambdas_15 :: a) :: (~>) b b
       where
-        Foo5Sym1KindInference :: SameKind (Apply (Foo5Sym1 a0123456789876543210) arg) (Foo5Sym2 a0123456789876543210 arg) =>
-                                 Foo5Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @b (Foo5Sym1 a0123456789876543210) a0123456789876543210 = Foo5 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Foo5Sym1 a0123456789876543210) where
+        Foo5Sym1KindInference :: SameKind (Apply (Foo5Sym1 a_Singletons_Lambdas_15) arg) (Foo5Sym2 a_Singletons_Lambdas_15 arg) =>
+                                 Foo5Sym1 a_Singletons_Lambdas_15 a_Singletons_Lambdas_16
+    type instance Apply @b @b (Foo5Sym1 a_Singletons_Lambdas_15) a_Singletons_Lambdas_16 = Foo5 a_Singletons_Lambdas_15 a_Singletons_Lambdas_16
+    instance SuppressUnusedWarnings (Foo5Sym1 a_Singletons_Lambdas_15) where
       suppressUnusedWarnings = snd ((,) Foo5Sym1KindInference ())
     type Foo5Sym2 :: a -> b -> b
-    type family Foo5Sym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: b where
-      Foo5Sym2 a0123456789876543210 a0123456789876543210 = Foo5 a0123456789876543210 a0123456789876543210
+    type family Foo5Sym2 @a @b (a_Singletons_Lambdas_15 :: a) (a_Singletons_Lambdas_16 :: b) :: b where
+      Foo5Sym2 a_Singletons_Lambdas_15 a_Singletons_Lambdas_16 = Foo5 a_Singletons_Lambdas_15 a_Singletons_Lambdas_16
     type Foo4Sym0 :: (~>) a ((~>) b ((~>) c a))
     data Foo4Sym0 :: (~>) a ((~>) b ((~>) c a))
       where
         Foo4Sym0KindInference :: SameKind (Apply Foo4Sym0 arg) (Foo4Sym1 arg) =>
-                                 Foo4Sym0 a0123456789876543210
-    type instance Apply @a @((~>) b ((~>) c a)) Foo4Sym0 a0123456789876543210 = Foo4Sym1 a0123456789876543210
+                                 Foo4Sym0 a_Singletons_Lambdas_19
+    type instance Apply @a @((~>) b ((~>) c a)) Foo4Sym0 a_Singletons_Lambdas_19 = Foo4Sym1 a_Singletons_Lambdas_19
     instance SuppressUnusedWarnings Foo4Sym0 where
       suppressUnusedWarnings = snd ((,) Foo4Sym0KindInference ())
     type Foo4Sym1 :: a -> (~>) b ((~>) c a)
-    data Foo4Sym1 (a0123456789876543210 :: a) :: (~>) b ((~>) c a)
+    data Foo4Sym1 (a_Singletons_Lambdas_19 :: a) :: (~>) b ((~>) c a)
       where
-        Foo4Sym1KindInference :: SameKind (Apply (Foo4Sym1 a0123456789876543210) arg) (Foo4Sym2 a0123456789876543210 arg) =>
-                                 Foo4Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @((~>) c a) (Foo4Sym1 a0123456789876543210) a0123456789876543210 = Foo4Sym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Foo4Sym1 a0123456789876543210) where
+        Foo4Sym1KindInference :: SameKind (Apply (Foo4Sym1 a_Singletons_Lambdas_19) arg) (Foo4Sym2 a_Singletons_Lambdas_19 arg) =>
+                                 Foo4Sym1 a_Singletons_Lambdas_19 a_Singletons_Lambdas_20
+    type instance Apply @b @((~>) c a) (Foo4Sym1 a_Singletons_Lambdas_19) a_Singletons_Lambdas_20 = Foo4Sym2 a_Singletons_Lambdas_19 a_Singletons_Lambdas_20
+    instance SuppressUnusedWarnings (Foo4Sym1 a_Singletons_Lambdas_19) where
       suppressUnusedWarnings = snd ((,) Foo4Sym1KindInference ())
     type Foo4Sym2 :: a -> b -> (~>) c a
-    data Foo4Sym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: (~>) c a
+    data Foo4Sym2 (a_Singletons_Lambdas_19 :: a) (a_Singletons_Lambdas_20 :: b) :: (~>) c a
       where
-        Foo4Sym2KindInference :: SameKind (Apply (Foo4Sym2 a0123456789876543210 a0123456789876543210) arg) (Foo4Sym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                 Foo4Sym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @c @a (Foo4Sym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = Foo4 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Foo4Sym2 a0123456789876543210 a0123456789876543210) where
+        Foo4Sym2KindInference :: SameKind (Apply (Foo4Sym2 a_Singletons_Lambdas_19 a_Singletons_Lambdas_20) arg) (Foo4Sym3 a_Singletons_Lambdas_19 a_Singletons_Lambdas_20 arg) =>
+                                 Foo4Sym2 a_Singletons_Lambdas_19 a_Singletons_Lambdas_20 a_Singletons_Lambdas_21
+    type instance Apply @c @a (Foo4Sym2 a_Singletons_Lambdas_19 a_Singletons_Lambdas_20) a_Singletons_Lambdas_21 = Foo4 a_Singletons_Lambdas_19 a_Singletons_Lambdas_20 a_Singletons_Lambdas_21
+    instance SuppressUnusedWarnings (Foo4Sym2 a_Singletons_Lambdas_19 a_Singletons_Lambdas_20) where
       suppressUnusedWarnings = snd ((,) Foo4Sym2KindInference ())
     type Foo4Sym3 :: a -> b -> c -> a
-    type family Foo4Sym3 @a @b @c (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: c) :: a where
-      Foo4Sym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = Foo4 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type family Foo4Sym3 @a @b @c (a_Singletons_Lambdas_19 :: a) (a_Singletons_Lambdas_20 :: b) (a_Singletons_Lambdas_21 :: c) :: a where
+      Foo4Sym3 a_Singletons_Lambdas_19 a_Singletons_Lambdas_20 a_Singletons_Lambdas_21 = Foo4 a_Singletons_Lambdas_19 a_Singletons_Lambdas_20 a_Singletons_Lambdas_21
     type Foo3Sym0 :: (~>) a a
     data Foo3Sym0 :: (~>) a a
       where
         Foo3Sym0KindInference :: SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
-                                 Foo3Sym0 a0123456789876543210
-    type instance Apply @a @a Foo3Sym0 a0123456789876543210 = Foo3 a0123456789876543210
+                                 Foo3Sym0 a_Singletons_Lambdas_25
+    type instance Apply @a @a Foo3Sym0 a_Singletons_Lambdas_25 = Foo3 a_Singletons_Lambdas_25
     instance SuppressUnusedWarnings Foo3Sym0 where
       suppressUnusedWarnings = snd ((,) Foo3Sym0KindInference ())
     type Foo3Sym1 :: a -> a
-    type family Foo3Sym1 @a (a0123456789876543210 :: a) :: a where
-      Foo3Sym1 a0123456789876543210 = Foo3 a0123456789876543210
+    type family Foo3Sym1 @a (a_Singletons_Lambdas_25 :: a) :: a where
+      Foo3Sym1 a_Singletons_Lambdas_25 = Foo3 a_Singletons_Lambdas_25
     type Foo2Sym0 :: (~>) a ((~>) b a)
     data Foo2Sym0 :: (~>) a ((~>) b a)
       where
         Foo2Sym0KindInference :: SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) =>
-                                 Foo2Sym0 a0123456789876543210
-    type instance Apply @a @((~>) b a) Foo2Sym0 a0123456789876543210 = Foo2Sym1 a0123456789876543210
+                                 Foo2Sym0 a_Singletons_Lambdas_28
+    type instance Apply @a @((~>) b a) Foo2Sym0 a_Singletons_Lambdas_28 = Foo2Sym1 a_Singletons_Lambdas_28
     instance SuppressUnusedWarnings Foo2Sym0 where
       suppressUnusedWarnings = snd ((,) Foo2Sym0KindInference ())
     type Foo2Sym1 :: a -> (~>) b a
-    data Foo2Sym1 (a0123456789876543210 :: a) :: (~>) b a
+    data Foo2Sym1 (a_Singletons_Lambdas_28 :: a) :: (~>) b a
       where
-        Foo2Sym1KindInference :: SameKind (Apply (Foo2Sym1 a0123456789876543210) arg) (Foo2Sym2 a0123456789876543210 arg) =>
-                                 Foo2Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @a (Foo2Sym1 a0123456789876543210) a0123456789876543210 = Foo2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Foo2Sym1 a0123456789876543210) where
+        Foo2Sym1KindInference :: SameKind (Apply (Foo2Sym1 a_Singletons_Lambdas_28) arg) (Foo2Sym2 a_Singletons_Lambdas_28 arg) =>
+                                 Foo2Sym1 a_Singletons_Lambdas_28 a_Singletons_Lambdas_29
+    type instance Apply @b @a (Foo2Sym1 a_Singletons_Lambdas_28) a_Singletons_Lambdas_29 = Foo2 a_Singletons_Lambdas_28 a_Singletons_Lambdas_29
+    instance SuppressUnusedWarnings (Foo2Sym1 a_Singletons_Lambdas_28) where
       suppressUnusedWarnings = snd ((,) Foo2Sym1KindInference ())
     type Foo2Sym2 :: a -> b -> a
-    type family Foo2Sym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: a where
-      Foo2Sym2 a0123456789876543210 a0123456789876543210 = Foo2 a0123456789876543210 a0123456789876543210
+    type family Foo2Sym2 @a @b (a_Singletons_Lambdas_28 :: a) (a_Singletons_Lambdas_29 :: b) :: a where
+      Foo2Sym2 a_Singletons_Lambdas_28 a_Singletons_Lambdas_29 = Foo2 a_Singletons_Lambdas_28 a_Singletons_Lambdas_29
     type Foo1Sym0 :: (~>) a ((~>) b a)
     data Foo1Sym0 :: (~>) a ((~>) b a)
       where
         Foo1Sym0KindInference :: SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
-                                 Foo1Sym0 a0123456789876543210
-    type instance Apply @a @((~>) b a) Foo1Sym0 a0123456789876543210 = Foo1Sym1 a0123456789876543210
+                                 Foo1Sym0 a_Singletons_Lambdas_33
+    type instance Apply @a @((~>) b a) Foo1Sym0 a_Singletons_Lambdas_33 = Foo1Sym1 a_Singletons_Lambdas_33
     instance SuppressUnusedWarnings Foo1Sym0 where
       suppressUnusedWarnings = snd ((,) Foo1Sym0KindInference ())
     type Foo1Sym1 :: a -> (~>) b a
-    data Foo1Sym1 (a0123456789876543210 :: a) :: (~>) b a
+    data Foo1Sym1 (a_Singletons_Lambdas_33 :: a) :: (~>) b a
       where
-        Foo1Sym1KindInference :: SameKind (Apply (Foo1Sym1 a0123456789876543210) arg) (Foo1Sym2 a0123456789876543210 arg) =>
-                                 Foo1Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @a (Foo1Sym1 a0123456789876543210) a0123456789876543210 = Foo1 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Foo1Sym1 a0123456789876543210) where
+        Foo1Sym1KindInference :: SameKind (Apply (Foo1Sym1 a_Singletons_Lambdas_33) arg) (Foo1Sym2 a_Singletons_Lambdas_33 arg) =>
+                                 Foo1Sym1 a_Singletons_Lambdas_33 a_Singletons_Lambdas_34
+    type instance Apply @b @a (Foo1Sym1 a_Singletons_Lambdas_33) a_Singletons_Lambdas_34 = Foo1 a_Singletons_Lambdas_33 a_Singletons_Lambdas_34
+    instance SuppressUnusedWarnings (Foo1Sym1 a_Singletons_Lambdas_33) where
       suppressUnusedWarnings = snd ((,) Foo1Sym1KindInference ())
     type Foo1Sym2 :: a -> b -> a
-    type family Foo1Sym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: a where
-      Foo1Sym2 a0123456789876543210 a0123456789876543210 = Foo1 a0123456789876543210 a0123456789876543210
+    type family Foo1Sym2 @a @b (a_Singletons_Lambdas_33 :: a) (a_Singletons_Lambdas_34 :: b) :: a where
+      Foo1Sym2 a_Singletons_Lambdas_33 a_Singletons_Lambdas_34 = Foo1 a_Singletons_Lambdas_33 a_Singletons_Lambdas_34
     type Foo0Sym0 :: (~>) a ((~>) b a)
     data Foo0Sym0 :: (~>) a ((~>) b a)
       where
         Foo0Sym0KindInference :: SameKind (Apply Foo0Sym0 arg) (Foo0Sym1 arg) =>
-                                 Foo0Sym0 a0123456789876543210
-    type instance Apply @a @((~>) b a) Foo0Sym0 a0123456789876543210 = Foo0Sym1 a0123456789876543210
+                                 Foo0Sym0 a_Singletons_Lambdas_39
+    type instance Apply @a @((~>) b a) Foo0Sym0 a_Singletons_Lambdas_39 = Foo0Sym1 a_Singletons_Lambdas_39
     instance SuppressUnusedWarnings Foo0Sym0 where
       suppressUnusedWarnings = snd ((,) Foo0Sym0KindInference ())
     type Foo0Sym1 :: a -> (~>) b a
-    data Foo0Sym1 (a0123456789876543210 :: a) :: (~>) b a
+    data Foo0Sym1 (a_Singletons_Lambdas_39 :: a) :: (~>) b a
       where
-        Foo0Sym1KindInference :: SameKind (Apply (Foo0Sym1 a0123456789876543210) arg) (Foo0Sym2 a0123456789876543210 arg) =>
-                                 Foo0Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @a (Foo0Sym1 a0123456789876543210) a0123456789876543210 = Foo0 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Foo0Sym1 a0123456789876543210) where
+        Foo0Sym1KindInference :: SameKind (Apply (Foo0Sym1 a_Singletons_Lambdas_39) arg) (Foo0Sym2 a_Singletons_Lambdas_39 arg) =>
+                                 Foo0Sym1 a_Singletons_Lambdas_39 a_Singletons_Lambdas_40
+    type instance Apply @b @a (Foo0Sym1 a_Singletons_Lambdas_39) a_Singletons_Lambdas_40 = Foo0 a_Singletons_Lambdas_39 a_Singletons_Lambdas_40
+    instance SuppressUnusedWarnings (Foo0Sym1 a_Singletons_Lambdas_39) where
       suppressUnusedWarnings = snd ((,) Foo0Sym1KindInference ())
     type Foo0Sym2 :: a -> b -> a
-    type family Foo0Sym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: a where
-      Foo0Sym2 a0123456789876543210 a0123456789876543210 = Foo0 a0123456789876543210 a0123456789876543210
+    type family Foo0Sym2 @a @b (a_Singletons_Lambdas_39 :: a) (a_Singletons_Lambdas_40 :: b) :: a where
+      Foo0Sym2 a_Singletons_Lambdas_39 a_Singletons_Lambdas_40 = Foo0 a_Singletons_Lambdas_39 a_Singletons_Lambdas_40
     type Foo8 :: Foo a b -> a
     type family Foo8 @a @b (a :: Foo a b) :: a where
-      Foo8 x = Apply (LamCases_0123456789876543210Sym0 x) x
+      Foo8 x = Apply (LamCases_Singletons_Lambdas_3Sym0 x) x
     type Foo7 :: a -> b -> b
     type family Foo7 @a @b (a :: a) (a :: b) :: b where
-      Foo7 x y = Apply (LamCases_0123456789876543210Sym0 x y) (Apply (Apply Tuple2Sym0 x) y)
+      Foo7 x y = Apply (LamCases_Singletons_Lambdas_7Sym0 x y) (Apply (Apply Tuple2Sym0 x) y)
     type Foo6 :: a -> b -> a
     type family Foo6 @a @b (a :: a) (a :: b) :: a where
-      Foo6 a b = Apply (Apply (LamCases_0123456789876543210Sym0 a b) a) b
+      Foo6 a b = Apply (Apply (LamCases_Singletons_Lambdas_11Sym0 a b) a) b
     type Foo5 :: a -> b -> b
     type family Foo5 @a @b (a :: a) (a :: b) :: b where
-      Foo5 x y = Apply (LamCases_0123456789876543210Sym0 x y) y
+      Foo5 x y = Apply (LamCases_Singletons_Lambdas_17Sym0 x y) y
     type Foo4 :: a -> b -> c -> a
     type family Foo4 @a @b @c (a :: a) (a :: b) (a :: c) :: a where
-      Foo4 x y z = Apply (Apply (LamCases_0123456789876543210Sym0 x y z) y) z
+      Foo4 x y z = Apply (Apply (LamCases_Singletons_Lambdas_22Sym0 x y z) y) z
     type Foo3 :: a -> a
     type family Foo3 @a (a :: a) :: a where
-      Foo3 x = Apply (LamCases_0123456789876543210Sym0 x) x
+      Foo3 x = Apply (LamCases_Singletons_Lambdas_26Sym0 x) x
     type Foo2 :: a -> b -> a
     type family Foo2 @a @b (a :: a) (a :: b) :: a where
-      Foo2 x y = Apply (LamCases_0123456789876543210Sym0 x y) y
+      Foo2 x y = Apply (LamCases_Singletons_Lambdas_30Sym0 x y) y
     type Foo1 :: a -> b -> a
     type family Foo1 @a @b (a :: a) (a :: b) :: a where
-      Foo1 x a_0123456789876543210 = Apply (LamCases_0123456789876543210Sym0 x a_0123456789876543210) a_0123456789876543210
+      Foo1 x a_Singletons_Lambdas_32 = Apply (LamCases_Singletons_Lambdas_35Sym0 x a_Singletons_Lambdas_32) a_Singletons_Lambdas_32
     type Foo0 :: a -> b -> a
     type family Foo0 @a @b (a :: a) (a :: b) :: a where
-      Foo0 a_0123456789876543210 a_0123456789876543210 = Apply (Apply (LamCases_0123456789876543210Sym0 a_0123456789876543210 a_0123456789876543210) a_0123456789876543210) a_0123456789876543210
+      Foo0 a_Singletons_Lambdas_37 a_Singletons_Lambdas_38 = Apply (Apply (LamCases_Singletons_Lambdas_41Sym0 a_Singletons_Lambdas_37 a_Singletons_Lambdas_38) a_Singletons_Lambdas_37) a_Singletons_Lambdas_38
     sFoo8 ::
       (forall (t :: Foo a b). Sing t -> Sing (Foo8 t :: a) :: Type)
     sFoo7 ::
@@ -412,67 +412,68 @@ Singletons/Lambdas.hs:(0,0)-(0,0): Splicing declarations
     sFoo8 (sX :: Sing x)
       = applySing
           (singFun1
-             @(LamCases_0123456789876543210Sym0 x)
+             @(LamCases_Singletons_Lambdas_3Sym0 x)
              (\cases (SFoo (sA :: Sing a) _) -> sA))
           sX
     sFoo7 (sX :: Sing x) (sY :: Sing y)
       = applySing
           (singFun1
-             @(LamCases_0123456789876543210Sym0 x y)
+             @(LamCases_Singletons_Lambdas_7Sym0 x y)
              (\cases (STuple2 _ (sB :: Sing b)) -> sB))
           (applySing (applySing (singFun2 @Tuple2Sym0 STuple2) sX) sY)
     sFoo6 (sA :: Sing a) (sB :: Sing b)
       = applySing
           (applySing
              (singFun1
-                @(LamCases_0123456789876543210Sym0 a b)
+                @(LamCases_Singletons_Lambdas_11Sym0 a b)
                 (\cases
                    (sX :: Sing x)
                      -> singFun1
-                          @(LamCases_0123456789876543210Sym0 x a b) (\cases _ -> sX)))
+                          @(LamCases_Singletons_Lambdas_12Sym0 x a b) (\cases _ -> sX)))
              sA)
           sB
     sFoo5 (sX :: Sing x) (sY :: Sing y)
       = applySing
           (singFun1
-             @(LamCases_0123456789876543210Sym0 x y)
+             @(LamCases_Singletons_Lambdas_17Sym0 x y)
              (\cases (sX :: Sing x) -> sX))
           sY
     sFoo4 (sX :: Sing x) (sY :: Sing y) (sZ :: Sing z)
       = applySing
           (applySing
              (singFun2
-                @(LamCases_0123456789876543210Sym0 x y z) (\cases _ _ -> sX))
+                @(LamCases_Singletons_Lambdas_22Sym0 x y z) (\cases _ _ -> sX))
              sY)
           sZ
     sFoo3 (sX :: Sing x)
       = applySing
           (singFun1
-             @(LamCases_0123456789876543210Sym0 x)
+             @(LamCases_Singletons_Lambdas_26Sym0 x)
              (\cases (sY :: Sing y) -> sY))
           sX
     sFoo2 (sX :: Sing x) (sY :: Sing y)
       = applySing
-          (singFun1 @(LamCases_0123456789876543210Sym0 x y) (\cases _ -> sX))
+          (singFun1
+             @(LamCases_Singletons_Lambdas_30Sym0 x y) (\cases _ -> sX))
           sY
     sFoo1
       (sX :: Sing x)
-      (sA_0123456789876543210 :: Sing a_0123456789876543210)
+      (sA_Singletons_Lambdas_32 :: Sing a_Singletons_Lambdas_32)
       = applySing
           (singFun1
-             @(LamCases_0123456789876543210Sym0 x a_0123456789876543210)
+             @(LamCases_Singletons_Lambdas_35Sym0 x a_Singletons_Lambdas_32)
              (\cases _ -> sX))
-          sA_0123456789876543210
+          sA_Singletons_Lambdas_32
     sFoo0
-      (sA_0123456789876543210 :: Sing a_0123456789876543210)
-      (sA_0123456789876543210 :: Sing a_0123456789876543210)
+      (sA_Singletons_Lambdas_37 :: Sing a_Singletons_Lambdas_37)
+      (sA_Singletons_Lambdas_38 :: Sing a_Singletons_Lambdas_38)
       = applySing
           (applySing
              (singFun2
-                @(LamCases_0123456789876543210Sym0 a_0123456789876543210 a_0123456789876543210)
+                @(LamCases_Singletons_Lambdas_41Sym0 a_Singletons_Lambdas_37 a_Singletons_Lambdas_38)
                 (\cases (sX :: Sing x) (sY :: Sing y) -> sX))
-             sA_0123456789876543210)
-          sA_0123456789876543210
+             sA_Singletons_Lambdas_37)
+          sA_Singletons_Lambdas_38
     instance SingI (Foo8Sym0 :: (~>) (Foo a b) a) where
       sing = singFun1 @Foo8Sym0 sFoo8
     instance SingI (Foo7Sym0 :: (~>) a ((~>) b b)) where

--- a/singletons-base/tests/compile-and-dump/Singletons/LambdasComprehensive.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/LambdasComprehensive.golden
@@ -11,18 +11,20 @@ Singletons/LambdasComprehensive.hs:(0,0)-(0,0): Splicing declarations
       = map (\ x -> either_ pred Succ x) [Left Zero, Right (Succ Zero)]
     bar :: [Nat]
     bar = map (either_ pred Succ) [Left Zero, Right (Succ Zero)]
-    type family LamCases_0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 x = Apply (Apply (Apply Either_Sym0 PredSym0) SuccSym0) x
-    data LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
+    type family LamCases_Singletons_LambdasComprehensive_0 a_Singletons_LambdasComprehensive_1 where
+      LamCases_Singletons_LambdasComprehensive_0 x = Apply (Apply (Apply Either_Sym0 PredSym0) SuccSym0) x
+    data LamCases_Singletons_LambdasComprehensive_0Sym0 a_Singletons_LambdasComprehensive_1
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply LamCases_0123456789876543210Sym0 arg) (LamCases_0123456789876543210Sym1 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings LamCases_0123456789876543210Sym0 where
+        LamCases_Singletons_LambdasComprehensive_0Sym0KindInference :: SameKind (Apply LamCases_Singletons_LambdasComprehensive_0Sym0 arg) (LamCases_Singletons_LambdasComprehensive_0Sym1 arg) =>
+                                                                       LamCases_Singletons_LambdasComprehensive_0Sym0 a_Singletons_LambdasComprehensive_1
+    type instance Apply @_ @_ LamCases_Singletons_LambdasComprehensive_0Sym0 a_Singletons_LambdasComprehensive_1 = LamCases_Singletons_LambdasComprehensive_0 a_Singletons_LambdasComprehensive_1
+    instance SuppressUnusedWarnings LamCases_Singletons_LambdasComprehensive_0Sym0 where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
+        = snd
+            ((,)
+               LamCases_Singletons_LambdasComprehensive_0Sym0KindInference ())
+    type family LamCases_Singletons_LambdasComprehensive_0Sym1 a_Singletons_LambdasComprehensive_1 where
+      LamCases_Singletons_LambdasComprehensive_0Sym1 a_Singletons_LambdasComprehensive_1 = LamCases_Singletons_LambdasComprehensive_0 a_Singletons_LambdasComprehensive_1
     type BarSym0 :: [Nat]
     type family BarSym0 :: [Nat] where
       BarSym0 = Bar
@@ -34,7 +36,7 @@ Singletons/LambdasComprehensive.hs:(0,0)-(0,0): Splicing declarations
       Bar = Apply (Apply MapSym0 (Apply (Apply Either_Sym0 PredSym0) SuccSym0)) (Apply (Apply (:@#@$) (Apply LeftSym0 ZeroSym0)) (Apply (Apply (:@#@$) (Apply RightSym0 (Apply SuccSym0 ZeroSym0))) NilSym0))
     type Foo :: [Nat]
     type family Foo :: [Nat] where
-      Foo = Apply (Apply MapSym0 LamCases_0123456789876543210Sym0) (Apply (Apply (:@#@$) (Apply LeftSym0 ZeroSym0)) (Apply (Apply (:@#@$) (Apply RightSym0 (Apply SuccSym0 ZeroSym0))) NilSym0))
+      Foo = Apply (Apply MapSym0 LamCases_Singletons_LambdasComprehensive_0Sym0) (Apply (Apply (:@#@$) (Apply LeftSym0 ZeroSym0)) (Apply (Apply (:@#@$) (Apply RightSym0 (Apply SuccSym0 ZeroSym0))) NilSym0))
     sBar :: (Sing (Bar :: [Nat]) :: Type)
     sFoo :: (Sing (Foo :: [Nat]) :: Type)
     sBar
@@ -61,7 +63,7 @@ Singletons/LambdasComprehensive.hs:(0,0)-(0,0): Splicing declarations
           (applySing
              (singFun2 @MapSym0 sMap)
              (singFun1
-                @LamCases_0123456789876543210Sym0
+                @LamCases_Singletons_LambdasComprehensive_0Sym0
                 (\cases
                    (sX :: Sing x)
                      -> applySing

--- a/singletons-base/tests/compile-and-dump/Singletons/LetStatements.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/LetStatements.golden
@@ -189,364 +189,356 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     foo13_ y = y
     foo14 :: Nat -> (Nat, Nat)
     foo14 x = let (y, z) = (Succ x, x) in (z, y)
-    type family LamCases_0123456789876543210 (x0123456789876543210 :: Nat) a_0123456789876543210 where
-      LamCases_0123456789876543210 x '(_,
-                                       y_0123456789876543210) = y_0123456789876543210
-    data LamCases_0123456789876543210Sym0 (x0123456789876543210 :: Nat) a_01234567898765432100123456789876543210
+    type family LamCases_Singletons_LetStatements_5 (x0 :: Nat) a_Singletons_LetStatements_6 where
+      LamCases_Singletons_LetStatements_5 x '(_,
+                                              y_Singletons_LetStatements_4) = y_Singletons_LetStatements_4
+    data LamCases_Singletons_LetStatements_5Sym0 (x0 :: Nat) a_Singletons_LetStatements_6
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210) where
+        LamCases_Singletons_LetStatements_5Sym0KindInference :: SameKind (Apply (LamCases_Singletons_LetStatements_5Sym0 x0) arg) (LamCases_Singletons_LetStatements_5Sym1 x0 arg) =>
+                                                                LamCases_Singletons_LetStatements_5Sym0 x0 a_Singletons_LetStatements_6
+    type instance Apply @_ @_ (LamCases_Singletons_LetStatements_5Sym0 x0) a_Singletons_LetStatements_6 = LamCases_Singletons_LetStatements_5 x0 a_Singletons_LetStatements_6
+    instance SuppressUnusedWarnings (LamCases_Singletons_LetStatements_5Sym0 x0) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (x0123456789876543210 :: Nat) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 x0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (x0123456789876543210 :: Nat) a_0123456789876543210 where
-      LamCases_0123456789876543210 x '(y_0123456789876543210,
-                                       _) = y_0123456789876543210
-    data LamCases_0123456789876543210Sym0 (x0123456789876543210 :: Nat) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_LetStatements_5Sym0KindInference ())
+    type family LamCases_Singletons_LetStatements_5Sym1 (x0 :: Nat) a_Singletons_LetStatements_6 where
+      LamCases_Singletons_LetStatements_5Sym1 x0 a_Singletons_LetStatements_6 = LamCases_Singletons_LetStatements_5 x0 a_Singletons_LetStatements_6
+    type family LamCases_Singletons_LetStatements_7 (x0 :: Nat) a_Singletons_LetStatements_8 where
+      LamCases_Singletons_LetStatements_7 x '(y_Singletons_LetStatements_3,
+                                              _) = y_Singletons_LetStatements_3
+    data LamCases_Singletons_LetStatements_7Sym0 (x0 :: Nat) a_Singletons_LetStatements_8
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210) where
+        LamCases_Singletons_LetStatements_7Sym0KindInference :: SameKind (Apply (LamCases_Singletons_LetStatements_7Sym0 x0) arg) (LamCases_Singletons_LetStatements_7Sym1 x0 arg) =>
+                                                                LamCases_Singletons_LetStatements_7Sym0 x0 a_Singletons_LetStatements_8
+    type instance Apply @_ @_ (LamCases_Singletons_LetStatements_7Sym0 x0) a_Singletons_LetStatements_8 = LamCases_Singletons_LetStatements_7 x0 a_Singletons_LetStatements_8
+    instance SuppressUnusedWarnings (LamCases_Singletons_LetStatements_7Sym0 x0) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (x0123456789876543210 :: Nat) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 x0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    type family Let0123456789876543210ZSym0 (x0123456789876543210 :: Nat) where
-      Let0123456789876543210ZSym0 x0123456789876543210 = Let0123456789876543210Z x0123456789876543210
-    type family Let0123456789876543210YSym0 (x0123456789876543210 :: Nat) where
-      Let0123456789876543210YSym0 x0123456789876543210 = Let0123456789876543210Y x0123456789876543210
-    type family Let0123456789876543210X_0123456789876543210Sym0 (x0123456789876543210 :: Nat) where
-      Let0123456789876543210X_0123456789876543210Sym0 x0123456789876543210 = Let0123456789876543210X_0123456789876543210 x0123456789876543210
-    type family Let0123456789876543210Z (x0123456789876543210 :: Nat) where
-      Let0123456789876543210Z x = Apply (LamCases_0123456789876543210Sym0 x) (Let0123456789876543210X_0123456789876543210Sym0 x)
-    type family Let0123456789876543210Y (x0123456789876543210 :: Nat) where
-      Let0123456789876543210Y x = Apply (LamCases_0123456789876543210Sym0 x) (Let0123456789876543210X_0123456789876543210Sym0 x)
-    type family Let0123456789876543210X_0123456789876543210 (x0123456789876543210 :: Nat) where
-      Let0123456789876543210X_0123456789876543210 x = Apply (Apply Tuple2Sym0 (Apply SuccSym0 x)) x
-    type family Let0123456789876543210BarSym0 a0123456789876543210 (x0123456789876543210 :: a0123456789876543210) :: a0123456789876543210 where
-      Let0123456789876543210BarSym0 a0123456789876543210 x0123456789876543210 = Let0123456789876543210Bar a0123456789876543210 x0123456789876543210
-    type family Let0123456789876543210Bar a0123456789876543210 (x0123456789876543210 :: a0123456789876543210) :: a0123456789876543210 where
-      Let0123456789876543210Bar a x = x
-    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$) (x0123456789876543210 :: Nat) :: (~>) Nat ((~>) Nat Nat)
+        = snd ((,) LamCases_Singletons_LetStatements_7Sym0KindInference ())
+    type family LamCases_Singletons_LetStatements_7Sym1 (x0 :: Nat) a_Singletons_LetStatements_8 where
+      LamCases_Singletons_LetStatements_7Sym1 x0 a_Singletons_LetStatements_8 = LamCases_Singletons_LetStatements_7 x0 a_Singletons_LetStatements_8
+    type family Let1ZSym0 (x0 :: Nat) where
+      Let1ZSym0 x0 = Let1Z x0
+    type family Let1YSym0 (x0 :: Nat) where
+      Let1YSym0 x0 = Let1Y x0
+    type family Let1X_Singletons_LetStatements_2Sym0 (x0 :: Nat) where
+      Let1X_Singletons_LetStatements_2Sym0 x0 = Let1X_Singletons_LetStatements_2 x0
+    type family Let1Z (x0 :: Nat) where
+      Let1Z x = Apply (LamCases_Singletons_LetStatements_5Sym0 x) (Let1X_Singletons_LetStatements_2Sym0 x)
+    type family Let1Y (x0 :: Nat) where
+      Let1Y x = Apply (LamCases_Singletons_LetStatements_7Sym0 x) (Let1X_Singletons_LetStatements_2Sym0 x)
+    type family Let1X_Singletons_LetStatements_2 (x0 :: Nat) where
+      Let1X_Singletons_LetStatements_2 x = Apply (Apply Tuple2Sym0 (Apply SuccSym0 x)) x
+    type family Let11BarSym0 a0 (x1 :: a0) :: a0 where
+      Let11BarSym0 a0 x1 = Let11Bar a0 x1
+    type family Let11Bar a0 (x1 :: a0) :: a0 where
+      Let11Bar a x = x
+    data (<<<#%+@#@$) (x0 :: Nat) :: (~>) Nat ((~>) Nat Nat)
       where
-        (:<<<%%%%%%%%%%%%%%%%%%%%@#@$###) :: SameKind (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$) x0123456789876543210) arg) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210 arg) =>
-                                             (<<<%%%%%%%%%%%%%%%%%%%%@#@$) x0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @((~>) Nat Nat) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$) x0123456789876543210) a0123456789876543210 = (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((<<<%%%%%%%%%%%%%%%%%%%%@#@$) x0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) (:<<<%%%%%%%%%%%%%%%%%%%%@#@$###) ())
-    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) (x0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: (~>) Nat Nat
+        (:<<<#%+@#@$###) :: SameKind (Apply ((<<<#%+@#@$) x0) arg) ((<<<#%+@#@$$) x0 arg) =>
+                            (<<<#%+@#@$) x0 a1
+    type instance Apply @Nat @((~>) Nat Nat) ((<<<#%+@#@$) x0) a1 = (<<<#%+@#@$$) x0 a1
+    instance SuppressUnusedWarnings ((<<<#%+@#@$) x0) where
+      suppressUnusedWarnings = snd ((,) (:<<<#%+@#@$###) ())
+    data (<<<#%+@#@$$) (x0 :: Nat) (a1 :: Nat) :: (~>) Nat Nat
       where
-        (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$###) :: SameKind (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210 a0123456789876543210) arg) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) x0123456789876543210 a0123456789876543210 arg) =>
-                                              (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @Nat ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210 a0123456789876543210) a0123456789876543210 = (<<<%%%%%%%%%%%%%%%%%%%%) x0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$###) ())
-    type family (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) (x0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Nat where
-      (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) x0123456789876543210 a0123456789876543210 a0123456789876543210 = (<<<%%%%%%%%%%%%%%%%%%%%) x0123456789876543210 a0123456789876543210 a0123456789876543210
-    type family (<<<%%%%%%%%%%%%%%%%%%%%) (x0123456789876543210 :: Nat) (a :: Nat) (a :: Nat) :: Nat where
-      (<<<%%%%%%%%%%%%%%%%%%%%) x 'Zero m = m
-      (<<<%%%%%%%%%%%%%%%%%%%%) x ('Succ n) m = Apply SuccSym0 (Apply (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$) x) n) x)
-    type family Let0123456789876543210ZSym0 (x0123456789876543210 :: Nat) :: Nat where
-      Let0123456789876543210ZSym0 x0123456789876543210 = Let0123456789876543210Z x0123456789876543210
-    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$) (x0123456789876543210 :: Nat) :: (~>) Nat ((~>) Nat Nat)
+        (:<<<#%+@#@$$###) :: SameKind (Apply ((<<<#%+@#@$$) x0 a1) arg) ((<<<#%+@#@$$$) x0 a1 arg) =>
+                             (<<<#%+@#@$$) x0 a1 a2
+    type instance Apply @Nat @Nat ((<<<#%+@#@$$) x0 a1) a2 = (<<<#%+) x0 a1 a2
+    instance SuppressUnusedWarnings ((<<<#%+@#@$$) x0 a1) where
+      suppressUnusedWarnings = snd ((,) (:<<<#%+@#@$$###) ())
+    type family (<<<#%+@#@$$$) (x0 :: Nat) (a1 :: Nat) (a2 :: Nat) :: Nat where
+      (<<<#%+@#@$$$) x0 a1 a2 = (<<<#%+) x0 a1 a2
+    type family (<<<#%+) (x0 :: Nat) (a :: Nat) (a :: Nat) :: Nat where
+      (<<<#%+) x 'Zero m = m
+      (<<<#%+) x ('Succ n) m = Apply SuccSym0 (Apply (Apply ((<<<#%+@#@$) x) n) x)
+    type family Let15ZSym0 (x0 :: Nat) :: Nat where
+      Let15ZSym0 x0 = Let15Z x0
+    data (<<<#*+@#@$) (x0 :: Nat) :: (~>) Nat ((~>) Nat Nat)
       where
-        (:<<<%%%%%%%%%%%%%%%%%%%%@#@$###) :: SameKind (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$) x0123456789876543210) arg) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210 arg) =>
-                                             (<<<%%%%%%%%%%%%%%%%%%%%@#@$) x0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @((~>) Nat Nat) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$) x0123456789876543210) a0123456789876543210 = (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((<<<%%%%%%%%%%%%%%%%%%%%@#@$) x0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) (:<<<%%%%%%%%%%%%%%%%%%%%@#@$###) ())
-    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) (x0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: (~>) Nat Nat
+        (:<<<#*+@#@$###) :: SameKind (Apply ((<<<#*+@#@$) x0) arg) ((<<<#*+@#@$$) x0 arg) =>
+                            (<<<#*+@#@$) x0 a1
+    type instance Apply @Nat @((~>) Nat Nat) ((<<<#*+@#@$) x0) a1 = (<<<#*+@#@$$) x0 a1
+    instance SuppressUnusedWarnings ((<<<#*+@#@$) x0) where
+      suppressUnusedWarnings = snd ((,) (:<<<#*+@#@$###) ())
+    data (<<<#*+@#@$$) (x0 :: Nat) (a1 :: Nat) :: (~>) Nat Nat
       where
-        (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$###) :: SameKind (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210 a0123456789876543210) arg) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) x0123456789876543210 a0123456789876543210 arg) =>
-                                              (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @Nat ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210 a0123456789876543210) a0123456789876543210 = (<<<%%%%%%%%%%%%%%%%%%%%) x0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$###) ())
-    type family (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) (x0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Nat where
-      (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) x0123456789876543210 a0123456789876543210 a0123456789876543210 = (<<<%%%%%%%%%%%%%%%%%%%%) x0123456789876543210 a0123456789876543210 a0123456789876543210
-    type family Let0123456789876543210Z (x0123456789876543210 :: Nat) :: Nat where
-      Let0123456789876543210Z x = x
-    type family (<<<%%%%%%%%%%%%%%%%%%%%) (x0123456789876543210 :: Nat) (a :: Nat) (a :: Nat) :: Nat where
-      (<<<%%%%%%%%%%%%%%%%%%%%) x 'Zero m = m
-      (<<<%%%%%%%%%%%%%%%%%%%%) x ('Succ n) m = Apply SuccSym0 (Apply (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$) x) n) m)
-    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$) (x0123456789876543210 :: Nat) :: (~>) Nat ((~>) Nat Nat)
+        (:<<<#*+@#@$$###) :: SameKind (Apply ((<<<#*+@#@$$) x0 a1) arg) ((<<<#*+@#@$$$) x0 a1 arg) =>
+                             (<<<#*+@#@$$) x0 a1 a2
+    type instance Apply @Nat @Nat ((<<<#*+@#@$$) x0 a1) a2 = (<<<#*+) x0 a1 a2
+    instance SuppressUnusedWarnings ((<<<#*+@#@$$) x0 a1) where
+      suppressUnusedWarnings = snd ((,) (:<<<#*+@#@$$###) ())
+    type family (<<<#*+@#@$$$) (x0 :: Nat) (a1 :: Nat) (a2 :: Nat) :: Nat where
+      (<<<#*+@#@$$$) x0 a1 a2 = (<<<#*+) x0 a1 a2
+    type family Let15Z (x0 :: Nat) :: Nat where
+      Let15Z x = x
+    type family (<<<#*+) (x0 :: Nat) (a :: Nat) (a :: Nat) :: Nat where
+      (<<<#*+) x 'Zero m = m
+      (<<<#*+) x ('Succ n) m = Apply SuccSym0 (Apply (Apply ((<<<#*+@#@$) x) n) m)
+    data (<<<#.+@#@$) (x0 :: Nat) :: (~>) Nat ((~>) Nat Nat)
       where
-        (:<<<%%%%%%%%%%%%%%%%%%%%@#@$###) :: SameKind (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$) x0123456789876543210) arg) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210 arg) =>
-                                             (<<<%%%%%%%%%%%%%%%%%%%%@#@$) x0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @((~>) Nat Nat) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$) x0123456789876543210) a0123456789876543210 = (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((<<<%%%%%%%%%%%%%%%%%%%%@#@$) x0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) (:<<<%%%%%%%%%%%%%%%%%%%%@#@$###) ())
-    data (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) (x0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: (~>) Nat Nat
+        (:<<<#.+@#@$###) :: SameKind (Apply ((<<<#.+@#@$) x0) arg) ((<<<#.+@#@$$) x0 arg) =>
+                            (<<<#.+@#@$) x0 a1
+    type instance Apply @Nat @((~>) Nat Nat) ((<<<#.+@#@$) x0) a1 = (<<<#.+@#@$$) x0 a1
+    instance SuppressUnusedWarnings ((<<<#.+@#@$) x0) where
+      suppressUnusedWarnings = snd ((,) (:<<<#.+@#@$###) ())
+    data (<<<#.+@#@$$) (x0 :: Nat) (a1 :: Nat) :: (~>) Nat Nat
       where
-        (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$###) :: SameKind (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210 a0123456789876543210) arg) ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) x0123456789876543210 a0123456789876543210 arg) =>
-                                              (<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @Nat ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210 a0123456789876543210) a0123456789876543210 = (<<<%%%%%%%%%%%%%%%%%%%%) x0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((<<<%%%%%%%%%%%%%%%%%%%%@#@$$) x0123456789876543210 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) (:<<<%%%%%%%%%%%%%%%%%%%%@#@$$###) ())
-    type family (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) (x0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Nat where
-      (<<<%%%%%%%%%%%%%%%%%%%%@#@$$$) x0123456789876543210 a0123456789876543210 a0123456789876543210 = (<<<%%%%%%%%%%%%%%%%%%%%) x0123456789876543210 a0123456789876543210 a0123456789876543210
-    type family (<<<%%%%%%%%%%%%%%%%%%%%) (x0123456789876543210 :: Nat) (a :: Nat) (a :: Nat) :: Nat where
-      (<<<%%%%%%%%%%%%%%%%%%%%) x 'Zero m = m
-      (<<<%%%%%%%%%%%%%%%%%%%%) x ('Succ n) m = Apply SuccSym0 (Apply (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$) x) n) m)
-    type family LamCases_0123456789876543210 (a_01234567898765432100123456789876543210 :: Nat) (x0123456789876543210 :: Nat) a_0123456789876543210 where
-      LamCases_0123456789876543210 a_0123456789876543210 x x = x
-    data LamCases_0123456789876543210Sym0 (a_01234567898765432100123456789876543210 :: Nat) (x0123456789876543210 :: Nat) a_01234567898765432100123456789876543210
+        (:<<<#.+@#@$$###) :: SameKind (Apply ((<<<#.+@#@$$) x0 a1) arg) ((<<<#.+@#@$$$) x0 a1 arg) =>
+                             (<<<#.+@#@$$) x0 a1 a2
+    type instance Apply @Nat @Nat ((<<<#.+@#@$$) x0 a1) a2 = (<<<#.+) x0 a1 a2
+    instance SuppressUnusedWarnings ((<<<#.+@#@$$) x0 a1) where
+      suppressUnusedWarnings = snd ((,) (:<<<#.+@#@$$###) ())
+    type family (<<<#.+@#@$$$) (x0 :: Nat) (a1 :: Nat) (a2 :: Nat) :: Nat where
+      (<<<#.+@#@$$$) x0 a1 a2 = (<<<#.+) x0 a1 a2
+    type family (<<<#.+) (x0 :: Nat) (a :: Nat) (a :: Nat) :: Nat where
+      (<<<#.+) x 'Zero m = m
+      (<<<#.+) x ('Succ n) m = Apply SuccSym0 (Apply (Apply ((<<<#.+@#@$) x) n) m)
+    type family LamCases_Singletons_LetStatements_21 (a_Singletons_LetStatements_200 :: Nat) (x1 :: Nat) a_Singletons_LetStatements_22 where
+      LamCases_Singletons_LetStatements_21 a_Singletons_LetStatements_20 x x = x
+    data LamCases_Singletons_LetStatements_21Sym0 (a_Singletons_LetStatements_200 :: Nat) (x1 :: Nat) a_Singletons_LetStatements_22
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 x0123456789876543210) arg) (LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 x0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 x0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 x0123456789876543210) where
+        LamCases_Singletons_LetStatements_21Sym0KindInference :: SameKind (Apply (LamCases_Singletons_LetStatements_21Sym0 a_Singletons_LetStatements_200 x1) arg) (LamCases_Singletons_LetStatements_21Sym1 a_Singletons_LetStatements_200 x1 arg) =>
+                                                                 LamCases_Singletons_LetStatements_21Sym0 a_Singletons_LetStatements_200 x1 a_Singletons_LetStatements_22
+    type instance Apply @_ @_ (LamCases_Singletons_LetStatements_21Sym0 a_Singletons_LetStatements_200 x1) a_Singletons_LetStatements_22 = LamCases_Singletons_LetStatements_21 a_Singletons_LetStatements_200 x1 a_Singletons_LetStatements_22
+    instance SuppressUnusedWarnings (LamCases_Singletons_LetStatements_21Sym0 a_Singletons_LetStatements_200 x1) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (a_01234567898765432100123456789876543210 :: Nat) (x0123456789876543210 :: Nat) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    data Let0123456789876543210ZSym0 (x0123456789876543210 :: Nat) :: (~>) Nat Nat
+        = snd
+            ((,) LamCases_Singletons_LetStatements_21Sym0KindInference ())
+    type family LamCases_Singletons_LetStatements_21Sym1 (a_Singletons_LetStatements_200 :: Nat) (x1 :: Nat) a_Singletons_LetStatements_22 where
+      LamCases_Singletons_LetStatements_21Sym1 a_Singletons_LetStatements_200 x1 a_Singletons_LetStatements_22 = LamCases_Singletons_LetStatements_21 a_Singletons_LetStatements_200 x1 a_Singletons_LetStatements_22
+    data Let19ZSym0 (x0 :: Nat) :: (~>) Nat Nat
       where
-        Let0123456789876543210ZSym0KindInference :: SameKind (Apply (Let0123456789876543210ZSym0 x0123456789876543210) arg) (Let0123456789876543210ZSym1 x0123456789876543210 arg) =>
-                                                    Let0123456789876543210ZSym0 x0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @Nat (Let0123456789876543210ZSym0 x0123456789876543210) a0123456789876543210 = Let0123456789876543210Z x0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Let0123456789876543210ZSym0 x0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Let0123456789876543210ZSym0KindInference ())
-    type family Let0123456789876543210ZSym1 (x0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Nat where
-      Let0123456789876543210ZSym1 x0123456789876543210 a0123456789876543210 = Let0123456789876543210Z x0123456789876543210 a0123456789876543210
-    type family Let0123456789876543210Z (x0123456789876543210 :: Nat) (a :: Nat) :: Nat where
-      Let0123456789876543210Z x a_0123456789876543210 = Apply (LamCases_0123456789876543210Sym0 a_0123456789876543210 x) a_0123456789876543210
-    type family LamCases_0123456789876543210 (x0123456789876543210 :: Nat) a_0123456789876543210 where
-      LamCases_0123456789876543210 x x = x
-    data LamCases_0123456789876543210Sym0 (x0123456789876543210 :: Nat) a_01234567898765432100123456789876543210
+        Let19ZSym0KindInference :: SameKind (Apply (Let19ZSym0 x0) arg) (Let19ZSym1 x0 arg) =>
+                                   Let19ZSym0 x0 a1
+    type instance Apply @Nat @Nat (Let19ZSym0 x0) a1 = Let19Z x0 a1
+    instance SuppressUnusedWarnings (Let19ZSym0 x0) where
+      suppressUnusedWarnings = snd ((,) Let19ZSym0KindInference ())
+    type family Let19ZSym1 (x0 :: Nat) (a1 :: Nat) :: Nat where
+      Let19ZSym1 x0 a1 = Let19Z x0 a1
+    type family Let19Z (x0 :: Nat) (a :: Nat) :: Nat where
+      Let19Z x a_Singletons_LetStatements_20 = Apply (LamCases_Singletons_LetStatements_21Sym0 a_Singletons_LetStatements_20 x) a_Singletons_LetStatements_20
+    type family LamCases_Singletons_LetStatements_25 (x0 :: Nat) a_Singletons_LetStatements_26 where
+      LamCases_Singletons_LetStatements_25 x x = x
+    data LamCases_Singletons_LetStatements_25Sym0 (x0 :: Nat) a_Singletons_LetStatements_26
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210) where
+        LamCases_Singletons_LetStatements_25Sym0KindInference :: SameKind (Apply (LamCases_Singletons_LetStatements_25Sym0 x0) arg) (LamCases_Singletons_LetStatements_25Sym1 x0 arg) =>
+                                                                 LamCases_Singletons_LetStatements_25Sym0 x0 a_Singletons_LetStatements_26
+    type instance Apply @_ @_ (LamCases_Singletons_LetStatements_25Sym0 x0) a_Singletons_LetStatements_26 = LamCases_Singletons_LetStatements_25 x0 a_Singletons_LetStatements_26
+    instance SuppressUnusedWarnings (LamCases_Singletons_LetStatements_25Sym0 x0) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (x0123456789876543210 :: Nat) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 x0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    type family Let0123456789876543210ZSym0 (x0123456789876543210 :: Nat) :: Nat where
-      Let0123456789876543210ZSym0 x0123456789876543210 = Let0123456789876543210Z x0123456789876543210
-    type family Let0123456789876543210Z (x0123456789876543210 :: Nat) :: Nat where
-      Let0123456789876543210Z x = Apply (LamCases_0123456789876543210Sym0 x) ZeroSym0
-    type family Let0123456789876543210XSym0 (x0123456789876543210 :: Nat) :: Nat where
-      Let0123456789876543210XSym0 x0123456789876543210 = Let0123456789876543210X x0123456789876543210
-    type family Let0123456789876543210X (x0123456789876543210 :: Nat) :: Nat where
-      Let0123456789876543210X x = ZeroSym0
-    data Let0123456789876543210FSym0 (x0123456789876543210 :: Nat) :: (~>) Nat Nat
+        = snd
+            ((,) LamCases_Singletons_LetStatements_25Sym0KindInference ())
+    type family LamCases_Singletons_LetStatements_25Sym1 (x0 :: Nat) a_Singletons_LetStatements_26 where
+      LamCases_Singletons_LetStatements_25Sym1 x0 a_Singletons_LetStatements_26 = LamCases_Singletons_LetStatements_25 x0 a_Singletons_LetStatements_26
+    type family Let24ZSym0 (x0 :: Nat) :: Nat where
+      Let24ZSym0 x0 = Let24Z x0
+    type family Let24Z (x0 :: Nat) :: Nat where
+      Let24Z x = Apply (LamCases_Singletons_LetStatements_25Sym0 x) ZeroSym0
+    type family Let28XSym0 (x0 :: Nat) :: Nat where
+      Let28XSym0 x0 = Let28X x0
+    type family Let28X (x0 :: Nat) :: Nat where
+      Let28X x = ZeroSym0
+    data Let30FSym0 (x0 :: Nat) :: (~>) Nat Nat
       where
-        Let0123456789876543210FSym0KindInference :: SameKind (Apply (Let0123456789876543210FSym0 x0123456789876543210) arg) (Let0123456789876543210FSym1 x0123456789876543210 arg) =>
-                                                    Let0123456789876543210FSym0 x0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @Nat (Let0123456789876543210FSym0 x0123456789876543210) a0123456789876543210 = Let0123456789876543210F x0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Let0123456789876543210FSym0 x0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Let0123456789876543210FSym0KindInference ())
-    type family Let0123456789876543210FSym1 (x0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Nat where
-      Let0123456789876543210FSym1 x0123456789876543210 a0123456789876543210 = Let0123456789876543210F x0123456789876543210 a0123456789876543210
-    type family Let0123456789876543210F (x0123456789876543210 :: Nat) (a :: Nat) :: Nat where
-      Let0123456789876543210F x y = Apply SuccSym0 y
-    type family Let0123456789876543210ZSym0 (x0123456789876543210 :: Nat) :: Nat where
-      Let0123456789876543210ZSym0 x0123456789876543210 = Let0123456789876543210Z x0123456789876543210
-    type family Let0123456789876543210Z (x0123456789876543210 :: Nat) :: Nat where
-      Let0123456789876543210Z x = Apply (Let0123456789876543210FSym0 x) x
-    type family Let0123456789876543210ZSym0 (y0123456789876543210 :: Nat) (x0123456789876543210 :: Nat) :: Nat where
-      Let0123456789876543210ZSym0 y0123456789876543210 x0123456789876543210 = Let0123456789876543210Z y0123456789876543210 x0123456789876543210
-    type family Let0123456789876543210Z (y0123456789876543210 :: Nat) (x0123456789876543210 :: Nat) :: Nat where
-      Let0123456789876543210Z y x = Apply SuccSym0 y
-    data Let0123456789876543210FSym0 (x0123456789876543210 :: Nat) :: (~>) Nat Nat
+        Let30FSym0KindInference :: SameKind (Apply (Let30FSym0 x0) arg) (Let30FSym1 x0 arg) =>
+                                   Let30FSym0 x0 a1
+    type instance Apply @Nat @Nat (Let30FSym0 x0) a1 = Let30F x0 a1
+    instance SuppressUnusedWarnings (Let30FSym0 x0) where
+      suppressUnusedWarnings = snd ((,) Let30FSym0KindInference ())
+    type family Let30FSym1 (x0 :: Nat) (a1 :: Nat) :: Nat where
+      Let30FSym1 x0 a1 = Let30F x0 a1
+    type family Let30F (x0 :: Nat) (a :: Nat) :: Nat where
+      Let30F x y = Apply SuccSym0 y
+    type family Let31ZSym0 (x0 :: Nat) :: Nat where
+      Let31ZSym0 x0 = Let31Z x0
+    type family Let31Z (x0 :: Nat) :: Nat where
+      Let31Z x = Apply (Let30FSym0 x) x
+    type family Let34ZSym0 (y0 :: Nat) (x1 :: Nat) :: Nat where
+      Let34ZSym0 y0 x1 = Let34Z y0 x1
+    type family Let34Z (y0 :: Nat) (x1 :: Nat) :: Nat where
+      Let34Z y x = Apply SuccSym0 y
+    data Let33FSym0 (x0 :: Nat) :: (~>) Nat Nat
       where
-        Let0123456789876543210FSym0KindInference :: SameKind (Apply (Let0123456789876543210FSym0 x0123456789876543210) arg) (Let0123456789876543210FSym1 x0123456789876543210 arg) =>
-                                                    Let0123456789876543210FSym0 x0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @Nat (Let0123456789876543210FSym0 x0123456789876543210) a0123456789876543210 = Let0123456789876543210F x0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Let0123456789876543210FSym0 x0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Let0123456789876543210FSym0KindInference ())
-    type family Let0123456789876543210FSym1 (x0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Nat where
-      Let0123456789876543210FSym1 x0123456789876543210 a0123456789876543210 = Let0123456789876543210F x0123456789876543210 a0123456789876543210
-    type family Let0123456789876543210F (x0123456789876543210 :: Nat) (a :: Nat) :: Nat where
-      Let0123456789876543210F x y = Apply SuccSym0 (Let0123456789876543210ZSym0 y x)
-    data Let0123456789876543210FSym0 (x0123456789876543210 :: Nat) :: (~>) Nat Nat
+        Let33FSym0KindInference :: SameKind (Apply (Let33FSym0 x0) arg) (Let33FSym1 x0 arg) =>
+                                   Let33FSym0 x0 a1
+    type instance Apply @Nat @Nat (Let33FSym0 x0) a1 = Let33F x0 a1
+    instance SuppressUnusedWarnings (Let33FSym0 x0) where
+      suppressUnusedWarnings = snd ((,) Let33FSym0KindInference ())
+    type family Let33FSym1 (x0 :: Nat) (a1 :: Nat) :: Nat where
+      Let33FSym1 x0 a1 = Let33F x0 a1
+    type family Let33F (x0 :: Nat) (a :: Nat) :: Nat where
+      Let33F x y = Apply SuccSym0 (Let34ZSym0 y x)
+    data Let36FSym0 (x0 :: Nat) :: (~>) Nat Nat
       where
-        Let0123456789876543210FSym0KindInference :: SameKind (Apply (Let0123456789876543210FSym0 x0123456789876543210) arg) (Let0123456789876543210FSym1 x0123456789876543210 arg) =>
-                                                    Let0123456789876543210FSym0 x0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @Nat (Let0123456789876543210FSym0 x0123456789876543210) a0123456789876543210 = Let0123456789876543210F x0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Let0123456789876543210FSym0 x0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Let0123456789876543210FSym0KindInference ())
-    type family Let0123456789876543210FSym1 (x0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Nat where
-      Let0123456789876543210FSym1 x0123456789876543210 a0123456789876543210 = Let0123456789876543210F x0123456789876543210 a0123456789876543210
-    type family Let0123456789876543210F (x0123456789876543210 :: Nat) (a :: Nat) :: Nat where
-      Let0123456789876543210F x y = Apply SuccSym0 y
-    type family Let0123456789876543210YSym0 (x0123456789876543210 :: Nat) :: Nat where
-      Let0123456789876543210YSym0 x0123456789876543210 = Let0123456789876543210Y x0123456789876543210
-    type family Let0123456789876543210Y (x0123456789876543210 :: Nat) :: Nat where
-      Let0123456789876543210Y x = Apply SuccSym0 x
-    type family Let0123456789876543210ZSym0 where
-      Let0123456789876543210ZSym0 = Let0123456789876543210Z
-    type family Let0123456789876543210YSym0 where
-      Let0123456789876543210YSym0 = Let0123456789876543210Y
-    type family Let0123456789876543210Z where
-      Let0123456789876543210Z = Apply SuccSym0 Let0123456789876543210YSym0
-    type family Let0123456789876543210Y where
-      Let0123456789876543210Y = Apply SuccSym0 ZeroSym0
-    type family Let0123456789876543210YSym0 (x0123456789876543210 :: Nat) :: Nat where
-      Let0123456789876543210YSym0 x0123456789876543210 = Let0123456789876543210Y x0123456789876543210
-    type family Let0123456789876543210Y (x0123456789876543210 :: Nat) :: Nat where
-      Let0123456789876543210Y x = Apply SuccSym0 ZeroSym0
+        Let36FSym0KindInference :: SameKind (Apply (Let36FSym0 x0) arg) (Let36FSym1 x0 arg) =>
+                                   Let36FSym0 x0 a1
+    type instance Apply @Nat @Nat (Let36FSym0 x0) a1 = Let36F x0 a1
+    instance SuppressUnusedWarnings (Let36FSym0 x0) where
+      suppressUnusedWarnings = snd ((,) Let36FSym0KindInference ())
+    type family Let36FSym1 (x0 :: Nat) (a1 :: Nat) :: Nat where
+      Let36FSym1 x0 a1 = Let36F x0 a1
+    type family Let36F (x0 :: Nat) (a :: Nat) :: Nat where
+      Let36F x y = Apply SuccSym0 y
+    type family Let38YSym0 (x0 :: Nat) :: Nat where
+      Let38YSym0 x0 = Let38Y x0
+    type family Let38Y (x0 :: Nat) :: Nat where
+      Let38Y x = Apply SuccSym0 x
+    type family Let39ZSym0 where
+      Let39ZSym0 = Let39Z
+    type family Let39YSym0 where
+      Let39YSym0 = Let39Y
+    type family Let39Z where
+      Let39Z = Apply SuccSym0 Let39YSym0
+    type family Let39Y where
+      Let39Y = Apply SuccSym0 ZeroSym0
+    type family Let41YSym0 (x0 :: Nat) :: Nat where
+      Let41YSym0 x0 = Let41Y x0
+    type family Let41Y (x0 :: Nat) :: Nat where
+      Let41Y x = Apply SuccSym0 ZeroSym0
     type Foo14Sym0 :: (~>) Nat (Nat, Nat)
     data Foo14Sym0 :: (~>) Nat (Nat, Nat)
       where
         Foo14Sym0KindInference :: SameKind (Apply Foo14Sym0 arg) (Foo14Sym1 arg) =>
-                                  Foo14Sym0 a0123456789876543210
+                                  Foo14Sym0 a_Singletons_LetStatements_0
     type instance Apply @Nat @(Nat,
-                               Nat) Foo14Sym0 a0123456789876543210 = Foo14 a0123456789876543210
+                               Nat) Foo14Sym0 a_Singletons_LetStatements_0 = Foo14 a_Singletons_LetStatements_0
     instance SuppressUnusedWarnings Foo14Sym0 where
       suppressUnusedWarnings = snd ((,) Foo14Sym0KindInference ())
     type Foo14Sym1 :: Nat -> (Nat, Nat)
-    type family Foo14Sym1 (a0123456789876543210 :: Nat) :: (Nat,
-                                                            Nat) where
-      Foo14Sym1 a0123456789876543210 = Foo14 a0123456789876543210
+    type family Foo14Sym1 (a_Singletons_LetStatements_0 :: Nat) :: (Nat,
+                                                                    Nat) where
+      Foo14Sym1 a_Singletons_LetStatements_0 = Foo14 a_Singletons_LetStatements_0
     type Foo13_Sym0 :: (~>) a a
     data Foo13_Sym0 :: (~>) a a
       where
         Foo13_Sym0KindInference :: SameKind (Apply Foo13_Sym0 arg) (Foo13_Sym1 arg) =>
-                                   Foo13_Sym0 a0123456789876543210
-    type instance Apply @a @a Foo13_Sym0 a0123456789876543210 = Foo13_ a0123456789876543210
+                                   Foo13_Sym0 a_Singletons_LetStatements_9
+    type instance Apply @a @a Foo13_Sym0 a_Singletons_LetStatements_9 = Foo13_ a_Singletons_LetStatements_9
     instance SuppressUnusedWarnings Foo13_Sym0 where
       suppressUnusedWarnings = snd ((,) Foo13_Sym0KindInference ())
     type Foo13_Sym1 :: a -> a
-    type family Foo13_Sym1 @a (a0123456789876543210 :: a) :: a where
-      Foo13_Sym1 a0123456789876543210 = Foo13_ a0123456789876543210
+    type family Foo13_Sym1 @a (a_Singletons_LetStatements_9 :: a) :: a where
+      Foo13_Sym1 a_Singletons_LetStatements_9 = Foo13_ a_Singletons_LetStatements_9
     type Foo13Sym0 :: forall a. (~>) a a
     data Foo13Sym0 :: (~>) a a
       where
         Foo13Sym0KindInference :: SameKind (Apply Foo13Sym0 arg) (Foo13Sym1 arg) =>
-                                  Foo13Sym0 a0123456789876543210
-    type instance Apply @a @a Foo13Sym0 a0123456789876543210 = Foo13 a0123456789876543210
+                                  Foo13Sym0 a_Singletons_LetStatements_10
+    type instance Apply @a @a Foo13Sym0 a_Singletons_LetStatements_10 = Foo13 a_Singletons_LetStatements_10
     instance SuppressUnusedWarnings Foo13Sym0 where
       suppressUnusedWarnings = snd ((,) Foo13Sym0KindInference ())
     type Foo13Sym1 :: forall a. a -> a
-    type family Foo13Sym1 @a (a0123456789876543210 :: a) :: a where
-      Foo13Sym1 a0123456789876543210 = Foo13 a0123456789876543210
+    type family Foo13Sym1 @a (a_Singletons_LetStatements_10 :: a) :: a where
+      Foo13Sym1 a_Singletons_LetStatements_10 = Foo13 a_Singletons_LetStatements_10
     type Foo12Sym0 :: (~>) Nat Nat
     data Foo12Sym0 :: (~>) Nat Nat
       where
         Foo12Sym0KindInference :: SameKind (Apply Foo12Sym0 arg) (Foo12Sym1 arg) =>
-                                  Foo12Sym0 a0123456789876543210
-    type instance Apply @Nat @Nat Foo12Sym0 a0123456789876543210 = Foo12 a0123456789876543210
+                                  Foo12Sym0 a_Singletons_LetStatements_12
+    type instance Apply @Nat @Nat Foo12Sym0 a_Singletons_LetStatements_12 = Foo12 a_Singletons_LetStatements_12
     instance SuppressUnusedWarnings Foo12Sym0 where
       suppressUnusedWarnings = snd ((,) Foo12Sym0KindInference ())
     type Foo12Sym1 :: Nat -> Nat
-    type family Foo12Sym1 (a0123456789876543210 :: Nat) :: Nat where
-      Foo12Sym1 a0123456789876543210 = Foo12 a0123456789876543210
+    type family Foo12Sym1 (a_Singletons_LetStatements_12 :: Nat) :: Nat where
+      Foo12Sym1 a_Singletons_LetStatements_12 = Foo12 a_Singletons_LetStatements_12
     type Foo11Sym0 :: (~>) Nat Nat
     data Foo11Sym0 :: (~>) Nat Nat
       where
         Foo11Sym0KindInference :: SameKind (Apply Foo11Sym0 arg) (Foo11Sym1 arg) =>
-                                  Foo11Sym0 a0123456789876543210
-    type instance Apply @Nat @Nat Foo11Sym0 a0123456789876543210 = Foo11 a0123456789876543210
+                                  Foo11Sym0 a_Singletons_LetStatements_14
+    type instance Apply @Nat @Nat Foo11Sym0 a_Singletons_LetStatements_14 = Foo11 a_Singletons_LetStatements_14
     instance SuppressUnusedWarnings Foo11Sym0 where
       suppressUnusedWarnings = snd ((,) Foo11Sym0KindInference ())
     type Foo11Sym1 :: Nat -> Nat
-    type family Foo11Sym1 (a0123456789876543210 :: Nat) :: Nat where
-      Foo11Sym1 a0123456789876543210 = Foo11 a0123456789876543210
+    type family Foo11Sym1 (a_Singletons_LetStatements_14 :: Nat) :: Nat where
+      Foo11Sym1 a_Singletons_LetStatements_14 = Foo11 a_Singletons_LetStatements_14
     type Foo10Sym0 :: (~>) Nat Nat
     data Foo10Sym0 :: (~>) Nat Nat
       where
         Foo10Sym0KindInference :: SameKind (Apply Foo10Sym0 arg) (Foo10Sym1 arg) =>
-                                  Foo10Sym0 a0123456789876543210
-    type instance Apply @Nat @Nat Foo10Sym0 a0123456789876543210 = Foo10 a0123456789876543210
+                                  Foo10Sym0 a_Singletons_LetStatements_16
+    type instance Apply @Nat @Nat Foo10Sym0 a_Singletons_LetStatements_16 = Foo10 a_Singletons_LetStatements_16
     instance SuppressUnusedWarnings Foo10Sym0 where
       suppressUnusedWarnings = snd ((,) Foo10Sym0KindInference ())
     type Foo10Sym1 :: Nat -> Nat
-    type family Foo10Sym1 (a0123456789876543210 :: Nat) :: Nat where
-      Foo10Sym1 a0123456789876543210 = Foo10 a0123456789876543210
+    type family Foo10Sym1 (a_Singletons_LetStatements_16 :: Nat) :: Nat where
+      Foo10Sym1 a_Singletons_LetStatements_16 = Foo10 a_Singletons_LetStatements_16
     type Foo9Sym0 :: (~>) Nat Nat
     data Foo9Sym0 :: (~>) Nat Nat
       where
         Foo9Sym0KindInference :: SameKind (Apply Foo9Sym0 arg) (Foo9Sym1 arg) =>
-                                 Foo9Sym0 a0123456789876543210
-    type instance Apply @Nat @Nat Foo9Sym0 a0123456789876543210 = Foo9 a0123456789876543210
+                                 Foo9Sym0 a_Singletons_LetStatements_18
+    type instance Apply @Nat @Nat Foo9Sym0 a_Singletons_LetStatements_18 = Foo9 a_Singletons_LetStatements_18
     instance SuppressUnusedWarnings Foo9Sym0 where
       suppressUnusedWarnings = snd ((,) Foo9Sym0KindInference ())
     type Foo9Sym1 :: Nat -> Nat
-    type family Foo9Sym1 (a0123456789876543210 :: Nat) :: Nat where
-      Foo9Sym1 a0123456789876543210 = Foo9 a0123456789876543210
+    type family Foo9Sym1 (a_Singletons_LetStatements_18 :: Nat) :: Nat where
+      Foo9Sym1 a_Singletons_LetStatements_18 = Foo9 a_Singletons_LetStatements_18
     type Foo8Sym0 :: (~>) Nat Nat
     data Foo8Sym0 :: (~>) Nat Nat
       where
         Foo8Sym0KindInference :: SameKind (Apply Foo8Sym0 arg) (Foo8Sym1 arg) =>
-                                 Foo8Sym0 a0123456789876543210
-    type instance Apply @Nat @Nat Foo8Sym0 a0123456789876543210 = Foo8 a0123456789876543210
+                                 Foo8Sym0 a_Singletons_LetStatements_23
+    type instance Apply @Nat @Nat Foo8Sym0 a_Singletons_LetStatements_23 = Foo8 a_Singletons_LetStatements_23
     instance SuppressUnusedWarnings Foo8Sym0 where
       suppressUnusedWarnings = snd ((,) Foo8Sym0KindInference ())
     type Foo8Sym1 :: Nat -> Nat
-    type family Foo8Sym1 (a0123456789876543210 :: Nat) :: Nat where
-      Foo8Sym1 a0123456789876543210 = Foo8 a0123456789876543210
+    type family Foo8Sym1 (a_Singletons_LetStatements_23 :: Nat) :: Nat where
+      Foo8Sym1 a_Singletons_LetStatements_23 = Foo8 a_Singletons_LetStatements_23
     type Foo7Sym0 :: (~>) Nat Nat
     data Foo7Sym0 :: (~>) Nat Nat
       where
         Foo7Sym0KindInference :: SameKind (Apply Foo7Sym0 arg) (Foo7Sym1 arg) =>
-                                 Foo7Sym0 a0123456789876543210
-    type instance Apply @Nat @Nat Foo7Sym0 a0123456789876543210 = Foo7 a0123456789876543210
+                                 Foo7Sym0 a_Singletons_LetStatements_27
+    type instance Apply @Nat @Nat Foo7Sym0 a_Singletons_LetStatements_27 = Foo7 a_Singletons_LetStatements_27
     instance SuppressUnusedWarnings Foo7Sym0 where
       suppressUnusedWarnings = snd ((,) Foo7Sym0KindInference ())
     type Foo7Sym1 :: Nat -> Nat
-    type family Foo7Sym1 (a0123456789876543210 :: Nat) :: Nat where
-      Foo7Sym1 a0123456789876543210 = Foo7 a0123456789876543210
+    type family Foo7Sym1 (a_Singletons_LetStatements_27 :: Nat) :: Nat where
+      Foo7Sym1 a_Singletons_LetStatements_27 = Foo7 a_Singletons_LetStatements_27
     type Foo6Sym0 :: (~>) Nat Nat
     data Foo6Sym0 :: (~>) Nat Nat
       where
         Foo6Sym0KindInference :: SameKind (Apply Foo6Sym0 arg) (Foo6Sym1 arg) =>
-                                 Foo6Sym0 a0123456789876543210
-    type instance Apply @Nat @Nat Foo6Sym0 a0123456789876543210 = Foo6 a0123456789876543210
+                                 Foo6Sym0 a_Singletons_LetStatements_29
+    type instance Apply @Nat @Nat Foo6Sym0 a_Singletons_LetStatements_29 = Foo6 a_Singletons_LetStatements_29
     instance SuppressUnusedWarnings Foo6Sym0 where
       suppressUnusedWarnings = snd ((,) Foo6Sym0KindInference ())
     type Foo6Sym1 :: Nat -> Nat
-    type family Foo6Sym1 (a0123456789876543210 :: Nat) :: Nat where
-      Foo6Sym1 a0123456789876543210 = Foo6 a0123456789876543210
+    type family Foo6Sym1 (a_Singletons_LetStatements_29 :: Nat) :: Nat where
+      Foo6Sym1 a_Singletons_LetStatements_29 = Foo6 a_Singletons_LetStatements_29
     type Foo5Sym0 :: (~>) Nat Nat
     data Foo5Sym0 :: (~>) Nat Nat
       where
         Foo5Sym0KindInference :: SameKind (Apply Foo5Sym0 arg) (Foo5Sym1 arg) =>
-                                 Foo5Sym0 a0123456789876543210
-    type instance Apply @Nat @Nat Foo5Sym0 a0123456789876543210 = Foo5 a0123456789876543210
+                                 Foo5Sym0 a_Singletons_LetStatements_32
+    type instance Apply @Nat @Nat Foo5Sym0 a_Singletons_LetStatements_32 = Foo5 a_Singletons_LetStatements_32
     instance SuppressUnusedWarnings Foo5Sym0 where
       suppressUnusedWarnings = snd ((,) Foo5Sym0KindInference ())
     type Foo5Sym1 :: Nat -> Nat
-    type family Foo5Sym1 (a0123456789876543210 :: Nat) :: Nat where
-      Foo5Sym1 a0123456789876543210 = Foo5 a0123456789876543210
+    type family Foo5Sym1 (a_Singletons_LetStatements_32 :: Nat) :: Nat where
+      Foo5Sym1 a_Singletons_LetStatements_32 = Foo5 a_Singletons_LetStatements_32
     type Foo4Sym0 :: (~>) Nat Nat
     data Foo4Sym0 :: (~>) Nat Nat
       where
         Foo4Sym0KindInference :: SameKind (Apply Foo4Sym0 arg) (Foo4Sym1 arg) =>
-                                 Foo4Sym0 a0123456789876543210
-    type instance Apply @Nat @Nat Foo4Sym0 a0123456789876543210 = Foo4 a0123456789876543210
+                                 Foo4Sym0 a_Singletons_LetStatements_35
+    type instance Apply @Nat @Nat Foo4Sym0 a_Singletons_LetStatements_35 = Foo4 a_Singletons_LetStatements_35
     instance SuppressUnusedWarnings Foo4Sym0 where
       suppressUnusedWarnings = snd ((,) Foo4Sym0KindInference ())
     type Foo4Sym1 :: Nat -> Nat
-    type family Foo4Sym1 (a0123456789876543210 :: Nat) :: Nat where
-      Foo4Sym1 a0123456789876543210 = Foo4 a0123456789876543210
+    type family Foo4Sym1 (a_Singletons_LetStatements_35 :: Nat) :: Nat where
+      Foo4Sym1 a_Singletons_LetStatements_35 = Foo4 a_Singletons_LetStatements_35
     type Foo3Sym0 :: (~>) Nat Nat
     data Foo3Sym0 :: (~>) Nat Nat
       where
         Foo3Sym0KindInference :: SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
-                                 Foo3Sym0 a0123456789876543210
-    type instance Apply @Nat @Nat Foo3Sym0 a0123456789876543210 = Foo3 a0123456789876543210
+                                 Foo3Sym0 a_Singletons_LetStatements_37
+    type instance Apply @Nat @Nat Foo3Sym0 a_Singletons_LetStatements_37 = Foo3 a_Singletons_LetStatements_37
     instance SuppressUnusedWarnings Foo3Sym0 where
       suppressUnusedWarnings = snd ((,) Foo3Sym0KindInference ())
     type Foo3Sym1 :: Nat -> Nat
-    type family Foo3Sym1 (a0123456789876543210 :: Nat) :: Nat where
-      Foo3Sym1 a0123456789876543210 = Foo3 a0123456789876543210
+    type family Foo3Sym1 (a_Singletons_LetStatements_37 :: Nat) :: Nat where
+      Foo3Sym1 a_Singletons_LetStatements_37 = Foo3 a_Singletons_LetStatements_37
     type Foo2Sym0 :: Nat
     type family Foo2Sym0 :: Nat where
       Foo2Sym0 = Foo2
@@ -554,58 +546,58 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     data Foo1Sym0 :: (~>) Nat Nat
       where
         Foo1Sym0KindInference :: SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
-                                 Foo1Sym0 a0123456789876543210
-    type instance Apply @Nat @Nat Foo1Sym0 a0123456789876543210 = Foo1 a0123456789876543210
+                                 Foo1Sym0 a_Singletons_LetStatements_40
+    type instance Apply @Nat @Nat Foo1Sym0 a_Singletons_LetStatements_40 = Foo1 a_Singletons_LetStatements_40
     instance SuppressUnusedWarnings Foo1Sym0 where
       suppressUnusedWarnings = snd ((,) Foo1Sym0KindInference ())
     type Foo1Sym1 :: Nat -> Nat
-    type family Foo1Sym1 (a0123456789876543210 :: Nat) :: Nat where
-      Foo1Sym1 a0123456789876543210 = Foo1 a0123456789876543210
+    type family Foo1Sym1 (a_Singletons_LetStatements_40 :: Nat) :: Nat where
+      Foo1Sym1 a_Singletons_LetStatements_40 = Foo1 a_Singletons_LetStatements_40
     type Foo14 :: Nat -> (Nat, Nat)
     type family Foo14 (a :: Nat) :: (Nat, Nat) where
-      Foo14 x = Apply (Apply Tuple2Sym0 (Let0123456789876543210ZSym0 x)) (Let0123456789876543210YSym0 x)
+      Foo14 x = Apply (Apply Tuple2Sym0 (Let1ZSym0 x)) (Let1YSym0 x)
     type Foo13_ :: a -> a
     type family Foo13_ @a (a :: a) :: a where
       Foo13_ y = y
     type Foo13 :: forall a. a -> a
     type family Foo13 @a (a :: a) :: a where
-      Foo13 @a (x :: a) = Apply Foo13_Sym0 (Let0123456789876543210BarSym0 a x)
+      Foo13 @a (x :: a) = Apply Foo13_Sym0 (Let11BarSym0 a x)
     type Foo12 :: Nat -> Nat
     type family Foo12 (a :: Nat) :: Nat where
-      Foo12 x = Apply (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$) x) x) (Apply SuccSym0 (Apply SuccSym0 ZeroSym0))
+      Foo12 x = Apply (Apply ((<<<#%+@#@$) x) x) (Apply SuccSym0 (Apply SuccSym0 ZeroSym0))
     type Foo11 :: Nat -> Nat
     type family Foo11 (a :: Nat) :: Nat where
-      Foo11 x = Apply (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$) x) (Apply SuccSym0 ZeroSym0)) (Let0123456789876543210ZSym0 x)
+      Foo11 x = Apply (Apply ((<<<#*+@#@$) x) (Apply SuccSym0 ZeroSym0)) (Let15ZSym0 x)
     type Foo10 :: Nat -> Nat
     type family Foo10 (a :: Nat) :: Nat where
-      Foo10 x = Apply (Apply ((<<<%%%%%%%%%%%%%%%%%%%%@#@$) x) (Apply SuccSym0 ZeroSym0)) x
+      Foo10 x = Apply (Apply ((<<<#.+@#@$) x) (Apply SuccSym0 ZeroSym0)) x
     type Foo9 :: Nat -> Nat
     type family Foo9 (a :: Nat) :: Nat where
-      Foo9 x = Apply (Let0123456789876543210ZSym0 x) x
+      Foo9 x = Apply (Let19ZSym0 x) x
     type Foo8 :: Nat -> Nat
     type family Foo8 (a :: Nat) :: Nat where
-      Foo8 x = Let0123456789876543210ZSym0 x
+      Foo8 x = Let24ZSym0 x
     type Foo7 :: Nat -> Nat
     type family Foo7 (a :: Nat) :: Nat where
-      Foo7 x = Let0123456789876543210XSym0 x
+      Foo7 x = Let28XSym0 x
     type Foo6 :: Nat -> Nat
     type family Foo6 (a :: Nat) :: Nat where
-      Foo6 x = Let0123456789876543210ZSym0 x
+      Foo6 x = Let31ZSym0 x
     type Foo5 :: Nat -> Nat
     type family Foo5 (a :: Nat) :: Nat where
-      Foo5 x = Apply (Let0123456789876543210FSym0 x) x
+      Foo5 x = Apply (Let33FSym0 x) x
     type Foo4 :: Nat -> Nat
     type family Foo4 (a :: Nat) :: Nat where
-      Foo4 x = Apply (Let0123456789876543210FSym0 x) x
+      Foo4 x = Apply (Let36FSym0 x) x
     type Foo3 :: Nat -> Nat
     type family Foo3 (a :: Nat) :: Nat where
-      Foo3 x = Let0123456789876543210YSym0 x
+      Foo3 x = Let38YSym0 x
     type Foo2 :: Nat
     type family Foo2 :: Nat where
-      Foo2 = Let0123456789876543210ZSym0
+      Foo2 = Let39ZSym0
     type Foo1 :: Nat -> Nat
     type family Foo1 (a :: Nat) :: Nat where
-      Foo1 x = Let0123456789876543210YSym0 x
+      Foo1 x = Let41YSym0 x
     sFoo14 ::
       (forall (t :: Nat). Sing t -> Sing (Foo14 t :: (Nat, Nat)) :: Type)
     sFoo13_ ::
@@ -636,27 +628,29 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
       (forall (t :: Nat). Sing t -> Sing (Foo1 t :: Nat) :: Type)
     sFoo14 (sX :: Sing x)
       = let
-          sZ :: Sing @_ (Let0123456789876543210Z x)
-          sY :: Sing @_ (Let0123456789876543210Y x)
-          sX_0123456789876543210 ::
-            Sing @_ (Let0123456789876543210X_0123456789876543210 x)
+          sZ :: Sing @_ (Let1Z x)
+          sY :: Sing @_ (Let1Y x)
+          sX_Singletons_LetStatements_2 ::
+            Sing @_ (Let1X_Singletons_LetStatements_2 x)
           sZ
             = applySing
                 (singFun1
-                   @(LamCases_0123456789876543210Sym0 x)
+                   @(LamCases_Singletons_LetStatements_5Sym0 x)
                    (\cases
-                      (STuple2 _ (sY_0123456789876543210 :: Sing y_0123456789876543210))
-                        -> sY_0123456789876543210))
-                sX_0123456789876543210
+                      (STuple2 _
+                               (sY_Singletons_LetStatements_4 :: Sing y_Singletons_LetStatements_4))
+                        -> sY_Singletons_LetStatements_4))
+                sX_Singletons_LetStatements_2
           sY
             = applySing
                 (singFun1
-                   @(LamCases_0123456789876543210Sym0 x)
+                   @(LamCases_Singletons_LetStatements_7Sym0 x)
                    (\cases
-                      (STuple2 (sY_0123456789876543210 :: Sing y_0123456789876543210) _)
-                        -> sY_0123456789876543210))
-                sX_0123456789876543210
-          sX_0123456789876543210
+                      (STuple2 (sY_Singletons_LetStatements_3 :: Sing y_Singletons_LetStatements_3)
+                               _)
+                        -> sY_Singletons_LetStatements_3))
+                sX_Singletons_LetStatements_2
+          sX_Singletons_LetStatements_2
             = applySing
                 (applySing
                    (singFun2 @Tuple2Sym0 STuple2)
@@ -666,138 +660,126 @@ Singletons/LetStatements.hs:(0,0)-(0,0): Splicing declarations
     sFoo13_ (sY :: Sing y) = sY
     sFoo13 (sX :: Sing x)
       = let
-          sBar :: (Sing (Let0123456789876543210Bar a x :: a) :: Type)
+          sBar :: (Sing (Let11Bar a x :: a) :: Type)
           sBar = sX
         in applySing (singFun1 @Foo13_Sym0 sFoo13_) sBar
     sFoo12 (sX :: Sing x)
       = let
           (%+) ::
             (forall (t :: Nat) (t :: Nat).
-             Sing t
-             -> Sing t -> Sing ((<<<%%%%%%%%%%%%%%%%%%%%) x t t :: Nat) :: Type)
+             Sing t -> Sing t -> Sing ((<<<#%+) x t t :: Nat) :: Type)
           (%+) SZero (sM :: Sing m) = sM
           (%+) (SSucc (sN :: Sing n)) (sM :: Sing m)
             = applySing
                 (singFun1 @SuccSym0 SSucc)
-                (applySing
-                   (applySing (singFun2 @((<<<%%%%%%%%%%%%%%%%%%%%@#@$) x) (%+)) sN)
-                   sX)
+                (applySing (applySing (singFun2 @((<<<#%+@#@$) x) (%+)) sN) sX)
         in
           applySing
-            (applySing (singFun2 @((<<<%%%%%%%%%%%%%%%%%%%%@#@$) x) (%+)) sX)
+            (applySing (singFun2 @((<<<#%+@#@$) x) (%+)) sX)
             (applySing
                (singFun1 @SuccSym0 SSucc)
                (applySing (singFun1 @SuccSym0 SSucc) SZero))
     sFoo11 (sX :: Sing x)
       = let
-          sZ :: (Sing (Let0123456789876543210Z x :: Nat) :: Type)
+          sZ :: (Sing (Let15Z x :: Nat) :: Type)
           (%+) ::
             (forall (t :: Nat) (t :: Nat).
-             Sing t
-             -> Sing t -> Sing ((<<<%%%%%%%%%%%%%%%%%%%%) x t t :: Nat) :: Type)
+             Sing t -> Sing t -> Sing ((<<<#*+) x t t :: Nat) :: Type)
           sZ = sX
           (%+) SZero (sM :: Sing m) = sM
           (%+) (SSucc (sN :: Sing n)) (sM :: Sing m)
             = applySing
                 (singFun1 @SuccSym0 SSucc)
-                (applySing
-                   (applySing (singFun2 @((<<<%%%%%%%%%%%%%%%%%%%%@#@$) x) (%+)) sN)
-                   sM)
+                (applySing (applySing (singFun2 @((<<<#*+@#@$) x) (%+)) sN) sM)
         in
           applySing
             (applySing
-               (singFun2 @((<<<%%%%%%%%%%%%%%%%%%%%@#@$) x) (%+))
+               (singFun2 @((<<<#*+@#@$) x) (%+))
                (applySing (singFun1 @SuccSym0 SSucc) SZero))
             sZ
     sFoo10 (sX :: Sing x)
       = let
           (%+) ::
             (forall (t :: Nat) (t :: Nat).
-             Sing t
-             -> Sing t -> Sing ((<<<%%%%%%%%%%%%%%%%%%%%) x t t :: Nat) :: Type)
+             Sing t -> Sing t -> Sing ((<<<#.+) x t t :: Nat) :: Type)
           (%+) SZero (sM :: Sing m) = sM
           (%+) (SSucc (sN :: Sing n)) (sM :: Sing m)
             = applySing
                 (singFun1 @SuccSym0 SSucc)
-                (applySing
-                   (applySing (singFun2 @((<<<%%%%%%%%%%%%%%%%%%%%@#@$) x) (%+)) sN)
-                   sM)
+                (applySing (applySing (singFun2 @((<<<#.+@#@$) x) (%+)) sN) sM)
         in
           applySing
             (applySing
-               (singFun2 @((<<<%%%%%%%%%%%%%%%%%%%%@#@$) x) (%+))
+               (singFun2 @((<<<#.+@#@$) x) (%+))
                (applySing (singFun1 @SuccSym0 SSucc) SZero))
             sX
     sFoo9 (sX :: Sing x)
       = let
           sZ ::
-            (forall (t :: Nat).
-             Sing t -> Sing (Let0123456789876543210Z x t :: Nat) :: Type)
-          sZ (sA_0123456789876543210 :: Sing a_0123456789876543210)
+            (forall (t :: Nat). Sing t -> Sing (Let19Z x t :: Nat) :: Type)
+          sZ
+            (sA_Singletons_LetStatements_20 :: Sing a_Singletons_LetStatements_20)
             = applySing
                 (singFun1
-                   @(LamCases_0123456789876543210Sym0 a_0123456789876543210 x)
+                   @(LamCases_Singletons_LetStatements_21Sym0 a_Singletons_LetStatements_20 x)
                    (\cases (sX :: Sing x) -> sX))
-                sA_0123456789876543210
-        in applySing (singFun1 @(Let0123456789876543210ZSym0 x) sZ) sX
+                sA_Singletons_LetStatements_20
+        in applySing (singFun1 @(Let19ZSym0 x) sZ) sX
     sFoo8 (sX :: Sing x)
       = let
-          sZ :: (Sing (Let0123456789876543210Z x :: Nat) :: Type)
+          sZ :: (Sing (Let24Z x :: Nat) :: Type)
           sZ
             = applySing
                 (singFun1
-                   @(LamCases_0123456789876543210Sym0 x)
+                   @(LamCases_Singletons_LetStatements_25Sym0 x)
                    (\cases (sX :: Sing x) -> sX))
                 SZero
         in sZ
     sFoo7 (sX :: Sing x)
       = let
-          sX :: (Sing (Let0123456789876543210X x :: Nat) :: Type)
+          sX :: (Sing (Let28X x :: Nat) :: Type)
           sX = SZero
         in sX
     sFoo6 (sX :: Sing x)
       = let
           sF ::
-            (forall (t :: Nat).
-             Sing t -> Sing (Let0123456789876543210F x t :: Nat) :: Type)
+            (forall (t :: Nat). Sing t -> Sing (Let30F x t :: Nat) :: Type)
           sF (sY :: Sing y) = applySing (singFun1 @SuccSym0 SSucc) sY in
         let
-          sZ :: (Sing (Let0123456789876543210Z x :: Nat) :: Type)
-          sZ = applySing (singFun1 @(Let0123456789876543210FSym0 x) sF) sX
+          sZ :: (Sing (Let31Z x :: Nat) :: Type)
+          sZ = applySing (singFun1 @(Let30FSym0 x) sF) sX
         in sZ
     sFoo5 (sX :: Sing x)
       = let
           sF ::
-            (forall (t :: Nat).
-             Sing t -> Sing (Let0123456789876543210F x t :: Nat) :: Type)
+            (forall (t :: Nat). Sing t -> Sing (Let33F x t :: Nat) :: Type)
           sF (sY :: Sing y)
             = let
-                sZ :: (Sing (Let0123456789876543210Z y x :: Nat) :: Type)
+                sZ :: (Sing (Let34Z y x :: Nat) :: Type)
                 sZ = applySing (singFun1 @SuccSym0 SSucc) sY
               in applySing (singFun1 @SuccSym0 SSucc) sZ
-        in applySing (singFun1 @(Let0123456789876543210FSym0 x) sF) sX
+        in applySing (singFun1 @(Let33FSym0 x) sF) sX
     sFoo4 (sX :: Sing x)
       = let
           sF ::
-            (forall (t :: Nat).
-             Sing t -> Sing (Let0123456789876543210F x t :: Nat) :: Type)
+            (forall (t :: Nat). Sing t -> Sing (Let36F x t :: Nat) :: Type)
           sF (sY :: Sing y) = applySing (singFun1 @SuccSym0 SSucc) sY
-        in applySing (singFun1 @(Let0123456789876543210FSym0 x) sF) sX
+        in applySing (singFun1 @(Let36FSym0 x) sF) sX
     sFoo3 (sX :: Sing x)
       = let
-          sY :: (Sing (Let0123456789876543210Y x :: Nat) :: Type)
+          sY :: (Sing (Let38Y x :: Nat) :: Type)
           sY = applySing (singFun1 @SuccSym0 SSucc) sX
         in sY
     sFoo2
       = let
-          sZ :: Sing @_ Let0123456789876543210Z
-          sY :: Sing @_ Let0123456789876543210Y
+          sZ :: Sing @_ Let39Z
+          sY :: Sing @_ Let39Y
           sZ = applySing (singFun1 @SuccSym0 SSucc) sY
           sY = applySing (singFun1 @SuccSym0 SSucc) SZero
         in sZ
     sFoo1 (sX :: Sing x)
       = let
-          sY :: (Sing (Let0123456789876543210Y x :: Nat) :: Type)
+          sY :: (Sing (Let41Y x :: Nat) :: Type)
           sY = applySing (singFun1 @SuccSym0 SSucc) SZero
         in sY
     instance SingI (Foo14Sym0 :: (~>) Nat (Nat, Nat)) where

--- a/singletons-base/tests/compile-and-dump/Singletons/Maybe.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Maybe.golden
@@ -14,31 +14,31 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
     data JustSym0 :: (~>) a (Maybe a)
       where
         JustSym0KindInference :: SameKind (Apply JustSym0 arg) (JustSym1 arg) =>
-                                 JustSym0 a0123456789876543210
-    type instance Apply @a @(Maybe a) JustSym0 a0123456789876543210 = Just a0123456789876543210
+                                 JustSym0 a_Singletons_Maybe_4
+    type instance Apply @a @(Maybe a) JustSym0 a_Singletons_Maybe_4 = Just a_Singletons_Maybe_4
     instance SuppressUnusedWarnings JustSym0 where
       suppressUnusedWarnings = snd ((,) JustSym0KindInference ())
     type JustSym1 :: forall a. a -> Maybe a
-    type family JustSym1 @a (a0123456789876543210 :: a) :: Maybe a where
-      JustSym1 a0123456789876543210 = Just a0123456789876543210
-    type TFHelper_0123456789876543210 :: forall a. Maybe a
-                                                   -> Maybe a -> Bool
-    type family TFHelper_0123456789876543210 @a (a :: Maybe a) (a :: Maybe a) :: Bool where
-      TFHelper_0123456789876543210 @a (Nothing :: Maybe a) (Nothing :: Maybe a) = TrueSym0
-      TFHelper_0123456789876543210 @a (Nothing :: Maybe a) (Just _ :: Maybe a) = FalseSym0
-      TFHelper_0123456789876543210 @a (Just _ :: Maybe a) (Nothing :: Maybe a) = FalseSym0
-      TFHelper_0123456789876543210 @a (Just a_0123456789876543210 :: Maybe a) (Just b_0123456789876543210 :: Maybe a) = Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210
+    type family JustSym1 @a (a_Singletons_Maybe_4 :: a) :: Maybe a where
+      JustSym1 a_Singletons_Maybe_4 = Just a_Singletons_Maybe_4
+    type TFHelper_Singletons_Maybe_5 :: forall a. Maybe a
+                                                  -> Maybe a -> Bool
+    type family TFHelper_Singletons_Maybe_5 @a (a :: Maybe a) (a :: Maybe a) :: Bool where
+      TFHelper_Singletons_Maybe_5 @a (Nothing :: Maybe a) (Nothing :: Maybe a) = TrueSym0
+      TFHelper_Singletons_Maybe_5 @a (Nothing :: Maybe a) (Just _ :: Maybe a) = FalseSym0
+      TFHelper_Singletons_Maybe_5 @a (Just _ :: Maybe a) (Nothing :: Maybe a) = FalseSym0
+      TFHelper_Singletons_Maybe_5 @a (Just a_Singletons_Maybe_0 :: Maybe a) (Just b_Singletons_Maybe_1 :: Maybe a) = Apply (Apply (==@#@$) a_Singletons_Maybe_0) b_Singletons_Maybe_1
     instance PEq (Maybe a) where
-      type (==) a a = TFHelper_0123456789876543210 a a
-    type ShowsPrec_0123456789876543210 :: forall a. GHC.Internal.Bignum.Natural.Natural
-                                                    -> Maybe a
-                                                       -> GHC.Internal.Types.Symbol
-                                                          -> GHC.Internal.Types.Symbol
-    type family ShowsPrec_0123456789876543210 @a (a :: GHC.Internal.Bignum.Natural.Natural) (a :: Maybe a) (a :: GHC.Internal.Types.Symbol) :: GHC.Internal.Types.Symbol where
-      ShowsPrec_0123456789876543210 @a (_ :: GHC.Internal.Bignum.Natural.Natural) (Nothing :: Maybe a) (a_0123456789876543210 :: GHC.Internal.Types.Symbol) = Apply (Apply ShowStringSym0 "Nothing") a_0123456789876543210
-      ShowsPrec_0123456789876543210 @a (p_0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) (Just arg_0123456789876543210 :: Maybe a) (a_0123456789876543210 :: GHC.Internal.Types.Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Just ")) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
+      type (==) a a = TFHelper_Singletons_Maybe_5 a a
+    type ShowsPrec_Singletons_Maybe_8 :: forall a. GHC.Internal.Bignum.Natural.Natural
+                                                   -> Maybe a
+                                                      -> GHC.Internal.Types.Symbol
+                                                         -> GHC.Internal.Types.Symbol
+    type family ShowsPrec_Singletons_Maybe_8 @a (a :: GHC.Internal.Bignum.Natural.Natural) (a :: Maybe a) (a :: GHC.Internal.Types.Symbol) :: GHC.Internal.Types.Symbol where
+      ShowsPrec_Singletons_Maybe_8 @a (_ :: GHC.Internal.Bignum.Natural.Natural) (Nothing :: Maybe a) (a_Singletons_Maybe_9 :: GHC.Internal.Types.Symbol) = Apply (Apply ShowStringSym0 "Nothing") a_Singletons_Maybe_9
+      ShowsPrec_Singletons_Maybe_8 @a (p_Singletons_Maybe_2 :: GHC.Internal.Bignum.Natural.Natural) (Just arg_Singletons_Maybe_3 :: Maybe a) (a_Singletons_Maybe_10 :: GHC.Internal.Types.Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_Singletons_Maybe_2) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Just ")) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_Singletons_Maybe_3))) a_Singletons_Maybe_10
     instance PShow (Maybe a) where
-      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
+      type ShowsPrec a a a = ShowsPrec_Singletons_Maybe_8 a a a
     data SMaybe :: forall a. Maybe a -> Type
       where
         SNothing :: forall a. SMaybe (Nothing :: Maybe a)
@@ -57,30 +57,30 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
       (%==) SNothing (SJust _) = SFalse
       (%==) (SJust _) SNothing = SFalse
       (%==)
-        (SJust (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SJust (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SJust (sA_Singletons_Maybe_0 :: Sing a_Singletons_Maybe_0))
+        (SJust (sB_Singletons_Maybe_1 :: Sing b_Singletons_Maybe_1))
         = applySing
-            (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-            sB_0123456789876543210
+            (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_Maybe_0)
+            sB_Singletons_Maybe_1
     instance SShow a => SShow (Maybe a) where
       sShowsPrec
         _
         SNothing
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_Singletons_Maybe_9 :: Sing a_Singletons_Maybe_9)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "Nothing"))
-            sA_0123456789876543210
+            sA_Singletons_Maybe_9
       sShowsPrec
-        (sP_0123456789876543210 :: Sing p_0123456789876543210)
-        (SJust (sArg_0123456789876543210 :: Sing arg_0123456789876543210))
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sP_Singletons_Maybe_2 :: Sing p_Singletons_Maybe_2)
+        (SJust (sArg_Singletons_Maybe_3 :: Sing arg_Singletons_Maybe_3))
+        (sA_Singletons_Maybe_10 :: Sing a_Singletons_Maybe_10)
         = applySing
             (applySing
                (applySing
                   (singFun3 @ShowParenSym0 sShowParen)
                   (applySing
-                     (applySing (singFun2 @(>@#@$) (%>)) sP_0123456789876543210)
+                     (applySing (singFun2 @(>@#@$) (%>)) sP_Singletons_Maybe_2)
                      (sFromInteger (sing :: Sing 10))))
                (applySing
                   (applySing
@@ -91,8 +91,8 @@ Singletons/Maybe.hs:(0,0)-(0,0): Splicing declarations
                      (applySing
                         (singFun3 @ShowsPrecSym0 sShowsPrec)
                         (sFromInteger (sing :: Sing 11)))
-                     sArg_0123456789876543210)))
-            sA_0123456789876543210
+                     sArg_Singletons_Maybe_3)))
+            sA_Singletons_Maybe_10
     instance SDecide a => SDecide (Maybe a) where
       (%~) SNothing SNothing = Proved Refl
       (%~) SNothing (SJust _) = Disproved (\case)

--- a/singletons-base/tests/compile-and-dump/Singletons/Nat.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Nat.golden
@@ -31,43 +31,43 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
     data SuccSym0 :: (~>) Nat Nat
       where
         SuccSym0KindInference :: SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
-                                 SuccSym0 a0123456789876543210
-    type instance Apply @Nat @Nat SuccSym0 a0123456789876543210 = Succ a0123456789876543210
+                                 SuccSym0 a_Singletons_Nat_6
+    type instance Apply @Nat @Nat SuccSym0 a_Singletons_Nat_6 = Succ a_Singletons_Nat_6
     instance SuppressUnusedWarnings SuccSym0 where
       suppressUnusedWarnings = snd ((,) SuccSym0KindInference ())
     type SuccSym1 :: Nat -> Nat
-    type family SuccSym1 (a0123456789876543210 :: Nat) :: Nat where
-      SuccSym1 a0123456789876543210 = Succ a0123456789876543210
+    type family SuccSym1 (a_Singletons_Nat_6 :: Nat) :: Nat where
+      SuccSym1 a_Singletons_Nat_6 = Succ a_Singletons_Nat_6
     type PredSym0 :: (~>) Nat Nat
     data PredSym0 :: (~>) Nat Nat
       where
         PredSym0KindInference :: SameKind (Apply PredSym0 arg) (PredSym1 arg) =>
-                                 PredSym0 a0123456789876543210
-    type instance Apply @Nat @Nat PredSym0 a0123456789876543210 = Pred a0123456789876543210
+                                 PredSym0 a_Singletons_Nat_7
+    type instance Apply @Nat @Nat PredSym0 a_Singletons_Nat_7 = Pred a_Singletons_Nat_7
     instance SuppressUnusedWarnings PredSym0 where
       suppressUnusedWarnings = snd ((,) PredSym0KindInference ())
     type PredSym1 :: Nat -> Nat
-    type family PredSym1 (a0123456789876543210 :: Nat) :: Nat where
-      PredSym1 a0123456789876543210 = Pred a0123456789876543210
+    type family PredSym1 (a_Singletons_Nat_7 :: Nat) :: Nat where
+      PredSym1 a_Singletons_Nat_7 = Pred a_Singletons_Nat_7
     type PlusSym0 :: (~>) Nat ((~>) Nat Nat)
     data PlusSym0 :: (~>) Nat ((~>) Nat Nat)
       where
         PlusSym0KindInference :: SameKind (Apply PlusSym0 arg) (PlusSym1 arg) =>
-                                 PlusSym0 a0123456789876543210
-    type instance Apply @Nat @((~>) Nat Nat) PlusSym0 a0123456789876543210 = PlusSym1 a0123456789876543210
+                                 PlusSym0 a_Singletons_Nat_8
+    type instance Apply @Nat @((~>) Nat Nat) PlusSym0 a_Singletons_Nat_8 = PlusSym1 a_Singletons_Nat_8
     instance SuppressUnusedWarnings PlusSym0 where
       suppressUnusedWarnings = snd ((,) PlusSym0KindInference ())
     type PlusSym1 :: Nat -> (~>) Nat Nat
-    data PlusSym1 (a0123456789876543210 :: Nat) :: (~>) Nat Nat
+    data PlusSym1 (a_Singletons_Nat_8 :: Nat) :: (~>) Nat Nat
       where
-        PlusSym1KindInference :: SameKind (Apply (PlusSym1 a0123456789876543210) arg) (PlusSym2 a0123456789876543210 arg) =>
-                                 PlusSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @Nat (PlusSym1 a0123456789876543210) a0123456789876543210 = Plus a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (PlusSym1 a0123456789876543210) where
+        PlusSym1KindInference :: SameKind (Apply (PlusSym1 a_Singletons_Nat_8) arg) (PlusSym2 a_Singletons_Nat_8 arg) =>
+                                 PlusSym1 a_Singletons_Nat_8 a_Singletons_Nat_9
+    type instance Apply @Nat @Nat (PlusSym1 a_Singletons_Nat_8) a_Singletons_Nat_9 = Plus a_Singletons_Nat_8 a_Singletons_Nat_9
+    instance SuppressUnusedWarnings (PlusSym1 a_Singletons_Nat_8) where
       suppressUnusedWarnings = snd ((,) PlusSym1KindInference ())
     type PlusSym2 :: Nat -> Nat -> Nat
-    type family PlusSym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Nat where
-      PlusSym2 a0123456789876543210 a0123456789876543210 = Plus a0123456789876543210 a0123456789876543210
+    type family PlusSym2 (a_Singletons_Nat_8 :: Nat) (a_Singletons_Nat_9 :: Nat) :: Nat where
+      PlusSym2 a_Singletons_Nat_8 a_Singletons_Nat_9 = Plus a_Singletons_Nat_8 a_Singletons_Nat_9
     type Pred :: Nat -> Nat
     type family Pred (a :: Nat) :: Nat where
       Pred Zero = ZeroSym0
@@ -76,31 +76,30 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
     type family Plus (a :: Nat) (a :: Nat) :: Nat where
       Plus Zero m = m
       Plus (Succ n) m = Apply SuccSym0 (Apply (Apply PlusSym0 n) m)
-    type TFHelper_0123456789876543210 :: Nat -> Nat -> Bool
-    type family TFHelper_0123456789876543210 (a :: Nat) (a :: Nat) :: Bool where
-      TFHelper_0123456789876543210 Zero Zero = TrueSym0
-      TFHelper_0123456789876543210 Zero (Succ _) = FalseSym0
-      TFHelper_0123456789876543210 (Succ _) Zero = FalseSym0
-      TFHelper_0123456789876543210 (Succ a_0123456789876543210) (Succ b_0123456789876543210) = Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210
+    type TFHelper_Singletons_Nat_10 :: Nat -> Nat -> Bool
+    type family TFHelper_Singletons_Nat_10 (a :: Nat) (a :: Nat) :: Bool where
+      TFHelper_Singletons_Nat_10 Zero Zero = TrueSym0
+      TFHelper_Singletons_Nat_10 Zero (Succ _) = FalseSym0
+      TFHelper_Singletons_Nat_10 (Succ _) Zero = FalseSym0
+      TFHelper_Singletons_Nat_10 (Succ a_Singletons_Nat_0) (Succ b_Singletons_Nat_1) = Apply (Apply (==@#@$) a_Singletons_Nat_0) b_Singletons_Nat_1
     instance PEq Nat where
-      type (==) a a = TFHelper_0123456789876543210 a a
-    type ShowsPrec_0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural
-                                          -> Nat
-                                             -> GHC.Internal.Types.Symbol
-                                                -> GHC.Internal.Types.Symbol
-    type family ShowsPrec_0123456789876543210 (a :: GHC.Internal.Bignum.Natural.Natural) (a :: Nat) (a :: GHC.Internal.Types.Symbol) :: GHC.Internal.Types.Symbol where
-      ShowsPrec_0123456789876543210 _ Zero a_0123456789876543210 = Apply (Apply ShowStringSym0 "Zero") a_0123456789876543210
-      ShowsPrec_0123456789876543210 p_0123456789876543210 (Succ arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Succ ")) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
+      type (==) a a = TFHelper_Singletons_Nat_10 a a
+    type ShowsPrec_Singletons_Nat_13 :: GHC.Internal.Bignum.Natural.Natural
+                                        -> Nat
+                                           -> GHC.Internal.Types.Symbol -> GHC.Internal.Types.Symbol
+    type family ShowsPrec_Singletons_Nat_13 (a :: GHC.Internal.Bignum.Natural.Natural) (a :: Nat) (a :: GHC.Internal.Types.Symbol) :: GHC.Internal.Types.Symbol where
+      ShowsPrec_Singletons_Nat_13 _ Zero a_Singletons_Nat_14 = Apply (Apply ShowStringSym0 "Zero") a_Singletons_Nat_14
+      ShowsPrec_Singletons_Nat_13 p_Singletons_Nat_2 (Succ arg_Singletons_Nat_3) a_Singletons_Nat_15 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_Singletons_Nat_2) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Succ ")) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_Singletons_Nat_3))) a_Singletons_Nat_15
     instance PShow Nat where
-      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
-    type Compare_0123456789876543210 :: Nat -> Nat -> Ordering
-    type family Compare_0123456789876543210 (a :: Nat) (a :: Nat) :: Ordering where
-      Compare_0123456789876543210 Zero Zero = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
-      Compare_0123456789876543210 (Succ a_0123456789876543210) (Succ b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0)
-      Compare_0123456789876543210 Zero (Succ _) = LTSym0
-      Compare_0123456789876543210 (Succ _) Zero = GTSym0
+      type ShowsPrec a a a = ShowsPrec_Singletons_Nat_13 a a a
+    type Compare_Singletons_Nat_19 :: Nat -> Nat -> Ordering
+    type family Compare_Singletons_Nat_19 (a :: Nat) (a :: Nat) :: Ordering where
+      Compare_Singletons_Nat_19 Zero Zero = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
+      Compare_Singletons_Nat_19 (Succ a_Singletons_Nat_4) (Succ b_Singletons_Nat_5) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_Nat_4) b_Singletons_Nat_5)) NilSym0)
+      Compare_Singletons_Nat_19 Zero (Succ _) = LTSym0
+      Compare_Singletons_Nat_19 (Succ _) Zero = GTSym0
     instance POrd Nat where
-      type Compare a a = Compare_0123456789876543210 a a
+      type Compare a a = Compare_Singletons_Nat_19 a a
     sPred ::
       (forall (t :: Nat). Sing t -> Sing (Pred t :: Nat) :: Type)
     sPlus ::
@@ -141,30 +140,30 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
       (%==) SZero (SSucc _) = SFalse
       (%==) (SSucc _) SZero = SFalse
       (%==)
-        (SSucc (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SSucc (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SSucc (sA_Singletons_Nat_0 :: Sing a_Singletons_Nat_0))
+        (SSucc (sB_Singletons_Nat_1 :: Sing b_Singletons_Nat_1))
         = applySing
-            (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-            sB_0123456789876543210
+            (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_Nat_0)
+            sB_Singletons_Nat_1
     instance SShow Nat => SShow Nat where
       sShowsPrec
         _
         SZero
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_Singletons_Nat_14 :: Sing a_Singletons_Nat_14)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "Zero"))
-            sA_0123456789876543210
+            sA_Singletons_Nat_14
       sShowsPrec
-        (sP_0123456789876543210 :: Sing p_0123456789876543210)
-        (SSucc (sArg_0123456789876543210 :: Sing arg_0123456789876543210))
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sP_Singletons_Nat_2 :: Sing p_Singletons_Nat_2)
+        (SSucc (sArg_Singletons_Nat_3 :: Sing arg_Singletons_Nat_3))
+        (sA_Singletons_Nat_15 :: Sing a_Singletons_Nat_15)
         = applySing
             (applySing
                (applySing
                   (singFun3 @ShowParenSym0 sShowParen)
                   (applySing
-                     (applySing (singFun2 @(>@#@$) (%>)) sP_0123456789876543210)
+                     (applySing (singFun2 @(>@#@$) (%>)) sP_Singletons_Nat_2)
                      (sFromInteger (sing :: Sing 10))))
                (applySing
                   (applySing
@@ -175,8 +174,8 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
                      (applySing
                         (singFun3 @ShowsPrecSym0 sShowsPrec)
                         (sFromInteger (sing :: Sing 11)))
-                     sArg_0123456789876543210)))
-            sA_0123456789876543210
+                     sArg_Singletons_Nat_3)))
+            sA_Singletons_Nat_15
     instance SOrd Nat => SOrd Nat where
       sCompare SZero SZero
         = applySing
@@ -185,8 +184,8 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
                SEQ)
             SNil
       sCompare
-        (SSucc (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SSucc (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SSucc (sA_Singletons_Nat_4 :: Sing a_Singletons_Nat_4))
+        (SSucc (sB_Singletons_Nat_5 :: Sing b_Singletons_Nat_5))
         = applySing
             (applySing
                (applySing (singFun3 @FoldlSym0 sFoldl) (singFun2 @(<>@#@$) (%<>)))
@@ -195,8 +194,8 @@ Singletons/Nat.hs:(0,0)-(0,0): Splicing declarations
                (applySing
                   (singFun2 @(:@#@$) SCons)
                   (applySing
-                     (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                     sB_0123456789876543210))
+                     (applySing (singFun2 @CompareSym0 sCompare) sA_Singletons_Nat_4)
+                     sB_Singletons_Nat_5))
                SNil)
       sCompare SZero (SSucc _) = SLT
       sCompare (SSucc _) SZero = SGT

--- a/singletons-base/tests/compile-and-dump/Singletons/Natural.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Natural.golden
@@ -14,32 +14,32 @@ Singletons/Natural.hs:(0,0)-(0,0): Splicing declarations
     data MkAgeSym0 :: (~>) Natural Age
       where
         MkAgeSym0KindInference :: SameKind (Apply MkAgeSym0 arg) (MkAgeSym1 arg) =>
-                                  MkAgeSym0 a0123456789876543210
-    type instance Apply @Natural @Age MkAgeSym0 a0123456789876543210 = MkAge a0123456789876543210
+                                  MkAgeSym0 a_Singletons_Natural_0
+    type instance Apply @Natural @Age MkAgeSym0 a_Singletons_Natural_0 = MkAge a_Singletons_Natural_0
     instance SuppressUnusedWarnings MkAgeSym0 where
       suppressUnusedWarnings = snd ((,) MkAgeSym0KindInference ())
     type MkAgeSym1 :: Natural -> Age
-    type family MkAgeSym1 (a0123456789876543210 :: Natural) :: Age where
-      MkAgeSym1 a0123456789876543210 = MkAge a0123456789876543210
+    type family MkAgeSym1 (a_Singletons_Natural_0 :: Natural) :: Age where
+      MkAgeSym1 a_Singletons_Natural_0 = MkAge a_Singletons_Natural_0
     type AddAgeSym0 :: (~>) Age ((~>) Age Age)
     data AddAgeSym0 :: (~>) Age ((~>) Age Age)
       where
         AddAgeSym0KindInference :: SameKind (Apply AddAgeSym0 arg) (AddAgeSym1 arg) =>
-                                   AddAgeSym0 a0123456789876543210
-    type instance Apply @Age @((~>) Age Age) AddAgeSym0 a0123456789876543210 = AddAgeSym1 a0123456789876543210
+                                   AddAgeSym0 a_Singletons_Natural_1
+    type instance Apply @Age @((~>) Age Age) AddAgeSym0 a_Singletons_Natural_1 = AddAgeSym1 a_Singletons_Natural_1
     instance SuppressUnusedWarnings AddAgeSym0 where
       suppressUnusedWarnings = snd ((,) AddAgeSym0KindInference ())
     type AddAgeSym1 :: Age -> (~>) Age Age
-    data AddAgeSym1 (a0123456789876543210 :: Age) :: (~>) Age Age
+    data AddAgeSym1 (a_Singletons_Natural_1 :: Age) :: (~>) Age Age
       where
-        AddAgeSym1KindInference :: SameKind (Apply (AddAgeSym1 a0123456789876543210) arg) (AddAgeSym2 a0123456789876543210 arg) =>
-                                   AddAgeSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Age @Age (AddAgeSym1 a0123456789876543210) a0123456789876543210 = AddAge a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (AddAgeSym1 a0123456789876543210) where
+        AddAgeSym1KindInference :: SameKind (Apply (AddAgeSym1 a_Singletons_Natural_1) arg) (AddAgeSym2 a_Singletons_Natural_1 arg) =>
+                                   AddAgeSym1 a_Singletons_Natural_1 a_Singletons_Natural_2
+    type instance Apply @Age @Age (AddAgeSym1 a_Singletons_Natural_1) a_Singletons_Natural_2 = AddAge a_Singletons_Natural_1 a_Singletons_Natural_2
+    instance SuppressUnusedWarnings (AddAgeSym1 a_Singletons_Natural_1) where
       suppressUnusedWarnings = snd ((,) AddAgeSym1KindInference ())
     type AddAgeSym2 :: Age -> Age -> Age
-    type family AddAgeSym2 (a0123456789876543210 :: Age) (a0123456789876543210 :: Age) :: Age where
-      AddAgeSym2 a0123456789876543210 a0123456789876543210 = AddAge a0123456789876543210 a0123456789876543210
+    type family AddAgeSym2 (a_Singletons_Natural_1 :: Age) (a_Singletons_Natural_2 :: Age) :: Age where
+      AddAgeSym2 a_Singletons_Natural_1 a_Singletons_Natural_2 = AddAge a_Singletons_Natural_1 a_Singletons_Natural_2
     type AddAge :: Age -> Age -> Age
     type family AddAge (a :: Age) (a :: Age) :: Age where
       AddAge (MkAge (x :: Natural)) (MkAge (y :: Natural)) = Apply MkAgeSym0 (Apply (Apply (+@#@$) x) y :: Natural)

--- a/singletons-base/tests/compile-and-dump/Singletons/Operators.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Operators.golden
@@ -29,51 +29,51 @@ Singletons/Operators.hs:(0,0)-(0,0): Splicing declarations
     data (:+:@#@$) :: (~>) Foo ((~>) Foo Foo)
       where
         (::+:@#@$###) :: SameKind (Apply (:+:@#@$) arg) ((:+:@#@$$) arg) =>
-                         (:+:@#@$) a0123456789876543210
-    type instance Apply @Foo @((~>) Foo Foo) (:+:@#@$) a0123456789876543210 = (:+:@#@$$) a0123456789876543210
+                         (:+:@#@$) a_Singletons_Operators_0
+    type instance Apply @Foo @((~>) Foo Foo) (:+:@#@$) a_Singletons_Operators_0 = (:+:@#@$$) a_Singletons_Operators_0
     instance SuppressUnusedWarnings (:+:@#@$) where
       suppressUnusedWarnings = snd ((,) (::+:@#@$###) ())
     type (:+:@#@$$) :: Foo -> (~>) Foo Foo
-    data (:+:@#@$$) (a0123456789876543210 :: Foo) :: (~>) Foo Foo
+    data (:+:@#@$$) (a_Singletons_Operators_0 :: Foo) :: (~>) Foo Foo
       where
-        (::+:@#@$$###) :: SameKind (Apply ((:+:@#@$$) a0123456789876543210) arg) ((:+:@#@$$$) a0123456789876543210 arg) =>
-                          (:+:@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @Foo @Foo ((:+:@#@$$) a0123456789876543210) a0123456789876543210 = (:+:) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((:+:@#@$$) a0123456789876543210) where
+        (::+:@#@$$###) :: SameKind (Apply ((:+:@#@$$) a_Singletons_Operators_0) arg) ((:+:@#@$$$) a_Singletons_Operators_0 arg) =>
+                          (:+:@#@$$) a_Singletons_Operators_0 a_Singletons_Operators_1
+    type instance Apply @Foo @Foo ((:+:@#@$$) a_Singletons_Operators_0) a_Singletons_Operators_1 = (:+:) a_Singletons_Operators_0 a_Singletons_Operators_1
+    instance SuppressUnusedWarnings ((:+:@#@$$) a_Singletons_Operators_0) where
       suppressUnusedWarnings = snd ((,) (::+:@#@$$###) ())
     type (:+:@#@$$$) :: Foo -> Foo -> Foo
-    type family (:+:@#@$$$) (a0123456789876543210 :: Foo) (a0123456789876543210 :: Foo) :: Foo where
-      (:+:@#@$$$) a0123456789876543210 a0123456789876543210 = (:+:) a0123456789876543210 a0123456789876543210
+    type family (:+:@#@$$$) (a_Singletons_Operators_0 :: Foo) (a_Singletons_Operators_1 :: Foo) :: Foo where
+      (:+:@#@$$$) a_Singletons_Operators_0 a_Singletons_Operators_1 = (:+:) a_Singletons_Operators_0 a_Singletons_Operators_1
     type (+@#@$) :: (~>) Nat ((~>) Nat Nat)
     data (+@#@$) :: (~>) Nat ((~>) Nat Nat)
       where
         (:+@#@$###) :: SameKind (Apply (+@#@$) arg) ((+@#@$$) arg) =>
-                       (+@#@$) a0123456789876543210
-    type instance Apply @Nat @((~>) Nat Nat) (+@#@$) a0123456789876543210 = (+@#@$$) a0123456789876543210
+                       (+@#@$) a_Singletons_Operators_2
+    type instance Apply @Nat @((~>) Nat Nat) (+@#@$) a_Singletons_Operators_2 = (+@#@$$) a_Singletons_Operators_2
     instance SuppressUnusedWarnings (+@#@$) where
       suppressUnusedWarnings = snd ((,) (:+@#@$###) ())
     type (+@#@$$) :: Nat -> (~>) Nat Nat
-    data (+@#@$$) (a0123456789876543210 :: Nat) :: (~>) Nat Nat
+    data (+@#@$$) (a_Singletons_Operators_2 :: Nat) :: (~>) Nat Nat
       where
-        (:+@#@$$###) :: SameKind (Apply ((+@#@$$) a0123456789876543210) arg) ((+@#@$$$) a0123456789876543210 arg) =>
-                        (+@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @Nat ((+@#@$$) a0123456789876543210) a0123456789876543210 = (+) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((+@#@$$) a0123456789876543210) where
+        (:+@#@$$###) :: SameKind (Apply ((+@#@$$) a_Singletons_Operators_2) arg) ((+@#@$$$) a_Singletons_Operators_2 arg) =>
+                        (+@#@$$) a_Singletons_Operators_2 a_Singletons_Operators_3
+    type instance Apply @Nat @Nat ((+@#@$$) a_Singletons_Operators_2) a_Singletons_Operators_3 = (+) a_Singletons_Operators_2 a_Singletons_Operators_3
+    instance SuppressUnusedWarnings ((+@#@$$) a_Singletons_Operators_2) where
       suppressUnusedWarnings = snd ((,) (:+@#@$$###) ())
     type (+@#@$$$) :: Nat -> Nat -> Nat
-    type family (+@#@$$$) (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Nat where
-      (+@#@$$$) a0123456789876543210 a0123456789876543210 = (+) a0123456789876543210 a0123456789876543210
+    type family (+@#@$$$) (a_Singletons_Operators_2 :: Nat) (a_Singletons_Operators_3 :: Nat) :: Nat where
+      (+@#@$$$) a_Singletons_Operators_2 a_Singletons_Operators_3 = (+) a_Singletons_Operators_2 a_Singletons_Operators_3
     type ChildSym0 :: (~>) Foo Foo
     data ChildSym0 :: (~>) Foo Foo
       where
         ChildSym0KindInference :: SameKind (Apply ChildSym0 arg) (ChildSym1 arg) =>
-                                  ChildSym0 a0123456789876543210
-    type instance Apply @Foo @Foo ChildSym0 a0123456789876543210 = Child a0123456789876543210
+                                  ChildSym0 a_Singletons_Operators_4
+    type instance Apply @Foo @Foo ChildSym0 a_Singletons_Operators_4 = Child a_Singletons_Operators_4
     instance SuppressUnusedWarnings ChildSym0 where
       suppressUnusedWarnings = snd ((,) ChildSym0KindInference ())
     type ChildSym1 :: Foo -> Foo
-    type family ChildSym1 (a0123456789876543210 :: Foo) :: Foo where
-      ChildSym1 a0123456789876543210 = Child a0123456789876543210
+    type family ChildSym1 (a_Singletons_Operators_4 :: Foo) :: Foo where
+      ChildSym1 a_Singletons_Operators_4 = Child a_Singletons_Operators_4
     type (+) :: Nat -> Nat -> Nat
     type family (+) (a :: Nat) (a :: Nat) :: Nat where
       (+) 'Zero m = m

--- a/singletons-base/tests/compile-and-dump/Singletons/OrdDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/OrdDeriving.golden
@@ -30,13 +30,13 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     data SuccSym0 :: (~>) Nat Nat
       where
         SuccSym0KindInference :: SameKind (Apply SuccSym0 arg) (SuccSym1 arg) =>
-                                 SuccSym0 a0123456789876543210
-    type instance Apply @Nat @Nat SuccSym0 a0123456789876543210 = Succ a0123456789876543210
+                                 SuccSym0 a_Singletons_OrdDeriving_100
+    type instance Apply @Nat @Nat SuccSym0 a_Singletons_OrdDeriving_100 = Succ a_Singletons_OrdDeriving_100
     instance SuppressUnusedWarnings SuccSym0 where
       suppressUnusedWarnings = snd ((,) SuccSym0KindInference ())
     type SuccSym1 :: Nat -> Nat
-    type family SuccSym1 (a0123456789876543210 :: Nat) :: Nat where
-      SuccSym1 a0123456789876543210 = Succ a0123456789876543210
+    type family SuccSym1 (a_Singletons_OrdDeriving_100 :: Nat) :: Nat where
+      SuccSym1 a_Singletons_OrdDeriving_100 = Succ a_Singletons_OrdDeriving_100
     type ASym0 :: forall a
                          b
                          c
@@ -44,39 +44,39 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     data ASym0 :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))
       where
         ASym0KindInference :: SameKind (Apply ASym0 arg) (ASym1 arg) =>
-                              ASym0 a0123456789876543210
-    type instance Apply @a @((~>) b ((~>) c ((~>) d (Foo a b c d)))) ASym0 a0123456789876543210 = ASym1 a0123456789876543210
+                              ASym0 a_Singletons_OrdDeriving_101
+    type instance Apply @a @((~>) b ((~>) c ((~>) d (Foo a b c d)))) ASym0 a_Singletons_OrdDeriving_101 = ASym1 a_Singletons_OrdDeriving_101
     instance SuppressUnusedWarnings ASym0 where
       suppressUnusedWarnings = snd ((,) ASym0KindInference ())
     type ASym1 :: forall a b c d. a
                                   -> (~>) b ((~>) c ((~>) d (Foo a b c d)))
-    data ASym1 (a0123456789876543210 :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))
+    data ASym1 (a_Singletons_OrdDeriving_101 :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))
       where
-        ASym1KindInference :: SameKind (Apply (ASym1 a0123456789876543210) arg) (ASym2 a0123456789876543210 arg) =>
-                              ASym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @((~>) c ((~>) d (Foo a b c d))) (ASym1 a0123456789876543210) a0123456789876543210 = ASym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ASym1 a0123456789876543210) where
+        ASym1KindInference :: SameKind (Apply (ASym1 a_Singletons_OrdDeriving_101) arg) (ASym2 a_Singletons_OrdDeriving_101 arg) =>
+                              ASym1 a_Singletons_OrdDeriving_101 a_Singletons_OrdDeriving_102
+    type instance Apply @b @((~>) c ((~>) d (Foo a b c d))) (ASym1 a_Singletons_OrdDeriving_101) a_Singletons_OrdDeriving_102 = ASym2 a_Singletons_OrdDeriving_101 a_Singletons_OrdDeriving_102
+    instance SuppressUnusedWarnings (ASym1 a_Singletons_OrdDeriving_101) where
       suppressUnusedWarnings = snd ((,) ASym1KindInference ())
     type ASym2 :: forall a b c d. a
                                   -> b -> (~>) c ((~>) d (Foo a b c d))
-    data ASym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: (~>) c ((~>) d (Foo a b c d))
+    data ASym2 (a_Singletons_OrdDeriving_101 :: a) (a_Singletons_OrdDeriving_102 :: b) :: (~>) c ((~>) d (Foo a b c d))
       where
-        ASym2KindInference :: SameKind (Apply (ASym2 a0123456789876543210 a0123456789876543210) arg) (ASym3 a0123456789876543210 a0123456789876543210 arg) =>
-                              ASym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @c @((~>) d (Foo a b c d)) (ASym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ASym3 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ASym2 a0123456789876543210 a0123456789876543210) where
+        ASym2KindInference :: SameKind (Apply (ASym2 a_Singletons_OrdDeriving_101 a_Singletons_OrdDeriving_102) arg) (ASym3 a_Singletons_OrdDeriving_101 a_Singletons_OrdDeriving_102 arg) =>
+                              ASym2 a_Singletons_OrdDeriving_101 a_Singletons_OrdDeriving_102 a_Singletons_OrdDeriving_103
+    type instance Apply @c @((~>) d (Foo a b c d)) (ASym2 a_Singletons_OrdDeriving_101 a_Singletons_OrdDeriving_102) a_Singletons_OrdDeriving_103 = ASym3 a_Singletons_OrdDeriving_101 a_Singletons_OrdDeriving_102 a_Singletons_OrdDeriving_103
+    instance SuppressUnusedWarnings (ASym2 a_Singletons_OrdDeriving_101 a_Singletons_OrdDeriving_102) where
       suppressUnusedWarnings = snd ((,) ASym2KindInference ())
     type ASym3 :: forall a b c d. a -> b -> c -> (~>) d (Foo a b c d)
-    data ASym3 (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: c) :: (~>) d (Foo a b c d)
+    data ASym3 (a_Singletons_OrdDeriving_101 :: a) (a_Singletons_OrdDeriving_102 :: b) (a_Singletons_OrdDeriving_103 :: c) :: (~>) d (Foo a b c d)
       where
-        ASym3KindInference :: SameKind (Apply (ASym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) arg) (ASym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 arg) =>
-                              ASym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @d @(Foo a b c d) (ASym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) a0123456789876543210 = A a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ASym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) where
+        ASym3KindInference :: SameKind (Apply (ASym3 a_Singletons_OrdDeriving_101 a_Singletons_OrdDeriving_102 a_Singletons_OrdDeriving_103) arg) (ASym4 a_Singletons_OrdDeriving_101 a_Singletons_OrdDeriving_102 a_Singletons_OrdDeriving_103 arg) =>
+                              ASym3 a_Singletons_OrdDeriving_101 a_Singletons_OrdDeriving_102 a_Singletons_OrdDeriving_103 a_Singletons_OrdDeriving_104
+    type instance Apply @d @(Foo a b c d) (ASym3 a_Singletons_OrdDeriving_101 a_Singletons_OrdDeriving_102 a_Singletons_OrdDeriving_103) a_Singletons_OrdDeriving_104 = A a_Singletons_OrdDeriving_101 a_Singletons_OrdDeriving_102 a_Singletons_OrdDeriving_103 a_Singletons_OrdDeriving_104
+    instance SuppressUnusedWarnings (ASym3 a_Singletons_OrdDeriving_101 a_Singletons_OrdDeriving_102 a_Singletons_OrdDeriving_103) where
       suppressUnusedWarnings = snd ((,) ASym3KindInference ())
     type ASym4 :: forall a b c d. a -> b -> c -> d -> Foo a b c d
-    type family ASym4 @a @b @c @d (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: c) (a0123456789876543210 :: d) :: Foo a b c d where
-      ASym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 = A a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type family ASym4 @a @b @c @d (a_Singletons_OrdDeriving_101 :: a) (a_Singletons_OrdDeriving_102 :: b) (a_Singletons_OrdDeriving_103 :: c) (a_Singletons_OrdDeriving_104 :: d) :: Foo a b c d where
+      ASym4 a_Singletons_OrdDeriving_101 a_Singletons_OrdDeriving_102 a_Singletons_OrdDeriving_103 a_Singletons_OrdDeriving_104 = A a_Singletons_OrdDeriving_101 a_Singletons_OrdDeriving_102 a_Singletons_OrdDeriving_103 a_Singletons_OrdDeriving_104
     type BSym0 :: forall a
                          b
                          c
@@ -84,39 +84,39 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     data BSym0 :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))
       where
         BSym0KindInference :: SameKind (Apply BSym0 arg) (BSym1 arg) =>
-                              BSym0 a0123456789876543210
-    type instance Apply @a @((~>) b ((~>) c ((~>) d (Foo a b c d)))) BSym0 a0123456789876543210 = BSym1 a0123456789876543210
+                              BSym0 a_Singletons_OrdDeriving_105
+    type instance Apply @a @((~>) b ((~>) c ((~>) d (Foo a b c d)))) BSym0 a_Singletons_OrdDeriving_105 = BSym1 a_Singletons_OrdDeriving_105
     instance SuppressUnusedWarnings BSym0 where
       suppressUnusedWarnings = snd ((,) BSym0KindInference ())
     type BSym1 :: forall a b c d. a
                                   -> (~>) b ((~>) c ((~>) d (Foo a b c d)))
-    data BSym1 (a0123456789876543210 :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))
+    data BSym1 (a_Singletons_OrdDeriving_105 :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))
       where
-        BSym1KindInference :: SameKind (Apply (BSym1 a0123456789876543210) arg) (BSym2 a0123456789876543210 arg) =>
-                              BSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @((~>) c ((~>) d (Foo a b c d))) (BSym1 a0123456789876543210) a0123456789876543210 = BSym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (BSym1 a0123456789876543210) where
+        BSym1KindInference :: SameKind (Apply (BSym1 a_Singletons_OrdDeriving_105) arg) (BSym2 a_Singletons_OrdDeriving_105 arg) =>
+                              BSym1 a_Singletons_OrdDeriving_105 a_Singletons_OrdDeriving_106
+    type instance Apply @b @((~>) c ((~>) d (Foo a b c d))) (BSym1 a_Singletons_OrdDeriving_105) a_Singletons_OrdDeriving_106 = BSym2 a_Singletons_OrdDeriving_105 a_Singletons_OrdDeriving_106
+    instance SuppressUnusedWarnings (BSym1 a_Singletons_OrdDeriving_105) where
       suppressUnusedWarnings = snd ((,) BSym1KindInference ())
     type BSym2 :: forall a b c d. a
                                   -> b -> (~>) c ((~>) d (Foo a b c d))
-    data BSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: (~>) c ((~>) d (Foo a b c d))
+    data BSym2 (a_Singletons_OrdDeriving_105 :: a) (a_Singletons_OrdDeriving_106 :: b) :: (~>) c ((~>) d (Foo a b c d))
       where
-        BSym2KindInference :: SameKind (Apply (BSym2 a0123456789876543210 a0123456789876543210) arg) (BSym3 a0123456789876543210 a0123456789876543210 arg) =>
-                              BSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @c @((~>) d (Foo a b c d)) (BSym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = BSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (BSym2 a0123456789876543210 a0123456789876543210) where
+        BSym2KindInference :: SameKind (Apply (BSym2 a_Singletons_OrdDeriving_105 a_Singletons_OrdDeriving_106) arg) (BSym3 a_Singletons_OrdDeriving_105 a_Singletons_OrdDeriving_106 arg) =>
+                              BSym2 a_Singletons_OrdDeriving_105 a_Singletons_OrdDeriving_106 a_Singletons_OrdDeriving_107
+    type instance Apply @c @((~>) d (Foo a b c d)) (BSym2 a_Singletons_OrdDeriving_105 a_Singletons_OrdDeriving_106) a_Singletons_OrdDeriving_107 = BSym3 a_Singletons_OrdDeriving_105 a_Singletons_OrdDeriving_106 a_Singletons_OrdDeriving_107
+    instance SuppressUnusedWarnings (BSym2 a_Singletons_OrdDeriving_105 a_Singletons_OrdDeriving_106) where
       suppressUnusedWarnings = snd ((,) BSym2KindInference ())
     type BSym3 :: forall a b c d. a -> b -> c -> (~>) d (Foo a b c d)
-    data BSym3 (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: c) :: (~>) d (Foo a b c d)
+    data BSym3 (a_Singletons_OrdDeriving_105 :: a) (a_Singletons_OrdDeriving_106 :: b) (a_Singletons_OrdDeriving_107 :: c) :: (~>) d (Foo a b c d)
       where
-        BSym3KindInference :: SameKind (Apply (BSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) arg) (BSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 arg) =>
-                              BSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @d @(Foo a b c d) (BSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) a0123456789876543210 = B a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (BSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) where
+        BSym3KindInference :: SameKind (Apply (BSym3 a_Singletons_OrdDeriving_105 a_Singletons_OrdDeriving_106 a_Singletons_OrdDeriving_107) arg) (BSym4 a_Singletons_OrdDeriving_105 a_Singletons_OrdDeriving_106 a_Singletons_OrdDeriving_107 arg) =>
+                              BSym3 a_Singletons_OrdDeriving_105 a_Singletons_OrdDeriving_106 a_Singletons_OrdDeriving_107 a_Singletons_OrdDeriving_108
+    type instance Apply @d @(Foo a b c d) (BSym3 a_Singletons_OrdDeriving_105 a_Singletons_OrdDeriving_106 a_Singletons_OrdDeriving_107) a_Singletons_OrdDeriving_108 = B a_Singletons_OrdDeriving_105 a_Singletons_OrdDeriving_106 a_Singletons_OrdDeriving_107 a_Singletons_OrdDeriving_108
+    instance SuppressUnusedWarnings (BSym3 a_Singletons_OrdDeriving_105 a_Singletons_OrdDeriving_106 a_Singletons_OrdDeriving_107) where
       suppressUnusedWarnings = snd ((,) BSym3KindInference ())
     type BSym4 :: forall a b c d. a -> b -> c -> d -> Foo a b c d
-    type family BSym4 @a @b @c @d (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: c) (a0123456789876543210 :: d) :: Foo a b c d where
-      BSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 = B a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type family BSym4 @a @b @c @d (a_Singletons_OrdDeriving_105 :: a) (a_Singletons_OrdDeriving_106 :: b) (a_Singletons_OrdDeriving_107 :: c) (a_Singletons_OrdDeriving_108 :: d) :: Foo a b c d where
+      BSym4 a_Singletons_OrdDeriving_105 a_Singletons_OrdDeriving_106 a_Singletons_OrdDeriving_107 a_Singletons_OrdDeriving_108 = B a_Singletons_OrdDeriving_105 a_Singletons_OrdDeriving_106 a_Singletons_OrdDeriving_107 a_Singletons_OrdDeriving_108
     type CSym0 :: forall a
                          b
                          c
@@ -124,39 +124,39 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     data CSym0 :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))
       where
         CSym0KindInference :: SameKind (Apply CSym0 arg) (CSym1 arg) =>
-                              CSym0 a0123456789876543210
-    type instance Apply @a @((~>) b ((~>) c ((~>) d (Foo a b c d)))) CSym0 a0123456789876543210 = CSym1 a0123456789876543210
+                              CSym0 a_Singletons_OrdDeriving_109
+    type instance Apply @a @((~>) b ((~>) c ((~>) d (Foo a b c d)))) CSym0 a_Singletons_OrdDeriving_109 = CSym1 a_Singletons_OrdDeriving_109
     instance SuppressUnusedWarnings CSym0 where
       suppressUnusedWarnings = snd ((,) CSym0KindInference ())
     type CSym1 :: forall a b c d. a
                                   -> (~>) b ((~>) c ((~>) d (Foo a b c d)))
-    data CSym1 (a0123456789876543210 :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))
+    data CSym1 (a_Singletons_OrdDeriving_109 :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))
       where
-        CSym1KindInference :: SameKind (Apply (CSym1 a0123456789876543210) arg) (CSym2 a0123456789876543210 arg) =>
-                              CSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @((~>) c ((~>) d (Foo a b c d))) (CSym1 a0123456789876543210) a0123456789876543210 = CSym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (CSym1 a0123456789876543210) where
+        CSym1KindInference :: SameKind (Apply (CSym1 a_Singletons_OrdDeriving_109) arg) (CSym2 a_Singletons_OrdDeriving_109 arg) =>
+                              CSym1 a_Singletons_OrdDeriving_109 a_Singletons_OrdDeriving_110
+    type instance Apply @b @((~>) c ((~>) d (Foo a b c d))) (CSym1 a_Singletons_OrdDeriving_109) a_Singletons_OrdDeriving_110 = CSym2 a_Singletons_OrdDeriving_109 a_Singletons_OrdDeriving_110
+    instance SuppressUnusedWarnings (CSym1 a_Singletons_OrdDeriving_109) where
       suppressUnusedWarnings = snd ((,) CSym1KindInference ())
     type CSym2 :: forall a b c d. a
                                   -> b -> (~>) c ((~>) d (Foo a b c d))
-    data CSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: (~>) c ((~>) d (Foo a b c d))
+    data CSym2 (a_Singletons_OrdDeriving_109 :: a) (a_Singletons_OrdDeriving_110 :: b) :: (~>) c ((~>) d (Foo a b c d))
       where
-        CSym2KindInference :: SameKind (Apply (CSym2 a0123456789876543210 a0123456789876543210) arg) (CSym3 a0123456789876543210 a0123456789876543210 arg) =>
-                              CSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @c @((~>) d (Foo a b c d)) (CSym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = CSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (CSym2 a0123456789876543210 a0123456789876543210) where
+        CSym2KindInference :: SameKind (Apply (CSym2 a_Singletons_OrdDeriving_109 a_Singletons_OrdDeriving_110) arg) (CSym3 a_Singletons_OrdDeriving_109 a_Singletons_OrdDeriving_110 arg) =>
+                              CSym2 a_Singletons_OrdDeriving_109 a_Singletons_OrdDeriving_110 a_Singletons_OrdDeriving_111
+    type instance Apply @c @((~>) d (Foo a b c d)) (CSym2 a_Singletons_OrdDeriving_109 a_Singletons_OrdDeriving_110) a_Singletons_OrdDeriving_111 = CSym3 a_Singletons_OrdDeriving_109 a_Singletons_OrdDeriving_110 a_Singletons_OrdDeriving_111
+    instance SuppressUnusedWarnings (CSym2 a_Singletons_OrdDeriving_109 a_Singletons_OrdDeriving_110) where
       suppressUnusedWarnings = snd ((,) CSym2KindInference ())
     type CSym3 :: forall a b c d. a -> b -> c -> (~>) d (Foo a b c d)
-    data CSym3 (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: c) :: (~>) d (Foo a b c d)
+    data CSym3 (a_Singletons_OrdDeriving_109 :: a) (a_Singletons_OrdDeriving_110 :: b) (a_Singletons_OrdDeriving_111 :: c) :: (~>) d (Foo a b c d)
       where
-        CSym3KindInference :: SameKind (Apply (CSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) arg) (CSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 arg) =>
-                              CSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @d @(Foo a b c d) (CSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) a0123456789876543210 = C a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (CSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) where
+        CSym3KindInference :: SameKind (Apply (CSym3 a_Singletons_OrdDeriving_109 a_Singletons_OrdDeriving_110 a_Singletons_OrdDeriving_111) arg) (CSym4 a_Singletons_OrdDeriving_109 a_Singletons_OrdDeriving_110 a_Singletons_OrdDeriving_111 arg) =>
+                              CSym3 a_Singletons_OrdDeriving_109 a_Singletons_OrdDeriving_110 a_Singletons_OrdDeriving_111 a_Singletons_OrdDeriving_112
+    type instance Apply @d @(Foo a b c d) (CSym3 a_Singletons_OrdDeriving_109 a_Singletons_OrdDeriving_110 a_Singletons_OrdDeriving_111) a_Singletons_OrdDeriving_112 = C a_Singletons_OrdDeriving_109 a_Singletons_OrdDeriving_110 a_Singletons_OrdDeriving_111 a_Singletons_OrdDeriving_112
+    instance SuppressUnusedWarnings (CSym3 a_Singletons_OrdDeriving_109 a_Singletons_OrdDeriving_110 a_Singletons_OrdDeriving_111) where
       suppressUnusedWarnings = snd ((,) CSym3KindInference ())
     type CSym4 :: forall a b c d. a -> b -> c -> d -> Foo a b c d
-    type family CSym4 @a @b @c @d (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: c) (a0123456789876543210 :: d) :: Foo a b c d where
-      CSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 = C a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type family CSym4 @a @b @c @d (a_Singletons_OrdDeriving_109 :: a) (a_Singletons_OrdDeriving_110 :: b) (a_Singletons_OrdDeriving_111 :: c) (a_Singletons_OrdDeriving_112 :: d) :: Foo a b c d where
+      CSym4 a_Singletons_OrdDeriving_109 a_Singletons_OrdDeriving_110 a_Singletons_OrdDeriving_111 a_Singletons_OrdDeriving_112 = C a_Singletons_OrdDeriving_109 a_Singletons_OrdDeriving_110 a_Singletons_OrdDeriving_111 a_Singletons_OrdDeriving_112
     type DSym0 :: forall a
                          b
                          c
@@ -164,39 +164,39 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     data DSym0 :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))
       where
         DSym0KindInference :: SameKind (Apply DSym0 arg) (DSym1 arg) =>
-                              DSym0 a0123456789876543210
-    type instance Apply @a @((~>) b ((~>) c ((~>) d (Foo a b c d)))) DSym0 a0123456789876543210 = DSym1 a0123456789876543210
+                              DSym0 a_Singletons_OrdDeriving_113
+    type instance Apply @a @((~>) b ((~>) c ((~>) d (Foo a b c d)))) DSym0 a_Singletons_OrdDeriving_113 = DSym1 a_Singletons_OrdDeriving_113
     instance SuppressUnusedWarnings DSym0 where
       suppressUnusedWarnings = snd ((,) DSym0KindInference ())
     type DSym1 :: forall a b c d. a
                                   -> (~>) b ((~>) c ((~>) d (Foo a b c d)))
-    data DSym1 (a0123456789876543210 :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))
+    data DSym1 (a_Singletons_OrdDeriving_113 :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))
       where
-        DSym1KindInference :: SameKind (Apply (DSym1 a0123456789876543210) arg) (DSym2 a0123456789876543210 arg) =>
-                              DSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @((~>) c ((~>) d (Foo a b c d))) (DSym1 a0123456789876543210) a0123456789876543210 = DSym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (DSym1 a0123456789876543210) where
+        DSym1KindInference :: SameKind (Apply (DSym1 a_Singletons_OrdDeriving_113) arg) (DSym2 a_Singletons_OrdDeriving_113 arg) =>
+                              DSym1 a_Singletons_OrdDeriving_113 a_Singletons_OrdDeriving_114
+    type instance Apply @b @((~>) c ((~>) d (Foo a b c d))) (DSym1 a_Singletons_OrdDeriving_113) a_Singletons_OrdDeriving_114 = DSym2 a_Singletons_OrdDeriving_113 a_Singletons_OrdDeriving_114
+    instance SuppressUnusedWarnings (DSym1 a_Singletons_OrdDeriving_113) where
       suppressUnusedWarnings = snd ((,) DSym1KindInference ())
     type DSym2 :: forall a b c d. a
                                   -> b -> (~>) c ((~>) d (Foo a b c d))
-    data DSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: (~>) c ((~>) d (Foo a b c d))
+    data DSym2 (a_Singletons_OrdDeriving_113 :: a) (a_Singletons_OrdDeriving_114 :: b) :: (~>) c ((~>) d (Foo a b c d))
       where
-        DSym2KindInference :: SameKind (Apply (DSym2 a0123456789876543210 a0123456789876543210) arg) (DSym3 a0123456789876543210 a0123456789876543210 arg) =>
-                              DSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @c @((~>) d (Foo a b c d)) (DSym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = DSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (DSym2 a0123456789876543210 a0123456789876543210) where
+        DSym2KindInference :: SameKind (Apply (DSym2 a_Singletons_OrdDeriving_113 a_Singletons_OrdDeriving_114) arg) (DSym3 a_Singletons_OrdDeriving_113 a_Singletons_OrdDeriving_114 arg) =>
+                              DSym2 a_Singletons_OrdDeriving_113 a_Singletons_OrdDeriving_114 a_Singletons_OrdDeriving_115
+    type instance Apply @c @((~>) d (Foo a b c d)) (DSym2 a_Singletons_OrdDeriving_113 a_Singletons_OrdDeriving_114) a_Singletons_OrdDeriving_115 = DSym3 a_Singletons_OrdDeriving_113 a_Singletons_OrdDeriving_114 a_Singletons_OrdDeriving_115
+    instance SuppressUnusedWarnings (DSym2 a_Singletons_OrdDeriving_113 a_Singletons_OrdDeriving_114) where
       suppressUnusedWarnings = snd ((,) DSym2KindInference ())
     type DSym3 :: forall a b c d. a -> b -> c -> (~>) d (Foo a b c d)
-    data DSym3 (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: c) :: (~>) d (Foo a b c d)
+    data DSym3 (a_Singletons_OrdDeriving_113 :: a) (a_Singletons_OrdDeriving_114 :: b) (a_Singletons_OrdDeriving_115 :: c) :: (~>) d (Foo a b c d)
       where
-        DSym3KindInference :: SameKind (Apply (DSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) arg) (DSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 arg) =>
-                              DSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @d @(Foo a b c d) (DSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) a0123456789876543210 = D a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (DSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) where
+        DSym3KindInference :: SameKind (Apply (DSym3 a_Singletons_OrdDeriving_113 a_Singletons_OrdDeriving_114 a_Singletons_OrdDeriving_115) arg) (DSym4 a_Singletons_OrdDeriving_113 a_Singletons_OrdDeriving_114 a_Singletons_OrdDeriving_115 arg) =>
+                              DSym3 a_Singletons_OrdDeriving_113 a_Singletons_OrdDeriving_114 a_Singletons_OrdDeriving_115 a_Singletons_OrdDeriving_116
+    type instance Apply @d @(Foo a b c d) (DSym3 a_Singletons_OrdDeriving_113 a_Singletons_OrdDeriving_114 a_Singletons_OrdDeriving_115) a_Singletons_OrdDeriving_116 = D a_Singletons_OrdDeriving_113 a_Singletons_OrdDeriving_114 a_Singletons_OrdDeriving_115 a_Singletons_OrdDeriving_116
+    instance SuppressUnusedWarnings (DSym3 a_Singletons_OrdDeriving_113 a_Singletons_OrdDeriving_114 a_Singletons_OrdDeriving_115) where
       suppressUnusedWarnings = snd ((,) DSym3KindInference ())
     type DSym4 :: forall a b c d. a -> b -> c -> d -> Foo a b c d
-    type family DSym4 @a @b @c @d (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: c) (a0123456789876543210 :: d) :: Foo a b c d where
-      DSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 = D a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type family DSym4 @a @b @c @d (a_Singletons_OrdDeriving_113 :: a) (a_Singletons_OrdDeriving_114 :: b) (a_Singletons_OrdDeriving_115 :: c) (a_Singletons_OrdDeriving_116 :: d) :: Foo a b c d where
+      DSym4 a_Singletons_OrdDeriving_113 a_Singletons_OrdDeriving_114 a_Singletons_OrdDeriving_115 a_Singletons_OrdDeriving_116 = D a_Singletons_OrdDeriving_113 a_Singletons_OrdDeriving_114 a_Singletons_OrdDeriving_115 a_Singletons_OrdDeriving_116
     type ESym0 :: forall a
                          b
                          c
@@ -204,39 +204,39 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     data ESym0 :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))
       where
         ESym0KindInference :: SameKind (Apply ESym0 arg) (ESym1 arg) =>
-                              ESym0 a0123456789876543210
-    type instance Apply @a @((~>) b ((~>) c ((~>) d (Foo a b c d)))) ESym0 a0123456789876543210 = ESym1 a0123456789876543210
+                              ESym0 a_Singletons_OrdDeriving_117
+    type instance Apply @a @((~>) b ((~>) c ((~>) d (Foo a b c d)))) ESym0 a_Singletons_OrdDeriving_117 = ESym1 a_Singletons_OrdDeriving_117
     instance SuppressUnusedWarnings ESym0 where
       suppressUnusedWarnings = snd ((,) ESym0KindInference ())
     type ESym1 :: forall a b c d. a
                                   -> (~>) b ((~>) c ((~>) d (Foo a b c d)))
-    data ESym1 (a0123456789876543210 :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))
+    data ESym1 (a_Singletons_OrdDeriving_117 :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))
       where
-        ESym1KindInference :: SameKind (Apply (ESym1 a0123456789876543210) arg) (ESym2 a0123456789876543210 arg) =>
-                              ESym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @((~>) c ((~>) d (Foo a b c d))) (ESym1 a0123456789876543210) a0123456789876543210 = ESym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ESym1 a0123456789876543210) where
+        ESym1KindInference :: SameKind (Apply (ESym1 a_Singletons_OrdDeriving_117) arg) (ESym2 a_Singletons_OrdDeriving_117 arg) =>
+                              ESym1 a_Singletons_OrdDeriving_117 a_Singletons_OrdDeriving_118
+    type instance Apply @b @((~>) c ((~>) d (Foo a b c d))) (ESym1 a_Singletons_OrdDeriving_117) a_Singletons_OrdDeriving_118 = ESym2 a_Singletons_OrdDeriving_117 a_Singletons_OrdDeriving_118
+    instance SuppressUnusedWarnings (ESym1 a_Singletons_OrdDeriving_117) where
       suppressUnusedWarnings = snd ((,) ESym1KindInference ())
     type ESym2 :: forall a b c d. a
                                   -> b -> (~>) c ((~>) d (Foo a b c d))
-    data ESym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: (~>) c ((~>) d (Foo a b c d))
+    data ESym2 (a_Singletons_OrdDeriving_117 :: a) (a_Singletons_OrdDeriving_118 :: b) :: (~>) c ((~>) d (Foo a b c d))
       where
-        ESym2KindInference :: SameKind (Apply (ESym2 a0123456789876543210 a0123456789876543210) arg) (ESym3 a0123456789876543210 a0123456789876543210 arg) =>
-                              ESym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @c @((~>) d (Foo a b c d)) (ESym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ESym3 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ESym2 a0123456789876543210 a0123456789876543210) where
+        ESym2KindInference :: SameKind (Apply (ESym2 a_Singletons_OrdDeriving_117 a_Singletons_OrdDeriving_118) arg) (ESym3 a_Singletons_OrdDeriving_117 a_Singletons_OrdDeriving_118 arg) =>
+                              ESym2 a_Singletons_OrdDeriving_117 a_Singletons_OrdDeriving_118 a_Singletons_OrdDeriving_119
+    type instance Apply @c @((~>) d (Foo a b c d)) (ESym2 a_Singletons_OrdDeriving_117 a_Singletons_OrdDeriving_118) a_Singletons_OrdDeriving_119 = ESym3 a_Singletons_OrdDeriving_117 a_Singletons_OrdDeriving_118 a_Singletons_OrdDeriving_119
+    instance SuppressUnusedWarnings (ESym2 a_Singletons_OrdDeriving_117 a_Singletons_OrdDeriving_118) where
       suppressUnusedWarnings = snd ((,) ESym2KindInference ())
     type ESym3 :: forall a b c d. a -> b -> c -> (~>) d (Foo a b c d)
-    data ESym3 (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: c) :: (~>) d (Foo a b c d)
+    data ESym3 (a_Singletons_OrdDeriving_117 :: a) (a_Singletons_OrdDeriving_118 :: b) (a_Singletons_OrdDeriving_119 :: c) :: (~>) d (Foo a b c d)
       where
-        ESym3KindInference :: SameKind (Apply (ESym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) arg) (ESym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 arg) =>
-                              ESym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @d @(Foo a b c d) (ESym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) a0123456789876543210 = E a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ESym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) where
+        ESym3KindInference :: SameKind (Apply (ESym3 a_Singletons_OrdDeriving_117 a_Singletons_OrdDeriving_118 a_Singletons_OrdDeriving_119) arg) (ESym4 a_Singletons_OrdDeriving_117 a_Singletons_OrdDeriving_118 a_Singletons_OrdDeriving_119 arg) =>
+                              ESym3 a_Singletons_OrdDeriving_117 a_Singletons_OrdDeriving_118 a_Singletons_OrdDeriving_119 a_Singletons_OrdDeriving_120
+    type instance Apply @d @(Foo a b c d) (ESym3 a_Singletons_OrdDeriving_117 a_Singletons_OrdDeriving_118 a_Singletons_OrdDeriving_119) a_Singletons_OrdDeriving_120 = E a_Singletons_OrdDeriving_117 a_Singletons_OrdDeriving_118 a_Singletons_OrdDeriving_119 a_Singletons_OrdDeriving_120
+    instance SuppressUnusedWarnings (ESym3 a_Singletons_OrdDeriving_117 a_Singletons_OrdDeriving_118 a_Singletons_OrdDeriving_119) where
       suppressUnusedWarnings = snd ((,) ESym3KindInference ())
     type ESym4 :: forall a b c d. a -> b -> c -> d -> Foo a b c d
-    type family ESym4 @a @b @c @d (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: c) (a0123456789876543210 :: d) :: Foo a b c d where
-      ESym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 = E a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type family ESym4 @a @b @c @d (a_Singletons_OrdDeriving_117 :: a) (a_Singletons_OrdDeriving_118 :: b) (a_Singletons_OrdDeriving_119 :: c) (a_Singletons_OrdDeriving_120 :: d) :: Foo a b c d where
+      ESym4 a_Singletons_OrdDeriving_117 a_Singletons_OrdDeriving_118 a_Singletons_OrdDeriving_119 a_Singletons_OrdDeriving_120 = E a_Singletons_OrdDeriving_117 a_Singletons_OrdDeriving_118 a_Singletons_OrdDeriving_119 a_Singletons_OrdDeriving_120
     type FSym0 :: forall a
                          b
                          c
@@ -244,137 +244,141 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
     data FSym0 :: (~>) a ((~>) b ((~>) c ((~>) d (Foo a b c d))))
       where
         FSym0KindInference :: SameKind (Apply FSym0 arg) (FSym1 arg) =>
-                              FSym0 a0123456789876543210
-    type instance Apply @a @((~>) b ((~>) c ((~>) d (Foo a b c d)))) FSym0 a0123456789876543210 = FSym1 a0123456789876543210
+                              FSym0 a_Singletons_OrdDeriving_121
+    type instance Apply @a @((~>) b ((~>) c ((~>) d (Foo a b c d)))) FSym0 a_Singletons_OrdDeriving_121 = FSym1 a_Singletons_OrdDeriving_121
     instance SuppressUnusedWarnings FSym0 where
       suppressUnusedWarnings = snd ((,) FSym0KindInference ())
     type FSym1 :: forall a b c d. a
                                   -> (~>) b ((~>) c ((~>) d (Foo a b c d)))
-    data FSym1 (a0123456789876543210 :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))
+    data FSym1 (a_Singletons_OrdDeriving_121 :: a) :: (~>) b ((~>) c ((~>) d (Foo a b c d)))
       where
-        FSym1KindInference :: SameKind (Apply (FSym1 a0123456789876543210) arg) (FSym2 a0123456789876543210 arg) =>
-                              FSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @((~>) c ((~>) d (Foo a b c d))) (FSym1 a0123456789876543210) a0123456789876543210 = FSym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (FSym1 a0123456789876543210) where
+        FSym1KindInference :: SameKind (Apply (FSym1 a_Singletons_OrdDeriving_121) arg) (FSym2 a_Singletons_OrdDeriving_121 arg) =>
+                              FSym1 a_Singletons_OrdDeriving_121 a_Singletons_OrdDeriving_122
+    type instance Apply @b @((~>) c ((~>) d (Foo a b c d))) (FSym1 a_Singletons_OrdDeriving_121) a_Singletons_OrdDeriving_122 = FSym2 a_Singletons_OrdDeriving_121 a_Singletons_OrdDeriving_122
+    instance SuppressUnusedWarnings (FSym1 a_Singletons_OrdDeriving_121) where
       suppressUnusedWarnings = snd ((,) FSym1KindInference ())
     type FSym2 :: forall a b c d. a
                                   -> b -> (~>) c ((~>) d (Foo a b c d))
-    data FSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: (~>) c ((~>) d (Foo a b c d))
+    data FSym2 (a_Singletons_OrdDeriving_121 :: a) (a_Singletons_OrdDeriving_122 :: b) :: (~>) c ((~>) d (Foo a b c d))
       where
-        FSym2KindInference :: SameKind (Apply (FSym2 a0123456789876543210 a0123456789876543210) arg) (FSym3 a0123456789876543210 a0123456789876543210 arg) =>
-                              FSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @c @((~>) d (Foo a b c d)) (FSym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = FSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (FSym2 a0123456789876543210 a0123456789876543210) where
+        FSym2KindInference :: SameKind (Apply (FSym2 a_Singletons_OrdDeriving_121 a_Singletons_OrdDeriving_122) arg) (FSym3 a_Singletons_OrdDeriving_121 a_Singletons_OrdDeriving_122 arg) =>
+                              FSym2 a_Singletons_OrdDeriving_121 a_Singletons_OrdDeriving_122 a_Singletons_OrdDeriving_123
+    type instance Apply @c @((~>) d (Foo a b c d)) (FSym2 a_Singletons_OrdDeriving_121 a_Singletons_OrdDeriving_122) a_Singletons_OrdDeriving_123 = FSym3 a_Singletons_OrdDeriving_121 a_Singletons_OrdDeriving_122 a_Singletons_OrdDeriving_123
+    instance SuppressUnusedWarnings (FSym2 a_Singletons_OrdDeriving_121 a_Singletons_OrdDeriving_122) where
       suppressUnusedWarnings = snd ((,) FSym2KindInference ())
     type FSym3 :: forall a b c d. a -> b -> c -> (~>) d (Foo a b c d)
-    data FSym3 (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: c) :: (~>) d (Foo a b c d)
+    data FSym3 (a_Singletons_OrdDeriving_121 :: a) (a_Singletons_OrdDeriving_122 :: b) (a_Singletons_OrdDeriving_123 :: c) :: (~>) d (Foo a b c d)
       where
-        FSym3KindInference :: SameKind (Apply (FSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) arg) (FSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 arg) =>
-                              FSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @d @(Foo a b c d) (FSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) a0123456789876543210 = F a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (FSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210) where
+        FSym3KindInference :: SameKind (Apply (FSym3 a_Singletons_OrdDeriving_121 a_Singletons_OrdDeriving_122 a_Singletons_OrdDeriving_123) arg) (FSym4 a_Singletons_OrdDeriving_121 a_Singletons_OrdDeriving_122 a_Singletons_OrdDeriving_123 arg) =>
+                              FSym3 a_Singletons_OrdDeriving_121 a_Singletons_OrdDeriving_122 a_Singletons_OrdDeriving_123 a_Singletons_OrdDeriving_124
+    type instance Apply @d @(Foo a b c d) (FSym3 a_Singletons_OrdDeriving_121 a_Singletons_OrdDeriving_122 a_Singletons_OrdDeriving_123) a_Singletons_OrdDeriving_124 = F a_Singletons_OrdDeriving_121 a_Singletons_OrdDeriving_122 a_Singletons_OrdDeriving_123 a_Singletons_OrdDeriving_124
+    instance SuppressUnusedWarnings (FSym3 a_Singletons_OrdDeriving_121 a_Singletons_OrdDeriving_122 a_Singletons_OrdDeriving_123) where
       suppressUnusedWarnings = snd ((,) FSym3KindInference ())
     type FSym4 :: forall a b c d. a -> b -> c -> d -> Foo a b c d
-    type family FSym4 @a @b @c @d (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: c) (a0123456789876543210 :: d) :: Foo a b c d where
-      FSym4 a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210 = F a0123456789876543210 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type TFHelper_0123456789876543210 :: Nat -> Nat -> Bool
-    type family TFHelper_0123456789876543210 (a :: Nat) (a :: Nat) :: Bool where
-      TFHelper_0123456789876543210 Zero Zero = TrueSym0
-      TFHelper_0123456789876543210 Zero (Succ _) = FalseSym0
-      TFHelper_0123456789876543210 (Succ _) Zero = FalseSym0
-      TFHelper_0123456789876543210 (Succ a_0123456789876543210) (Succ b_0123456789876543210) = Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210
+    type family FSym4 @a @b @c @d (a_Singletons_OrdDeriving_121 :: a) (a_Singletons_OrdDeriving_122 :: b) (a_Singletons_OrdDeriving_123 :: c) (a_Singletons_OrdDeriving_124 :: d) :: Foo a b c d where
+      FSym4 a_Singletons_OrdDeriving_121 a_Singletons_OrdDeriving_122 a_Singletons_OrdDeriving_123 a_Singletons_OrdDeriving_124 = F a_Singletons_OrdDeriving_121 a_Singletons_OrdDeriving_122 a_Singletons_OrdDeriving_123 a_Singletons_OrdDeriving_124
+    type TFHelper_Singletons_OrdDeriving_125 :: Nat -> Nat -> Bool
+    type family TFHelper_Singletons_OrdDeriving_125 (a :: Nat) (a :: Nat) :: Bool where
+      TFHelper_Singletons_OrdDeriving_125 Zero Zero = TrueSym0
+      TFHelper_Singletons_OrdDeriving_125 Zero (Succ _) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_125 (Succ _) Zero = FalseSym0
+      TFHelper_Singletons_OrdDeriving_125 (Succ a_Singletons_OrdDeriving_0) (Succ b_Singletons_OrdDeriving_1) = Apply (Apply (==@#@$) a_Singletons_OrdDeriving_0) b_Singletons_OrdDeriving_1
     instance PEq Nat where
-      type (==) a a = TFHelper_0123456789876543210 a a
-    type Compare_0123456789876543210 :: Nat -> Nat -> Ordering
-    type family Compare_0123456789876543210 (a :: Nat) (a :: Nat) :: Ordering where
-      Compare_0123456789876543210 Zero Zero = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
-      Compare_0123456789876543210 (Succ a_0123456789876543210) (Succ b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0)
-      Compare_0123456789876543210 Zero (Succ _) = LTSym0
-      Compare_0123456789876543210 (Succ _) Zero = GTSym0
+      type (==) a a = TFHelper_Singletons_OrdDeriving_125 a a
+    type Compare_Singletons_OrdDeriving_128 :: Nat -> Nat -> Ordering
+    type family Compare_Singletons_OrdDeriving_128 (a :: Nat) (a :: Nat) :: Ordering where
+      Compare_Singletons_OrdDeriving_128 Zero Zero = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
+      Compare_Singletons_OrdDeriving_128 (Succ a_Singletons_OrdDeriving_2) (Succ b_Singletons_OrdDeriving_3) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_OrdDeriving_2) b_Singletons_OrdDeriving_3)) NilSym0)
+      Compare_Singletons_OrdDeriving_128 Zero (Succ _) = LTSym0
+      Compare_Singletons_OrdDeriving_128 (Succ _) Zero = GTSym0
     instance POrd Nat where
-      type Compare a a = Compare_0123456789876543210 a a
-    type TFHelper_0123456789876543210 :: forall a b c d. Foo a b c d
-                                                         -> Foo a b c d -> Bool
-    type family TFHelper_0123456789876543210 @a @b @c @d (a :: Foo a b c d) (a :: Foo a b c d) :: Bool where
-      TFHelper_0123456789876543210 @a @b @c @d (A a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 :: Foo a b c d) (A b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 :: Foo a b c d) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)))
-      TFHelper_0123456789876543210 @a @b @c @d (A _ _ _ _ :: Foo a b c d) (B _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (A _ _ _ _ :: Foo a b c d) (C _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (A _ _ _ _ :: Foo a b c d) (D _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (A _ _ _ _ :: Foo a b c d) (E _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (A _ _ _ _ :: Foo a b c d) (F _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (B _ _ _ _ :: Foo a b c d) (A _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (B a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 :: Foo a b c d) (B b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 :: Foo a b c d) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)))
-      TFHelper_0123456789876543210 @a @b @c @d (B _ _ _ _ :: Foo a b c d) (C _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (B _ _ _ _ :: Foo a b c d) (D _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (B _ _ _ _ :: Foo a b c d) (E _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (B _ _ _ _ :: Foo a b c d) (F _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (C _ _ _ _ :: Foo a b c d) (A _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (C _ _ _ _ :: Foo a b c d) (B _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (C a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 :: Foo a b c d) (C b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 :: Foo a b c d) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)))
-      TFHelper_0123456789876543210 @a @b @c @d (C _ _ _ _ :: Foo a b c d) (D _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (C _ _ _ _ :: Foo a b c d) (E _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (C _ _ _ _ :: Foo a b c d) (F _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (D _ _ _ _ :: Foo a b c d) (A _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (D _ _ _ _ :: Foo a b c d) (B _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (D _ _ _ _ :: Foo a b c d) (C _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (D a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 :: Foo a b c d) (D b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 :: Foo a b c d) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)))
-      TFHelper_0123456789876543210 @a @b @c @d (D _ _ _ _ :: Foo a b c d) (E _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (D _ _ _ _ :: Foo a b c d) (F _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (E _ _ _ _ :: Foo a b c d) (A _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (E _ _ _ _ :: Foo a b c d) (B _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (E _ _ _ _ :: Foo a b c d) (C _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (E _ _ _ _ :: Foo a b c d) (D _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (E a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 :: Foo a b c d) (E b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 :: Foo a b c d) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)))
-      TFHelper_0123456789876543210 @a @b @c @d (E _ _ _ _ :: Foo a b c d) (F _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (F _ _ _ _ :: Foo a b c d) (A _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (F _ _ _ _ :: Foo a b c d) (B _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (F _ _ _ _ :: Foo a b c d) (C _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (F _ _ _ _ :: Foo a b c d) (D _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (F _ _ _ _ :: Foo a b c d) (E _ _ _ _ :: Foo a b c d) = FalseSym0
-      TFHelper_0123456789876543210 @a @b @c @d (F a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 :: Foo a b c d) (F b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 :: Foo a b c d) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)))
+      type Compare a a = Compare_Singletons_OrdDeriving_128 a a
+    type TFHelper_Singletons_OrdDeriving_131 :: forall a
+                                                       b
+                                                       c
+                                                       d. Foo a b c d -> Foo a b c d -> Bool
+    type family TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (a :: Foo a b c d) (a :: Foo a b c d) :: Bool where
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (A a_Singletons_OrdDeriving_4 a_Singletons_OrdDeriving_5 a_Singletons_OrdDeriving_6 a_Singletons_OrdDeriving_7 :: Foo a b c d) (A b_Singletons_OrdDeriving_8 b_Singletons_OrdDeriving_9 b_Singletons_OrdDeriving_10 b_Singletons_OrdDeriving_11 :: Foo a b c d) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_Singletons_OrdDeriving_4) b_Singletons_OrdDeriving_8)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_Singletons_OrdDeriving_5) b_Singletons_OrdDeriving_9)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_Singletons_OrdDeriving_6) b_Singletons_OrdDeriving_10)) (Apply (Apply (==@#@$) a_Singletons_OrdDeriving_7) b_Singletons_OrdDeriving_11)))
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (A _ _ _ _ :: Foo a b c d) (B _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (A _ _ _ _ :: Foo a b c d) (C _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (A _ _ _ _ :: Foo a b c d) (D _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (A _ _ _ _ :: Foo a b c d) (E _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (A _ _ _ _ :: Foo a b c d) (F _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (B _ _ _ _ :: Foo a b c d) (A _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (B a_Singletons_OrdDeriving_12 a_Singletons_OrdDeriving_13 a_Singletons_OrdDeriving_14 a_Singletons_OrdDeriving_15 :: Foo a b c d) (B b_Singletons_OrdDeriving_16 b_Singletons_OrdDeriving_17 b_Singletons_OrdDeriving_18 b_Singletons_OrdDeriving_19 :: Foo a b c d) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_Singletons_OrdDeriving_12) b_Singletons_OrdDeriving_16)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_Singletons_OrdDeriving_13) b_Singletons_OrdDeriving_17)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_Singletons_OrdDeriving_14) b_Singletons_OrdDeriving_18)) (Apply (Apply (==@#@$) a_Singletons_OrdDeriving_15) b_Singletons_OrdDeriving_19)))
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (B _ _ _ _ :: Foo a b c d) (C _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (B _ _ _ _ :: Foo a b c d) (D _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (B _ _ _ _ :: Foo a b c d) (E _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (B _ _ _ _ :: Foo a b c d) (F _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (C _ _ _ _ :: Foo a b c d) (A _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (C _ _ _ _ :: Foo a b c d) (B _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (C a_Singletons_OrdDeriving_20 a_Singletons_OrdDeriving_21 a_Singletons_OrdDeriving_22 a_Singletons_OrdDeriving_23 :: Foo a b c d) (C b_Singletons_OrdDeriving_24 b_Singletons_OrdDeriving_25 b_Singletons_OrdDeriving_26 b_Singletons_OrdDeriving_27 :: Foo a b c d) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_Singletons_OrdDeriving_20) b_Singletons_OrdDeriving_24)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_Singletons_OrdDeriving_21) b_Singletons_OrdDeriving_25)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_Singletons_OrdDeriving_22) b_Singletons_OrdDeriving_26)) (Apply (Apply (==@#@$) a_Singletons_OrdDeriving_23) b_Singletons_OrdDeriving_27)))
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (C _ _ _ _ :: Foo a b c d) (D _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (C _ _ _ _ :: Foo a b c d) (E _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (C _ _ _ _ :: Foo a b c d) (F _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (D _ _ _ _ :: Foo a b c d) (A _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (D _ _ _ _ :: Foo a b c d) (B _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (D _ _ _ _ :: Foo a b c d) (C _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (D a_Singletons_OrdDeriving_28 a_Singletons_OrdDeriving_29 a_Singletons_OrdDeriving_30 a_Singletons_OrdDeriving_31 :: Foo a b c d) (D b_Singletons_OrdDeriving_32 b_Singletons_OrdDeriving_33 b_Singletons_OrdDeriving_34 b_Singletons_OrdDeriving_35 :: Foo a b c d) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_Singletons_OrdDeriving_28) b_Singletons_OrdDeriving_32)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_Singletons_OrdDeriving_29) b_Singletons_OrdDeriving_33)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_Singletons_OrdDeriving_30) b_Singletons_OrdDeriving_34)) (Apply (Apply (==@#@$) a_Singletons_OrdDeriving_31) b_Singletons_OrdDeriving_35)))
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (D _ _ _ _ :: Foo a b c d) (E _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (D _ _ _ _ :: Foo a b c d) (F _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (E _ _ _ _ :: Foo a b c d) (A _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (E _ _ _ _ :: Foo a b c d) (B _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (E _ _ _ _ :: Foo a b c d) (C _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (E _ _ _ _ :: Foo a b c d) (D _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (E a_Singletons_OrdDeriving_36 a_Singletons_OrdDeriving_37 a_Singletons_OrdDeriving_38 a_Singletons_OrdDeriving_39 :: Foo a b c d) (E b_Singletons_OrdDeriving_40 b_Singletons_OrdDeriving_41 b_Singletons_OrdDeriving_42 b_Singletons_OrdDeriving_43 :: Foo a b c d) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_Singletons_OrdDeriving_36) b_Singletons_OrdDeriving_40)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_Singletons_OrdDeriving_37) b_Singletons_OrdDeriving_41)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_Singletons_OrdDeriving_38) b_Singletons_OrdDeriving_42)) (Apply (Apply (==@#@$) a_Singletons_OrdDeriving_39) b_Singletons_OrdDeriving_43)))
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (E _ _ _ _ :: Foo a b c d) (F _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (F _ _ _ _ :: Foo a b c d) (A _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (F _ _ _ _ :: Foo a b c d) (B _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (F _ _ _ _ :: Foo a b c d) (C _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (F _ _ _ _ :: Foo a b c d) (D _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (F _ _ _ _ :: Foo a b c d) (E _ _ _ _ :: Foo a b c d) = FalseSym0
+      TFHelper_Singletons_OrdDeriving_131 @a @b @c @d (F a_Singletons_OrdDeriving_44 a_Singletons_OrdDeriving_45 a_Singletons_OrdDeriving_46 a_Singletons_OrdDeriving_47 :: Foo a b c d) (F b_Singletons_OrdDeriving_48 b_Singletons_OrdDeriving_49 b_Singletons_OrdDeriving_50 b_Singletons_OrdDeriving_51 :: Foo a b c d) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_Singletons_OrdDeriving_44) b_Singletons_OrdDeriving_48)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_Singletons_OrdDeriving_45) b_Singletons_OrdDeriving_49)) (Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_Singletons_OrdDeriving_46) b_Singletons_OrdDeriving_50)) (Apply (Apply (==@#@$) a_Singletons_OrdDeriving_47) b_Singletons_OrdDeriving_51)))
     instance PEq (Foo a b c d) where
-      type (==) a a = TFHelper_0123456789876543210 a a
-    type Compare_0123456789876543210 :: forall a b c d. Foo a b c d
-                                                        -> Foo a b c d -> Ordering
-    type family Compare_0123456789876543210 @a @b @c @d (a :: Foo a b c d) (a :: Foo a b c d) :: Ordering where
-      Compare_0123456789876543210 @a @b @c @d (A a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 :: Foo a b c d) (A b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 :: Foo a b c d) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0))))
-      Compare_0123456789876543210 @a @b @c @d (B a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 :: Foo a b c d) (B b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 :: Foo a b c d) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0))))
-      Compare_0123456789876543210 @a @b @c @d (C a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 :: Foo a b c d) (C b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 :: Foo a b c d) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0))))
-      Compare_0123456789876543210 @a @b @c @d (D a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 :: Foo a b c d) (D b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 :: Foo a b c d) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0))))
-      Compare_0123456789876543210 @a @b @c @d (E a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 :: Foo a b c d) (E b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 :: Foo a b c d) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0))))
-      Compare_0123456789876543210 @a @b @c @d (F a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 a_0123456789876543210 :: Foo a b c d) (F b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 b_0123456789876543210 :: Foo a b c d) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0))))
-      Compare_0123456789876543210 @a @b @c @d (A _ _ _ _ :: Foo a b c d) (B _ _ _ _ :: Foo a b c d) = LTSym0
-      Compare_0123456789876543210 @a @b @c @d (A _ _ _ _ :: Foo a b c d) (C _ _ _ _ :: Foo a b c d) = LTSym0
-      Compare_0123456789876543210 @a @b @c @d (A _ _ _ _ :: Foo a b c d) (D _ _ _ _ :: Foo a b c d) = LTSym0
-      Compare_0123456789876543210 @a @b @c @d (A _ _ _ _ :: Foo a b c d) (E _ _ _ _ :: Foo a b c d) = LTSym0
-      Compare_0123456789876543210 @a @b @c @d (A _ _ _ _ :: Foo a b c d) (F _ _ _ _ :: Foo a b c d) = LTSym0
-      Compare_0123456789876543210 @a @b @c @d (B _ _ _ _ :: Foo a b c d) (A _ _ _ _ :: Foo a b c d) = GTSym0
-      Compare_0123456789876543210 @a @b @c @d (B _ _ _ _ :: Foo a b c d) (C _ _ _ _ :: Foo a b c d) = LTSym0
-      Compare_0123456789876543210 @a @b @c @d (B _ _ _ _ :: Foo a b c d) (D _ _ _ _ :: Foo a b c d) = LTSym0
-      Compare_0123456789876543210 @a @b @c @d (B _ _ _ _ :: Foo a b c d) (E _ _ _ _ :: Foo a b c d) = LTSym0
-      Compare_0123456789876543210 @a @b @c @d (B _ _ _ _ :: Foo a b c d) (F _ _ _ _ :: Foo a b c d) = LTSym0
-      Compare_0123456789876543210 @a @b @c @d (C _ _ _ _ :: Foo a b c d) (A _ _ _ _ :: Foo a b c d) = GTSym0
-      Compare_0123456789876543210 @a @b @c @d (C _ _ _ _ :: Foo a b c d) (B _ _ _ _ :: Foo a b c d) = GTSym0
-      Compare_0123456789876543210 @a @b @c @d (C _ _ _ _ :: Foo a b c d) (D _ _ _ _ :: Foo a b c d) = LTSym0
-      Compare_0123456789876543210 @a @b @c @d (C _ _ _ _ :: Foo a b c d) (E _ _ _ _ :: Foo a b c d) = LTSym0
-      Compare_0123456789876543210 @a @b @c @d (C _ _ _ _ :: Foo a b c d) (F _ _ _ _ :: Foo a b c d) = LTSym0
-      Compare_0123456789876543210 @a @b @c @d (D _ _ _ _ :: Foo a b c d) (A _ _ _ _ :: Foo a b c d) = GTSym0
-      Compare_0123456789876543210 @a @b @c @d (D _ _ _ _ :: Foo a b c d) (B _ _ _ _ :: Foo a b c d) = GTSym0
-      Compare_0123456789876543210 @a @b @c @d (D _ _ _ _ :: Foo a b c d) (C _ _ _ _ :: Foo a b c d) = GTSym0
-      Compare_0123456789876543210 @a @b @c @d (D _ _ _ _ :: Foo a b c d) (E _ _ _ _ :: Foo a b c d) = LTSym0
-      Compare_0123456789876543210 @a @b @c @d (D _ _ _ _ :: Foo a b c d) (F _ _ _ _ :: Foo a b c d) = LTSym0
-      Compare_0123456789876543210 @a @b @c @d (E _ _ _ _ :: Foo a b c d) (A _ _ _ _ :: Foo a b c d) = GTSym0
-      Compare_0123456789876543210 @a @b @c @d (E _ _ _ _ :: Foo a b c d) (B _ _ _ _ :: Foo a b c d) = GTSym0
-      Compare_0123456789876543210 @a @b @c @d (E _ _ _ _ :: Foo a b c d) (C _ _ _ _ :: Foo a b c d) = GTSym0
-      Compare_0123456789876543210 @a @b @c @d (E _ _ _ _ :: Foo a b c d) (D _ _ _ _ :: Foo a b c d) = GTSym0
-      Compare_0123456789876543210 @a @b @c @d (E _ _ _ _ :: Foo a b c d) (F _ _ _ _ :: Foo a b c d) = LTSym0
-      Compare_0123456789876543210 @a @b @c @d (F _ _ _ _ :: Foo a b c d) (A _ _ _ _ :: Foo a b c d) = GTSym0
-      Compare_0123456789876543210 @a @b @c @d (F _ _ _ _ :: Foo a b c d) (B _ _ _ _ :: Foo a b c d) = GTSym0
-      Compare_0123456789876543210 @a @b @c @d (F _ _ _ _ :: Foo a b c d) (C _ _ _ _ :: Foo a b c d) = GTSym0
-      Compare_0123456789876543210 @a @b @c @d (F _ _ _ _ :: Foo a b c d) (D _ _ _ _ :: Foo a b c d) = GTSym0
-      Compare_0123456789876543210 @a @b @c @d (F _ _ _ _ :: Foo a b c d) (E _ _ _ _ :: Foo a b c d) = GTSym0
+      type (==) a a = TFHelper_Singletons_OrdDeriving_131 a a
+    type Compare_Singletons_OrdDeriving_134 :: forall a
+                                                      b
+                                                      c
+                                                      d. Foo a b c d -> Foo a b c d -> Ordering
+    type family Compare_Singletons_OrdDeriving_134 @a @b @c @d (a :: Foo a b c d) (a :: Foo a b c d) :: Ordering where
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (A a_Singletons_OrdDeriving_52 a_Singletons_OrdDeriving_53 a_Singletons_OrdDeriving_54 a_Singletons_OrdDeriving_55 :: Foo a b c d) (A b_Singletons_OrdDeriving_56 b_Singletons_OrdDeriving_57 b_Singletons_OrdDeriving_58 b_Singletons_OrdDeriving_59 :: Foo a b c d) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_OrdDeriving_52) b_Singletons_OrdDeriving_56)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_OrdDeriving_53) b_Singletons_OrdDeriving_57)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_OrdDeriving_54) b_Singletons_OrdDeriving_58)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_OrdDeriving_55) b_Singletons_OrdDeriving_59)) NilSym0))))
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (B a_Singletons_OrdDeriving_60 a_Singletons_OrdDeriving_61 a_Singletons_OrdDeriving_62 a_Singletons_OrdDeriving_63 :: Foo a b c d) (B b_Singletons_OrdDeriving_64 b_Singletons_OrdDeriving_65 b_Singletons_OrdDeriving_66 b_Singletons_OrdDeriving_67 :: Foo a b c d) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_OrdDeriving_60) b_Singletons_OrdDeriving_64)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_OrdDeriving_61) b_Singletons_OrdDeriving_65)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_OrdDeriving_62) b_Singletons_OrdDeriving_66)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_OrdDeriving_63) b_Singletons_OrdDeriving_67)) NilSym0))))
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (C a_Singletons_OrdDeriving_68 a_Singletons_OrdDeriving_69 a_Singletons_OrdDeriving_70 a_Singletons_OrdDeriving_71 :: Foo a b c d) (C b_Singletons_OrdDeriving_72 b_Singletons_OrdDeriving_73 b_Singletons_OrdDeriving_74 b_Singletons_OrdDeriving_75 :: Foo a b c d) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_OrdDeriving_68) b_Singletons_OrdDeriving_72)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_OrdDeriving_69) b_Singletons_OrdDeriving_73)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_OrdDeriving_70) b_Singletons_OrdDeriving_74)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_OrdDeriving_71) b_Singletons_OrdDeriving_75)) NilSym0))))
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (D a_Singletons_OrdDeriving_76 a_Singletons_OrdDeriving_77 a_Singletons_OrdDeriving_78 a_Singletons_OrdDeriving_79 :: Foo a b c d) (D b_Singletons_OrdDeriving_80 b_Singletons_OrdDeriving_81 b_Singletons_OrdDeriving_82 b_Singletons_OrdDeriving_83 :: Foo a b c d) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_OrdDeriving_76) b_Singletons_OrdDeriving_80)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_OrdDeriving_77) b_Singletons_OrdDeriving_81)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_OrdDeriving_78) b_Singletons_OrdDeriving_82)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_OrdDeriving_79) b_Singletons_OrdDeriving_83)) NilSym0))))
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (E a_Singletons_OrdDeriving_84 a_Singletons_OrdDeriving_85 a_Singletons_OrdDeriving_86 a_Singletons_OrdDeriving_87 :: Foo a b c d) (E b_Singletons_OrdDeriving_88 b_Singletons_OrdDeriving_89 b_Singletons_OrdDeriving_90 b_Singletons_OrdDeriving_91 :: Foo a b c d) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_OrdDeriving_84) b_Singletons_OrdDeriving_88)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_OrdDeriving_85) b_Singletons_OrdDeriving_89)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_OrdDeriving_86) b_Singletons_OrdDeriving_90)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_OrdDeriving_87) b_Singletons_OrdDeriving_91)) NilSym0))))
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (F a_Singletons_OrdDeriving_92 a_Singletons_OrdDeriving_93 a_Singletons_OrdDeriving_94 a_Singletons_OrdDeriving_95 :: Foo a b c d) (F b_Singletons_OrdDeriving_96 b_Singletons_OrdDeriving_97 b_Singletons_OrdDeriving_98 b_Singletons_OrdDeriving_99 :: Foo a b c d) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_OrdDeriving_92) b_Singletons_OrdDeriving_96)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_OrdDeriving_93) b_Singletons_OrdDeriving_97)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_OrdDeriving_94) b_Singletons_OrdDeriving_98)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_OrdDeriving_95) b_Singletons_OrdDeriving_99)) NilSym0))))
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (A _ _ _ _ :: Foo a b c d) (B _ _ _ _ :: Foo a b c d) = LTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (A _ _ _ _ :: Foo a b c d) (C _ _ _ _ :: Foo a b c d) = LTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (A _ _ _ _ :: Foo a b c d) (D _ _ _ _ :: Foo a b c d) = LTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (A _ _ _ _ :: Foo a b c d) (E _ _ _ _ :: Foo a b c d) = LTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (A _ _ _ _ :: Foo a b c d) (F _ _ _ _ :: Foo a b c d) = LTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (B _ _ _ _ :: Foo a b c d) (A _ _ _ _ :: Foo a b c d) = GTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (B _ _ _ _ :: Foo a b c d) (C _ _ _ _ :: Foo a b c d) = LTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (B _ _ _ _ :: Foo a b c d) (D _ _ _ _ :: Foo a b c d) = LTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (B _ _ _ _ :: Foo a b c d) (E _ _ _ _ :: Foo a b c d) = LTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (B _ _ _ _ :: Foo a b c d) (F _ _ _ _ :: Foo a b c d) = LTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (C _ _ _ _ :: Foo a b c d) (A _ _ _ _ :: Foo a b c d) = GTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (C _ _ _ _ :: Foo a b c d) (B _ _ _ _ :: Foo a b c d) = GTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (C _ _ _ _ :: Foo a b c d) (D _ _ _ _ :: Foo a b c d) = LTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (C _ _ _ _ :: Foo a b c d) (E _ _ _ _ :: Foo a b c d) = LTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (C _ _ _ _ :: Foo a b c d) (F _ _ _ _ :: Foo a b c d) = LTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (D _ _ _ _ :: Foo a b c d) (A _ _ _ _ :: Foo a b c d) = GTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (D _ _ _ _ :: Foo a b c d) (B _ _ _ _ :: Foo a b c d) = GTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (D _ _ _ _ :: Foo a b c d) (C _ _ _ _ :: Foo a b c d) = GTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (D _ _ _ _ :: Foo a b c d) (E _ _ _ _ :: Foo a b c d) = LTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (D _ _ _ _ :: Foo a b c d) (F _ _ _ _ :: Foo a b c d) = LTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (E _ _ _ _ :: Foo a b c d) (A _ _ _ _ :: Foo a b c d) = GTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (E _ _ _ _ :: Foo a b c d) (B _ _ _ _ :: Foo a b c d) = GTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (E _ _ _ _ :: Foo a b c d) (C _ _ _ _ :: Foo a b c d) = GTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (E _ _ _ _ :: Foo a b c d) (D _ _ _ _ :: Foo a b c d) = GTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (E _ _ _ _ :: Foo a b c d) (F _ _ _ _ :: Foo a b c d) = LTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (F _ _ _ _ :: Foo a b c d) (A _ _ _ _ :: Foo a b c d) = GTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (F _ _ _ _ :: Foo a b c d) (B _ _ _ _ :: Foo a b c d) = GTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (F _ _ _ _ :: Foo a b c d) (C _ _ _ _ :: Foo a b c d) = GTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (F _ _ _ _ :: Foo a b c d) (D _ _ _ _ :: Foo a b c d) = GTSym0
+      Compare_Singletons_OrdDeriving_134 @a @b @c @d (F _ _ _ _ :: Foo a b c d) (E _ _ _ _ :: Foo a b c d) = GTSym0
     instance POrd (Foo a b c d) where
-      type Compare a a = Compare_0123456789876543210 a a
+      type Compare a a = Compare_Singletons_OrdDeriving_134 a a
     data SNat :: Nat -> Type
       where
         SZero :: SNat (Zero :: Nat)
@@ -489,11 +493,11 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       (%==) SZero (SSucc _) = SFalse
       (%==) (SSucc _) SZero = SFalse
       (%==)
-        (SSucc (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SSucc (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SSucc (sA_Singletons_OrdDeriving_0 :: Sing a_Singletons_OrdDeriving_0))
+        (SSucc (sB_Singletons_OrdDeriving_1 :: Sing b_Singletons_OrdDeriving_1))
         = applySing
-            (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-            sB_0123456789876543210
+            (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_OrdDeriving_0)
+            sB_Singletons_OrdDeriving_1
     instance SOrd Nat => SOrd Nat where
       sCompare SZero SZero
         = applySing
@@ -502,8 +506,8 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                SEQ)
             SNil
       sCompare
-        (SSucc (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SSucc (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SSucc (sA_Singletons_OrdDeriving_2 :: Sing a_Singletons_OrdDeriving_2))
+        (SSucc (sB_Singletons_OrdDeriving_3 :: Sing b_Singletons_OrdDeriving_3))
         = applySing
             (applySing
                (applySing (singFun3 @FoldlSym0 sFoldl) (singFun2 @(<>@#@$) (%<>)))
@@ -512,42 +516,43 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                (applySing
                   (singFun2 @(:@#@$) SCons)
                   (applySing
-                     (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                     sB_0123456789876543210))
+                     (applySing
+                        (singFun2 @CompareSym0 sCompare) sA_Singletons_OrdDeriving_2)
+                     sB_Singletons_OrdDeriving_3))
                SNil)
       sCompare SZero (SSucc _) = SLT
       sCompare (SSucc _) SZero = SGT
     instance (SEq a, SEq b, SEq c, SEq d) => SEq (Foo a b c d) where
       (%==)
-        (SA (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SA (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SA (sA_Singletons_OrdDeriving_4 :: Sing a_Singletons_OrdDeriving_4)
+            (sA_Singletons_OrdDeriving_5 :: Sing a_Singletons_OrdDeriving_5)
+            (sA_Singletons_OrdDeriving_6 :: Sing a_Singletons_OrdDeriving_6)
+            (sA_Singletons_OrdDeriving_7 :: Sing a_Singletons_OrdDeriving_7))
+        (SA (sB_Singletons_OrdDeriving_8 :: Sing b_Singletons_OrdDeriving_8)
+            (sB_Singletons_OrdDeriving_9 :: Sing b_Singletons_OrdDeriving_9)
+            (sB_Singletons_OrdDeriving_10 :: Sing b_Singletons_OrdDeriving_10)
+            (sB_Singletons_OrdDeriving_11 :: Sing b_Singletons_OrdDeriving_11))
         = applySing
             (applySing
                (singFun2 @(&&@#@$) (%&&))
                (applySing
-                  (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                  sB_0123456789876543210))
+                  (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_OrdDeriving_4)
+                  sB_Singletons_OrdDeriving_8))
             (applySing
                (applySing
                   (singFun2 @(&&@#@$) (%&&))
                   (applySing
-                     (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                     sB_0123456789876543210))
+                     (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_OrdDeriving_5)
+                     sB_Singletons_OrdDeriving_9))
                (applySing
                   (applySing
                      (singFun2 @(&&@#@$) (%&&))
                      (applySing
-                        (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                        sB_0123456789876543210))
+                        (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_OrdDeriving_6)
+                        sB_Singletons_OrdDeriving_10))
                   (applySing
-                     (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                     sB_0123456789876543210)))
+                     (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_OrdDeriving_7)
+                     sB_Singletons_OrdDeriving_11)))
       (%==) (SA _ _ _ _) (SB _ _ _ _) = SFalse
       (%==) (SA _ _ _ _) (SC _ _ _ _) = SFalse
       (%==) (SA _ _ _ _) (SD _ _ _ _) = SFalse
@@ -555,35 +560,35 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       (%==) (SA _ _ _ _) (SF _ _ _ _) = SFalse
       (%==) (SB _ _ _ _) (SA _ _ _ _) = SFalse
       (%==)
-        (SB (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SB (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SB (sA_Singletons_OrdDeriving_12 :: Sing a_Singletons_OrdDeriving_12)
+            (sA_Singletons_OrdDeriving_13 :: Sing a_Singletons_OrdDeriving_13)
+            (sA_Singletons_OrdDeriving_14 :: Sing a_Singletons_OrdDeriving_14)
+            (sA_Singletons_OrdDeriving_15 :: Sing a_Singletons_OrdDeriving_15))
+        (SB (sB_Singletons_OrdDeriving_16 :: Sing b_Singletons_OrdDeriving_16)
+            (sB_Singletons_OrdDeriving_17 :: Sing b_Singletons_OrdDeriving_17)
+            (sB_Singletons_OrdDeriving_18 :: Sing b_Singletons_OrdDeriving_18)
+            (sB_Singletons_OrdDeriving_19 :: Sing b_Singletons_OrdDeriving_19))
         = applySing
             (applySing
                (singFun2 @(&&@#@$) (%&&))
                (applySing
-                  (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                  sB_0123456789876543210))
+                  (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_OrdDeriving_12)
+                  sB_Singletons_OrdDeriving_16))
             (applySing
                (applySing
                   (singFun2 @(&&@#@$) (%&&))
                   (applySing
-                     (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                     sB_0123456789876543210))
+                     (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_OrdDeriving_13)
+                     sB_Singletons_OrdDeriving_17))
                (applySing
                   (applySing
                      (singFun2 @(&&@#@$) (%&&))
                      (applySing
-                        (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                        sB_0123456789876543210))
+                        (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_OrdDeriving_14)
+                        sB_Singletons_OrdDeriving_18))
                   (applySing
-                     (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                     sB_0123456789876543210)))
+                     (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_OrdDeriving_15)
+                     sB_Singletons_OrdDeriving_19)))
       (%==) (SB _ _ _ _) (SC _ _ _ _) = SFalse
       (%==) (SB _ _ _ _) (SD _ _ _ _) = SFalse
       (%==) (SB _ _ _ _) (SE _ _ _ _) = SFalse
@@ -591,35 +596,35 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       (%==) (SC _ _ _ _) (SA _ _ _ _) = SFalse
       (%==) (SC _ _ _ _) (SB _ _ _ _) = SFalse
       (%==)
-        (SC (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SC (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SC (sA_Singletons_OrdDeriving_20 :: Sing a_Singletons_OrdDeriving_20)
+            (sA_Singletons_OrdDeriving_21 :: Sing a_Singletons_OrdDeriving_21)
+            (sA_Singletons_OrdDeriving_22 :: Sing a_Singletons_OrdDeriving_22)
+            (sA_Singletons_OrdDeriving_23 :: Sing a_Singletons_OrdDeriving_23))
+        (SC (sB_Singletons_OrdDeriving_24 :: Sing b_Singletons_OrdDeriving_24)
+            (sB_Singletons_OrdDeriving_25 :: Sing b_Singletons_OrdDeriving_25)
+            (sB_Singletons_OrdDeriving_26 :: Sing b_Singletons_OrdDeriving_26)
+            (sB_Singletons_OrdDeriving_27 :: Sing b_Singletons_OrdDeriving_27))
         = applySing
             (applySing
                (singFun2 @(&&@#@$) (%&&))
                (applySing
-                  (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                  sB_0123456789876543210))
+                  (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_OrdDeriving_20)
+                  sB_Singletons_OrdDeriving_24))
             (applySing
                (applySing
                   (singFun2 @(&&@#@$) (%&&))
                   (applySing
-                     (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                     sB_0123456789876543210))
+                     (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_OrdDeriving_21)
+                     sB_Singletons_OrdDeriving_25))
                (applySing
                   (applySing
                      (singFun2 @(&&@#@$) (%&&))
                      (applySing
-                        (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                        sB_0123456789876543210))
+                        (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_OrdDeriving_22)
+                        sB_Singletons_OrdDeriving_26))
                   (applySing
-                     (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                     sB_0123456789876543210)))
+                     (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_OrdDeriving_23)
+                     sB_Singletons_OrdDeriving_27)))
       (%==) (SC _ _ _ _) (SD _ _ _ _) = SFalse
       (%==) (SC _ _ _ _) (SE _ _ _ _) = SFalse
       (%==) (SC _ _ _ _) (SF _ _ _ _) = SFalse
@@ -627,35 +632,35 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       (%==) (SD _ _ _ _) (SB _ _ _ _) = SFalse
       (%==) (SD _ _ _ _) (SC _ _ _ _) = SFalse
       (%==)
-        (SD (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SD (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SD (sA_Singletons_OrdDeriving_28 :: Sing a_Singletons_OrdDeriving_28)
+            (sA_Singletons_OrdDeriving_29 :: Sing a_Singletons_OrdDeriving_29)
+            (sA_Singletons_OrdDeriving_30 :: Sing a_Singletons_OrdDeriving_30)
+            (sA_Singletons_OrdDeriving_31 :: Sing a_Singletons_OrdDeriving_31))
+        (SD (sB_Singletons_OrdDeriving_32 :: Sing b_Singletons_OrdDeriving_32)
+            (sB_Singletons_OrdDeriving_33 :: Sing b_Singletons_OrdDeriving_33)
+            (sB_Singletons_OrdDeriving_34 :: Sing b_Singletons_OrdDeriving_34)
+            (sB_Singletons_OrdDeriving_35 :: Sing b_Singletons_OrdDeriving_35))
         = applySing
             (applySing
                (singFun2 @(&&@#@$) (%&&))
                (applySing
-                  (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                  sB_0123456789876543210))
+                  (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_OrdDeriving_28)
+                  sB_Singletons_OrdDeriving_32))
             (applySing
                (applySing
                   (singFun2 @(&&@#@$) (%&&))
                   (applySing
-                     (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                     sB_0123456789876543210))
+                     (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_OrdDeriving_29)
+                     sB_Singletons_OrdDeriving_33))
                (applySing
                   (applySing
                      (singFun2 @(&&@#@$) (%&&))
                      (applySing
-                        (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                        sB_0123456789876543210))
+                        (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_OrdDeriving_30)
+                        sB_Singletons_OrdDeriving_34))
                   (applySing
-                     (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                     sB_0123456789876543210)))
+                     (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_OrdDeriving_31)
+                     sB_Singletons_OrdDeriving_35)))
       (%==) (SD _ _ _ _) (SE _ _ _ _) = SFalse
       (%==) (SD _ _ _ _) (SF _ _ _ _) = SFalse
       (%==) (SE _ _ _ _) (SA _ _ _ _) = SFalse
@@ -663,35 +668,35 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       (%==) (SE _ _ _ _) (SC _ _ _ _) = SFalse
       (%==) (SE _ _ _ _) (SD _ _ _ _) = SFalse
       (%==)
-        (SE (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SE (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SE (sA_Singletons_OrdDeriving_36 :: Sing a_Singletons_OrdDeriving_36)
+            (sA_Singletons_OrdDeriving_37 :: Sing a_Singletons_OrdDeriving_37)
+            (sA_Singletons_OrdDeriving_38 :: Sing a_Singletons_OrdDeriving_38)
+            (sA_Singletons_OrdDeriving_39 :: Sing a_Singletons_OrdDeriving_39))
+        (SE (sB_Singletons_OrdDeriving_40 :: Sing b_Singletons_OrdDeriving_40)
+            (sB_Singletons_OrdDeriving_41 :: Sing b_Singletons_OrdDeriving_41)
+            (sB_Singletons_OrdDeriving_42 :: Sing b_Singletons_OrdDeriving_42)
+            (sB_Singletons_OrdDeriving_43 :: Sing b_Singletons_OrdDeriving_43))
         = applySing
             (applySing
                (singFun2 @(&&@#@$) (%&&))
                (applySing
-                  (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                  sB_0123456789876543210))
+                  (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_OrdDeriving_36)
+                  sB_Singletons_OrdDeriving_40))
             (applySing
                (applySing
                   (singFun2 @(&&@#@$) (%&&))
                   (applySing
-                     (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                     sB_0123456789876543210))
+                     (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_OrdDeriving_37)
+                     sB_Singletons_OrdDeriving_41))
                (applySing
                   (applySing
                      (singFun2 @(&&@#@$) (%&&))
                      (applySing
-                        (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                        sB_0123456789876543210))
+                        (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_OrdDeriving_38)
+                        sB_Singletons_OrdDeriving_42))
                   (applySing
-                     (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                     sB_0123456789876543210)))
+                     (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_OrdDeriving_39)
+                     sB_Singletons_OrdDeriving_43)))
       (%==) (SE _ _ _ _) (SF _ _ _ _) = SFalse
       (%==) (SF _ _ _ _) (SA _ _ _ _) = SFalse
       (%==) (SF _ _ _ _) (SB _ _ _ _) = SFalse
@@ -699,46 +704,46 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
       (%==) (SF _ _ _ _) (SD _ _ _ _) = SFalse
       (%==) (SF _ _ _ _) (SE _ _ _ _) = SFalse
       (%==)
-        (SF (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SF (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SF (sA_Singletons_OrdDeriving_44 :: Sing a_Singletons_OrdDeriving_44)
+            (sA_Singletons_OrdDeriving_45 :: Sing a_Singletons_OrdDeriving_45)
+            (sA_Singletons_OrdDeriving_46 :: Sing a_Singletons_OrdDeriving_46)
+            (sA_Singletons_OrdDeriving_47 :: Sing a_Singletons_OrdDeriving_47))
+        (SF (sB_Singletons_OrdDeriving_48 :: Sing b_Singletons_OrdDeriving_48)
+            (sB_Singletons_OrdDeriving_49 :: Sing b_Singletons_OrdDeriving_49)
+            (sB_Singletons_OrdDeriving_50 :: Sing b_Singletons_OrdDeriving_50)
+            (sB_Singletons_OrdDeriving_51 :: Sing b_Singletons_OrdDeriving_51))
         = applySing
             (applySing
                (singFun2 @(&&@#@$) (%&&))
                (applySing
-                  (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                  sB_0123456789876543210))
+                  (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_OrdDeriving_44)
+                  sB_Singletons_OrdDeriving_48))
             (applySing
                (applySing
                   (singFun2 @(&&@#@$) (%&&))
                   (applySing
-                     (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                     sB_0123456789876543210))
+                     (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_OrdDeriving_45)
+                     sB_Singletons_OrdDeriving_49))
                (applySing
                   (applySing
                      (singFun2 @(&&@#@$) (%&&))
                      (applySing
-                        (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                        sB_0123456789876543210))
+                        (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_OrdDeriving_46)
+                        sB_Singletons_OrdDeriving_50))
                   (applySing
-                     (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                     sB_0123456789876543210)))
+                     (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_OrdDeriving_47)
+                     sB_Singletons_OrdDeriving_51)))
     instance (SOrd a, SOrd b, SOrd c, SOrd d) =>
              SOrd (Foo a b c d) where
       sCompare
-        (SA (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SA (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SA (sA_Singletons_OrdDeriving_52 :: Sing a_Singletons_OrdDeriving_52)
+            (sA_Singletons_OrdDeriving_53 :: Sing a_Singletons_OrdDeriving_53)
+            (sA_Singletons_OrdDeriving_54 :: Sing a_Singletons_OrdDeriving_54)
+            (sA_Singletons_OrdDeriving_55 :: Sing a_Singletons_OrdDeriving_55))
+        (SA (sB_Singletons_OrdDeriving_56 :: Sing b_Singletons_OrdDeriving_56)
+            (sB_Singletons_OrdDeriving_57 :: Sing b_Singletons_OrdDeriving_57)
+            (sB_Singletons_OrdDeriving_58 :: Sing b_Singletons_OrdDeriving_58)
+            (sB_Singletons_OrdDeriving_59 :: Sing b_Singletons_OrdDeriving_59))
         = applySing
             (applySing
                (applySing (singFun3 @FoldlSym0 sFoldl) (singFun2 @(<>@#@$) (%<>)))
@@ -747,36 +752,40 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                (applySing
                   (singFun2 @(:@#@$) SCons)
                   (applySing
-                     (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                     sB_0123456789876543210))
+                     (applySing
+                        (singFun2 @CompareSym0 sCompare) sA_Singletons_OrdDeriving_52)
+                     sB_Singletons_OrdDeriving_56))
                (applySing
                   (applySing
                      (singFun2 @(:@#@$) SCons)
                      (applySing
-                        (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                        sB_0123456789876543210))
+                        (applySing
+                           (singFun2 @CompareSym0 sCompare) sA_Singletons_OrdDeriving_53)
+                        sB_Singletons_OrdDeriving_57))
                   (applySing
                      (applySing
                         (singFun2 @(:@#@$) SCons)
                         (applySing
-                           (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                           sB_0123456789876543210))
+                           (applySing
+                              (singFun2 @CompareSym0 sCompare) sA_Singletons_OrdDeriving_54)
+                           sB_Singletons_OrdDeriving_58))
                      (applySing
                         (applySing
                            (singFun2 @(:@#@$) SCons)
                            (applySing
-                              (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                              sB_0123456789876543210))
+                              (applySing
+                                 (singFun2 @CompareSym0 sCompare) sA_Singletons_OrdDeriving_55)
+                              sB_Singletons_OrdDeriving_59))
                         SNil))))
       sCompare
-        (SB (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SB (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SB (sA_Singletons_OrdDeriving_60 :: Sing a_Singletons_OrdDeriving_60)
+            (sA_Singletons_OrdDeriving_61 :: Sing a_Singletons_OrdDeriving_61)
+            (sA_Singletons_OrdDeriving_62 :: Sing a_Singletons_OrdDeriving_62)
+            (sA_Singletons_OrdDeriving_63 :: Sing a_Singletons_OrdDeriving_63))
+        (SB (sB_Singletons_OrdDeriving_64 :: Sing b_Singletons_OrdDeriving_64)
+            (sB_Singletons_OrdDeriving_65 :: Sing b_Singletons_OrdDeriving_65)
+            (sB_Singletons_OrdDeriving_66 :: Sing b_Singletons_OrdDeriving_66)
+            (sB_Singletons_OrdDeriving_67 :: Sing b_Singletons_OrdDeriving_67))
         = applySing
             (applySing
                (applySing (singFun3 @FoldlSym0 sFoldl) (singFun2 @(<>@#@$) (%<>)))
@@ -785,36 +794,40 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                (applySing
                   (singFun2 @(:@#@$) SCons)
                   (applySing
-                     (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                     sB_0123456789876543210))
+                     (applySing
+                        (singFun2 @CompareSym0 sCompare) sA_Singletons_OrdDeriving_60)
+                     sB_Singletons_OrdDeriving_64))
                (applySing
                   (applySing
                      (singFun2 @(:@#@$) SCons)
                      (applySing
-                        (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                        sB_0123456789876543210))
+                        (applySing
+                           (singFun2 @CompareSym0 sCompare) sA_Singletons_OrdDeriving_61)
+                        sB_Singletons_OrdDeriving_65))
                   (applySing
                      (applySing
                         (singFun2 @(:@#@$) SCons)
                         (applySing
-                           (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                           sB_0123456789876543210))
+                           (applySing
+                              (singFun2 @CompareSym0 sCompare) sA_Singletons_OrdDeriving_62)
+                           sB_Singletons_OrdDeriving_66))
                      (applySing
                         (applySing
                            (singFun2 @(:@#@$) SCons)
                            (applySing
-                              (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                              sB_0123456789876543210))
+                              (applySing
+                                 (singFun2 @CompareSym0 sCompare) sA_Singletons_OrdDeriving_63)
+                              sB_Singletons_OrdDeriving_67))
                         SNil))))
       sCompare
-        (SC (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SC (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SC (sA_Singletons_OrdDeriving_68 :: Sing a_Singletons_OrdDeriving_68)
+            (sA_Singletons_OrdDeriving_69 :: Sing a_Singletons_OrdDeriving_69)
+            (sA_Singletons_OrdDeriving_70 :: Sing a_Singletons_OrdDeriving_70)
+            (sA_Singletons_OrdDeriving_71 :: Sing a_Singletons_OrdDeriving_71))
+        (SC (sB_Singletons_OrdDeriving_72 :: Sing b_Singletons_OrdDeriving_72)
+            (sB_Singletons_OrdDeriving_73 :: Sing b_Singletons_OrdDeriving_73)
+            (sB_Singletons_OrdDeriving_74 :: Sing b_Singletons_OrdDeriving_74)
+            (sB_Singletons_OrdDeriving_75 :: Sing b_Singletons_OrdDeriving_75))
         = applySing
             (applySing
                (applySing (singFun3 @FoldlSym0 sFoldl) (singFun2 @(<>@#@$) (%<>)))
@@ -823,36 +836,40 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                (applySing
                   (singFun2 @(:@#@$) SCons)
                   (applySing
-                     (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                     sB_0123456789876543210))
+                     (applySing
+                        (singFun2 @CompareSym0 sCompare) sA_Singletons_OrdDeriving_68)
+                     sB_Singletons_OrdDeriving_72))
                (applySing
                   (applySing
                      (singFun2 @(:@#@$) SCons)
                      (applySing
-                        (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                        sB_0123456789876543210))
+                        (applySing
+                           (singFun2 @CompareSym0 sCompare) sA_Singletons_OrdDeriving_69)
+                        sB_Singletons_OrdDeriving_73))
                   (applySing
                      (applySing
                         (singFun2 @(:@#@$) SCons)
                         (applySing
-                           (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                           sB_0123456789876543210))
+                           (applySing
+                              (singFun2 @CompareSym0 sCompare) sA_Singletons_OrdDeriving_70)
+                           sB_Singletons_OrdDeriving_74))
                      (applySing
                         (applySing
                            (singFun2 @(:@#@$) SCons)
                            (applySing
-                              (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                              sB_0123456789876543210))
+                              (applySing
+                                 (singFun2 @CompareSym0 sCompare) sA_Singletons_OrdDeriving_71)
+                              sB_Singletons_OrdDeriving_75))
                         SNil))))
       sCompare
-        (SD (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SD (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SD (sA_Singletons_OrdDeriving_76 :: Sing a_Singletons_OrdDeriving_76)
+            (sA_Singletons_OrdDeriving_77 :: Sing a_Singletons_OrdDeriving_77)
+            (sA_Singletons_OrdDeriving_78 :: Sing a_Singletons_OrdDeriving_78)
+            (sA_Singletons_OrdDeriving_79 :: Sing a_Singletons_OrdDeriving_79))
+        (SD (sB_Singletons_OrdDeriving_80 :: Sing b_Singletons_OrdDeriving_80)
+            (sB_Singletons_OrdDeriving_81 :: Sing b_Singletons_OrdDeriving_81)
+            (sB_Singletons_OrdDeriving_82 :: Sing b_Singletons_OrdDeriving_82)
+            (sB_Singletons_OrdDeriving_83 :: Sing b_Singletons_OrdDeriving_83))
         = applySing
             (applySing
                (applySing (singFun3 @FoldlSym0 sFoldl) (singFun2 @(<>@#@$) (%<>)))
@@ -861,36 +878,40 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                (applySing
                   (singFun2 @(:@#@$) SCons)
                   (applySing
-                     (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                     sB_0123456789876543210))
+                     (applySing
+                        (singFun2 @CompareSym0 sCompare) sA_Singletons_OrdDeriving_76)
+                     sB_Singletons_OrdDeriving_80))
                (applySing
                   (applySing
                      (singFun2 @(:@#@$) SCons)
                      (applySing
-                        (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                        sB_0123456789876543210))
+                        (applySing
+                           (singFun2 @CompareSym0 sCompare) sA_Singletons_OrdDeriving_77)
+                        sB_Singletons_OrdDeriving_81))
                   (applySing
                      (applySing
                         (singFun2 @(:@#@$) SCons)
                         (applySing
-                           (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                           sB_0123456789876543210))
+                           (applySing
+                              (singFun2 @CompareSym0 sCompare) sA_Singletons_OrdDeriving_78)
+                           sB_Singletons_OrdDeriving_82))
                      (applySing
                         (applySing
                            (singFun2 @(:@#@$) SCons)
                            (applySing
-                              (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                              sB_0123456789876543210))
+                              (applySing
+                                 (singFun2 @CompareSym0 sCompare) sA_Singletons_OrdDeriving_79)
+                              sB_Singletons_OrdDeriving_83))
                         SNil))))
       sCompare
-        (SE (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SE (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SE (sA_Singletons_OrdDeriving_84 :: Sing a_Singletons_OrdDeriving_84)
+            (sA_Singletons_OrdDeriving_85 :: Sing a_Singletons_OrdDeriving_85)
+            (sA_Singletons_OrdDeriving_86 :: Sing a_Singletons_OrdDeriving_86)
+            (sA_Singletons_OrdDeriving_87 :: Sing a_Singletons_OrdDeriving_87))
+        (SE (sB_Singletons_OrdDeriving_88 :: Sing b_Singletons_OrdDeriving_88)
+            (sB_Singletons_OrdDeriving_89 :: Sing b_Singletons_OrdDeriving_89)
+            (sB_Singletons_OrdDeriving_90 :: Sing b_Singletons_OrdDeriving_90)
+            (sB_Singletons_OrdDeriving_91 :: Sing b_Singletons_OrdDeriving_91))
         = applySing
             (applySing
                (applySing (singFun3 @FoldlSym0 sFoldl) (singFun2 @(<>@#@$) (%<>)))
@@ -899,36 +920,40 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                (applySing
                   (singFun2 @(:@#@$) SCons)
                   (applySing
-                     (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                     sB_0123456789876543210))
+                     (applySing
+                        (singFun2 @CompareSym0 sCompare) sA_Singletons_OrdDeriving_84)
+                     sB_Singletons_OrdDeriving_88))
                (applySing
                   (applySing
                      (singFun2 @(:@#@$) SCons)
                      (applySing
-                        (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                        sB_0123456789876543210))
+                        (applySing
+                           (singFun2 @CompareSym0 sCompare) sA_Singletons_OrdDeriving_85)
+                        sB_Singletons_OrdDeriving_89))
                   (applySing
                      (applySing
                         (singFun2 @(:@#@$) SCons)
                         (applySing
-                           (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                           sB_0123456789876543210))
+                           (applySing
+                              (singFun2 @CompareSym0 sCompare) sA_Singletons_OrdDeriving_86)
+                           sB_Singletons_OrdDeriving_90))
                      (applySing
                         (applySing
                            (singFun2 @(:@#@$) SCons)
                            (applySing
-                              (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                              sB_0123456789876543210))
+                              (applySing
+                                 (singFun2 @CompareSym0 sCompare) sA_Singletons_OrdDeriving_87)
+                              sB_Singletons_OrdDeriving_91))
                         SNil))))
       sCompare
-        (SF (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210)
-            (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SF (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210)
-            (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SF (sA_Singletons_OrdDeriving_92 :: Sing a_Singletons_OrdDeriving_92)
+            (sA_Singletons_OrdDeriving_93 :: Sing a_Singletons_OrdDeriving_93)
+            (sA_Singletons_OrdDeriving_94 :: Sing a_Singletons_OrdDeriving_94)
+            (sA_Singletons_OrdDeriving_95 :: Sing a_Singletons_OrdDeriving_95))
+        (SF (sB_Singletons_OrdDeriving_96 :: Sing b_Singletons_OrdDeriving_96)
+            (sB_Singletons_OrdDeriving_97 :: Sing b_Singletons_OrdDeriving_97)
+            (sB_Singletons_OrdDeriving_98 :: Sing b_Singletons_OrdDeriving_98)
+            (sB_Singletons_OrdDeriving_99 :: Sing b_Singletons_OrdDeriving_99))
         = applySing
             (applySing
                (applySing (singFun3 @FoldlSym0 sFoldl) (singFun2 @(<>@#@$) (%<>)))
@@ -937,26 +962,30 @@ Singletons/OrdDeriving.hs:(0,0)-(0,0): Splicing declarations
                (applySing
                   (singFun2 @(:@#@$) SCons)
                   (applySing
-                     (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                     sB_0123456789876543210))
+                     (applySing
+                        (singFun2 @CompareSym0 sCompare) sA_Singletons_OrdDeriving_92)
+                     sB_Singletons_OrdDeriving_96))
                (applySing
                   (applySing
                      (singFun2 @(:@#@$) SCons)
                      (applySing
-                        (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                        sB_0123456789876543210))
+                        (applySing
+                           (singFun2 @CompareSym0 sCompare) sA_Singletons_OrdDeriving_93)
+                        sB_Singletons_OrdDeriving_97))
                   (applySing
                      (applySing
                         (singFun2 @(:@#@$) SCons)
                         (applySing
-                           (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                           sB_0123456789876543210))
+                           (applySing
+                              (singFun2 @CompareSym0 sCompare) sA_Singletons_OrdDeriving_94)
+                           sB_Singletons_OrdDeriving_98))
                      (applySing
                         (applySing
                            (singFun2 @(:@#@$) SCons)
                            (applySing
-                              (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                              sB_0123456789876543210))
+                              (applySing
+                                 (singFun2 @CompareSym0 sCompare) sA_Singletons_OrdDeriving_95)
+                              sB_Singletons_OrdDeriving_99))
                         SNil))))
       sCompare (SA _ _ _ _) (SB _ _ _ _) = SLT
       sCompare (SA _ _ _ _) (SC _ _ _ _) = SLT

--- a/singletons-base/tests/compile-and-dump/Singletons/OverloadedStrings.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/OverloadedStrings.golden
@@ -16,13 +16,13 @@ Singletons/OverloadedStrings.hs:(0,0)-(0,0): Splicing declarations
     data SymIdSym0 :: (~>) Symbol Symbol
       where
         SymIdSym0KindInference :: SameKind (Apply SymIdSym0 arg) (SymIdSym1 arg) =>
-                                  SymIdSym0 a0123456789876543210
-    type instance Apply @Symbol @Symbol SymIdSym0 a0123456789876543210 = SymId a0123456789876543210
+                                  SymIdSym0 a_OverloadedStrings_0
+    type instance Apply @Symbol @Symbol SymIdSym0 a_OverloadedStrings_0 = SymId a_OverloadedStrings_0
     instance SuppressUnusedWarnings SymIdSym0 where
       suppressUnusedWarnings = snd ((,) SymIdSym0KindInference ())
     type SymIdSym1 :: Symbol -> Symbol
-    type family SymIdSym1 (a0123456789876543210 :: Symbol) :: Symbol where
-      SymIdSym1 a0123456789876543210 = SymId a0123456789876543210
+    type family SymIdSym1 (a_OverloadedStrings_0 :: Symbol) :: Symbol where
+      SymIdSym1 a_OverloadedStrings_0 = SymId a_OverloadedStrings_0
     type Foo :: Symbol
     type family Foo :: Symbol where
       Foo = Apply SymIdSym0 (FromString "foo")

--- a/singletons-base/tests/compile-and-dump/Singletons/PatternMatching.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/PatternMatching.golden
@@ -20,21 +20,21 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     data PairSym0 :: (~>) a ((~>) b (Pair a b))
       where
         PairSym0KindInference :: SameKind (Apply PairSym0 arg) (PairSym1 arg) =>
-                                 PairSym0 a0123456789876543210
-    type instance Apply @a @((~>) b (Pair a b)) PairSym0 a0123456789876543210 = PairSym1 a0123456789876543210
+                                 PairSym0 a_Singletons_PatternMatching_3
+    type instance Apply @a @((~>) b (Pair a b)) PairSym0 a_Singletons_PatternMatching_3 = PairSym1 a_Singletons_PatternMatching_3
     instance SuppressUnusedWarnings PairSym0 where
       suppressUnusedWarnings = snd ((,) PairSym0KindInference ())
     type PairSym1 :: forall a b. a -> (~>) b (Pair a b)
-    data PairSym1 (a0123456789876543210 :: a) :: (~>) b (Pair a b)
+    data PairSym1 (a_Singletons_PatternMatching_3 :: a) :: (~>) b (Pair a b)
       where
-        PairSym1KindInference :: SameKind (Apply (PairSym1 a0123456789876543210) arg) (PairSym2 a0123456789876543210 arg) =>
-                                 PairSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @(Pair a b) (PairSym1 a0123456789876543210) a0123456789876543210 = Pair a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (PairSym1 a0123456789876543210) where
+        PairSym1KindInference :: SameKind (Apply (PairSym1 a_Singletons_PatternMatching_3) arg) (PairSym2 a_Singletons_PatternMatching_3 arg) =>
+                                 PairSym1 a_Singletons_PatternMatching_3 a_Singletons_PatternMatching_4
+    type instance Apply @b @(Pair a b) (PairSym1 a_Singletons_PatternMatching_3) a_Singletons_PatternMatching_4 = Pair a_Singletons_PatternMatching_3 a_Singletons_PatternMatching_4
+    instance SuppressUnusedWarnings (PairSym1 a_Singletons_PatternMatching_3) where
       suppressUnusedWarnings = snd ((,) PairSym1KindInference ())
     type PairSym2 :: forall a b. a -> b -> Pair a b
-    type family PairSym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: Pair a b where
-      PairSym2 a0123456789876543210 a0123456789876543210 = Pair a0123456789876543210 a0123456789876543210
+    type family PairSym2 @a @b (a_Singletons_PatternMatching_3 :: a) (a_Singletons_PatternMatching_4 :: b) :: Pair a b where
+      PairSym2 a_Singletons_PatternMatching_3 a_Singletons_PatternMatching_4 = Pair a_Singletons_PatternMatching_3 a_Singletons_PatternMatching_4
     type family AListSym0 where
       AListSym0 = AList
     type family TupleSym0 where
@@ -51,13 +51,13 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
       Complex = Apply (Apply PairSym0 (Apply (Apply PairSym0 (Apply JustSym0 ZeroSym0)) ZeroSym0)) FalseSym0
     type family Pr where
       Pr = Apply (Apply PairSym0 (Apply SuccSym0 ZeroSym0)) (Apply (Apply (:@#@$) ZeroSym0) NilSym0)
-    type ShowsPrec_0123456789876543210 :: forall a
-                                                 b. GHC.Internal.Bignum.Natural.Natural
-                                                    -> Pair a b -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210 @a @b (a :: GHC.Internal.Bignum.Natural.Natural) (a :: Pair a b) (a :: Symbol) :: Symbol where
-      ShowsPrec_0123456789876543210 @a @b (p_0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) (Pair arg_0123456789876543210 arg_0123456789876543210 :: Pair a b) (a_0123456789876543210 :: Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Pair ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
+    type ShowsPrec_Singletons_PatternMatching_5 :: forall a
+                                                          b. GHC.Internal.Bignum.Natural.Natural
+                                                             -> Pair a b -> Symbol -> Symbol
+    type family ShowsPrec_Singletons_PatternMatching_5 @a @b (a :: GHC.Internal.Bignum.Natural.Natural) (a :: Pair a b) (a :: Symbol) :: Symbol where
+      ShowsPrec_Singletons_PatternMatching_5 @a @b (p_Singletons_PatternMatching_0 :: GHC.Internal.Bignum.Natural.Natural) (Pair arg_Singletons_PatternMatching_1 arg_Singletons_PatternMatching_2 :: Pair a b) (a_Singletons_PatternMatching_6 :: Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_Singletons_PatternMatching_0) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Pair ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_Singletons_PatternMatching_1)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_Singletons_PatternMatching_2))))) a_Singletons_PatternMatching_6
     instance PShow (Pair a b) where
-      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
+      type ShowsPrec a a a = ShowsPrec_Singletons_PatternMatching_5 a a a
     sAList :: Sing @_ AList
     sTuple :: Sing @_ Tuple
     sComplex :: Sing @_ Complex
@@ -111,16 +111,17 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
             (toSing b :: SomeSing a) (toSing b :: SomeSing b)
     instance (SShow a, SShow b) => SShow (Pair a b) where
       sShowsPrec
-        (sP_0123456789876543210 :: Sing p_0123456789876543210)
-        (SPair (sArg_0123456789876543210 :: Sing arg_0123456789876543210)
-               (sArg_0123456789876543210 :: Sing arg_0123456789876543210))
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sP_Singletons_PatternMatching_0 :: Sing p_Singletons_PatternMatching_0)
+        (SPair (sArg_Singletons_PatternMatching_1 :: Sing arg_Singletons_PatternMatching_1)
+               (sArg_Singletons_PatternMatching_2 :: Sing arg_Singletons_PatternMatching_2))
+        (sA_Singletons_PatternMatching_6 :: Sing a_Singletons_PatternMatching_6)
         = applySing
             (applySing
                (applySing
                   (singFun3 @ShowParenSym0 sShowParen)
                   (applySing
-                     (applySing (singFun2 @(>@#@$) (%>)) sP_0123456789876543210)
+                     (applySing
+                        (singFun2 @(>@#@$) (%>)) sP_Singletons_PatternMatching_0)
                      (sFromInteger (sing :: Sing 10))))
                (applySing
                   (applySing
@@ -134,7 +135,7 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
                            (applySing
                               (singFun3 @ShowsPrecSym0 sShowsPrec)
                               (sFromInteger (sing :: Sing 11)))
-                           sArg_0123456789876543210))
+                           sArg_Singletons_PatternMatching_1))
                      (applySing
                         (applySing
                            (singFun3 @(.@#@$) (%.)) (singFun1 @ShowSpaceSym0 sShowSpace))
@@ -142,8 +143,8 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
                            (applySing
                               (singFun3 @ShowsPrecSym0 sShowsPrec)
                               (sFromInteger (sing :: Sing 11)))
-                           sArg_0123456789876543210)))))
-            sA_0123456789876543210
+                           sArg_Singletons_PatternMatching_2)))))
+            sA_Singletons_PatternMatching_6
     deriving instance (Data.Singletons.ShowSing.ShowSing a,
                        Data.Singletons.ShowSing.ShowSing b) =>
                       Show (SPair (z :: Pair a b))
@@ -188,241 +189,255 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
     foo2 t@(# x, y #) = case t of (# a, b #) -> (\ _ -> a) b
     silly :: a -> ()
     silly x = case x of _ -> ()
-    type family LamCases_0123456789876543210 (x0123456789876543210 :: a0123456789876543210) a_0123456789876543210 where
-      LamCases_0123456789876543210 x _ = Tuple0Sym0
-    data LamCases_0123456789876543210Sym0 (x0123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210
+    type family LamCases_Singletons_PatternMatching_25 (x1 :: a0) a_Singletons_PatternMatching_26 where
+      LamCases_Singletons_PatternMatching_25 x _ = Tuple0Sym0
+    data LamCases_Singletons_PatternMatching_25Sym0 (x1 :: a0) a_Singletons_PatternMatching_26
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210) where
+        LamCases_Singletons_PatternMatching_25Sym0KindInference :: SameKind (Apply (LamCases_Singletons_PatternMatching_25Sym0 x1) arg) (LamCases_Singletons_PatternMatching_25Sym1 x1 arg) =>
+                                                                   LamCases_Singletons_PatternMatching_25Sym0 x1 a_Singletons_PatternMatching_26
+    type instance Apply @_ @_ (LamCases_Singletons_PatternMatching_25Sym0 x1) a_Singletons_PatternMatching_26 = LamCases_Singletons_PatternMatching_25 x1 a_Singletons_PatternMatching_26
+    instance SuppressUnusedWarnings (LamCases_Singletons_PatternMatching_25Sym0 x1) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (x0123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 x0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    type family Let0123456789876543210TSym0 x0123456789876543210 y0123456789876543210 where
-      Let0123456789876543210TSym0 x0123456789876543210 y0123456789876543210 = Let0123456789876543210T x0123456789876543210 y0123456789876543210
-    type family Let0123456789876543210T x0123456789876543210 y0123456789876543210 where
-      Let0123456789876543210T x y = Apply (Apply Tuple2Sym0 x) y
-    type family LamCases_0123456789876543210 a0123456789876543210 b0123456789876543210 x0123456789876543210 y0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 a b x y _ = a
-    data LamCases_0123456789876543210Sym0 a0123456789876543210 b0123456789876543210 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
+        = snd
+            ((,) LamCases_Singletons_PatternMatching_25Sym0KindInference ())
+    type family LamCases_Singletons_PatternMatching_25Sym1 (x1 :: a0) a_Singletons_PatternMatching_26 where
+      LamCases_Singletons_PatternMatching_25Sym1 x1 a_Singletons_PatternMatching_26 = LamCases_Singletons_PatternMatching_25 x1 a_Singletons_PatternMatching_26
+    type family Let28TSym0 x0 y1 where
+      Let28TSym0 x0 y1 = Let28T x0 y1
+    type family Let28T x0 y1 where
+      Let28T x y = Apply (Apply Tuple2Sym0 x) y
+    type family LamCases_Singletons_PatternMatching_30 a0 b1 x2 y3 a_Singletons_PatternMatching_31 where
+      LamCases_Singletons_PatternMatching_30 a b x y _ = a
+    data LamCases_Singletons_PatternMatching_30Sym0 a0 b1 x2 y3 a_Singletons_PatternMatching_31
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 a0123456789876543210 b0123456789876543210 x0123456789876543210 y0123456789876543210) arg) (LamCases_0123456789876543210Sym1 a0123456789876543210 b0123456789876543210 x0123456789876543210 y0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a0123456789876543210 b0123456789876543210 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 a0123456789876543210 b0123456789876543210 x0123456789876543210 y0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a0123456789876543210 b0123456789876543210 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 a0123456789876543210 b0123456789876543210 x0123456789876543210 y0123456789876543210) where
+        LamCases_Singletons_PatternMatching_30Sym0KindInference :: SameKind (Apply (LamCases_Singletons_PatternMatching_30Sym0 a0 b1 x2 y3) arg) (LamCases_Singletons_PatternMatching_30Sym1 a0 b1 x2 y3 arg) =>
+                                                                   LamCases_Singletons_PatternMatching_30Sym0 a0 b1 x2 y3 a_Singletons_PatternMatching_31
+    type instance Apply @_ @_ (LamCases_Singletons_PatternMatching_30Sym0 a0 b1 x2 y3) a_Singletons_PatternMatching_31 = LamCases_Singletons_PatternMatching_30 a0 b1 x2 y3 a_Singletons_PatternMatching_31
+    instance SuppressUnusedWarnings (LamCases_Singletons_PatternMatching_30Sym0 a0 b1 x2 y3) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 a0123456789876543210 b0123456789876543210 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a0123456789876543210 b0123456789876543210 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a0123456789876543210 b0123456789876543210 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 x0123456789876543210 y0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 x y '(a,
-                                         b) = Apply (LamCases_0123456789876543210Sym0 a b x y) b
-    data LamCases_0123456789876543210Sym0 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
+        = snd
+            ((,) LamCases_Singletons_PatternMatching_30Sym0KindInference ())
+    type family LamCases_Singletons_PatternMatching_30Sym1 a0 b1 x2 y3 a_Singletons_PatternMatching_31 where
+      LamCases_Singletons_PatternMatching_30Sym1 a0 b1 x2 y3 a_Singletons_PatternMatching_31 = LamCases_Singletons_PatternMatching_30 a0 b1 x2 y3 a_Singletons_PatternMatching_31
+    type family LamCases_Singletons_PatternMatching_29 x0 y1 a_Singletons_PatternMatching_32 where
+      LamCases_Singletons_PatternMatching_29 x y '(a,
+                                                   b) = Apply (LamCases_Singletons_PatternMatching_30Sym0 a b x y) b
+    data LamCases_Singletons_PatternMatching_29Sym0 x0 y1 a_Singletons_PatternMatching_32
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210 y0123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210 y0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210 y0123456789876543210) where
+        LamCases_Singletons_PatternMatching_29Sym0KindInference :: SameKind (Apply (LamCases_Singletons_PatternMatching_29Sym0 x0 y1) arg) (LamCases_Singletons_PatternMatching_29Sym1 x0 y1 arg) =>
+                                                                   LamCases_Singletons_PatternMatching_29Sym0 x0 y1 a_Singletons_PatternMatching_32
+    type instance Apply @_ @_ (LamCases_Singletons_PatternMatching_29Sym0 x0 y1) a_Singletons_PatternMatching_32 = LamCases_Singletons_PatternMatching_29 x0 y1 a_Singletons_PatternMatching_32
+    instance SuppressUnusedWarnings (LamCases_Singletons_PatternMatching_29Sym0 x0 y1) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 x0123456789876543210 y0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 x y _ = x
-    data LamCases_0123456789876543210Sym0 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
+        = snd
+            ((,) LamCases_Singletons_PatternMatching_29Sym0KindInference ())
+    type family LamCases_Singletons_PatternMatching_29Sym1 x0 y1 a_Singletons_PatternMatching_32 where
+      LamCases_Singletons_PatternMatching_29Sym1 x0 y1 a_Singletons_PatternMatching_32 = LamCases_Singletons_PatternMatching_29 x0 y1 a_Singletons_PatternMatching_32
+    type family LamCases_Singletons_PatternMatching_34 x0 y1 a_Singletons_PatternMatching_35 where
+      LamCases_Singletons_PatternMatching_34 x y _ = x
+    data LamCases_Singletons_PatternMatching_34Sym0 x0 y1 a_Singletons_PatternMatching_35
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210 y0123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210 y0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210 y0123456789876543210) where
+        LamCases_Singletons_PatternMatching_34Sym0KindInference :: SameKind (Apply (LamCases_Singletons_PatternMatching_34Sym0 x0 y1) arg) (LamCases_Singletons_PatternMatching_34Sym1 x0 y1 arg) =>
+                                                                   LamCases_Singletons_PatternMatching_34Sym0 x0 y1 a_Singletons_PatternMatching_35
+    type instance Apply @_ @_ (LamCases_Singletons_PatternMatching_34Sym0 x0 y1) a_Singletons_PatternMatching_35 = LamCases_Singletons_PatternMatching_34 x0 y1 a_Singletons_PatternMatching_35
+    instance SuppressUnusedWarnings (LamCases_Singletons_PatternMatching_34Sym0 x0 y1) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 '[_,
-                                     _,
-                                     'Succ y_0123456789876543210] = y_0123456789876543210
-    data LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
+        = snd
+            ((,) LamCases_Singletons_PatternMatching_34Sym0KindInference ())
+    type family LamCases_Singletons_PatternMatching_34Sym1 x0 y1 a_Singletons_PatternMatching_35 where
+      LamCases_Singletons_PatternMatching_34Sym1 x0 y1 a_Singletons_PatternMatching_35 = LamCases_Singletons_PatternMatching_34 x0 y1 a_Singletons_PatternMatching_35
+    type family LamCases_Singletons_PatternMatching_36 a_Singletons_PatternMatching_37 where
+      LamCases_Singletons_PatternMatching_36 '[_,
+                                               _,
+                                               'Succ y_Singletons_PatternMatching_23] = y_Singletons_PatternMatching_23
+    data LamCases_Singletons_PatternMatching_36Sym0 a_Singletons_PatternMatching_37
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply LamCases_0123456789876543210Sym0 arg) (LamCases_0123456789876543210Sym1 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings LamCases_0123456789876543210Sym0 where
+        LamCases_Singletons_PatternMatching_36Sym0KindInference :: SameKind (Apply LamCases_Singletons_PatternMatching_36Sym0 arg) (LamCases_Singletons_PatternMatching_36Sym1 arg) =>
+                                                                   LamCases_Singletons_PatternMatching_36Sym0 a_Singletons_PatternMatching_37
+    type instance Apply @_ @_ LamCases_Singletons_PatternMatching_36Sym0 a_Singletons_PatternMatching_37 = LamCases_Singletons_PatternMatching_36 a_Singletons_PatternMatching_37
+    instance SuppressUnusedWarnings LamCases_Singletons_PatternMatching_36Sym0 where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 '[_,
-                                     y_0123456789876543210,
-                                     'Succ _] = y_0123456789876543210
-    data LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
+        = snd
+            ((,) LamCases_Singletons_PatternMatching_36Sym0KindInference ())
+    type family LamCases_Singletons_PatternMatching_36Sym1 a_Singletons_PatternMatching_37 where
+      LamCases_Singletons_PatternMatching_36Sym1 a_Singletons_PatternMatching_37 = LamCases_Singletons_PatternMatching_36 a_Singletons_PatternMatching_37
+    type family LamCases_Singletons_PatternMatching_38 a_Singletons_PatternMatching_39 where
+      LamCases_Singletons_PatternMatching_38 '[_,
+                                               y_Singletons_PatternMatching_22,
+                                               'Succ _] = y_Singletons_PatternMatching_22
+    data LamCases_Singletons_PatternMatching_38Sym0 a_Singletons_PatternMatching_39
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply LamCases_0123456789876543210Sym0 arg) (LamCases_0123456789876543210Sym1 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings LamCases_0123456789876543210Sym0 where
+        LamCases_Singletons_PatternMatching_38Sym0KindInference :: SameKind (Apply LamCases_Singletons_PatternMatching_38Sym0 arg) (LamCases_Singletons_PatternMatching_38Sym1 arg) =>
+                                                                   LamCases_Singletons_PatternMatching_38Sym0 a_Singletons_PatternMatching_39
+    type instance Apply @_ @_ LamCases_Singletons_PatternMatching_38Sym0 a_Singletons_PatternMatching_39 = LamCases_Singletons_PatternMatching_38 a_Singletons_PatternMatching_39
+    instance SuppressUnusedWarnings LamCases_Singletons_PatternMatching_38Sym0 where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 '(_,
-                                     _,
-                                     y_0123456789876543210) = y_0123456789876543210
-    data LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
+        = snd
+            ((,) LamCases_Singletons_PatternMatching_38Sym0KindInference ())
+    type family LamCases_Singletons_PatternMatching_38Sym1 a_Singletons_PatternMatching_39 where
+      LamCases_Singletons_PatternMatching_38Sym1 a_Singletons_PatternMatching_39 = LamCases_Singletons_PatternMatching_38 a_Singletons_PatternMatching_39
+    type family LamCases_Singletons_PatternMatching_40 a_Singletons_PatternMatching_41 where
+      LamCases_Singletons_PatternMatching_40 '(_,
+                                               _,
+                                               y_Singletons_PatternMatching_20) = y_Singletons_PatternMatching_20
+    data LamCases_Singletons_PatternMatching_40Sym0 a_Singletons_PatternMatching_41
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply LamCases_0123456789876543210Sym0 arg) (LamCases_0123456789876543210Sym1 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings LamCases_0123456789876543210Sym0 where
+        LamCases_Singletons_PatternMatching_40Sym0KindInference :: SameKind (Apply LamCases_Singletons_PatternMatching_40Sym0 arg) (LamCases_Singletons_PatternMatching_40Sym1 arg) =>
+                                                                   LamCases_Singletons_PatternMatching_40Sym0 a_Singletons_PatternMatching_41
+    type instance Apply @_ @_ LamCases_Singletons_PatternMatching_40Sym0 a_Singletons_PatternMatching_41 = LamCases_Singletons_PatternMatching_40 a_Singletons_PatternMatching_41
+    instance SuppressUnusedWarnings LamCases_Singletons_PatternMatching_40Sym0 where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 '(_,
-                                     y_0123456789876543210,
-                                     _) = y_0123456789876543210
-    data LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
+        = snd
+            ((,) LamCases_Singletons_PatternMatching_40Sym0KindInference ())
+    type family LamCases_Singletons_PatternMatching_40Sym1 a_Singletons_PatternMatching_41 where
+      LamCases_Singletons_PatternMatching_40Sym1 a_Singletons_PatternMatching_41 = LamCases_Singletons_PatternMatching_40 a_Singletons_PatternMatching_41
+    type family LamCases_Singletons_PatternMatching_42 a_Singletons_PatternMatching_43 where
+      LamCases_Singletons_PatternMatching_42 '(_,
+                                               y_Singletons_PatternMatching_19,
+                                               _) = y_Singletons_PatternMatching_19
+    data LamCases_Singletons_PatternMatching_42Sym0 a_Singletons_PatternMatching_43
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply LamCases_0123456789876543210Sym0 arg) (LamCases_0123456789876543210Sym1 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings LamCases_0123456789876543210Sym0 where
+        LamCases_Singletons_PatternMatching_42Sym0KindInference :: SameKind (Apply LamCases_Singletons_PatternMatching_42Sym0 arg) (LamCases_Singletons_PatternMatching_42Sym1 arg) =>
+                                                                   LamCases_Singletons_PatternMatching_42Sym0 a_Singletons_PatternMatching_43
+    type instance Apply @_ @_ LamCases_Singletons_PatternMatching_42Sym0 a_Singletons_PatternMatching_43 = LamCases_Singletons_PatternMatching_42 a_Singletons_PatternMatching_43
+    instance SuppressUnusedWarnings LamCases_Singletons_PatternMatching_42Sym0 where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 '(y_0123456789876543210,
-                                     _,
-                                     _) = y_0123456789876543210
-    data LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
+        = snd
+            ((,) LamCases_Singletons_PatternMatching_42Sym0KindInference ())
+    type family LamCases_Singletons_PatternMatching_42Sym1 a_Singletons_PatternMatching_43 where
+      LamCases_Singletons_PatternMatching_42Sym1 a_Singletons_PatternMatching_43 = LamCases_Singletons_PatternMatching_42 a_Singletons_PatternMatching_43
+    type family LamCases_Singletons_PatternMatching_44 a_Singletons_PatternMatching_45 where
+      LamCases_Singletons_PatternMatching_44 '(y_Singletons_PatternMatching_18,
+                                               _,
+                                               _) = y_Singletons_PatternMatching_18
+    data LamCases_Singletons_PatternMatching_44Sym0 a_Singletons_PatternMatching_45
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply LamCases_0123456789876543210Sym0 arg) (LamCases_0123456789876543210Sym1 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings LamCases_0123456789876543210Sym0 where
+        LamCases_Singletons_PatternMatching_44Sym0KindInference :: SameKind (Apply LamCases_Singletons_PatternMatching_44Sym0 arg) (LamCases_Singletons_PatternMatching_44Sym1 arg) =>
+                                                                   LamCases_Singletons_PatternMatching_44Sym0 a_Singletons_PatternMatching_45
+    type instance Apply @_ @_ LamCases_Singletons_PatternMatching_44Sym0 a_Singletons_PatternMatching_45 = LamCases_Singletons_PatternMatching_44 a_Singletons_PatternMatching_45
+    instance SuppressUnusedWarnings LamCases_Singletons_PatternMatching_44Sym0 where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 ('Pair ('Pair _ _) y_0123456789876543210) = y_0123456789876543210
-    data LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
+        = snd
+            ((,) LamCases_Singletons_PatternMatching_44Sym0KindInference ())
+    type family LamCases_Singletons_PatternMatching_44Sym1 a_Singletons_PatternMatching_45 where
+      LamCases_Singletons_PatternMatching_44Sym1 a_Singletons_PatternMatching_45 = LamCases_Singletons_PatternMatching_44 a_Singletons_PatternMatching_45
+    type family LamCases_Singletons_PatternMatching_46 a_Singletons_PatternMatching_47 where
+      LamCases_Singletons_PatternMatching_46 ('Pair ('Pair _ _) y_Singletons_PatternMatching_16) = y_Singletons_PatternMatching_16
+    data LamCases_Singletons_PatternMatching_46Sym0 a_Singletons_PatternMatching_47
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply LamCases_0123456789876543210Sym0 arg) (LamCases_0123456789876543210Sym1 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings LamCases_0123456789876543210Sym0 where
+        LamCases_Singletons_PatternMatching_46Sym0KindInference :: SameKind (Apply LamCases_Singletons_PatternMatching_46Sym0 arg) (LamCases_Singletons_PatternMatching_46Sym1 arg) =>
+                                                                   LamCases_Singletons_PatternMatching_46Sym0 a_Singletons_PatternMatching_47
+    type instance Apply @_ @_ LamCases_Singletons_PatternMatching_46Sym0 a_Singletons_PatternMatching_47 = LamCases_Singletons_PatternMatching_46 a_Singletons_PatternMatching_47
+    instance SuppressUnusedWarnings LamCases_Singletons_PatternMatching_46Sym0 where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 ('Pair ('Pair _ y_0123456789876543210) _) = y_0123456789876543210
-    data LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
+        = snd
+            ((,) LamCases_Singletons_PatternMatching_46Sym0KindInference ())
+    type family LamCases_Singletons_PatternMatching_46Sym1 a_Singletons_PatternMatching_47 where
+      LamCases_Singletons_PatternMatching_46Sym1 a_Singletons_PatternMatching_47 = LamCases_Singletons_PatternMatching_46 a_Singletons_PatternMatching_47
+    type family LamCases_Singletons_PatternMatching_48 a_Singletons_PatternMatching_49 where
+      LamCases_Singletons_PatternMatching_48 ('Pair ('Pair _ y_Singletons_PatternMatching_15) _) = y_Singletons_PatternMatching_15
+    data LamCases_Singletons_PatternMatching_48Sym0 a_Singletons_PatternMatching_49
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply LamCases_0123456789876543210Sym0 arg) (LamCases_0123456789876543210Sym1 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings LamCases_0123456789876543210Sym0 where
+        LamCases_Singletons_PatternMatching_48Sym0KindInference :: SameKind (Apply LamCases_Singletons_PatternMatching_48Sym0 arg) (LamCases_Singletons_PatternMatching_48Sym1 arg) =>
+                                                                   LamCases_Singletons_PatternMatching_48Sym0 a_Singletons_PatternMatching_49
+    type instance Apply @_ @_ LamCases_Singletons_PatternMatching_48Sym0 a_Singletons_PatternMatching_49 = LamCases_Singletons_PatternMatching_48 a_Singletons_PatternMatching_49
+    instance SuppressUnusedWarnings LamCases_Singletons_PatternMatching_48Sym0 where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 ('Pair ('Pair y_0123456789876543210 _) _) = y_0123456789876543210
-    data LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
+        = snd
+            ((,) LamCases_Singletons_PatternMatching_48Sym0KindInference ())
+    type family LamCases_Singletons_PatternMatching_48Sym1 a_Singletons_PatternMatching_49 where
+      LamCases_Singletons_PatternMatching_48Sym1 a_Singletons_PatternMatching_49 = LamCases_Singletons_PatternMatching_48 a_Singletons_PatternMatching_49
+    type family LamCases_Singletons_PatternMatching_50 a_Singletons_PatternMatching_51 where
+      LamCases_Singletons_PatternMatching_50 ('Pair ('Pair y_Singletons_PatternMatching_14 _) _) = y_Singletons_PatternMatching_14
+    data LamCases_Singletons_PatternMatching_50Sym0 a_Singletons_PatternMatching_51
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply LamCases_0123456789876543210Sym0 arg) (LamCases_0123456789876543210Sym1 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings LamCases_0123456789876543210Sym0 where
+        LamCases_Singletons_PatternMatching_50Sym0KindInference :: SameKind (Apply LamCases_Singletons_PatternMatching_50Sym0 arg) (LamCases_Singletons_PatternMatching_50Sym1 arg) =>
+                                                                   LamCases_Singletons_PatternMatching_50Sym0 a_Singletons_PatternMatching_51
+    type instance Apply @_ @_ LamCases_Singletons_PatternMatching_50Sym0 a_Singletons_PatternMatching_51 = LamCases_Singletons_PatternMatching_50 a_Singletons_PatternMatching_51
+    instance SuppressUnusedWarnings LamCases_Singletons_PatternMatching_50Sym0 where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 ('Pair _ y_0123456789876543210) = y_0123456789876543210
-    data LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
+        = snd
+            ((,) LamCases_Singletons_PatternMatching_50Sym0KindInference ())
+    type family LamCases_Singletons_PatternMatching_50Sym1 a_Singletons_PatternMatching_51 where
+      LamCases_Singletons_PatternMatching_50Sym1 a_Singletons_PatternMatching_51 = LamCases_Singletons_PatternMatching_50 a_Singletons_PatternMatching_51
+    type family LamCases_Singletons_PatternMatching_52 a_Singletons_PatternMatching_53 where
+      LamCases_Singletons_PatternMatching_52 ('Pair _ y_Singletons_PatternMatching_12) = y_Singletons_PatternMatching_12
+    data LamCases_Singletons_PatternMatching_52Sym0 a_Singletons_PatternMatching_53
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply LamCases_0123456789876543210Sym0 arg) (LamCases_0123456789876543210Sym1 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings LamCases_0123456789876543210Sym0 where
+        LamCases_Singletons_PatternMatching_52Sym0KindInference :: SameKind (Apply LamCases_Singletons_PatternMatching_52Sym0 arg) (LamCases_Singletons_PatternMatching_52Sym1 arg) =>
+                                                                   LamCases_Singletons_PatternMatching_52Sym0 a_Singletons_PatternMatching_53
+    type instance Apply @_ @_ LamCases_Singletons_PatternMatching_52Sym0 a_Singletons_PatternMatching_53 = LamCases_Singletons_PatternMatching_52 a_Singletons_PatternMatching_53
+    instance SuppressUnusedWarnings LamCases_Singletons_PatternMatching_52Sym0 where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 ('Pair y_0123456789876543210 _) = y_0123456789876543210
-    data LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
+        = snd
+            ((,) LamCases_Singletons_PatternMatching_52Sym0KindInference ())
+    type family LamCases_Singletons_PatternMatching_52Sym1 a_Singletons_PatternMatching_53 where
+      LamCases_Singletons_PatternMatching_52Sym1 a_Singletons_PatternMatching_53 = LamCases_Singletons_PatternMatching_52 a_Singletons_PatternMatching_53
+    type family LamCases_Singletons_PatternMatching_54 a_Singletons_PatternMatching_55 where
+      LamCases_Singletons_PatternMatching_54 ('Pair y_Singletons_PatternMatching_11 _) = y_Singletons_PatternMatching_11
+    data LamCases_Singletons_PatternMatching_54Sym0 a_Singletons_PatternMatching_55
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply LamCases_0123456789876543210Sym0 arg) (LamCases_0123456789876543210Sym1 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings LamCases_0123456789876543210Sym0 where
+        LamCases_Singletons_PatternMatching_54Sym0KindInference :: SameKind (Apply LamCases_Singletons_PatternMatching_54Sym0 arg) (LamCases_Singletons_PatternMatching_54Sym1 arg) =>
+                                                                   LamCases_Singletons_PatternMatching_54Sym0 a_Singletons_PatternMatching_55
+    type instance Apply @_ @_ LamCases_Singletons_PatternMatching_54Sym0 a_Singletons_PatternMatching_55 = LamCases_Singletons_PatternMatching_54 a_Singletons_PatternMatching_55
+    instance SuppressUnusedWarnings LamCases_Singletons_PatternMatching_54Sym0 where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
+        = snd
+            ((,) LamCases_Singletons_PatternMatching_54Sym0KindInference ())
+    type family LamCases_Singletons_PatternMatching_54Sym1 a_Singletons_PatternMatching_55 where
+      LamCases_Singletons_PatternMatching_54Sym1 a_Singletons_PatternMatching_55 = LamCases_Singletons_PatternMatching_54 a_Singletons_PatternMatching_55
     type SillySym0 :: (~>) a ()
     data SillySym0 :: (~>) a ()
       where
         SillySym0KindInference :: SameKind (Apply SillySym0 arg) (SillySym1 arg) =>
-                                  SillySym0 a0123456789876543210
-    type instance Apply @a @() SillySym0 a0123456789876543210 = Silly a0123456789876543210
+                                  SillySym0 a_Singletons_PatternMatching_24
+    type instance Apply @a @() SillySym0 a_Singletons_PatternMatching_24 = Silly a_Singletons_PatternMatching_24
     instance SuppressUnusedWarnings SillySym0 where
       suppressUnusedWarnings = snd ((,) SillySym0KindInference ())
     type SillySym1 :: a -> ()
-    type family SillySym1 @a (a0123456789876543210 :: a) :: () where
-      SillySym1 a0123456789876543210 = Silly a0123456789876543210
+    type family SillySym1 @a (a_Singletons_PatternMatching_24 :: a) :: () where
+      SillySym1 a_Singletons_PatternMatching_24 = Silly a_Singletons_PatternMatching_24
     type Foo2Sym0 :: (~>) (a, b) a
     data Foo2Sym0 :: (~>) (a, b) a
       where
         Foo2Sym0KindInference :: SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) =>
-                                 Foo2Sym0 a0123456789876543210
+                                 Foo2Sym0 a_Singletons_PatternMatching_27
     type instance Apply @(a,
-                          b) @a Foo2Sym0 a0123456789876543210 = Foo2 a0123456789876543210
+                          b) @a Foo2Sym0 a_Singletons_PatternMatching_27 = Foo2 a_Singletons_PatternMatching_27
     instance SuppressUnusedWarnings Foo2Sym0 where
       suppressUnusedWarnings = snd ((,) Foo2Sym0KindInference ())
     type Foo2Sym1 :: (a, b) -> a
-    type family Foo2Sym1 @a @b (a0123456789876543210 :: (a,
-                                                         b)) :: a where
-      Foo2Sym1 a0123456789876543210 = Foo2 a0123456789876543210
+    type family Foo2Sym1 @a @b (a_Singletons_PatternMatching_27 :: (a,
+                                                                    b)) :: a where
+      Foo2Sym1 a_Singletons_PatternMatching_27 = Foo2 a_Singletons_PatternMatching_27
     type Foo1Sym0 :: (~>) (a, b) a
     data Foo1Sym0 :: (~>) (a, b) a
       where
         Foo1Sym0KindInference :: SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
-                                 Foo1Sym0 a0123456789876543210
+                                 Foo1Sym0 a_Singletons_PatternMatching_33
     type instance Apply @(a,
-                          b) @a Foo1Sym0 a0123456789876543210 = Foo1 a0123456789876543210
+                          b) @a Foo1Sym0 a_Singletons_PatternMatching_33 = Foo1 a_Singletons_PatternMatching_33
     instance SuppressUnusedWarnings Foo1Sym0 where
       suppressUnusedWarnings = snd ((,) Foo1Sym0KindInference ())
     type Foo1Sym1 :: (a, b) -> a
-    type family Foo1Sym1 @a @b (a0123456789876543210 :: (a,
-                                                         b)) :: a where
-      Foo1Sym1 a0123456789876543210 = Foo1 a0123456789876543210
+    type family Foo1Sym1 @a @b (a_Singletons_PatternMatching_33 :: (a,
+                                                                    b)) :: a where
+      Foo1Sym1 a_Singletons_PatternMatching_33 = Foo1 a_Singletons_PatternMatching_33
     type family BlimySym0 where
       BlimySym0 = Blimy
     type LszSym0 :: Nat
     type family LszSym0 :: Nat where
       LszSym0 = Lsz
-    type family X_0123456789876543210Sym0 where
-      X_0123456789876543210Sym0 = X_0123456789876543210
+    type family X_Singletons_PatternMatching_21Sym0 where
+      X_Singletons_PatternMatching_21Sym0 = X_Singletons_PatternMatching_21
     type family TtSym0 where
       TtSym0 = Tt
     type family TjzSym0 where
       TjzSym0 = Tjz
     type family TfSym0 where
       TfSym0 = Tf
-    type family X_0123456789876543210Sym0 where
-      X_0123456789876543210Sym0 = X_0123456789876543210
+    type family X_Singletons_PatternMatching_17Sym0 where
+      X_Singletons_PatternMatching_17Sym0 = X_Singletons_PatternMatching_17
     type FlsSym0 :: Bool
     type family FlsSym0 :: Bool where
       FlsSym0 = Fls
@@ -430,54 +445,55 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
       ZzSym0 = Zz
     type family JzSym0 where
       JzSym0 = Jz
-    type family X_0123456789876543210Sym0 where
-      X_0123456789876543210Sym0 = X_0123456789876543210
+    type family X_Singletons_PatternMatching_13Sym0 where
+      X_Singletons_PatternMatching_13Sym0 = X_Singletons_PatternMatching_13
     type family LzSym0 where
       LzSym0 = Lz
     type family SzSym0 where
       SzSym0 = Sz
-    type family X_0123456789876543210Sym0 where
-      X_0123456789876543210Sym0 = X_0123456789876543210
+    type family X_Singletons_PatternMatching_10Sym0 where
+      X_Singletons_PatternMatching_10Sym0 = X_Singletons_PatternMatching_10
     type Silly :: a -> ()
     type family Silly @a (a :: a) :: () where
-      Silly x = Apply (LamCases_0123456789876543210Sym0 x) x
+      Silly x = Apply (LamCases_Singletons_PatternMatching_25Sym0 x) x
     type Foo2 :: (a, b) -> a
     type family Foo2 @a @b (a :: (a, b)) :: a where
       Foo2 '(x,
-             y) = Apply (LamCases_0123456789876543210Sym0 x y) (Let0123456789876543210TSym0 x y)
+             y) = Apply (LamCases_Singletons_PatternMatching_29Sym0 x y) (Let28TSym0 x y)
     type Foo1 :: (a, b) -> a
     type family Foo1 @a @b (a :: (a, b)) :: a where
-      Foo1 '(x, y) = Apply (LamCases_0123456789876543210Sym0 x y) y
+      Foo1 '(x,
+             y) = Apply (LamCases_Singletons_PatternMatching_34Sym0 x y) y
     type family Blimy where
-      Blimy = Apply LamCases_0123456789876543210Sym0 X_0123456789876543210Sym0
+      Blimy = Apply LamCases_Singletons_PatternMatching_36Sym0 X_Singletons_PatternMatching_21Sym0
     type Lsz :: Nat
     type family Lsz :: Nat where
-      Lsz = Apply LamCases_0123456789876543210Sym0 X_0123456789876543210Sym0
-    type family X_0123456789876543210 where
-      X_0123456789876543210 = AListSym0
+      Lsz = Apply LamCases_Singletons_PatternMatching_38Sym0 X_Singletons_PatternMatching_21Sym0
+    type family X_Singletons_PatternMatching_21 where
+      X_Singletons_PatternMatching_21 = AListSym0
     type family Tt where
-      Tt = Apply LamCases_0123456789876543210Sym0 X_0123456789876543210Sym0
+      Tt = Apply LamCases_Singletons_PatternMatching_40Sym0 X_Singletons_PatternMatching_17Sym0
     type family Tjz where
-      Tjz = Apply LamCases_0123456789876543210Sym0 X_0123456789876543210Sym0
+      Tjz = Apply LamCases_Singletons_PatternMatching_42Sym0 X_Singletons_PatternMatching_17Sym0
     type family Tf where
-      Tf = Apply LamCases_0123456789876543210Sym0 X_0123456789876543210Sym0
-    type family X_0123456789876543210 where
-      X_0123456789876543210 = TupleSym0
+      Tf = Apply LamCases_Singletons_PatternMatching_44Sym0 X_Singletons_PatternMatching_17Sym0
+    type family X_Singletons_PatternMatching_17 where
+      X_Singletons_PatternMatching_17 = TupleSym0
     type Fls :: Bool
     type family Fls :: Bool where
-      Fls = Apply LamCases_0123456789876543210Sym0 X_0123456789876543210Sym0
+      Fls = Apply LamCases_Singletons_PatternMatching_46Sym0 X_Singletons_PatternMatching_13Sym0
     type family Zz where
-      Zz = Apply LamCases_0123456789876543210Sym0 X_0123456789876543210Sym0
+      Zz = Apply LamCases_Singletons_PatternMatching_48Sym0 X_Singletons_PatternMatching_13Sym0
     type family Jz where
-      Jz = Apply LamCases_0123456789876543210Sym0 X_0123456789876543210Sym0
-    type family X_0123456789876543210 where
-      X_0123456789876543210 = ComplexSym0
+      Jz = Apply LamCases_Singletons_PatternMatching_50Sym0 X_Singletons_PatternMatching_13Sym0
+    type family X_Singletons_PatternMatching_13 where
+      X_Singletons_PatternMatching_13 = ComplexSym0
     type family Lz where
-      Lz = Apply LamCases_0123456789876543210Sym0 X_0123456789876543210Sym0
+      Lz = Apply LamCases_Singletons_PatternMatching_52Sym0 X_Singletons_PatternMatching_10Sym0
     type family Sz where
-      Sz = Apply LamCases_0123456789876543210Sym0 X_0123456789876543210Sym0
-    type family X_0123456789876543210 where
-      X_0123456789876543210 = PrSym0
+      Sz = Apply LamCases_Singletons_PatternMatching_54Sym0 X_Singletons_PatternMatching_10Sym0
+    type family X_Singletons_PatternMatching_10 where
+      X_Singletons_PatternMatching_10 = PrSym0
     sSilly :: (forall (t :: a). Sing t -> Sing (Silly t :: ()) :: Type)
     sFoo2 ::
       (forall (t :: (a, b)). Sing t -> Sing (Foo2 t :: a) :: Type)
@@ -485,139 +501,149 @@ Singletons/PatternMatching.hs:(0,0)-(0,0): Splicing declarations
       (forall (t :: (a, b)). Sing t -> Sing (Foo1 t :: a) :: Type)
     sBlimy :: Sing @_ Blimy
     sLsz :: (Sing (Lsz :: Nat) :: Type)
-    sX_0123456789876543210 :: Sing @_ X_0123456789876543210
+    sX_Singletons_PatternMatching_21 ::
+      Sing @_ X_Singletons_PatternMatching_21
     sTt :: Sing @_ Tt
     sTjz :: Sing @_ Tjz
     sTf :: Sing @_ Tf
-    sX_0123456789876543210 :: Sing @_ X_0123456789876543210
+    sX_Singletons_PatternMatching_17 ::
+      Sing @_ X_Singletons_PatternMatching_17
     sFls :: (Sing (Fls :: Bool) :: Type)
     sZz :: Sing @_ Zz
     sJz :: Sing @_ Jz
-    sX_0123456789876543210 :: Sing @_ X_0123456789876543210
+    sX_Singletons_PatternMatching_13 ::
+      Sing @_ X_Singletons_PatternMatching_13
     sLz :: Sing @_ Lz
     sSz :: Sing @_ Sz
-    sX_0123456789876543210 :: Sing @_ X_0123456789876543210
+    sX_Singletons_PatternMatching_10 ::
+      Sing @_ X_Singletons_PatternMatching_10
     sSilly (sX :: Sing x)
       = applySing
           (singFun1
-             @(LamCases_0123456789876543210Sym0 x) (\cases _ -> STuple0))
+             @(LamCases_Singletons_PatternMatching_25Sym0 x)
+             (\cases _ -> STuple0))
           sX
     sFoo2 (STuple2 (sX :: Sing x) (sY :: Sing y))
       = let
-          sT :: Sing @_ (Let0123456789876543210T x y)
+          sT :: Sing @_ (Let28T x y)
           sT = applySing (applySing (singFun2 @Tuple2Sym0 STuple2) sX) sY
         in
           applySing
             (singFun1
-               @(LamCases_0123456789876543210Sym0 x y)
+               @(LamCases_Singletons_PatternMatching_29Sym0 x y)
                (\cases
                   (STuple2 (sA :: Sing a) (sB :: Sing b))
                     -> applySing
                          (singFun1
-                            @(LamCases_0123456789876543210Sym0 a b x y) (\cases _ -> sA))
+                            @(LamCases_Singletons_PatternMatching_30Sym0 a b x y)
+                            (\cases _ -> sA))
                          sB))
             sT
     sFoo1 (STuple2 (sX :: Sing x) (sY :: Sing y))
       = applySing
-          (singFun1 @(LamCases_0123456789876543210Sym0 x y) (\cases _ -> sX))
+          (singFun1
+             @(LamCases_Singletons_PatternMatching_34Sym0 x y) (\cases _ -> sX))
           sY
     sBlimy
       = applySing
           (singFun1
-             @LamCases_0123456789876543210Sym0
+             @LamCases_Singletons_PatternMatching_36Sym0
              (\cases
                 (SCons _
                        (SCons _
-                              (SCons (SSucc (sY_0123456789876543210 :: Sing y_0123456789876543210))
+                              (SCons (SSucc (sY_Singletons_PatternMatching_23 :: Sing y_Singletons_PatternMatching_23))
                                      SNil)))
-                  -> sY_0123456789876543210))
-          sX_0123456789876543210
+                  -> sY_Singletons_PatternMatching_23))
+          sX_Singletons_PatternMatching_21
     sLsz
       = applySing
           (singFun1
-             @LamCases_0123456789876543210Sym0
+             @LamCases_Singletons_PatternMatching_38Sym0
              (\cases
                 (SCons _
-                       (SCons (sY_0123456789876543210 :: Sing y_0123456789876543210)
+                       (SCons (sY_Singletons_PatternMatching_22 :: Sing y_Singletons_PatternMatching_22)
                               (SCons (SSucc _) SNil)))
-                  -> sY_0123456789876543210))
-          sX_0123456789876543210
-    sX_0123456789876543210 = sAList
+                  -> sY_Singletons_PatternMatching_22))
+          sX_Singletons_PatternMatching_21
+    sX_Singletons_PatternMatching_21 = sAList
     sTt
       = applySing
           (singFun1
-             @LamCases_0123456789876543210Sym0
+             @LamCases_Singletons_PatternMatching_40Sym0
              (\cases
                 (STuple3 _ _
-                         (sY_0123456789876543210 :: Sing y_0123456789876543210))
-                  -> sY_0123456789876543210))
-          sX_0123456789876543210
+                         (sY_Singletons_PatternMatching_20 :: Sing y_Singletons_PatternMatching_20))
+                  -> sY_Singletons_PatternMatching_20))
+          sX_Singletons_PatternMatching_17
     sTjz
       = applySing
           (singFun1
-             @LamCases_0123456789876543210Sym0
+             @LamCases_Singletons_PatternMatching_42Sym0
              (\cases
-                (STuple3 _ (sY_0123456789876543210 :: Sing y_0123456789876543210)
+                (STuple3 _
+                         (sY_Singletons_PatternMatching_19 :: Sing y_Singletons_PatternMatching_19)
                          _)
-                  -> sY_0123456789876543210))
-          sX_0123456789876543210
+                  -> sY_Singletons_PatternMatching_19))
+          sX_Singletons_PatternMatching_17
     sTf
       = applySing
           (singFun1
-             @LamCases_0123456789876543210Sym0
+             @LamCases_Singletons_PatternMatching_44Sym0
              (\cases
-                (STuple3 (sY_0123456789876543210 :: Sing y_0123456789876543210) _
-                         _)
-                  -> sY_0123456789876543210))
-          sX_0123456789876543210
-    sX_0123456789876543210 = sTuple
+                (STuple3 (sY_Singletons_PatternMatching_18 :: Sing y_Singletons_PatternMatching_18)
+                         _ _)
+                  -> sY_Singletons_PatternMatching_18))
+          sX_Singletons_PatternMatching_17
+    sX_Singletons_PatternMatching_17 = sTuple
     sFls
       = applySing
           (singFun1
-             @LamCases_0123456789876543210Sym0
+             @LamCases_Singletons_PatternMatching_46Sym0
              (\cases
                 (SPair (SPair _ _)
-                       (sY_0123456789876543210 :: Sing y_0123456789876543210))
-                  -> sY_0123456789876543210))
-          sX_0123456789876543210
+                       (sY_Singletons_PatternMatching_16 :: Sing y_Singletons_PatternMatching_16))
+                  -> sY_Singletons_PatternMatching_16))
+          sX_Singletons_PatternMatching_13
     sZz
       = applySing
           (singFun1
-             @LamCases_0123456789876543210Sym0
+             @LamCases_Singletons_PatternMatching_48Sym0
              (\cases
                 (SPair (SPair _
-                              (sY_0123456789876543210 :: Sing y_0123456789876543210))
+                              (sY_Singletons_PatternMatching_15 :: Sing y_Singletons_PatternMatching_15))
                        _)
-                  -> sY_0123456789876543210))
-          sX_0123456789876543210
+                  -> sY_Singletons_PatternMatching_15))
+          sX_Singletons_PatternMatching_13
     sJz
       = applySing
           (singFun1
-             @LamCases_0123456789876543210Sym0
+             @LamCases_Singletons_PatternMatching_50Sym0
              (\cases
-                (SPair (SPair (sY_0123456789876543210 :: Sing y_0123456789876543210)
+                (SPair (SPair (sY_Singletons_PatternMatching_14 :: Sing y_Singletons_PatternMatching_14)
                               _)
                        _)
-                  -> sY_0123456789876543210))
-          sX_0123456789876543210
-    sX_0123456789876543210 = sComplex
+                  -> sY_Singletons_PatternMatching_14))
+          sX_Singletons_PatternMatching_13
+    sX_Singletons_PatternMatching_13 = sComplex
     sLz
       = applySing
           (singFun1
-             @LamCases_0123456789876543210Sym0
+             @LamCases_Singletons_PatternMatching_52Sym0
              (\cases
-                (SPair _ (sY_0123456789876543210 :: Sing y_0123456789876543210))
-                  -> sY_0123456789876543210))
-          sX_0123456789876543210
+                (SPair _
+                       (sY_Singletons_PatternMatching_12 :: Sing y_Singletons_PatternMatching_12))
+                  -> sY_Singletons_PatternMatching_12))
+          sX_Singletons_PatternMatching_10
     sSz
       = applySing
           (singFun1
-             @LamCases_0123456789876543210Sym0
+             @LamCases_Singletons_PatternMatching_54Sym0
              (\cases
-                (SPair (sY_0123456789876543210 :: Sing y_0123456789876543210) _)
-                  -> sY_0123456789876543210))
-          sX_0123456789876543210
-    sX_0123456789876543210 = sPr
+                (SPair (sY_Singletons_PatternMatching_11 :: Sing y_Singletons_PatternMatching_11)
+                       _)
+                  -> sY_Singletons_PatternMatching_11))
+          sX_Singletons_PatternMatching_10
+    sX_Singletons_PatternMatching_10 = sPr
     instance SingI (SillySym0 :: (~>) a ()) where
       sing = singFun1 @SillySym0 sSilly
     instance SingI (Foo2Sym0 :: (~>) (a, b) a) where

--- a/singletons-base/tests/compile-and-dump/Singletons/PolyKinds.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/PolyKinds.golden
@@ -9,13 +9,13 @@ Singletons/PolyKinds.hs:(0,0)-(0,0): Splicing declarations
     data FffSym0 :: (~>) (Proxy (a :: k)) ()
       where
         FffSym0KindInference :: SameKind (Apply FffSym0 arg) (FffSym1 arg) =>
-                                FffSym0 a0123456789876543210
-    type instance Apply @(Proxy (a :: k)) @() FffSym0 a0123456789876543210 = Fff a0123456789876543210
+                                FffSym0 a_Singletons_PolyKinds_0
+    type instance Apply @(Proxy (a :: k)) @() FffSym0 a_Singletons_PolyKinds_0 = Fff a_Singletons_PolyKinds_0
     instance SuppressUnusedWarnings FffSym0 where
       suppressUnusedWarnings = snd ((,) FffSym0KindInference ())
     type FffSym1 :: forall k (a :: k). Proxy (a :: k) -> ()
-    type family FffSym1 @k @(a :: k) (a0123456789876543210 :: Proxy (a :: k)) :: () where
-      FffSym1 a0123456789876543210 = Fff a0123456789876543210
+    type family FffSym1 @k @(a :: k) (a_Singletons_PolyKinds_0 :: Proxy (a :: k)) :: () where
+      FffSym1 a_Singletons_PolyKinds_0 = Fff a_Singletons_PolyKinds_0
     class PCls (a :: k) where
       type family Fff (arg :: Proxy (a :: k)) :: ()
     class SCls (a :: k) where

--- a/singletons-base/tests/compile-and-dump/Singletons/Records.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Records.golden
@@ -7,43 +7,43 @@ Singletons/Records.hs:(0,0)-(0,0): Splicing declarations
     data MkRecordSym0 :: (~>) a ((~>) Bool (Record a))
       where
         MkRecordSym0KindInference :: SameKind (Apply MkRecordSym0 arg) (MkRecordSym1 arg) =>
-                                     MkRecordSym0 a0123456789876543210
-    type instance Apply @a @((~>) Bool (Record a)) MkRecordSym0 a0123456789876543210 = MkRecordSym1 a0123456789876543210
+                                     MkRecordSym0 a_Singletons_Records_0
+    type instance Apply @a @((~>) Bool (Record a)) MkRecordSym0 a_Singletons_Records_0 = MkRecordSym1 a_Singletons_Records_0
     instance SuppressUnusedWarnings MkRecordSym0 where
       suppressUnusedWarnings = snd ((,) MkRecordSym0KindInference ())
     type MkRecordSym1 :: forall a. a -> (~>) Bool (Record a)
-    data MkRecordSym1 (a0123456789876543210 :: a) :: (~>) Bool (Record a)
+    data MkRecordSym1 (a_Singletons_Records_0 :: a) :: (~>) Bool (Record a)
       where
-        MkRecordSym1KindInference :: SameKind (Apply (MkRecordSym1 a0123456789876543210) arg) (MkRecordSym2 a0123456789876543210 arg) =>
-                                     MkRecordSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Bool @(Record a) (MkRecordSym1 a0123456789876543210) a0123456789876543210 = MkRecord a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (MkRecordSym1 a0123456789876543210) where
+        MkRecordSym1KindInference :: SameKind (Apply (MkRecordSym1 a_Singletons_Records_0) arg) (MkRecordSym2 a_Singletons_Records_0 arg) =>
+                                     MkRecordSym1 a_Singletons_Records_0 a_Singletons_Records_1
+    type instance Apply @Bool @(Record a) (MkRecordSym1 a_Singletons_Records_0) a_Singletons_Records_1 = MkRecord a_Singletons_Records_0 a_Singletons_Records_1
+    instance SuppressUnusedWarnings (MkRecordSym1 a_Singletons_Records_0) where
       suppressUnusedWarnings = snd ((,) MkRecordSym1KindInference ())
     type MkRecordSym2 :: forall a. a -> Bool -> Record a
-    type family MkRecordSym2 @a (a0123456789876543210 :: a) (a0123456789876543210 :: Bool) :: Record a where
-      MkRecordSym2 a0123456789876543210 a0123456789876543210 = MkRecord a0123456789876543210 a0123456789876543210
+    type family MkRecordSym2 @a (a_Singletons_Records_0 :: a) (a_Singletons_Records_1 :: Bool) :: Record a where
+      MkRecordSym2 a_Singletons_Records_0 a_Singletons_Records_1 = MkRecord a_Singletons_Records_0 a_Singletons_Records_1
     type Field2Sym0 :: forall a. (~>) (Record a) Bool
     data Field2Sym0 :: (~>) (Record a) Bool
       where
         Field2Sym0KindInference :: SameKind (Apply Field2Sym0 arg) (Field2Sym1 arg) =>
-                                   Field2Sym0 a0123456789876543210
-    type instance Apply @(Record a) @Bool Field2Sym0 a0123456789876543210 = Field2 a0123456789876543210
+                                   Field2Sym0 a_Singletons_Records_2
+    type instance Apply @(Record a) @Bool Field2Sym0 a_Singletons_Records_2 = Field2 a_Singletons_Records_2
     instance SuppressUnusedWarnings Field2Sym0 where
       suppressUnusedWarnings = snd ((,) Field2Sym0KindInference ())
     type Field2Sym1 :: forall a. Record a -> Bool
-    type family Field2Sym1 @a (a0123456789876543210 :: Record a) :: Bool where
-      Field2Sym1 a0123456789876543210 = Field2 a0123456789876543210
+    type family Field2Sym1 @a (a_Singletons_Records_2 :: Record a) :: Bool where
+      Field2Sym1 a_Singletons_Records_2 = Field2 a_Singletons_Records_2
     type Field1Sym0 :: forall a. (~>) (Record a) a
     data Field1Sym0 :: (~>) (Record a) a
       where
         Field1Sym0KindInference :: SameKind (Apply Field1Sym0 arg) (Field1Sym1 arg) =>
-                                   Field1Sym0 a0123456789876543210
-    type instance Apply @(Record a) @a Field1Sym0 a0123456789876543210 = Field1 a0123456789876543210
+                                   Field1Sym0 a_Singletons_Records_3
+    type instance Apply @(Record a) @a Field1Sym0 a_Singletons_Records_3 = Field1 a_Singletons_Records_3
     instance SuppressUnusedWarnings Field1Sym0 where
       suppressUnusedWarnings = snd ((,) Field1Sym0KindInference ())
     type Field1Sym1 :: forall a. Record a -> a
-    type family Field1Sym1 @a (a0123456789876543210 :: Record a) :: a where
-      Field1Sym1 a0123456789876543210 = Field1 a0123456789876543210
+    type family Field1Sym1 @a (a_Singletons_Records_3 :: Record a) :: a where
+      Field1Sym1 a_Singletons_Records_3 = Field1 a_Singletons_Records_3
     type Field2 :: forall a. Record a -> Bool
     type family Field2 @a (a :: Record a) :: Bool where
       Field2 @a (MkRecord _ field :: Record a) = field

--- a/singletons-base/tests/compile-and-dump/Singletons/ReturnFunc.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/ReturnFunc.golden
@@ -17,60 +17,60 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
     data IdFooSym0 :: (~>) c ((~>) a a)
       where
         IdFooSym0KindInference :: SameKind (Apply IdFooSym0 arg) (IdFooSym1 arg) =>
-                                  IdFooSym0 a0123456789876543210
-    type instance Apply @c @((~>) a a) IdFooSym0 a0123456789876543210 = IdFooSym1 a0123456789876543210
+                                  IdFooSym0 a_Singletons_ReturnFunc_1
+    type instance Apply @c @((~>) a a) IdFooSym0 a_Singletons_ReturnFunc_1 = IdFooSym1 a_Singletons_ReturnFunc_1
     instance SuppressUnusedWarnings IdFooSym0 where
       suppressUnusedWarnings = snd ((,) IdFooSym0KindInference ())
     type IdFooSym1 :: c -> (~>) a a
-    data IdFooSym1 (a0123456789876543210 :: c) :: (~>) a a
+    data IdFooSym1 (a_Singletons_ReturnFunc_1 :: c) :: (~>) a a
       where
-        IdFooSym1KindInference :: SameKind (Apply (IdFooSym1 a0123456789876543210) arg) (IdFooSym2 a0123456789876543210 arg) =>
-                                  IdFooSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @a @a (IdFooSym1 a0123456789876543210) a0123456789876543210 = IdFoo a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (IdFooSym1 a0123456789876543210) where
+        IdFooSym1KindInference :: SameKind (Apply (IdFooSym1 a_Singletons_ReturnFunc_1) arg) (IdFooSym2 a_Singletons_ReturnFunc_1 arg) =>
+                                  IdFooSym1 a_Singletons_ReturnFunc_1 a_Singletons_ReturnFunc_2
+    type instance Apply @a @a (IdFooSym1 a_Singletons_ReturnFunc_1) a_Singletons_ReturnFunc_2 = IdFoo a_Singletons_ReturnFunc_1 a_Singletons_ReturnFunc_2
+    instance SuppressUnusedWarnings (IdFooSym1 a_Singletons_ReturnFunc_1) where
       suppressUnusedWarnings = snd ((,) IdFooSym1KindInference ())
     type IdFooSym2 :: c -> a -> a
-    type family IdFooSym2 @c @a (a0123456789876543210 :: c) (a0123456789876543210 :: a) :: a where
-      IdFooSym2 a0123456789876543210 a0123456789876543210 = IdFoo a0123456789876543210 a0123456789876543210
+    type family IdFooSym2 @c @a (a_Singletons_ReturnFunc_1 :: c) (a_Singletons_ReturnFunc_2 :: a) :: a where
+      IdFooSym2 a_Singletons_ReturnFunc_1 a_Singletons_ReturnFunc_2 = IdFoo a_Singletons_ReturnFunc_1 a_Singletons_ReturnFunc_2
     type IdSym0 :: (~>) a a
     data IdSym0 :: (~>) a a
       where
         IdSym0KindInference :: SameKind (Apply IdSym0 arg) (IdSym1 arg) =>
-                               IdSym0 a0123456789876543210
-    type instance Apply @a @a IdSym0 a0123456789876543210 = Id a0123456789876543210
+                               IdSym0 a_Singletons_ReturnFunc_3
+    type instance Apply @a @a IdSym0 a_Singletons_ReturnFunc_3 = Id a_Singletons_ReturnFunc_3
     instance SuppressUnusedWarnings IdSym0 where
       suppressUnusedWarnings = snd ((,) IdSym0KindInference ())
     type IdSym1 :: a -> a
-    type family IdSym1 @a (a0123456789876543210 :: a) :: a where
-      IdSym1 a0123456789876543210 = Id a0123456789876543210
+    type family IdSym1 @a (a_Singletons_ReturnFunc_3 :: a) :: a where
+      IdSym1 a_Singletons_ReturnFunc_3 = Id a_Singletons_ReturnFunc_3
     type ReturnFuncSym0 :: (~>) Nat ((~>) Nat Nat)
     data ReturnFuncSym0 :: (~>) Nat ((~>) Nat Nat)
       where
         ReturnFuncSym0KindInference :: SameKind (Apply ReturnFuncSym0 arg) (ReturnFuncSym1 arg) =>
-                                       ReturnFuncSym0 a0123456789876543210
-    type instance Apply @Nat @((~>) Nat Nat) ReturnFuncSym0 a0123456789876543210 = ReturnFuncSym1 a0123456789876543210
+                                       ReturnFuncSym0 a_Singletons_ReturnFunc_5
+    type instance Apply @Nat @((~>) Nat Nat) ReturnFuncSym0 a_Singletons_ReturnFunc_5 = ReturnFuncSym1 a_Singletons_ReturnFunc_5
     instance SuppressUnusedWarnings ReturnFuncSym0 where
       suppressUnusedWarnings = snd ((,) ReturnFuncSym0KindInference ())
     type ReturnFuncSym1 :: Nat -> (~>) Nat Nat
-    data ReturnFuncSym1 (a0123456789876543210 :: Nat) :: (~>) Nat Nat
+    data ReturnFuncSym1 (a_Singletons_ReturnFunc_5 :: Nat) :: (~>) Nat Nat
       where
-        ReturnFuncSym1KindInference :: SameKind (Apply (ReturnFuncSym1 a0123456789876543210) arg) (ReturnFuncSym2 a0123456789876543210 arg) =>
-                                       ReturnFuncSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @Nat (ReturnFuncSym1 a0123456789876543210) a0123456789876543210 = ReturnFunc a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ReturnFuncSym1 a0123456789876543210) where
+        ReturnFuncSym1KindInference :: SameKind (Apply (ReturnFuncSym1 a_Singletons_ReturnFunc_5) arg) (ReturnFuncSym2 a_Singletons_ReturnFunc_5 arg) =>
+                                       ReturnFuncSym1 a_Singletons_ReturnFunc_5 a_Singletons_ReturnFunc_6
+    type instance Apply @Nat @Nat (ReturnFuncSym1 a_Singletons_ReturnFunc_5) a_Singletons_ReturnFunc_6 = ReturnFunc a_Singletons_ReturnFunc_5 a_Singletons_ReturnFunc_6
+    instance SuppressUnusedWarnings (ReturnFuncSym1 a_Singletons_ReturnFunc_5) where
       suppressUnusedWarnings = snd ((,) ReturnFuncSym1KindInference ())
     type ReturnFuncSym2 :: Nat -> Nat -> Nat
-    type family ReturnFuncSym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Nat where
-      ReturnFuncSym2 a0123456789876543210 a0123456789876543210 = ReturnFunc a0123456789876543210 a0123456789876543210
+    type family ReturnFuncSym2 (a_Singletons_ReturnFunc_5 :: Nat) (a_Singletons_ReturnFunc_6 :: Nat) :: Nat where
+      ReturnFuncSym2 a_Singletons_ReturnFunc_5 a_Singletons_ReturnFunc_6 = ReturnFunc a_Singletons_ReturnFunc_5 a_Singletons_ReturnFunc_6
     type IdFoo :: c -> a -> a
     type family IdFoo @c @a (a :: c) (a :: a) :: a where
-      IdFoo _ a_0123456789876543210 = Apply IdSym0 a_0123456789876543210
+      IdFoo _ a_Singletons_ReturnFunc_0 = Apply IdSym0 a_Singletons_ReturnFunc_0
     type Id :: a -> a
     type family Id @a (a :: a) :: a where
       Id x = x
     type ReturnFunc :: Nat -> Nat -> Nat
     type family ReturnFunc (a :: Nat) (a :: Nat) :: Nat where
-      ReturnFunc _ a_0123456789876543210 = Apply SuccSym0 a_0123456789876543210
+      ReturnFunc _ a_Singletons_ReturnFunc_4 = Apply SuccSym0 a_Singletons_ReturnFunc_4
     sIdFoo ::
       (forall (t :: c) (t :: a).
        Sing t -> Sing t -> Sing (IdFoo t t :: a) :: Type)
@@ -78,13 +78,15 @@ Singletons/ReturnFunc.hs:(0,0)-(0,0): Splicing declarations
     sReturnFunc ::
       (forall (t :: Nat) (t :: Nat).
        Sing t -> Sing t -> Sing (ReturnFunc t t :: Nat) :: Type)
-    sIdFoo _ (sA_0123456789876543210 :: Sing a_0123456789876543210)
-      = applySing (singFun1 @IdSym0 sId) sA_0123456789876543210
+    sIdFoo
+      _
+      (sA_Singletons_ReturnFunc_0 :: Sing a_Singletons_ReturnFunc_0)
+      = applySing (singFun1 @IdSym0 sId) sA_Singletons_ReturnFunc_0
     sId (sX :: Sing x) = sX
     sReturnFunc
       _
-      (sA_0123456789876543210 :: Sing a_0123456789876543210)
-      = applySing (singFun1 @SuccSym0 SSucc) sA_0123456789876543210
+      (sA_Singletons_ReturnFunc_4 :: Sing a_Singletons_ReturnFunc_4)
+      = applySing (singFun1 @SuccSym0 SSucc) sA_Singletons_ReturnFunc_4
     instance SingI (IdFooSym0 :: (~>) c ((~>) a a)) where
       sing = singFun2 @IdFooSym0 sIdFoo
     instance SingI d => SingI (IdFooSym1 (d :: c) :: (~>) a a) where

--- a/singletons-base/tests/compile-and-dump/Singletons/Sections.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Sections.golden
@@ -19,18 +19,18 @@ Singletons/Sections.hs:(0,0)-(0,0): Splicing declarations
     foo2 = map (+ Succ Zero) [Zero, Succ Zero]
     foo3 :: [Nat]
     foo3 = zipWith (+) [Succ Zero, Succ Zero] [Zero, Succ Zero]
-    type family LamCases_0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 lhs_0123456789876543210 = Apply (Apply (+@#@$) lhs_0123456789876543210) (Apply SuccSym0 ZeroSym0)
-    data LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
+    type family LamCases_Singletons_Sections_1 a_Singletons_Sections_2 where
+      LamCases_Singletons_Sections_1 lhs_Singletons_Sections_0 = Apply (Apply (+@#@$) lhs_Singletons_Sections_0) (Apply SuccSym0 ZeroSym0)
+    data LamCases_Singletons_Sections_1Sym0 a_Singletons_Sections_2
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply LamCases_0123456789876543210Sym0 arg) (LamCases_0123456789876543210Sym1 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings LamCases_0123456789876543210Sym0 where
+        LamCases_Singletons_Sections_1Sym0KindInference :: SameKind (Apply LamCases_Singletons_Sections_1Sym0 arg) (LamCases_Singletons_Sections_1Sym1 arg) =>
+                                                           LamCases_Singletons_Sections_1Sym0 a_Singletons_Sections_2
+    type instance Apply @_ @_ LamCases_Singletons_Sections_1Sym0 a_Singletons_Sections_2 = LamCases_Singletons_Sections_1 a_Singletons_Sections_2
+    instance SuppressUnusedWarnings LamCases_Singletons_Sections_1Sym0 where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_Sections_1Sym0KindInference ())
+    type family LamCases_Singletons_Sections_1Sym1 a_Singletons_Sections_2 where
+      LamCases_Singletons_Sections_1Sym1 a_Singletons_Sections_2 = LamCases_Singletons_Sections_1 a_Singletons_Sections_2
     type Foo3Sym0 :: [Nat]
     type family Foo3Sym0 :: [Nat] where
       Foo3Sym0 = Foo3
@@ -44,27 +44,27 @@ Singletons/Sections.hs:(0,0)-(0,0): Splicing declarations
     data (+@#@$) :: (~>) Nat ((~>) Nat Nat)
       where
         (:+@#@$###) :: SameKind (Apply (+@#@$) arg) ((+@#@$$) arg) =>
-                       (+@#@$) a0123456789876543210
-    type instance Apply @Nat @((~>) Nat Nat) (+@#@$) a0123456789876543210 = (+@#@$$) a0123456789876543210
+                       (+@#@$) a_Singletons_Sections_3
+    type instance Apply @Nat @((~>) Nat Nat) (+@#@$) a_Singletons_Sections_3 = (+@#@$$) a_Singletons_Sections_3
     instance SuppressUnusedWarnings (+@#@$) where
       suppressUnusedWarnings = snd ((,) (:+@#@$###) ())
     type (+@#@$$) :: Nat -> (~>) Nat Nat
-    data (+@#@$$) (a0123456789876543210 :: Nat) :: (~>) Nat Nat
+    data (+@#@$$) (a_Singletons_Sections_3 :: Nat) :: (~>) Nat Nat
       where
-        (:+@#@$$###) :: SameKind (Apply ((+@#@$$) a0123456789876543210) arg) ((+@#@$$$) a0123456789876543210 arg) =>
-                        (+@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @Nat ((+@#@$$) a0123456789876543210) a0123456789876543210 = (+) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((+@#@$$) a0123456789876543210) where
+        (:+@#@$$###) :: SameKind (Apply ((+@#@$$) a_Singletons_Sections_3) arg) ((+@#@$$$) a_Singletons_Sections_3 arg) =>
+                        (+@#@$$) a_Singletons_Sections_3 a_Singletons_Sections_4
+    type instance Apply @Nat @Nat ((+@#@$$) a_Singletons_Sections_3) a_Singletons_Sections_4 = (+) a_Singletons_Sections_3 a_Singletons_Sections_4
+    instance SuppressUnusedWarnings ((+@#@$$) a_Singletons_Sections_3) where
       suppressUnusedWarnings = snd ((,) (:+@#@$$###) ())
     type (+@#@$$$) :: Nat -> Nat -> Nat
-    type family (+@#@$$$) (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Nat where
-      (+@#@$$$) a0123456789876543210 a0123456789876543210 = (+) a0123456789876543210 a0123456789876543210
+    type family (+@#@$$$) (a_Singletons_Sections_3 :: Nat) (a_Singletons_Sections_4 :: Nat) :: Nat where
+      (+@#@$$$) a_Singletons_Sections_3 a_Singletons_Sections_4 = (+) a_Singletons_Sections_3 a_Singletons_Sections_4
     type Foo3 :: [Nat]
     type family Foo3 :: [Nat] where
       Foo3 = Apply (Apply (Apply ZipWithSym0 (+@#@$)) (Apply (Apply (:@#@$) (Apply SuccSym0 ZeroSym0)) (Apply (Apply (:@#@$) (Apply SuccSym0 ZeroSym0)) NilSym0))) (Apply (Apply (:@#@$) ZeroSym0) (Apply (Apply (:@#@$) (Apply SuccSym0 ZeroSym0)) NilSym0))
     type Foo2 :: [Nat]
     type family Foo2 :: [Nat] where
-      Foo2 = Apply (Apply MapSym0 LamCases_0123456789876543210Sym0) (Apply (Apply (:@#@$) ZeroSym0) (Apply (Apply (:@#@$) (Apply SuccSym0 ZeroSym0)) NilSym0))
+      Foo2 = Apply (Apply MapSym0 LamCases_Singletons_Sections_1Sym0) (Apply (Apply (:@#@$) ZeroSym0) (Apply (Apply (:@#@$) (Apply SuccSym0 ZeroSym0)) NilSym0))
     type Foo1 :: [Nat]
     type family Foo1 :: [Nat] where
       Foo1 = Apply (Apply MapSym0 (Apply (+@#@$) (Apply SuccSym0 ZeroSym0))) (Apply (Apply (:@#@$) ZeroSym0) (Apply (Apply (:@#@$) (Apply SuccSym0 ZeroSym0)) NilSym0))
@@ -104,11 +104,11 @@ Singletons/Sections.hs:(0,0)-(0,0): Splicing declarations
           (applySing
              (singFun2 @MapSym0 sMap)
              (singFun1
-                @LamCases_0123456789876543210Sym0
+                @LamCases_Singletons_Sections_1Sym0
                 (\cases
-                   (sLhs_0123456789876543210 :: Sing lhs_0123456789876543210)
+                   (sLhs_Singletons_Sections_0 :: Sing lhs_Singletons_Sections_0)
                      -> applySing
-                          (applySing (singFun2 @(+@#@$) (%+)) sLhs_0123456789876543210)
+                          (applySing (singFun2 @(+@#@$) (%+)) sLhs_Singletons_Sections_0)
                           (applySing (singFun1 @SuccSym0 SSucc) SZero))))
           (applySing
              (applySing (singFun2 @(:@#@$) SCons) SZero)

--- a/singletons-base/tests/compile-and-dump/Singletons/ShowDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/ShowDeriving.golden
@@ -31,155 +31,155 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
     data MkFoo2aSym0 :: (~>) a ((~>) a (Foo2 a))
       where
         MkFoo2aSym0KindInference :: SameKind (Apply MkFoo2aSym0 arg) (MkFoo2aSym1 arg) =>
-                                    MkFoo2aSym0 a0123456789876543210
-    type instance Apply @a @((~>) a (Foo2 a)) MkFoo2aSym0 a0123456789876543210 = MkFoo2aSym1 a0123456789876543210
+                                    MkFoo2aSym0 a_Singletons_ShowDeriving_13
+    type instance Apply @a @((~>) a (Foo2 a)) MkFoo2aSym0 a_Singletons_ShowDeriving_13 = MkFoo2aSym1 a_Singletons_ShowDeriving_13
     instance SuppressUnusedWarnings MkFoo2aSym0 where
       suppressUnusedWarnings = snd ((,) MkFoo2aSym0KindInference ())
     type MkFoo2aSym1 :: forall a. a -> (~>) a (Foo2 a)
-    data MkFoo2aSym1 (a0123456789876543210 :: a) :: (~>) a (Foo2 a)
+    data MkFoo2aSym1 (a_Singletons_ShowDeriving_13 :: a) :: (~>) a (Foo2 a)
       where
-        MkFoo2aSym1KindInference :: SameKind (Apply (MkFoo2aSym1 a0123456789876543210) arg) (MkFoo2aSym2 a0123456789876543210 arg) =>
-                                    MkFoo2aSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @a @(Foo2 a) (MkFoo2aSym1 a0123456789876543210) a0123456789876543210 = MkFoo2a a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (MkFoo2aSym1 a0123456789876543210) where
+        MkFoo2aSym1KindInference :: SameKind (Apply (MkFoo2aSym1 a_Singletons_ShowDeriving_13) arg) (MkFoo2aSym2 a_Singletons_ShowDeriving_13 arg) =>
+                                    MkFoo2aSym1 a_Singletons_ShowDeriving_13 a_Singletons_ShowDeriving_14
+    type instance Apply @a @(Foo2 a) (MkFoo2aSym1 a_Singletons_ShowDeriving_13) a_Singletons_ShowDeriving_14 = MkFoo2a a_Singletons_ShowDeriving_13 a_Singletons_ShowDeriving_14
+    instance SuppressUnusedWarnings (MkFoo2aSym1 a_Singletons_ShowDeriving_13) where
       suppressUnusedWarnings = snd ((,) MkFoo2aSym1KindInference ())
     type MkFoo2aSym2 :: forall a. a -> a -> Foo2 a
-    type family MkFoo2aSym2 @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Foo2 a where
-      MkFoo2aSym2 a0123456789876543210 a0123456789876543210 = MkFoo2a a0123456789876543210 a0123456789876543210
+    type family MkFoo2aSym2 @a (a_Singletons_ShowDeriving_13 :: a) (a_Singletons_ShowDeriving_14 :: a) :: Foo2 a where
+      MkFoo2aSym2 a_Singletons_ShowDeriving_13 a_Singletons_ShowDeriving_14 = MkFoo2a a_Singletons_ShowDeriving_13 a_Singletons_ShowDeriving_14
     type MkFoo2bSym0 :: forall a. (~>) a ((~>) a (Foo2 a))
     data MkFoo2bSym0 :: (~>) a ((~>) a (Foo2 a))
       where
         MkFoo2bSym0KindInference :: SameKind (Apply MkFoo2bSym0 arg) (MkFoo2bSym1 arg) =>
-                                    MkFoo2bSym0 a0123456789876543210
-    type instance Apply @a @((~>) a (Foo2 a)) MkFoo2bSym0 a0123456789876543210 = MkFoo2bSym1 a0123456789876543210
+                                    MkFoo2bSym0 a_Singletons_ShowDeriving_15
+    type instance Apply @a @((~>) a (Foo2 a)) MkFoo2bSym0 a_Singletons_ShowDeriving_15 = MkFoo2bSym1 a_Singletons_ShowDeriving_15
     instance SuppressUnusedWarnings MkFoo2bSym0 where
       suppressUnusedWarnings = snd ((,) MkFoo2bSym0KindInference ())
     infixl 5 type `MkFoo2bSym0`
     type MkFoo2bSym1 :: forall a. a -> (~>) a (Foo2 a)
-    data MkFoo2bSym1 (a0123456789876543210 :: a) :: (~>) a (Foo2 a)
+    data MkFoo2bSym1 (a_Singletons_ShowDeriving_15 :: a) :: (~>) a (Foo2 a)
       where
-        MkFoo2bSym1KindInference :: SameKind (Apply (MkFoo2bSym1 a0123456789876543210) arg) (MkFoo2bSym2 a0123456789876543210 arg) =>
-                                    MkFoo2bSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @a @(Foo2 a) (MkFoo2bSym1 a0123456789876543210) a0123456789876543210 = MkFoo2b a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (MkFoo2bSym1 a0123456789876543210) where
+        MkFoo2bSym1KindInference :: SameKind (Apply (MkFoo2bSym1 a_Singletons_ShowDeriving_15) arg) (MkFoo2bSym2 a_Singletons_ShowDeriving_15 arg) =>
+                                    MkFoo2bSym1 a_Singletons_ShowDeriving_15 a_Singletons_ShowDeriving_16
+    type instance Apply @a @(Foo2 a) (MkFoo2bSym1 a_Singletons_ShowDeriving_15) a_Singletons_ShowDeriving_16 = MkFoo2b a_Singletons_ShowDeriving_15 a_Singletons_ShowDeriving_16
+    instance SuppressUnusedWarnings (MkFoo2bSym1 a_Singletons_ShowDeriving_15) where
       suppressUnusedWarnings = snd ((,) MkFoo2bSym1KindInference ())
     infixl 5 type `MkFoo2bSym1`
     type MkFoo2bSym2 :: forall a. a -> a -> Foo2 a
-    type family MkFoo2bSym2 @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Foo2 a where
-      MkFoo2bSym2 a0123456789876543210 a0123456789876543210 = MkFoo2b a0123456789876543210 a0123456789876543210
+    type family MkFoo2bSym2 @a (a_Singletons_ShowDeriving_15 :: a) (a_Singletons_ShowDeriving_16 :: a) :: Foo2 a where
+      MkFoo2bSym2 a_Singletons_ShowDeriving_15 a_Singletons_ShowDeriving_16 = MkFoo2b a_Singletons_ShowDeriving_15 a_Singletons_ShowDeriving_16
     infixl 5 type `MkFoo2bSym2`
     type (:*:@#@$) :: forall a. (~>) a ((~>) a (Foo2 a))
     data (:*:@#@$) :: (~>) a ((~>) a (Foo2 a))
       where
         (::*:@#@$###) :: SameKind (Apply (:*:@#@$) arg) ((:*:@#@$$) arg) =>
-                         (:*:@#@$) a0123456789876543210
-    type instance Apply @a @((~>) a (Foo2 a)) (:*:@#@$) a0123456789876543210 = (:*:@#@$$) a0123456789876543210
+                         (:*:@#@$) a_Singletons_ShowDeriving_17
+    type instance Apply @a @((~>) a (Foo2 a)) (:*:@#@$) a_Singletons_ShowDeriving_17 = (:*:@#@$$) a_Singletons_ShowDeriving_17
     instance SuppressUnusedWarnings (:*:@#@$) where
       suppressUnusedWarnings = snd ((,) (::*:@#@$###) ())
     infixl 5 type :*:@#@$
     type (:*:@#@$$) :: forall a. a -> (~>) a (Foo2 a)
-    data (:*:@#@$$) (a0123456789876543210 :: a) :: (~>) a (Foo2 a)
+    data (:*:@#@$$) (a_Singletons_ShowDeriving_17 :: a) :: (~>) a (Foo2 a)
       where
-        (::*:@#@$$###) :: SameKind (Apply ((:*:@#@$$) a0123456789876543210) arg) ((:*:@#@$$$) a0123456789876543210 arg) =>
-                          (:*:@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @a @(Foo2 a) ((:*:@#@$$) a0123456789876543210) a0123456789876543210 = (:*:) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((:*:@#@$$) a0123456789876543210) where
+        (::*:@#@$$###) :: SameKind (Apply ((:*:@#@$$) a_Singletons_ShowDeriving_17) arg) ((:*:@#@$$$) a_Singletons_ShowDeriving_17 arg) =>
+                          (:*:@#@$$) a_Singletons_ShowDeriving_17 a_Singletons_ShowDeriving_18
+    type instance Apply @a @(Foo2 a) ((:*:@#@$$) a_Singletons_ShowDeriving_17) a_Singletons_ShowDeriving_18 = (:*:) a_Singletons_ShowDeriving_17 a_Singletons_ShowDeriving_18
+    instance SuppressUnusedWarnings ((:*:@#@$$) a_Singletons_ShowDeriving_17) where
       suppressUnusedWarnings = snd ((,) (::*:@#@$$###) ())
     infixl 5 type :*:@#@$$
     type (:*:@#@$$$) :: forall a. a -> a -> Foo2 a
-    type family (:*:@#@$$$) @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Foo2 a where
-      (:*:@#@$$$) a0123456789876543210 a0123456789876543210 = (:*:) a0123456789876543210 a0123456789876543210
+    type family (:*:@#@$$$) @a (a_Singletons_ShowDeriving_17 :: a) (a_Singletons_ShowDeriving_18 :: a) :: Foo2 a where
+      (:*:@#@$$$) a_Singletons_ShowDeriving_17 a_Singletons_ShowDeriving_18 = (:*:) a_Singletons_ShowDeriving_17 a_Singletons_ShowDeriving_18
     infixl 5 type :*:@#@$$$
     type (:&:@#@$) :: forall a. (~>) a ((~>) a (Foo2 a))
     data (:&:@#@$) :: (~>) a ((~>) a (Foo2 a))
       where
         (::&:@#@$###) :: SameKind (Apply (:&:@#@$) arg) ((:&:@#@$$) arg) =>
-                         (:&:@#@$) a0123456789876543210
-    type instance Apply @a @((~>) a (Foo2 a)) (:&:@#@$) a0123456789876543210 = (:&:@#@$$) a0123456789876543210
+                         (:&:@#@$) a_Singletons_ShowDeriving_19
+    type instance Apply @a @((~>) a (Foo2 a)) (:&:@#@$) a_Singletons_ShowDeriving_19 = (:&:@#@$$) a_Singletons_ShowDeriving_19
     instance SuppressUnusedWarnings (:&:@#@$) where
       suppressUnusedWarnings = snd ((,) (::&:@#@$###) ())
     infixl 5 type :&:@#@$
     type (:&:@#@$$) :: forall a. a -> (~>) a (Foo2 a)
-    data (:&:@#@$$) (a0123456789876543210 :: a) :: (~>) a (Foo2 a)
+    data (:&:@#@$$) (a_Singletons_ShowDeriving_19 :: a) :: (~>) a (Foo2 a)
       where
-        (::&:@#@$$###) :: SameKind (Apply ((:&:@#@$$) a0123456789876543210) arg) ((:&:@#@$$$) a0123456789876543210 arg) =>
-                          (:&:@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @a @(Foo2 a) ((:&:@#@$$) a0123456789876543210) a0123456789876543210 = (:&:) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((:&:@#@$$) a0123456789876543210) where
+        (::&:@#@$$###) :: SameKind (Apply ((:&:@#@$$) a_Singletons_ShowDeriving_19) arg) ((:&:@#@$$$) a_Singletons_ShowDeriving_19 arg) =>
+                          (:&:@#@$$) a_Singletons_ShowDeriving_19 a_Singletons_ShowDeriving_20
+    type instance Apply @a @(Foo2 a) ((:&:@#@$$) a_Singletons_ShowDeriving_19) a_Singletons_ShowDeriving_20 = (:&:) a_Singletons_ShowDeriving_19 a_Singletons_ShowDeriving_20
+    instance SuppressUnusedWarnings ((:&:@#@$$) a_Singletons_ShowDeriving_19) where
       suppressUnusedWarnings = snd ((,) (::&:@#@$$###) ())
     infixl 5 type :&:@#@$$
     type (:&:@#@$$$) :: forall a. a -> a -> Foo2 a
-    type family (:&:@#@$$$) @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Foo2 a where
-      (:&:@#@$$$) a0123456789876543210 a0123456789876543210 = (:&:) a0123456789876543210 a0123456789876543210
+    type family (:&:@#@$$$) @a (a_Singletons_ShowDeriving_19 :: a) (a_Singletons_ShowDeriving_20 :: a) :: Foo2 a where
+      (:&:@#@$$$) a_Singletons_ShowDeriving_19 a_Singletons_ShowDeriving_20 = (:&:) a_Singletons_ShowDeriving_19 a_Singletons_ShowDeriving_20
     infixl 5 type :&:@#@$$$
     type MkFoo3Sym0 :: (~>) Bool ((~>) Bool Foo3)
     data MkFoo3Sym0 :: (~>) Bool ((~>) Bool Foo3)
       where
         MkFoo3Sym0KindInference :: SameKind (Apply MkFoo3Sym0 arg) (MkFoo3Sym1 arg) =>
-                                   MkFoo3Sym0 a0123456789876543210
-    type instance Apply @Bool @((~>) Bool Foo3) MkFoo3Sym0 a0123456789876543210 = MkFoo3Sym1 a0123456789876543210
+                                   MkFoo3Sym0 a_Singletons_ShowDeriving_21
+    type instance Apply @Bool @((~>) Bool Foo3) MkFoo3Sym0 a_Singletons_ShowDeriving_21 = MkFoo3Sym1 a_Singletons_ShowDeriving_21
     instance SuppressUnusedWarnings MkFoo3Sym0 where
       suppressUnusedWarnings = snd ((,) MkFoo3Sym0KindInference ())
     type MkFoo3Sym1 :: Bool -> (~>) Bool Foo3
-    data MkFoo3Sym1 (a0123456789876543210 :: Bool) :: (~>) Bool Foo3
+    data MkFoo3Sym1 (a_Singletons_ShowDeriving_21 :: Bool) :: (~>) Bool Foo3
       where
-        MkFoo3Sym1KindInference :: SameKind (Apply (MkFoo3Sym1 a0123456789876543210) arg) (MkFoo3Sym2 a0123456789876543210 arg) =>
-                                   MkFoo3Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Bool @Foo3 (MkFoo3Sym1 a0123456789876543210) a0123456789876543210 = MkFoo3 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (MkFoo3Sym1 a0123456789876543210) where
+        MkFoo3Sym1KindInference :: SameKind (Apply (MkFoo3Sym1 a_Singletons_ShowDeriving_21) arg) (MkFoo3Sym2 a_Singletons_ShowDeriving_21 arg) =>
+                                   MkFoo3Sym1 a_Singletons_ShowDeriving_21 a_Singletons_ShowDeriving_22
+    type instance Apply @Bool @Foo3 (MkFoo3Sym1 a_Singletons_ShowDeriving_21) a_Singletons_ShowDeriving_22 = MkFoo3 a_Singletons_ShowDeriving_21 a_Singletons_ShowDeriving_22
+    instance SuppressUnusedWarnings (MkFoo3Sym1 a_Singletons_ShowDeriving_21) where
       suppressUnusedWarnings = snd ((,) MkFoo3Sym1KindInference ())
     type MkFoo3Sym2 :: Bool -> Bool -> Foo3
-    type family MkFoo3Sym2 (a0123456789876543210 :: Bool) (a0123456789876543210 :: Bool) :: Foo3 where
-      MkFoo3Sym2 a0123456789876543210 a0123456789876543210 = MkFoo3 a0123456789876543210 a0123456789876543210
+    type family MkFoo3Sym2 (a_Singletons_ShowDeriving_21 :: Bool) (a_Singletons_ShowDeriving_22 :: Bool) :: Foo3 where
+      MkFoo3Sym2 a_Singletons_ShowDeriving_21 a_Singletons_ShowDeriving_22 = MkFoo3 a_Singletons_ShowDeriving_21 a_Singletons_ShowDeriving_22
     type (***@#@$) :: (~>) Foo3 Bool
     data (***@#@$) :: (~>) Foo3 Bool
       where
         (:***@#@$###) :: SameKind (Apply (***@#@$) arg) ((***@#@$$) arg) =>
-                         (***@#@$) a0123456789876543210
-    type instance Apply @Foo3 @Bool (***@#@$) a0123456789876543210 = (***) a0123456789876543210
+                         (***@#@$) a_Singletons_ShowDeriving_23
+    type instance Apply @Foo3 @Bool (***@#@$) a_Singletons_ShowDeriving_23 = (***) a_Singletons_ShowDeriving_23
     instance SuppressUnusedWarnings (***@#@$) where
       suppressUnusedWarnings = snd ((,) (:***@#@$###) ())
     type (***@#@$$) :: Foo3 -> Bool
-    type family (***@#@$$) (a0123456789876543210 :: Foo3) :: Bool where
-      (***@#@$$) a0123456789876543210 = (***) a0123456789876543210
+    type family (***@#@$$) (a_Singletons_ShowDeriving_23 :: Foo3) :: Bool where
+      (***@#@$$) a_Singletons_ShowDeriving_23 = (***) a_Singletons_ShowDeriving_23
     type GetFoo3aSym0 :: (~>) Foo3 Bool
     data GetFoo3aSym0 :: (~>) Foo3 Bool
       where
         GetFoo3aSym0KindInference :: SameKind (Apply GetFoo3aSym0 arg) (GetFoo3aSym1 arg) =>
-                                     GetFoo3aSym0 a0123456789876543210
-    type instance Apply @Foo3 @Bool GetFoo3aSym0 a0123456789876543210 = GetFoo3a a0123456789876543210
+                                     GetFoo3aSym0 a_Singletons_ShowDeriving_24
+    type instance Apply @Foo3 @Bool GetFoo3aSym0 a_Singletons_ShowDeriving_24 = GetFoo3a a_Singletons_ShowDeriving_24
     instance SuppressUnusedWarnings GetFoo3aSym0 where
       suppressUnusedWarnings = snd ((,) GetFoo3aSym0KindInference ())
     type GetFoo3aSym1 :: Foo3 -> Bool
-    type family GetFoo3aSym1 (a0123456789876543210 :: Foo3) :: Bool where
-      GetFoo3aSym1 a0123456789876543210 = GetFoo3a a0123456789876543210
+    type family GetFoo3aSym1 (a_Singletons_ShowDeriving_24 :: Foo3) :: Bool where
+      GetFoo3aSym1 a_Singletons_ShowDeriving_24 = GetFoo3a a_Singletons_ShowDeriving_24
     type (***) :: Foo3 -> Bool
     type family (***) (a :: Foo3) :: Bool where
       (***) (MkFoo3 _ field) = field
     type GetFoo3a :: Foo3 -> Bool
     type family GetFoo3a (a :: Foo3) :: Bool where
       GetFoo3a (MkFoo3 field _) = field
-    type ShowsPrec_0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural
-                                          -> Foo1 -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210 (a :: GHC.Internal.Bignum.Natural.Natural) (a :: Foo1) (a :: Symbol) :: Symbol where
-      ShowsPrec_0123456789876543210 _ MkFoo1 a_0123456789876543210 = Apply (Apply ShowStringSym0 "MkFoo1") a_0123456789876543210
+    type ShowsPrec_Singletons_ShowDeriving_25 :: GHC.Internal.Bignum.Natural.Natural
+                                                 -> Foo1 -> Symbol -> Symbol
+    type family ShowsPrec_Singletons_ShowDeriving_25 (a :: GHC.Internal.Bignum.Natural.Natural) (a :: Foo1) (a :: Symbol) :: Symbol where
+      ShowsPrec_Singletons_ShowDeriving_25 _ MkFoo1 a_Singletons_ShowDeriving_26 = Apply (Apply ShowStringSym0 "MkFoo1") a_Singletons_ShowDeriving_26
     instance PShow Foo1 where
-      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
-    type ShowsPrec_0123456789876543210 :: forall a. GHC.Internal.Bignum.Natural.Natural
-                                                    -> Foo2 a -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210 @a (a :: GHC.Internal.Bignum.Natural.Natural) (a :: Foo2 a) (a :: Symbol) :: Symbol where
-      ShowsPrec_0123456789876543210 @a (p_0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) (MkFoo2a arg_0123456789876543210 arg_0123456789876543210 :: Foo2 a) (a_0123456789876543210 :: Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "MkFoo2a ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
-      ShowsPrec_0123456789876543210 @a (p_0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) (MkFoo2b argL_0123456789876543210 argR_0123456789876543210 :: Foo2 a) (a_0123456789876543210 :: Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 5))) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 6)) argL_0123456789876543210)) (Apply (Apply (.@#@$) (Apply ShowStringSym0 " `MkFoo2b` ")) (Apply (Apply ShowsPrecSym0 (FromInteger 6)) argR_0123456789876543210)))) a_0123456789876543210
-      ShowsPrec_0123456789876543210 @a (p_0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) ((:*:) arg_0123456789876543210 arg_0123456789876543210 :: Foo2 a) (a_0123456789876543210 :: Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "(:*:) ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
-      ShowsPrec_0123456789876543210 @a (p_0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) ((:&:) argL_0123456789876543210 argR_0123456789876543210 :: Foo2 a) (a_0123456789876543210 :: Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 5))) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 6)) argL_0123456789876543210)) (Apply (Apply (.@#@$) (Apply ShowStringSym0 " :&: ")) (Apply (Apply ShowsPrecSym0 (FromInteger 6)) argR_0123456789876543210)))) a_0123456789876543210
+      type ShowsPrec a a a = ShowsPrec_Singletons_ShowDeriving_25 a a a
+    type ShowsPrec_Singletons_ShowDeriving_30 :: forall a. GHC.Internal.Bignum.Natural.Natural
+                                                           -> Foo2 a -> Symbol -> Symbol
+    type family ShowsPrec_Singletons_ShowDeriving_30 @a (a :: GHC.Internal.Bignum.Natural.Natural) (a :: Foo2 a) (a :: Symbol) :: Symbol where
+      ShowsPrec_Singletons_ShowDeriving_30 @a (p_Singletons_ShowDeriving_1 :: GHC.Internal.Bignum.Natural.Natural) (MkFoo2a arg_Singletons_ShowDeriving_2 arg_Singletons_ShowDeriving_3 :: Foo2 a) (a_Singletons_ShowDeriving_31 :: Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_Singletons_ShowDeriving_1) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "MkFoo2a ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_Singletons_ShowDeriving_2)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_Singletons_ShowDeriving_3))))) a_Singletons_ShowDeriving_31
+      ShowsPrec_Singletons_ShowDeriving_30 @a (p_Singletons_ShowDeriving_1 :: GHC.Internal.Bignum.Natural.Natural) (MkFoo2b argL_Singletons_ShowDeriving_4 argR_Singletons_ShowDeriving_5 :: Foo2 a) (a_Singletons_ShowDeriving_32 :: Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_Singletons_ShowDeriving_1) (FromInteger 5))) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 6)) argL_Singletons_ShowDeriving_4)) (Apply (Apply (.@#@$) (Apply ShowStringSym0 " `MkFoo2b` ")) (Apply (Apply ShowsPrecSym0 (FromInteger 6)) argR_Singletons_ShowDeriving_5)))) a_Singletons_ShowDeriving_32
+      ShowsPrec_Singletons_ShowDeriving_30 @a (p_Singletons_ShowDeriving_1 :: GHC.Internal.Bignum.Natural.Natural) ((:*:) arg_Singletons_ShowDeriving_6 arg_Singletons_ShowDeriving_7 :: Foo2 a) (a_Singletons_ShowDeriving_33 :: Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_Singletons_ShowDeriving_1) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "(:*:) ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_Singletons_ShowDeriving_6)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_Singletons_ShowDeriving_7))))) a_Singletons_ShowDeriving_33
+      ShowsPrec_Singletons_ShowDeriving_30 @a (p_Singletons_ShowDeriving_1 :: GHC.Internal.Bignum.Natural.Natural) ((:&:) argL_Singletons_ShowDeriving_8 argR_Singletons_ShowDeriving_9 :: Foo2 a) (a_Singletons_ShowDeriving_34 :: Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_Singletons_ShowDeriving_1) (FromInteger 5))) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 6)) argL_Singletons_ShowDeriving_8)) (Apply (Apply (.@#@$) (Apply ShowStringSym0 " :&: ")) (Apply (Apply ShowsPrecSym0 (FromInteger 6)) argR_Singletons_ShowDeriving_9)))) a_Singletons_ShowDeriving_34
     instance PShow (Foo2 a) where
-      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
-    type ShowsPrec_0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural
-                                          -> Foo3 -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210 (a :: GHC.Internal.Bignum.Natural.Natural) (a :: Foo3) (a :: Symbol) :: Symbol where
-      ShowsPrec_0123456789876543210 p_0123456789876543210 (MkFoo3 arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "MkFoo3 ")) (Apply (Apply (.@#@$) (Apply ShowCharSym0 '{')) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "getFoo3a = ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 0)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowCommaSpaceSym0) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "(***) = ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 0)) arg_0123456789876543210)) (Apply ShowCharSym0 '}'))))))))) a_0123456789876543210
+      type ShowsPrec a a a = ShowsPrec_Singletons_ShowDeriving_30 a a a
+    type ShowsPrec_Singletons_ShowDeriving_38 :: GHC.Internal.Bignum.Natural.Natural
+                                                 -> Foo3 -> Symbol -> Symbol
+    type family ShowsPrec_Singletons_ShowDeriving_38 (a :: GHC.Internal.Bignum.Natural.Natural) (a :: Foo3) (a :: Symbol) :: Symbol where
+      ShowsPrec_Singletons_ShowDeriving_38 p_Singletons_ShowDeriving_10 (MkFoo3 arg_Singletons_ShowDeriving_11 arg_Singletons_ShowDeriving_12) a_Singletons_ShowDeriving_39 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_Singletons_ShowDeriving_10) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "MkFoo3 ")) (Apply (Apply (.@#@$) (Apply ShowCharSym0 '{')) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "getFoo3a = ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 0)) arg_Singletons_ShowDeriving_11)) (Apply (Apply (.@#@$) ShowCommaSpaceSym0) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "(***) = ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 0)) arg_Singletons_ShowDeriving_12)) (Apply ShowCharSym0 '}'))))))))) a_Singletons_ShowDeriving_39
     instance PShow Foo3 where
-      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
+      type ShowsPrec a a a = ShowsPrec_Singletons_ShowDeriving_38 a a a
     infixl 5 data :%&:
     infixl 5 data :%*:
     infixl 5 data `SMkFoo2b`
@@ -243,23 +243,23 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
       sShowsPrec
         _
         SMkFoo1
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_Singletons_ShowDeriving_26 :: Sing a_Singletons_ShowDeriving_26)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "MkFoo1"))
-            sA_0123456789876543210
+            sA_Singletons_ShowDeriving_26
     instance SShow a => SShow (Foo2 a) where
       sShowsPrec
-        (sP_0123456789876543210 :: Sing p_0123456789876543210)
-        (SMkFoo2a (sArg_0123456789876543210 :: Sing arg_0123456789876543210)
-                  (sArg_0123456789876543210 :: Sing arg_0123456789876543210))
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sP_Singletons_ShowDeriving_1 :: Sing p_Singletons_ShowDeriving_1)
+        (SMkFoo2a (sArg_Singletons_ShowDeriving_2 :: Sing arg_Singletons_ShowDeriving_2)
+                  (sArg_Singletons_ShowDeriving_3 :: Sing arg_Singletons_ShowDeriving_3))
+        (sA_Singletons_ShowDeriving_31 :: Sing a_Singletons_ShowDeriving_31)
         = applySing
             (applySing
                (applySing
                   (singFun3 @ShowParenSym0 sShowParen)
                   (applySing
-                     (applySing (singFun2 @(>@#@$) (%>)) sP_0123456789876543210)
+                     (applySing (singFun2 @(>@#@$) (%>)) sP_Singletons_ShowDeriving_1)
                      (sFromInteger (sing :: Sing 10))))
                (applySing
                   (applySing
@@ -273,7 +273,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                            (applySing
                               (singFun3 @ShowsPrecSym0 sShowsPrec)
                               (sFromInteger (sing :: Sing 11)))
-                           sArg_0123456789876543210))
+                           sArg_Singletons_ShowDeriving_2))
                      (applySing
                         (applySing
                            (singFun3 @(.@#@$) (%.)) (singFun1 @ShowSpaceSym0 sShowSpace))
@@ -281,19 +281,19 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                            (applySing
                               (singFun3 @ShowsPrecSym0 sShowsPrec)
                               (sFromInteger (sing :: Sing 11)))
-                           sArg_0123456789876543210)))))
-            sA_0123456789876543210
+                           sArg_Singletons_ShowDeriving_3)))))
+            sA_Singletons_ShowDeriving_31
       sShowsPrec
-        (sP_0123456789876543210 :: Sing p_0123456789876543210)
-        (SMkFoo2b (sArgL_0123456789876543210 :: Sing argL_0123456789876543210)
-                  (sArgR_0123456789876543210 :: Sing argR_0123456789876543210))
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sP_Singletons_ShowDeriving_1 :: Sing p_Singletons_ShowDeriving_1)
+        (SMkFoo2b (sArgL_Singletons_ShowDeriving_4 :: Sing argL_Singletons_ShowDeriving_4)
+                  (sArgR_Singletons_ShowDeriving_5 :: Sing argR_Singletons_ShowDeriving_5))
+        (sA_Singletons_ShowDeriving_32 :: Sing a_Singletons_ShowDeriving_32)
         = applySing
             (applySing
                (applySing
                   (singFun3 @ShowParenSym0 sShowParen)
                   (applySing
-                     (applySing (singFun2 @(>@#@$) (%>)) sP_0123456789876543210)
+                     (applySing (singFun2 @(>@#@$) (%>)) sP_Singletons_ShowDeriving_1)
                      (sFromInteger (sing :: Sing 5))))
                (applySing
                   (applySing
@@ -302,7 +302,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                         (applySing
                            (singFun3 @ShowsPrecSym0 sShowsPrec)
                            (sFromInteger (sing :: Sing 6)))
-                        sArgL_0123456789876543210))
+                        sArgL_Singletons_ShowDeriving_4))
                   (applySing
                      (applySing
                         (singFun3 @(.@#@$) (%.))
@@ -313,19 +313,19 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                         (applySing
                            (singFun3 @ShowsPrecSym0 sShowsPrec)
                            (sFromInteger (sing :: Sing 6)))
-                        sArgR_0123456789876543210))))
-            sA_0123456789876543210
+                        sArgR_Singletons_ShowDeriving_5))))
+            sA_Singletons_ShowDeriving_32
       sShowsPrec
-        (sP_0123456789876543210 :: Sing p_0123456789876543210)
-        ((:%*:) (sArg_0123456789876543210 :: Sing arg_0123456789876543210)
-                (sArg_0123456789876543210 :: Sing arg_0123456789876543210))
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sP_Singletons_ShowDeriving_1 :: Sing p_Singletons_ShowDeriving_1)
+        ((:%*:) (sArg_Singletons_ShowDeriving_6 :: Sing arg_Singletons_ShowDeriving_6)
+                (sArg_Singletons_ShowDeriving_7 :: Sing arg_Singletons_ShowDeriving_7))
+        (sA_Singletons_ShowDeriving_33 :: Sing a_Singletons_ShowDeriving_33)
         = applySing
             (applySing
                (applySing
                   (singFun3 @ShowParenSym0 sShowParen)
                   (applySing
-                     (applySing (singFun2 @(>@#@$) (%>)) sP_0123456789876543210)
+                     (applySing (singFun2 @(>@#@$) (%>)) sP_Singletons_ShowDeriving_1)
                      (sFromInteger (sing :: Sing 10))))
                (applySing
                   (applySing
@@ -339,7 +339,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                            (applySing
                               (singFun3 @ShowsPrecSym0 sShowsPrec)
                               (sFromInteger (sing :: Sing 11)))
-                           sArg_0123456789876543210))
+                           sArg_Singletons_ShowDeriving_6))
                      (applySing
                         (applySing
                            (singFun3 @(.@#@$) (%.)) (singFun1 @ShowSpaceSym0 sShowSpace))
@@ -347,19 +347,19 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                            (applySing
                               (singFun3 @ShowsPrecSym0 sShowsPrec)
                               (sFromInteger (sing :: Sing 11)))
-                           sArg_0123456789876543210)))))
-            sA_0123456789876543210
+                           sArg_Singletons_ShowDeriving_7)))))
+            sA_Singletons_ShowDeriving_33
       sShowsPrec
-        (sP_0123456789876543210 :: Sing p_0123456789876543210)
-        ((:%&:) (sArgL_0123456789876543210 :: Sing argL_0123456789876543210)
-                (sArgR_0123456789876543210 :: Sing argR_0123456789876543210))
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sP_Singletons_ShowDeriving_1 :: Sing p_Singletons_ShowDeriving_1)
+        ((:%&:) (sArgL_Singletons_ShowDeriving_8 :: Sing argL_Singletons_ShowDeriving_8)
+                (sArgR_Singletons_ShowDeriving_9 :: Sing argR_Singletons_ShowDeriving_9))
+        (sA_Singletons_ShowDeriving_34 :: Sing a_Singletons_ShowDeriving_34)
         = applySing
             (applySing
                (applySing
                   (singFun3 @ShowParenSym0 sShowParen)
                   (applySing
-                     (applySing (singFun2 @(>@#@$) (%>)) sP_0123456789876543210)
+                     (applySing (singFun2 @(>@#@$) (%>)) sP_Singletons_ShowDeriving_1)
                      (sFromInteger (sing :: Sing 5))))
                (applySing
                   (applySing
@@ -368,7 +368,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                         (applySing
                            (singFun3 @ShowsPrecSym0 sShowsPrec)
                            (sFromInteger (sing :: Sing 6)))
-                        sArgL_0123456789876543210))
+                        sArgL_Singletons_ShowDeriving_8))
                   (applySing
                      (applySing
                         (singFun3 @(.@#@$) (%.))
@@ -378,20 +378,20 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                         (applySing
                            (singFun3 @ShowsPrecSym0 sShowsPrec)
                            (sFromInteger (sing :: Sing 6)))
-                        sArgR_0123456789876543210))))
-            sA_0123456789876543210
+                        sArgR_Singletons_ShowDeriving_9))))
+            sA_Singletons_ShowDeriving_34
     instance SShow Bool => SShow Foo3 where
       sShowsPrec
-        (sP_0123456789876543210 :: Sing p_0123456789876543210)
-        (SMkFoo3 (sArg_0123456789876543210 :: Sing arg_0123456789876543210)
-                 (sArg_0123456789876543210 :: Sing arg_0123456789876543210))
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sP_Singletons_ShowDeriving_10 :: Sing p_Singletons_ShowDeriving_10)
+        (SMkFoo3 (sArg_Singletons_ShowDeriving_11 :: Sing arg_Singletons_ShowDeriving_11)
+                 (sArg_Singletons_ShowDeriving_12 :: Sing arg_Singletons_ShowDeriving_12))
+        (sA_Singletons_ShowDeriving_39 :: Sing a_Singletons_ShowDeriving_39)
         = applySing
             (applySing
                (applySing
                   (singFun3 @ShowParenSym0 sShowParen)
                   (applySing
-                     (applySing (singFun2 @(>@#@$) (%>)) sP_0123456789876543210)
+                     (applySing (singFun2 @(>@#@$) (%>)) sP_Singletons_ShowDeriving_10)
                      (sFromInteger (sing :: Sing 10))))
                (applySing
                   (applySing
@@ -415,7 +415,7 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                                  (applySing
                                     (singFun3 @ShowsPrecSym0 sShowsPrec)
                                     (sFromInteger (sing :: Sing 0)))
-                                 sArg_0123456789876543210))
+                                 sArg_Singletons_ShowDeriving_11))
                            (applySing
                               (applySing
                                  (singFun3 @(.@#@$) (%.))
@@ -433,11 +433,11 @@ Singletons/ShowDeriving.hs:(0,0)-(0,0): Splicing declarations
                                           (applySing
                                              (singFun3 @ShowsPrecSym0 sShowsPrec)
                                              (sFromInteger (sing :: Sing 0)))
-                                          sArg_0123456789876543210))
+                                          sArg_Singletons_ShowDeriving_12))
                                     (applySing
                                        (singFun2 @ShowCharSym0 sShowChar)
                                        (sing :: Sing '}'))))))))))
-            sA_0123456789876543210
+            sA_Singletons_ShowDeriving_39
     deriving instance Show (SFoo1 (z :: Foo1))
     deriving instance Data.Singletons.ShowSing.ShowSing a =>
                       Show (SFoo2 (z :: Foo2 a))

--- a/singletons-base/tests/compile-and-dump/Singletons/StandaloneDeriving.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/StandaloneDeriving.golden
@@ -29,23 +29,23 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
     data (:*:@#@$) :: (~>) a ((~>) b (T a b))
       where
         (::*:@#@$###) :: SameKind (Apply (:*:@#@$) arg) ((:*:@#@$$) arg) =>
-                         (:*:@#@$) a0123456789876543210
-    type instance Apply @a @((~>) b (T a b)) (:*:@#@$) a0123456789876543210 = (:*:@#@$$) a0123456789876543210
+                         (:*:@#@$) a_Singletons_StandaloneDeriving_12
+    type instance Apply @a @((~>) b (T a b)) (:*:@#@$) a_Singletons_StandaloneDeriving_12 = (:*:@#@$$) a_Singletons_StandaloneDeriving_12
     instance SuppressUnusedWarnings (:*:@#@$) where
       suppressUnusedWarnings = snd ((,) (::*:@#@$###) ())
     infixl 6 type :*:@#@$
     type (:*:@#@$$) :: forall a b. a -> (~>) b (T a b)
-    data (:*:@#@$$) (a0123456789876543210 :: a) :: (~>) b (T a b)
+    data (:*:@#@$$) (a_Singletons_StandaloneDeriving_12 :: a) :: (~>) b (T a b)
       where
-        (::*:@#@$$###) :: SameKind (Apply ((:*:@#@$$) a0123456789876543210) arg) ((:*:@#@$$$) a0123456789876543210 arg) =>
-                          (:*:@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @b @(T a b) ((:*:@#@$$) a0123456789876543210) a0123456789876543210 = (:*:) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((:*:@#@$$) a0123456789876543210) where
+        (::*:@#@$$###) :: SameKind (Apply ((:*:@#@$$) a_Singletons_StandaloneDeriving_12) arg) ((:*:@#@$$$) a_Singletons_StandaloneDeriving_12 arg) =>
+                          (:*:@#@$$) a_Singletons_StandaloneDeriving_12 a_Singletons_StandaloneDeriving_13
+    type instance Apply @b @(T a b) ((:*:@#@$$) a_Singletons_StandaloneDeriving_12) a_Singletons_StandaloneDeriving_13 = (:*:) a_Singletons_StandaloneDeriving_12 a_Singletons_StandaloneDeriving_13
+    instance SuppressUnusedWarnings ((:*:@#@$$) a_Singletons_StandaloneDeriving_12) where
       suppressUnusedWarnings = snd ((,) (::*:@#@$$###) ())
     infixl 6 type :*:@#@$$
     type (:*:@#@$$$) :: forall a b. a -> b -> T a b
-    type family (:*:@#@$$$) @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: T a b where
-      (:*:@#@$$$) a0123456789876543210 a0123456789876543210 = (:*:) a0123456789876543210 a0123456789876543210
+    type family (:*:@#@$$$) @a @b (a_Singletons_StandaloneDeriving_12 :: a) (a_Singletons_StandaloneDeriving_13 :: b) :: T a b where
+      (:*:@#@$$$) a_Singletons_StandaloneDeriving_12 a_Singletons_StandaloneDeriving_13 = (:*:) a_Singletons_StandaloneDeriving_12 a_Singletons_StandaloneDeriving_13
     infixl 6 type :*:@#@$$$
     type S1Sym0 :: S
     type family S1Sym0 :: S where
@@ -53,94 +53,96 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
     type S2Sym0 :: S
     type family S2Sym0 :: S where
       S2Sym0 = S2
-    type TFHelper_0123456789876543210 :: forall a. T a ()
-                                                   -> T a () -> Bool
-    type family TFHelper_0123456789876543210 @a (a :: T a ()) (a :: T a ()) :: Bool where
-      TFHelper_0123456789876543210 @a ((:*:) a_0123456789876543210 a_0123456789876543210 :: T a ()) ((:*:) b_0123456789876543210 b_0123456789876543210 :: T a ()) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)
+    type TFHelper_Singletons_StandaloneDeriving_14 :: forall a. T a ()
+                                                                -> T a () -> Bool
+    type family TFHelper_Singletons_StandaloneDeriving_14 @a (a :: T a ()) (a :: T a ()) :: Bool where
+      TFHelper_Singletons_StandaloneDeriving_14 @a ((:*:) a_Singletons_StandaloneDeriving_0 a_Singletons_StandaloneDeriving_1 :: T a ()) ((:*:) b_Singletons_StandaloneDeriving_2 b_Singletons_StandaloneDeriving_3 :: T a ()) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_Singletons_StandaloneDeriving_0) b_Singletons_StandaloneDeriving_2)) (Apply (Apply (==@#@$) a_Singletons_StandaloneDeriving_1) b_Singletons_StandaloneDeriving_3)
     instance PEq (T a ()) where
-      type (==) a a = TFHelper_0123456789876543210 a a
-    type Compare_0123456789876543210 :: forall a. T a ()
-                                                  -> T a () -> Ordering
-    type family Compare_0123456789876543210 @a (a :: T a ()) (a :: T a ()) :: Ordering where
-      Compare_0123456789876543210 @a ((:*:) a_0123456789876543210 a_0123456789876543210 :: T a ()) ((:*:) b_0123456789876543210 b_0123456789876543210 :: T a ()) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0))
+      type (==) a a = TFHelper_Singletons_StandaloneDeriving_14 a a
+    type Compare_Singletons_StandaloneDeriving_17 :: forall a. T a ()
+                                                               -> T a () -> Ordering
+    type family Compare_Singletons_StandaloneDeriving_17 @a (a :: T a ()) (a :: T a ()) :: Ordering where
+      Compare_Singletons_StandaloneDeriving_17 @a ((:*:) a_Singletons_StandaloneDeriving_4 a_Singletons_StandaloneDeriving_5 :: T a ()) ((:*:) b_Singletons_StandaloneDeriving_6 b_Singletons_StandaloneDeriving_7 :: T a ()) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_StandaloneDeriving_4) b_Singletons_StandaloneDeriving_6)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_StandaloneDeriving_5) b_Singletons_StandaloneDeriving_7)) NilSym0))
     instance POrd (T a ()) where
-      type Compare a a = Compare_0123456789876543210 a a
-    type ShowsPrec_0123456789876543210 :: forall a. GHC.Internal.Bignum.Natural.Natural
-                                                    -> T a () -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210 @a (a :: GHC.Internal.Bignum.Natural.Natural) (a :: T a ()) (a :: Symbol) :: Symbol where
-      ShowsPrec_0123456789876543210 @a (p_0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) ((:*:) argL_0123456789876543210 argR_0123456789876543210 :: T a ()) (a_0123456789876543210 :: Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 6))) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 7)) argL_0123456789876543210)) (Apply (Apply (.@#@$) (Apply ShowStringSym0 " :*: ")) (Apply (Apply ShowsPrecSym0 (FromInteger 7)) argR_0123456789876543210)))) a_0123456789876543210
+      type Compare a a = Compare_Singletons_StandaloneDeriving_17 a a
+    type ShowsPrec_Singletons_StandaloneDeriving_20 :: forall a. GHC.Internal.Bignum.Natural.Natural
+                                                                 -> T a () -> Symbol -> Symbol
+    type family ShowsPrec_Singletons_StandaloneDeriving_20 @a (a :: GHC.Internal.Bignum.Natural.Natural) (a :: T a ()) (a :: Symbol) :: Symbol where
+      ShowsPrec_Singletons_StandaloneDeriving_20 @a (p_Singletons_StandaloneDeriving_8 :: GHC.Internal.Bignum.Natural.Natural) ((:*:) argL_Singletons_StandaloneDeriving_9 argR_Singletons_StandaloneDeriving_10 :: T a ()) (a_Singletons_StandaloneDeriving_21 :: Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_Singletons_StandaloneDeriving_8) (FromInteger 6))) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 7)) argL_Singletons_StandaloneDeriving_9)) (Apply (Apply (.@#@$) (Apply ShowStringSym0 " :*: ")) (Apply (Apply ShowsPrecSym0 (FromInteger 7)) argR_Singletons_StandaloneDeriving_10)))) a_Singletons_StandaloneDeriving_21
     instance PShow (T a ()) where
-      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
-    type TFHelper_0123456789876543210 :: S -> S -> Bool
-    type family TFHelper_0123456789876543210 (a :: S) (a :: S) :: Bool where
-      TFHelper_0123456789876543210 S1 S1 = TrueSym0
-      TFHelper_0123456789876543210 S1 S2 = FalseSym0
-      TFHelper_0123456789876543210 S2 S1 = FalseSym0
-      TFHelper_0123456789876543210 S2 S2 = TrueSym0
+      type ShowsPrec a a a = ShowsPrec_Singletons_StandaloneDeriving_20 a a a
+    type TFHelper_Singletons_StandaloneDeriving_25 :: S -> S -> Bool
+    type family TFHelper_Singletons_StandaloneDeriving_25 (a :: S) (a :: S) :: Bool where
+      TFHelper_Singletons_StandaloneDeriving_25 S1 S1 = TrueSym0
+      TFHelper_Singletons_StandaloneDeriving_25 S1 S2 = FalseSym0
+      TFHelper_Singletons_StandaloneDeriving_25 S2 S1 = FalseSym0
+      TFHelper_Singletons_StandaloneDeriving_25 S2 S2 = TrueSym0
     instance PEq S where
-      type (==) a a = TFHelper_0123456789876543210 a a
-    type Compare_0123456789876543210 :: S -> S -> Ordering
-    type family Compare_0123456789876543210 (a :: S) (a :: S) :: Ordering where
-      Compare_0123456789876543210 S1 S1 = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
-      Compare_0123456789876543210 S2 S2 = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
-      Compare_0123456789876543210 S1 S2 = LTSym0
-      Compare_0123456789876543210 S2 S1 = GTSym0
+      type (==) a a = TFHelper_Singletons_StandaloneDeriving_25 a a
+    type Compare_Singletons_StandaloneDeriving_28 :: S -> S -> Ordering
+    type family Compare_Singletons_StandaloneDeriving_28 (a :: S) (a :: S) :: Ordering where
+      Compare_Singletons_StandaloneDeriving_28 S1 S1 = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
+      Compare_Singletons_StandaloneDeriving_28 S2 S2 = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
+      Compare_Singletons_StandaloneDeriving_28 S1 S2 = LTSym0
+      Compare_Singletons_StandaloneDeriving_28 S2 S1 = GTSym0
     instance POrd S where
-      type Compare a a = Compare_0123456789876543210 a a
-    type ShowsPrec_0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural
-                                          -> S -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210 (a :: GHC.Internal.Bignum.Natural.Natural) (a :: S) (a :: Symbol) :: Symbol where
-      ShowsPrec_0123456789876543210 _ S1 a_0123456789876543210 = Apply (Apply ShowStringSym0 "S1") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ S2 a_0123456789876543210 = Apply (Apply ShowStringSym0 "S2") a_0123456789876543210
+      type Compare a a = Compare_Singletons_StandaloneDeriving_28 a a
+    type ShowsPrec_Singletons_StandaloneDeriving_31 :: GHC.Internal.Bignum.Natural.Natural
+                                                       -> S -> Symbol -> Symbol
+    type family ShowsPrec_Singletons_StandaloneDeriving_31 (a :: GHC.Internal.Bignum.Natural.Natural) (a :: S) (a :: Symbol) :: Symbol where
+      ShowsPrec_Singletons_StandaloneDeriving_31 _ S1 a_Singletons_StandaloneDeriving_32 = Apply (Apply ShowStringSym0 "S1") a_Singletons_StandaloneDeriving_32
+      ShowsPrec_Singletons_StandaloneDeriving_31 _ S2 a_Singletons_StandaloneDeriving_33 = Apply (Apply ShowStringSym0 "S2") a_Singletons_StandaloneDeriving_33
     instance PShow S where
-      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
-    type MinBound_0123456789876543210 :: S
-    type family MinBound_0123456789876543210 :: S where
-      MinBound_0123456789876543210 = S1Sym0
-    type MaxBound_0123456789876543210 :: S
-    type family MaxBound_0123456789876543210 :: S where
-      MaxBound_0123456789876543210 = S2Sym0
+      type ShowsPrec a a a = ShowsPrec_Singletons_StandaloneDeriving_31 a a a
+    type MinBound_Singletons_StandaloneDeriving_37 :: S
+    type family MinBound_Singletons_StandaloneDeriving_37 :: S where
+      MinBound_Singletons_StandaloneDeriving_37 = S1Sym0
+    type MaxBound_Singletons_StandaloneDeriving_38 :: S
+    type family MaxBound_Singletons_StandaloneDeriving_38 :: S where
+      MaxBound_Singletons_StandaloneDeriving_38 = S2Sym0
     instance PBounded S where
-      type MinBound = MinBound_0123456789876543210
-      type MaxBound = MaxBound_0123456789876543210
-    type family LamCases_0123456789876543210 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_0123456789876543210 where
-      LamCases_0123456789876543210 n 'True = S2Sym0
-      LamCases_0123456789876543210 n 'False = Apply ErrorSym0 "toEnum: bad argument"
-    data LamCases_0123456789876543210Sym0 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_01234567898765432100123456789876543210
+      type MinBound = MinBound_Singletons_StandaloneDeriving_37
+      type MaxBound = MaxBound_Singletons_StandaloneDeriving_38
+    type family LamCases_Singletons_StandaloneDeriving_42 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_Singletons_StandaloneDeriving_43 where
+      LamCases_Singletons_StandaloneDeriving_42 n 'True = S2Sym0
+      LamCases_Singletons_StandaloneDeriving_42 n 'False = Apply ErrorSym0 "toEnum: bad argument"
+    data LamCases_Singletons_StandaloneDeriving_42Sym0 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_Singletons_StandaloneDeriving_43
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 n0123456789876543210) arg) (LamCases_0123456789876543210Sym1 n0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 n0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 n0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 n0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 n0123456789876543210) where
+        LamCases_Singletons_StandaloneDeriving_42Sym0KindInference :: SameKind (Apply (LamCases_Singletons_StandaloneDeriving_42Sym0 n0) arg) (LamCases_Singletons_StandaloneDeriving_42Sym1 n0 arg) =>
+                                                                      LamCases_Singletons_StandaloneDeriving_42Sym0 n0 a_Singletons_StandaloneDeriving_43
+    type instance Apply @_ @_ (LamCases_Singletons_StandaloneDeriving_42Sym0 n0) a_Singletons_StandaloneDeriving_43 = LamCases_Singletons_StandaloneDeriving_42 n0 a_Singletons_StandaloneDeriving_43
+    instance SuppressUnusedWarnings (LamCases_Singletons_StandaloneDeriving_42Sym0 n0) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 n0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 n0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_0123456789876543210 where
-      LamCases_0123456789876543210 n 'True = S1Sym0
-      LamCases_0123456789876543210 n 'False = Apply (LamCases_0123456789876543210Sym0 n) (Apply (Apply (==@#@$) n) (FromInteger 1))
-    data LamCases_0123456789876543210Sym0 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_01234567898765432100123456789876543210
+        = snd
+            ((,) LamCases_Singletons_StandaloneDeriving_42Sym0KindInference ())
+    type family LamCases_Singletons_StandaloneDeriving_42Sym1 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_Singletons_StandaloneDeriving_43 where
+      LamCases_Singletons_StandaloneDeriving_42Sym1 n0 a_Singletons_StandaloneDeriving_43 = LamCases_Singletons_StandaloneDeriving_42 n0 a_Singletons_StandaloneDeriving_43
+    type family LamCases_Singletons_StandaloneDeriving_41 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_Singletons_StandaloneDeriving_44 where
+      LamCases_Singletons_StandaloneDeriving_41 n 'True = S1Sym0
+      LamCases_Singletons_StandaloneDeriving_41 n 'False = Apply (LamCases_Singletons_StandaloneDeriving_42Sym0 n) (Apply (Apply (==@#@$) n) (FromInteger 1))
+    data LamCases_Singletons_StandaloneDeriving_41Sym0 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_Singletons_StandaloneDeriving_44
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 n0123456789876543210) arg) (LamCases_0123456789876543210Sym1 n0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 n0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 n0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 n0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 n0123456789876543210) where
+        LamCases_Singletons_StandaloneDeriving_41Sym0KindInference :: SameKind (Apply (LamCases_Singletons_StandaloneDeriving_41Sym0 n0) arg) (LamCases_Singletons_StandaloneDeriving_41Sym1 n0 arg) =>
+                                                                      LamCases_Singletons_StandaloneDeriving_41Sym0 n0 a_Singletons_StandaloneDeriving_44
+    type instance Apply @_ @_ (LamCases_Singletons_StandaloneDeriving_41Sym0 n0) a_Singletons_StandaloneDeriving_44 = LamCases_Singletons_StandaloneDeriving_41 n0 a_Singletons_StandaloneDeriving_44
+    instance SuppressUnusedWarnings (LamCases_Singletons_StandaloneDeriving_41Sym0 n0) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 n0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 n0123456789876543210 a_01234567898765432100123456789876543210
-    type ToEnum_0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural
-                                       -> S
-    type family ToEnum_0123456789876543210 (a :: GHC.Internal.Bignum.Natural.Natural) :: S where
-      ToEnum_0123456789876543210 n = Apply (LamCases_0123456789876543210Sym0 n) (Apply (Apply (==@#@$) n) (FromInteger 0))
-    type FromEnum_0123456789876543210 :: S
-                                         -> GHC.Internal.Bignum.Natural.Natural
-    type family FromEnum_0123456789876543210 (a :: S) :: GHC.Internal.Bignum.Natural.Natural where
-      FromEnum_0123456789876543210 S1 = FromInteger 0
-      FromEnum_0123456789876543210 S2 = FromInteger 1
+        = snd
+            ((,) LamCases_Singletons_StandaloneDeriving_41Sym0KindInference ())
+    type family LamCases_Singletons_StandaloneDeriving_41Sym1 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_Singletons_StandaloneDeriving_44 where
+      LamCases_Singletons_StandaloneDeriving_41Sym1 n0 a_Singletons_StandaloneDeriving_44 = LamCases_Singletons_StandaloneDeriving_41 n0 a_Singletons_StandaloneDeriving_44
+    type ToEnum_Singletons_StandaloneDeriving_39 :: GHC.Internal.Bignum.Natural.Natural
+                                                    -> S
+    type family ToEnum_Singletons_StandaloneDeriving_39 (a :: GHC.Internal.Bignum.Natural.Natural) :: S where
+      ToEnum_Singletons_StandaloneDeriving_39 n = Apply (LamCases_Singletons_StandaloneDeriving_41Sym0 n) (Apply (Apply (==@#@$) n) (FromInteger 0))
+    type FromEnum_Singletons_StandaloneDeriving_45 :: S
+                                                      -> GHC.Internal.Bignum.Natural.Natural
+    type family FromEnum_Singletons_StandaloneDeriving_45 (a :: S) :: GHC.Internal.Bignum.Natural.Natural where
+      FromEnum_Singletons_StandaloneDeriving_45 S1 = FromInteger 0
+      FromEnum_Singletons_StandaloneDeriving_45 S2 = FromInteger 1
     instance PEnum S where
-      type ToEnum a = ToEnum_0123456789876543210 a
-      type FromEnum a = FromEnum_0123456789876543210 a
+      type ToEnum a = ToEnum_Singletons_StandaloneDeriving_39 a
+      type FromEnum a = FromEnum_Singletons_StandaloneDeriving_45 a
     infixl 6 data :%*:
     data ST :: forall a b. T a b -> Type
       where
@@ -166,25 +168,27 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
       toSing S2 = SomeSing SS2
     instance SEq a => SEq (T a ()) where
       (%==)
-        ((:%*:) (sA_0123456789876543210 :: Sing a_0123456789876543210)
-                (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        ((:%*:) (sB_0123456789876543210 :: Sing b_0123456789876543210)
-                (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        ((:%*:) (sA_Singletons_StandaloneDeriving_0 :: Sing a_Singletons_StandaloneDeriving_0)
+                (sA_Singletons_StandaloneDeriving_1 :: Sing a_Singletons_StandaloneDeriving_1))
+        ((:%*:) (sB_Singletons_StandaloneDeriving_2 :: Sing b_Singletons_StandaloneDeriving_2)
+                (sB_Singletons_StandaloneDeriving_3 :: Sing b_Singletons_StandaloneDeriving_3))
         = applySing
             (applySing
                (singFun2 @(&&@#@$) (%&&))
                (applySing
-                  (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                  sB_0123456789876543210))
+                  (applySing
+                     (singFun2 @(==@#@$) (%==)) sA_Singletons_StandaloneDeriving_0)
+                  sB_Singletons_StandaloneDeriving_2))
             (applySing
-               (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-               sB_0123456789876543210)
+               (applySing
+                  (singFun2 @(==@#@$) (%==)) sA_Singletons_StandaloneDeriving_1)
+               sB_Singletons_StandaloneDeriving_3)
     instance SOrd a => SOrd (T a ()) where
       sCompare
-        ((:%*:) (sA_0123456789876543210 :: Sing a_0123456789876543210)
-                (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        ((:%*:) (sB_0123456789876543210 :: Sing b_0123456789876543210)
-                (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        ((:%*:) (sA_Singletons_StandaloneDeriving_4 :: Sing a_Singletons_StandaloneDeriving_4)
+                (sA_Singletons_StandaloneDeriving_5 :: Sing a_Singletons_StandaloneDeriving_5))
+        ((:%*:) (sB_Singletons_StandaloneDeriving_6 :: Sing b_Singletons_StandaloneDeriving_6)
+                (sB_Singletons_StandaloneDeriving_7 :: Sing b_Singletons_StandaloneDeriving_7))
         = applySing
             (applySing
                (applySing (singFun3 @FoldlSym0 sFoldl) (singFun2 @(<>@#@$) (%<>)))
@@ -193,27 +197,32 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
                (applySing
                   (singFun2 @(:@#@$) SCons)
                   (applySing
-                     (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                     sB_0123456789876543210))
+                     (applySing
+                        (singFun2 @CompareSym0 sCompare)
+                        sA_Singletons_StandaloneDeriving_4)
+                     sB_Singletons_StandaloneDeriving_6))
                (applySing
                   (applySing
                      (singFun2 @(:@#@$) SCons)
                      (applySing
-                        (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                        sB_0123456789876543210))
+                        (applySing
+                           (singFun2 @CompareSym0 sCompare)
+                           sA_Singletons_StandaloneDeriving_5)
+                        sB_Singletons_StandaloneDeriving_7))
                   SNil))
     instance SShow a => SShow (T a ()) where
       sShowsPrec
-        (sP_0123456789876543210 :: Sing p_0123456789876543210)
-        ((:%*:) (sArgL_0123456789876543210 :: Sing argL_0123456789876543210)
-                (sArgR_0123456789876543210 :: Sing argR_0123456789876543210))
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sP_Singletons_StandaloneDeriving_8 :: Sing p_Singletons_StandaloneDeriving_8)
+        ((:%*:) (sArgL_Singletons_StandaloneDeriving_9 :: Sing argL_Singletons_StandaloneDeriving_9)
+                (sArgR_Singletons_StandaloneDeriving_10 :: Sing argR_Singletons_StandaloneDeriving_10))
+        (sA_Singletons_StandaloneDeriving_21 :: Sing a_Singletons_StandaloneDeriving_21)
         = applySing
             (applySing
                (applySing
                   (singFun3 @ShowParenSym0 sShowParen)
                   (applySing
-                     (applySing (singFun2 @(>@#@$) (%>)) sP_0123456789876543210)
+                     (applySing
+                        (singFun2 @(>@#@$) (%>)) sP_Singletons_StandaloneDeriving_8)
                      (sFromInteger (sing :: Sing 6))))
                (applySing
                   (applySing
@@ -222,7 +231,7 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
                         (applySing
                            (singFun3 @ShowsPrecSym0 sShowsPrec)
                            (sFromInteger (sing :: Sing 7)))
-                        sArgL_0123456789876543210))
+                        sArgL_Singletons_StandaloneDeriving_9))
                   (applySing
                      (applySing
                         (singFun3 @(.@#@$) (%.))
@@ -232,8 +241,8 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
                         (applySing
                            (singFun3 @ShowsPrecSym0 sShowsPrec)
                            (sFromInteger (sing :: Sing 7)))
-                        sArgR_0123456789876543210))))
-            sA_0123456789876543210
+                        sArgR_Singletons_StandaloneDeriving_10))))
+            sA_Singletons_StandaloneDeriving_21
     instance SEq S where
       (%==) SS1 SS1 = STrue
       (%==) SS1 SS2 = SFalse
@@ -258,19 +267,19 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
       sShowsPrec
         _
         SS1
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_Singletons_StandaloneDeriving_32 :: Sing a_Singletons_StandaloneDeriving_32)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "S1"))
-            sA_0123456789876543210
+            sA_Singletons_StandaloneDeriving_32
       sShowsPrec
         _
         SS2
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_Singletons_StandaloneDeriving_33 :: Sing a_Singletons_StandaloneDeriving_33)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "S2"))
-            sA_0123456789876543210
+            sA_Singletons_StandaloneDeriving_33
     instance SBounded S where
       sMinBound = SS1
       sMaxBound = SS2
@@ -278,13 +287,13 @@ Singletons/StandaloneDeriving.hs:(0,0)-(0,0): Splicing declarations
       sToEnum (sN :: Sing n)
         = applySing
             (singFun1
-               @(LamCases_0123456789876543210Sym0 n)
+               @(LamCases_Singletons_StandaloneDeriving_41Sym0 n)
                (\cases
                   STrue -> SS1
                   SFalse
                     -> applySing
                          (singFun1
-                            @(LamCases_0123456789876543210Sym0 n)
+                            @(LamCases_Singletons_StandaloneDeriving_42Sym0 n)
                             (\cases
                                STrue -> SS2
                                SFalse

--- a/singletons-base/tests/compile-and-dump/Singletons/Star.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Star.golden
@@ -22,100 +22,100 @@ Singletons/Star.hs:0:0:: Splicing declarations
     data MaybeSym0 :: (~>) Type Type
       where
         MaybeSym0KindInference :: SameKind (Apply MaybeSym0 arg) (MaybeSym1 arg) =>
-                                  MaybeSym0 a0123456789876543210
-    type instance Apply @Type @Type MaybeSym0 a0123456789876543210 = Maybe a0123456789876543210
+                                  MaybeSym0 a_Singletons_Star_16
+    type instance Apply @Type @Type MaybeSym0 a_Singletons_Star_16 = Maybe a_Singletons_Star_16
     instance SuppressUnusedWarnings MaybeSym0 where
       suppressUnusedWarnings = snd ((,) MaybeSym0KindInference ())
     type MaybeSym1 :: Type -> Type
-    type family MaybeSym1 (a0123456789876543210 :: Type) :: Type where
-      MaybeSym1 a0123456789876543210 = Maybe a0123456789876543210
+    type family MaybeSym1 (a_Singletons_Star_16 :: Type) :: Type where
+      MaybeSym1 a_Singletons_Star_16 = Maybe a_Singletons_Star_16
     type VecSym0 :: (~>) Type ((~>) Nat Type)
     data VecSym0 :: (~>) Type ((~>) Nat Type)
       where
         VecSym0KindInference :: SameKind (Apply VecSym0 arg) (VecSym1 arg) =>
-                                VecSym0 a0123456789876543210
-    type instance Apply @Type @((~>) Nat Type) VecSym0 a0123456789876543210 = VecSym1 a0123456789876543210
+                                VecSym0 a_Singletons_Star_17
+    type instance Apply @Type @((~>) Nat Type) VecSym0 a_Singletons_Star_17 = VecSym1 a_Singletons_Star_17
     instance SuppressUnusedWarnings VecSym0 where
       suppressUnusedWarnings = snd ((,) VecSym0KindInference ())
     type VecSym1 :: Type -> (~>) Nat Type
-    data VecSym1 (a0123456789876543210 :: Type) :: (~>) Nat Type
+    data VecSym1 (a_Singletons_Star_17 :: Type) :: (~>) Nat Type
       where
-        VecSym1KindInference :: SameKind (Apply (VecSym1 a0123456789876543210) arg) (VecSym2 a0123456789876543210 arg) =>
-                                VecSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @Type (VecSym1 a0123456789876543210) a0123456789876543210 = Vec a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (VecSym1 a0123456789876543210) where
+        VecSym1KindInference :: SameKind (Apply (VecSym1 a_Singletons_Star_17) arg) (VecSym2 a_Singletons_Star_17 arg) =>
+                                VecSym1 a_Singletons_Star_17 a_Singletons_Star_18
+    type instance Apply @Nat @Type (VecSym1 a_Singletons_Star_17) a_Singletons_Star_18 = Vec a_Singletons_Star_17 a_Singletons_Star_18
+    instance SuppressUnusedWarnings (VecSym1 a_Singletons_Star_17) where
       suppressUnusedWarnings = snd ((,) VecSym1KindInference ())
     type VecSym2 :: Type -> Nat -> Type
-    type family VecSym2 (a0123456789876543210 :: Type) (a0123456789876543210 :: Nat) :: Type where
-      VecSym2 a0123456789876543210 a0123456789876543210 = Vec a0123456789876543210 a0123456789876543210
-    type TFHelper_0123456789876543210 :: Type -> Type -> Bool
-    type family TFHelper_0123456789876543210 (a :: Type) (a :: Type) :: Bool where
-      TFHelper_0123456789876543210 Nat Nat = TrueSym0
-      TFHelper_0123456789876543210 Nat Int = FalseSym0
-      TFHelper_0123456789876543210 Nat String = FalseSym0
-      TFHelper_0123456789876543210 Nat (Maybe _) = FalseSym0
-      TFHelper_0123456789876543210 Nat (Vec _ _) = FalseSym0
-      TFHelper_0123456789876543210 Int Nat = FalseSym0
-      TFHelper_0123456789876543210 Int Int = TrueSym0
-      TFHelper_0123456789876543210 Int String = FalseSym0
-      TFHelper_0123456789876543210 Int (Maybe _) = FalseSym0
-      TFHelper_0123456789876543210 Int (Vec _ _) = FalseSym0
-      TFHelper_0123456789876543210 String Nat = FalseSym0
-      TFHelper_0123456789876543210 String Int = FalseSym0
-      TFHelper_0123456789876543210 String String = TrueSym0
-      TFHelper_0123456789876543210 String (Maybe _) = FalseSym0
-      TFHelper_0123456789876543210 String (Vec _ _) = FalseSym0
-      TFHelper_0123456789876543210 (Maybe _) Nat = FalseSym0
-      TFHelper_0123456789876543210 (Maybe _) Int = FalseSym0
-      TFHelper_0123456789876543210 (Maybe _) String = FalseSym0
-      TFHelper_0123456789876543210 (Maybe a_0123456789876543210) (Maybe b_0123456789876543210) = Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210
-      TFHelper_0123456789876543210 (Maybe _) (Vec _ _) = FalseSym0
-      TFHelper_0123456789876543210 (Vec _ _) Nat = FalseSym0
-      TFHelper_0123456789876543210 (Vec _ _) Int = FalseSym0
-      TFHelper_0123456789876543210 (Vec _ _) String = FalseSym0
-      TFHelper_0123456789876543210 (Vec _ _) (Maybe _) = FalseSym0
-      TFHelper_0123456789876543210 (Vec a_0123456789876543210 a_0123456789876543210) (Vec b_0123456789876543210 b_0123456789876543210) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210)
+    type family VecSym2 (a_Singletons_Star_17 :: Type) (a_Singletons_Star_18 :: Nat) :: Type where
+      VecSym2 a_Singletons_Star_17 a_Singletons_Star_18 = Vec a_Singletons_Star_17 a_Singletons_Star_18
+    type TFHelper_Singletons_Star_19 :: Type -> Type -> Bool
+    type family TFHelper_Singletons_Star_19 (a :: Type) (a :: Type) :: Bool where
+      TFHelper_Singletons_Star_19 Nat Nat = TrueSym0
+      TFHelper_Singletons_Star_19 Nat Int = FalseSym0
+      TFHelper_Singletons_Star_19 Nat String = FalseSym0
+      TFHelper_Singletons_Star_19 Nat (Maybe _) = FalseSym0
+      TFHelper_Singletons_Star_19 Nat (Vec _ _) = FalseSym0
+      TFHelper_Singletons_Star_19 Int Nat = FalseSym0
+      TFHelper_Singletons_Star_19 Int Int = TrueSym0
+      TFHelper_Singletons_Star_19 Int String = FalseSym0
+      TFHelper_Singletons_Star_19 Int (Maybe _) = FalseSym0
+      TFHelper_Singletons_Star_19 Int (Vec _ _) = FalseSym0
+      TFHelper_Singletons_Star_19 String Nat = FalseSym0
+      TFHelper_Singletons_Star_19 String Int = FalseSym0
+      TFHelper_Singletons_Star_19 String String = TrueSym0
+      TFHelper_Singletons_Star_19 String (Maybe _) = FalseSym0
+      TFHelper_Singletons_Star_19 String (Vec _ _) = FalseSym0
+      TFHelper_Singletons_Star_19 (Maybe _) Nat = FalseSym0
+      TFHelper_Singletons_Star_19 (Maybe _) Int = FalseSym0
+      TFHelper_Singletons_Star_19 (Maybe _) String = FalseSym0
+      TFHelper_Singletons_Star_19 (Maybe a_Singletons_Star_0) (Maybe b_Singletons_Star_1) = Apply (Apply (==@#@$) a_Singletons_Star_0) b_Singletons_Star_1
+      TFHelper_Singletons_Star_19 (Maybe _) (Vec _ _) = FalseSym0
+      TFHelper_Singletons_Star_19 (Vec _ _) Nat = FalseSym0
+      TFHelper_Singletons_Star_19 (Vec _ _) Int = FalseSym0
+      TFHelper_Singletons_Star_19 (Vec _ _) String = FalseSym0
+      TFHelper_Singletons_Star_19 (Vec _ _) (Maybe _) = FalseSym0
+      TFHelper_Singletons_Star_19 (Vec a_Singletons_Star_2 a_Singletons_Star_3) (Vec b_Singletons_Star_4 b_Singletons_Star_5) = Apply (Apply (&&@#@$) (Apply (Apply (==@#@$) a_Singletons_Star_2) b_Singletons_Star_4)) (Apply (Apply (==@#@$) a_Singletons_Star_3) b_Singletons_Star_5)
     instance PEq Type where
-      type (==) a a = TFHelper_0123456789876543210 a a
-    type Compare_0123456789876543210 :: Type -> Type -> Ordering
-    type family Compare_0123456789876543210 (a :: Type) (a :: Type) :: Ordering where
-      Compare_0123456789876543210 Nat Nat = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
-      Compare_0123456789876543210 Int Int = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
-      Compare_0123456789876543210 String String = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
-      Compare_0123456789876543210 (Maybe a_0123456789876543210) (Maybe b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0)
-      Compare_0123456789876543210 (Vec a_0123456789876543210 a_0123456789876543210) (Vec b_0123456789876543210 b_0123456789876543210) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0))
-      Compare_0123456789876543210 Nat Int = LTSym0
-      Compare_0123456789876543210 Nat String = LTSym0
-      Compare_0123456789876543210 Nat (Maybe _) = LTSym0
-      Compare_0123456789876543210 Nat (Vec _ _) = LTSym0
-      Compare_0123456789876543210 Int Nat = GTSym0
-      Compare_0123456789876543210 Int String = LTSym0
-      Compare_0123456789876543210 Int (Maybe _) = LTSym0
-      Compare_0123456789876543210 Int (Vec _ _) = LTSym0
-      Compare_0123456789876543210 String Nat = GTSym0
-      Compare_0123456789876543210 String Int = GTSym0
-      Compare_0123456789876543210 String (Maybe _) = LTSym0
-      Compare_0123456789876543210 String (Vec _ _) = LTSym0
-      Compare_0123456789876543210 (Maybe _) Nat = GTSym0
-      Compare_0123456789876543210 (Maybe _) Int = GTSym0
-      Compare_0123456789876543210 (Maybe _) String = GTSym0
-      Compare_0123456789876543210 (Maybe _) (Vec _ _) = LTSym0
-      Compare_0123456789876543210 (Vec _ _) Nat = GTSym0
-      Compare_0123456789876543210 (Vec _ _) Int = GTSym0
-      Compare_0123456789876543210 (Vec _ _) String = GTSym0
-      Compare_0123456789876543210 (Vec _ _) (Maybe _) = GTSym0
+      type (==) a a = TFHelper_Singletons_Star_19 a a
+    type Compare_Singletons_Star_22 :: Type -> Type -> Ordering
+    type family Compare_Singletons_Star_22 (a :: Type) (a :: Type) :: Ordering where
+      Compare_Singletons_Star_22 Nat Nat = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
+      Compare_Singletons_Star_22 Int Int = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
+      Compare_Singletons_Star_22 String String = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
+      Compare_Singletons_Star_22 (Maybe a_Singletons_Star_6) (Maybe b_Singletons_Star_7) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_Star_6) b_Singletons_Star_7)) NilSym0)
+      Compare_Singletons_Star_22 (Vec a_Singletons_Star_8 a_Singletons_Star_9) (Vec b_Singletons_Star_10 b_Singletons_Star_11) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_Star_8) b_Singletons_Star_10)) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_Singletons_Star_9) b_Singletons_Star_11)) NilSym0))
+      Compare_Singletons_Star_22 Nat Int = LTSym0
+      Compare_Singletons_Star_22 Nat String = LTSym0
+      Compare_Singletons_Star_22 Nat (Maybe _) = LTSym0
+      Compare_Singletons_Star_22 Nat (Vec _ _) = LTSym0
+      Compare_Singletons_Star_22 Int Nat = GTSym0
+      Compare_Singletons_Star_22 Int String = LTSym0
+      Compare_Singletons_Star_22 Int (Maybe _) = LTSym0
+      Compare_Singletons_Star_22 Int (Vec _ _) = LTSym0
+      Compare_Singletons_Star_22 String Nat = GTSym0
+      Compare_Singletons_Star_22 String Int = GTSym0
+      Compare_Singletons_Star_22 String (Maybe _) = LTSym0
+      Compare_Singletons_Star_22 String (Vec _ _) = LTSym0
+      Compare_Singletons_Star_22 (Maybe _) Nat = GTSym0
+      Compare_Singletons_Star_22 (Maybe _) Int = GTSym0
+      Compare_Singletons_Star_22 (Maybe _) String = GTSym0
+      Compare_Singletons_Star_22 (Maybe _) (Vec _ _) = LTSym0
+      Compare_Singletons_Star_22 (Vec _ _) Nat = GTSym0
+      Compare_Singletons_Star_22 (Vec _ _) Int = GTSym0
+      Compare_Singletons_Star_22 (Vec _ _) String = GTSym0
+      Compare_Singletons_Star_22 (Vec _ _) (Maybe _) = GTSym0
     instance POrd Type where
-      type Compare a a = Compare_0123456789876543210 a a
-    type ShowsPrec_0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural
-                                          -> Type -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210 (a :: GHC.Internal.Bignum.Natural.Natural) (a :: Type) (a :: Symbol) :: Symbol where
-      ShowsPrec_0123456789876543210 _ Nat a_0123456789876543210 = Apply (Apply ShowStringSym0 "Nat") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ Int a_0123456789876543210 = Apply (Apply ShowStringSym0 "Int") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ String a_0123456789876543210 = Apply (Apply ShowStringSym0 "String") a_0123456789876543210
-      ShowsPrec_0123456789876543210 p_0123456789876543210 (Maybe arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Maybe ")) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
-      ShowsPrec_0123456789876543210 p_0123456789876543210 (Vec arg_0123456789876543210 arg_0123456789876543210) a_0123456789876543210 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Vec ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))))) a_0123456789876543210
+      type Compare a a = Compare_Singletons_Star_22 a a
+    type ShowsPrec_Singletons_Star_25 :: GHC.Internal.Bignum.Natural.Natural
+                                         -> Type -> Symbol -> Symbol
+    type family ShowsPrec_Singletons_Star_25 (a :: GHC.Internal.Bignum.Natural.Natural) (a :: Type) (a :: Symbol) :: Symbol where
+      ShowsPrec_Singletons_Star_25 _ Nat a_Singletons_Star_26 = Apply (Apply ShowStringSym0 "Nat") a_Singletons_Star_26
+      ShowsPrec_Singletons_Star_25 _ Int a_Singletons_Star_27 = Apply (Apply ShowStringSym0 "Int") a_Singletons_Star_27
+      ShowsPrec_Singletons_Star_25 _ String a_Singletons_Star_28 = Apply (Apply ShowStringSym0 "String") a_Singletons_Star_28
+      ShowsPrec_Singletons_Star_25 p_Singletons_Star_12 (Maybe arg_Singletons_Star_13) a_Singletons_Star_29 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_Singletons_Star_12) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Maybe ")) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_Singletons_Star_13))) a_Singletons_Star_29
+      ShowsPrec_Singletons_Star_25 p_Singletons_Star_12 (Vec arg_Singletons_Star_14 arg_Singletons_Star_15) a_Singletons_Star_30 = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_Singletons_Star_12) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Vec ")) (Apply (Apply (.@#@$) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_Singletons_Star_14)) (Apply (Apply (.@#@$) ShowSpaceSym0) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_Singletons_Star_15))))) a_Singletons_Star_30
     instance PShow Type where
-      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
+      type ShowsPrec a a a = ShowsPrec_Singletons_Star_25 a a a
     data SRep :: Type -> Type
       where
         SNat :: SRep (Nat :: Type)
@@ -206,30 +206,30 @@ Singletons/Star.hs:0:0:: Splicing declarations
       (%==) (SMaybe _) SInt = SFalse
       (%==) (SMaybe _) SString = SFalse
       (%==)
-        (SMaybe (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SMaybe (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SMaybe (sA_Singletons_Star_0 :: Sing a_Singletons_Star_0))
+        (SMaybe (sB_Singletons_Star_1 :: Sing b_Singletons_Star_1))
         = applySing
-            (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-            sB_0123456789876543210
+            (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_Star_0)
+            sB_Singletons_Star_1
       (%==) (SMaybe _) (SVec _ _) = SFalse
       (%==) (SVec _ _) SNat = SFalse
       (%==) (SVec _ _) SInt = SFalse
       (%==) (SVec _ _) SString = SFalse
       (%==) (SVec _ _) (SMaybe _) = SFalse
       (%==)
-        (SVec (sA_0123456789876543210 :: Sing a_0123456789876543210)
-              (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SVec (sB_0123456789876543210 :: Sing b_0123456789876543210)
-              (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SVec (sA_Singletons_Star_2 :: Sing a_Singletons_Star_2)
+              (sA_Singletons_Star_3 :: Sing a_Singletons_Star_3))
+        (SVec (sB_Singletons_Star_4 :: Sing b_Singletons_Star_4)
+              (sB_Singletons_Star_5 :: Sing b_Singletons_Star_5))
         = applySing
             (applySing
                (singFun2 @(&&@#@$) (%&&))
                (applySing
-                  (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-                  sB_0123456789876543210))
+                  (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_Star_2)
+                  sB_Singletons_Star_4))
             (applySing
-               (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-               sB_0123456789876543210)
+               (applySing (singFun2 @(==@#@$) (%==)) sA_Singletons_Star_3)
+               sB_Singletons_Star_5)
     instance (SOrd Type, SOrd Nat) => SOrd Type where
       sCompare SNat SNat
         = applySing
@@ -250,8 +250,8 @@ Singletons/Star.hs:0:0:: Splicing declarations
                SEQ)
             SNil
       sCompare
-        (SMaybe (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SMaybe (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SMaybe (sA_Singletons_Star_6 :: Sing a_Singletons_Star_6))
+        (SMaybe (sB_Singletons_Star_7 :: Sing b_Singletons_Star_7))
         = applySing
             (applySing
                (applySing (singFun3 @FoldlSym0 sFoldl) (singFun2 @(<>@#@$) (%<>)))
@@ -260,14 +260,14 @@ Singletons/Star.hs:0:0:: Splicing declarations
                (applySing
                   (singFun2 @(:@#@$) SCons)
                   (applySing
-                     (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                     sB_0123456789876543210))
+                     (applySing (singFun2 @CompareSym0 sCompare) sA_Singletons_Star_6)
+                     sB_Singletons_Star_7))
                SNil)
       sCompare
-        (SVec (sA_0123456789876543210 :: Sing a_0123456789876543210)
-              (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SVec (sB_0123456789876543210 :: Sing b_0123456789876543210)
-              (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SVec (sA_Singletons_Star_8 :: Sing a_Singletons_Star_8)
+              (sA_Singletons_Star_9 :: Sing a_Singletons_Star_9))
+        (SVec (sB_Singletons_Star_10 :: Sing b_Singletons_Star_10)
+              (sB_Singletons_Star_11 :: Sing b_Singletons_Star_11))
         = applySing
             (applySing
                (applySing (singFun3 @FoldlSym0 sFoldl) (singFun2 @(<>@#@$) (%<>)))
@@ -276,14 +276,14 @@ Singletons/Star.hs:0:0:: Splicing declarations
                (applySing
                   (singFun2 @(:@#@$) SCons)
                   (applySing
-                     (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                     sB_0123456789876543210))
+                     (applySing (singFun2 @CompareSym0 sCompare) sA_Singletons_Star_8)
+                     sB_Singletons_Star_10))
                (applySing
                   (applySing
                      (singFun2 @(:@#@$) SCons)
                      (applySing
-                        (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                        sB_0123456789876543210))
+                        (applySing (singFun2 @CompareSym0 sCompare) sA_Singletons_Star_9)
+                        sB_Singletons_Star_11))
                   SNil))
       sCompare SNat SInt = SLT
       sCompare SNat SString = SLT
@@ -309,37 +309,37 @@ Singletons/Star.hs:0:0:: Splicing declarations
       sShowsPrec
         _
         SNat
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_Singletons_Star_26 :: Sing a_Singletons_Star_26)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "Nat"))
-            sA_0123456789876543210
+            sA_Singletons_Star_26
       sShowsPrec
         _
         SInt
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_Singletons_Star_27 :: Sing a_Singletons_Star_27)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "Int"))
-            sA_0123456789876543210
+            sA_Singletons_Star_27
       sShowsPrec
         _
         SString
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_Singletons_Star_28 :: Sing a_Singletons_Star_28)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "String"))
-            sA_0123456789876543210
+            sA_Singletons_Star_28
       sShowsPrec
-        (sP_0123456789876543210 :: Sing p_0123456789876543210)
-        (SMaybe (sArg_0123456789876543210 :: Sing arg_0123456789876543210))
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sP_Singletons_Star_12 :: Sing p_Singletons_Star_12)
+        (SMaybe (sArg_Singletons_Star_13 :: Sing arg_Singletons_Star_13))
+        (sA_Singletons_Star_29 :: Sing a_Singletons_Star_29)
         = applySing
             (applySing
                (applySing
                   (singFun3 @ShowParenSym0 sShowParen)
                   (applySing
-                     (applySing (singFun2 @(>@#@$) (%>)) sP_0123456789876543210)
+                     (applySing (singFun2 @(>@#@$) (%>)) sP_Singletons_Star_12)
                      (sFromInteger (sing :: Sing 10))))
                (applySing
                   (applySing
@@ -350,19 +350,19 @@ Singletons/Star.hs:0:0:: Splicing declarations
                      (applySing
                         (singFun3 @ShowsPrecSym0 sShowsPrec)
                         (sFromInteger (sing :: Sing 11)))
-                     sArg_0123456789876543210)))
-            sA_0123456789876543210
+                     sArg_Singletons_Star_13)))
+            sA_Singletons_Star_29
       sShowsPrec
-        (sP_0123456789876543210 :: Sing p_0123456789876543210)
-        (SVec (sArg_0123456789876543210 :: Sing arg_0123456789876543210)
-              (sArg_0123456789876543210 :: Sing arg_0123456789876543210))
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sP_Singletons_Star_12 :: Sing p_Singletons_Star_12)
+        (SVec (sArg_Singletons_Star_14 :: Sing arg_Singletons_Star_14)
+              (sArg_Singletons_Star_15 :: Sing arg_Singletons_Star_15))
+        (sA_Singletons_Star_30 :: Sing a_Singletons_Star_30)
         = applySing
             (applySing
                (applySing
                   (singFun3 @ShowParenSym0 sShowParen)
                   (applySing
-                     (applySing (singFun2 @(>@#@$) (%>)) sP_0123456789876543210)
+                     (applySing (singFun2 @(>@#@$) (%>)) sP_Singletons_Star_12)
                      (sFromInteger (sing :: Sing 10))))
                (applySing
                   (applySing
@@ -376,7 +376,7 @@ Singletons/Star.hs:0:0:: Splicing declarations
                            (applySing
                               (singFun3 @ShowsPrecSym0 sShowsPrec)
                               (sFromInteger (sing :: Sing 11)))
-                           sArg_0123456789876543210))
+                           sArg_Singletons_Star_14))
                      (applySing
                         (applySing
                            (singFun3 @(.@#@$) (%.)) (singFun1 @ShowSpaceSym0 sShowSpace))
@@ -384,8 +384,8 @@ Singletons/Star.hs:0:0:: Splicing declarations
                            (applySing
                               (singFun3 @ShowsPrecSym0 sShowsPrec)
                               (sFromInteger (sing :: Sing 11)))
-                           sArg_0123456789876543210)))))
-            sA_0123456789876543210
+                           sArg_Singletons_Star_15)))))
+            sA_Singletons_Star_30
     instance SingI Nat where
       sing = SNat
     instance SingI Int where

--- a/singletons-base/tests/compile-and-dump/Singletons/T124.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T124.golden
@@ -11,13 +11,13 @@ Singletons/T124.hs:(0,0)-(0,0): Splicing declarations
     data FooSym0 :: (~>) Bool ()
       where
         FooSym0KindInference :: SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
-                                FooSym0 a0123456789876543210
-    type instance Apply @Bool @() FooSym0 a0123456789876543210 = Foo a0123456789876543210
+                                FooSym0 a_Singletons_T124_0
+    type instance Apply @Bool @() FooSym0 a_Singletons_T124_0 = Foo a_Singletons_T124_0
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings = snd ((,) FooSym0KindInference ())
     type FooSym1 :: Bool -> ()
-    type family FooSym1 (a0123456789876543210 :: Bool) :: () where
-      FooSym1 a0123456789876543210 = Foo a0123456789876543210
+    type family FooSym1 (a_Singletons_T124_0 :: Bool) :: () where
+      FooSym1 a_Singletons_T124_0 = Foo a_Singletons_T124_0
     type Foo :: Bool -> ()
     type family Foo (a :: Bool) :: () where
       Foo 'True = Tuple0Sym0

--- a/singletons-base/tests/compile-and-dump/Singletons/T136.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T136.golden
@@ -29,69 +29,69 @@ Singletons/T136.hs:(0,0)-(0,0): Splicing declarations
       fromEnum [] = 0
       fromEnum (False : as) = (2 * fromEnum as)
       fromEnum (True : as) = (1 + (2 * fromEnum as))
-    type Succ_0123456789876543210 :: [Bool] -> [Bool]
-    type family Succ_0123456789876543210 (a :: [Bool]) :: [Bool] where
-      Succ_0123456789876543210 '[] = Apply (Apply (:@#@$) TrueSym0) NilSym0
-      Succ_0123456789876543210 ('(:) 'False as) = Apply (Apply (:@#@$) TrueSym0) as
-      Succ_0123456789876543210 ('(:) 'True as) = Apply (Apply (:@#@$) FalseSym0) (Apply SuccSym0 as)
-    type Pred_0123456789876543210 :: [Bool] -> [Bool]
-    type family Pred_0123456789876543210 (a :: [Bool]) :: [Bool] where
-      Pred_0123456789876543210 '[] = Apply ErrorSym0 "pred 0"
-      Pred_0123456789876543210 ('(:) 'False as) = Apply (Apply (:@#@$) TrueSym0) (Apply PredSym0 as)
-      Pred_0123456789876543210 ('(:) 'True as) = Apply (Apply (:@#@$) FalseSym0) as
-    type family LamCases_0123456789876543210 i0123456789876543210 (arg_01234567898765432100123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_0123456789876543210 where
-      LamCases_0123456789876543210 i arg_0123456789876543210 'True = NilSym0
-      LamCases_0123456789876543210 i arg_0123456789876543210 'False = Apply SuccSym0 (Apply ToEnumSym0 (Apply PredSym0 i))
-    data LamCases_0123456789876543210Sym0 i0123456789876543210 (arg_01234567898765432100123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_01234567898765432100123456789876543210
+    type Succ_Binary_1 :: [Bool] -> [Bool]
+    type family Succ_Binary_1 (a :: [Bool]) :: [Bool] where
+      Succ_Binary_1 '[] = Apply (Apply (:@#@$) TrueSym0) NilSym0
+      Succ_Binary_1 ('(:) 'False as) = Apply (Apply (:@#@$) TrueSym0) as
+      Succ_Binary_1 ('(:) 'True as) = Apply (Apply (:@#@$) FalseSym0) (Apply SuccSym0 as)
+    type Pred_Binary_3 :: [Bool] -> [Bool]
+    type family Pred_Binary_3 (a :: [Bool]) :: [Bool] where
+      Pred_Binary_3 '[] = Apply ErrorSym0 "pred 0"
+      Pred_Binary_3 ('(:) 'False as) = Apply (Apply (:@#@$) TrueSym0) (Apply PredSym0 as)
+      Pred_Binary_3 ('(:) 'True as) = Apply (Apply (:@#@$) FalseSym0) as
+    type family LamCases_Binary_9 i0 (arg_Binary_01 :: GHC.Internal.Bignum.Natural.Natural) a_Binary_10 where
+      LamCases_Binary_9 i arg_Binary_0 'True = NilSym0
+      LamCases_Binary_9 i arg_Binary_0 'False = Apply SuccSym0 (Apply ToEnumSym0 (Apply PredSym0 i))
+    data LamCases_Binary_9Sym0 i0 (arg_Binary_01 :: GHC.Internal.Bignum.Natural.Natural) a_Binary_10
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 i0123456789876543210 arg_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 i0123456789876543210 arg_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 i0123456789876543210 arg_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 i0123456789876543210 arg_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 i0123456789876543210 arg_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 i0123456789876543210 arg_01234567898765432100123456789876543210) where
+        LamCases_Binary_9Sym0KindInference :: SameKind (Apply (LamCases_Binary_9Sym0 i0 arg_Binary_01) arg) (LamCases_Binary_9Sym1 i0 arg_Binary_01 arg) =>
+                                              LamCases_Binary_9Sym0 i0 arg_Binary_01 a_Binary_10
+    type instance Apply @_ @_ (LamCases_Binary_9Sym0 i0 arg_Binary_01) a_Binary_10 = LamCases_Binary_9 i0 arg_Binary_01 a_Binary_10
+    instance SuppressUnusedWarnings (LamCases_Binary_9Sym0 i0 arg_Binary_01) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 i0123456789876543210 (arg_01234567898765432100123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 i0123456789876543210 arg_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 i0123456789876543210 arg_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 i0123456789876543210 (arg_01234567898765432100123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_0123456789876543210 where
-      LamCases_0123456789876543210 i arg_0123456789876543210 'True = Apply ErrorSym0 "negative toEnum"
-      LamCases_0123456789876543210 i arg_0123456789876543210 'False = Apply (LamCases_0123456789876543210Sym0 i arg_0123456789876543210) (Apply (Apply (==@#@$) i) (FromInteger 0))
-    data LamCases_0123456789876543210Sym0 i0123456789876543210 (arg_01234567898765432100123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Binary_9Sym0KindInference ())
+    type family LamCases_Binary_9Sym1 i0 (arg_Binary_01 :: GHC.Internal.Bignum.Natural.Natural) a_Binary_10 where
+      LamCases_Binary_9Sym1 i0 arg_Binary_01 a_Binary_10 = LamCases_Binary_9 i0 arg_Binary_01 a_Binary_10
+    type family LamCases_Binary_8 i0 (arg_Binary_01 :: GHC.Internal.Bignum.Natural.Natural) a_Binary_11 where
+      LamCases_Binary_8 i arg_Binary_0 'True = Apply ErrorSym0 "negative toEnum"
+      LamCases_Binary_8 i arg_Binary_0 'False = Apply (LamCases_Binary_9Sym0 i arg_Binary_0) (Apply (Apply (==@#@$) i) (FromInteger 0))
+    data LamCases_Binary_8Sym0 i0 (arg_Binary_01 :: GHC.Internal.Bignum.Natural.Natural) a_Binary_11
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 i0123456789876543210 arg_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 i0123456789876543210 arg_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 i0123456789876543210 arg_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 i0123456789876543210 arg_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 i0123456789876543210 arg_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 i0123456789876543210 arg_01234567898765432100123456789876543210) where
+        LamCases_Binary_8Sym0KindInference :: SameKind (Apply (LamCases_Binary_8Sym0 i0 arg_Binary_01) arg) (LamCases_Binary_8Sym1 i0 arg_Binary_01 arg) =>
+                                              LamCases_Binary_8Sym0 i0 arg_Binary_01 a_Binary_11
+    type instance Apply @_ @_ (LamCases_Binary_8Sym0 i0 arg_Binary_01) a_Binary_11 = LamCases_Binary_8 i0 arg_Binary_01 a_Binary_11
+    instance SuppressUnusedWarnings (LamCases_Binary_8Sym0 i0 arg_Binary_01) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 i0123456789876543210 (arg_01234567898765432100123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 i0123456789876543210 arg_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 i0123456789876543210 arg_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (arg_01234567898765432100123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_0123456789876543210 where
-      LamCases_0123456789876543210 arg_0123456789876543210 i = Apply (LamCases_0123456789876543210Sym0 i arg_0123456789876543210) (Apply (Apply (<@#@$) i) (FromInteger 0))
-    data LamCases_0123456789876543210Sym0 (arg_01234567898765432100123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Binary_8Sym0KindInference ())
+    type family LamCases_Binary_8Sym1 i0 (arg_Binary_01 :: GHC.Internal.Bignum.Natural.Natural) a_Binary_11 where
+      LamCases_Binary_8Sym1 i0 arg_Binary_01 a_Binary_11 = LamCases_Binary_8 i0 arg_Binary_01 a_Binary_11
+    type family LamCases_Binary_7 (arg_Binary_00 :: GHC.Internal.Bignum.Natural.Natural) a_Binary_12 where
+      LamCases_Binary_7 arg_Binary_0 i = Apply (LamCases_Binary_8Sym0 i arg_Binary_0) (Apply (Apply (<@#@$) i) (FromInteger 0))
+    data LamCases_Binary_7Sym0 (arg_Binary_00 :: GHC.Internal.Bignum.Natural.Natural) a_Binary_12
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 arg_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 arg_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 arg_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 arg_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 arg_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 arg_01234567898765432100123456789876543210) where
+        LamCases_Binary_7Sym0KindInference :: SameKind (Apply (LamCases_Binary_7Sym0 arg_Binary_00) arg) (LamCases_Binary_7Sym1 arg_Binary_00 arg) =>
+                                              LamCases_Binary_7Sym0 arg_Binary_00 a_Binary_12
+    type instance Apply @_ @_ (LamCases_Binary_7Sym0 arg_Binary_00) a_Binary_12 = LamCases_Binary_7 arg_Binary_00 a_Binary_12
+    instance SuppressUnusedWarnings (LamCases_Binary_7Sym0 arg_Binary_00) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (arg_01234567898765432100123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 arg_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 arg_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type ToEnum_0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural
-                                       -> [Bool]
-    type family ToEnum_0123456789876543210 (a :: GHC.Internal.Bignum.Natural.Natural) :: [Bool] where
-      ToEnum_0123456789876543210 arg_0123456789876543210 = Apply (LamCases_0123456789876543210Sym0 arg_0123456789876543210) arg_0123456789876543210
-    type FromEnum_0123456789876543210 :: [Bool]
-                                         -> GHC.Internal.Bignum.Natural.Natural
-    type family FromEnum_0123456789876543210 (a :: [Bool]) :: GHC.Internal.Bignum.Natural.Natural where
-      FromEnum_0123456789876543210 '[] = FromInteger 0
-      FromEnum_0123456789876543210 ('(:) 'False as) = Apply (Apply (*@#@$) (FromInteger 2)) (Apply FromEnumSym0 as)
-      FromEnum_0123456789876543210 ('(:) 'True as) = Apply (Apply (+@#@$) (FromInteger 1)) (Apply (Apply (*@#@$) (FromInteger 2)) (Apply FromEnumSym0 as))
+        = snd ((,) LamCases_Binary_7Sym0KindInference ())
+    type family LamCases_Binary_7Sym1 (arg_Binary_00 :: GHC.Internal.Bignum.Natural.Natural) a_Binary_12 where
+      LamCases_Binary_7Sym1 arg_Binary_00 a_Binary_12 = LamCases_Binary_7 arg_Binary_00 a_Binary_12
+    type ToEnum_Binary_5 :: GHC.Internal.Bignum.Natural.Natural
+                            -> [Bool]
+    type family ToEnum_Binary_5 (a :: GHC.Internal.Bignum.Natural.Natural) :: [Bool] where
+      ToEnum_Binary_5 arg_Binary_0 = Apply (LamCases_Binary_7Sym0 arg_Binary_0) arg_Binary_0
+    type FromEnum_Binary_13 :: [Bool]
+                               -> GHC.Internal.Bignum.Natural.Natural
+    type family FromEnum_Binary_13 (a :: [Bool]) :: GHC.Internal.Bignum.Natural.Natural where
+      FromEnum_Binary_13 '[] = FromInteger 0
+      FromEnum_Binary_13 ('(:) 'False as) = Apply (Apply (*@#@$) (FromInteger 2)) (Apply FromEnumSym0 as)
+      FromEnum_Binary_13 ('(:) 'True as) = Apply (Apply (+@#@$) (FromInteger 1)) (Apply (Apply (*@#@$) (FromInteger 2)) (Apply FromEnumSym0 as))
     instance PEnum [Bool] where
-      type Succ a = Succ_0123456789876543210 a
-      type Pred a = Pred_0123456789876543210 a
-      type ToEnum a = ToEnum_0123456789876543210 a
-      type FromEnum a = FromEnum_0123456789876543210 a
+      type Succ a = Succ_Binary_1 a
+      type Pred a = Pred_Binary_3 a
+      type ToEnum a = ToEnum_Binary_5 a
+      type FromEnum a = FromEnum_Binary_13 a
     instance SEnum [Bool] where
       sSucc SNil
         = applySing (applySing (singFun2 @(:@#@$) SCons) STrue) SNil
@@ -109,15 +109,15 @@ Singletons/T136.hs:(0,0)-(0,0): Splicing declarations
             (applySing (singFun1 @PredSym0 sPred) sAs)
       sPred (SCons STrue (sAs :: Sing as))
         = applySing (applySing (singFun2 @(:@#@$) SCons) SFalse) sAs
-      sToEnum (sArg_0123456789876543210 :: Sing arg_0123456789876543210)
+      sToEnum (sArg_Binary_0 :: Sing arg_Binary_0)
         = applySing
             (singFun1
-               @(LamCases_0123456789876543210Sym0 arg_0123456789876543210)
+               @(LamCases_Binary_7Sym0 arg_Binary_0)
                (\cases
                   (sI :: Sing i)
                     -> applySing
                          (singFun1
-                            @(LamCases_0123456789876543210Sym0 i arg_0123456789876543210)
+                            @(LamCases_Binary_8Sym0 i arg_Binary_0)
                             (\cases
                                STrue
                                  -> applySing
@@ -125,7 +125,7 @@ Singletons/T136.hs:(0,0)-(0,0): Splicing declarations
                                SFalse
                                  -> applySing
                                       (singFun1
-                                         @(LamCases_0123456789876543210Sym0 i arg_0123456789876543210)
+                                         @(LamCases_Binary_9Sym0 i arg_Binary_0)
                                          (\cases
                                             STrue -> SNil
                                             SFalse
@@ -140,7 +140,7 @@ Singletons/T136.hs:(0,0)-(0,0): Splicing declarations
                          (applySing
                             (applySing (singFun2 @(<@#@$) (%<)) sI)
                             (sFromInteger (sing :: Sing 0)))))
-            sArg_0123456789876543210
+            sArg_Binary_0
       sFromEnum SNil = sFromInteger (sing :: Sing 0)
       sFromEnum (SCons SFalse (sAs :: Sing as))
         = applySing

--- a/singletons-base/tests/compile-and-dump/Singletons/T136b.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T136b.golden
@@ -9,13 +9,13 @@ Singletons/T136b.hs:(0,0)-(0,0): Splicing declarations
     data MethSym0 :: (~>) a a
       where
         MethSym0KindInference :: SameKind (Apply MethSym0 arg) (MethSym1 arg) =>
-                                 MethSym0 a0123456789876543210
-    type instance Apply @a @a MethSym0 a0123456789876543210 = Meth a0123456789876543210
+                                 MethSym0 a_T136b_0
+    type instance Apply @a @a MethSym0 a_T136b_0 = Meth a_T136b_0
     instance SuppressUnusedWarnings MethSym0 where
       suppressUnusedWarnings = snd ((,) MethSym0KindInference ())
     type MethSym1 :: forall a. a -> a
-    type family MethSym1 @a (a0123456789876543210 :: a) :: a where
-      MethSym1 a0123456789876543210 = Meth a0123456789876543210
+    type family MethSym1 @a (a_T136b_0 :: a) :: a where
+      MethSym1 a_T136b_0 = Meth a_T136b_0
     class PC a where
       type family Meth (arg :: a) :: a
     class SC a where
@@ -29,11 +29,11 @@ Singletons/T136b.hs:(0,0)-(0,0): Splicing declarations
   ======>
     instance C Bool where
       meth = not
-    type Meth_0123456789876543210 :: Bool -> Bool
-    type family Meth_0123456789876543210 (a :: Bool) :: Bool where
-      Meth_0123456789876543210 a_0123456789876543210 = Apply NotSym0 a_0123456789876543210
+    type Meth_T136b_1 :: Bool -> Bool
+    type family Meth_T136b_1 (a :: Bool) :: Bool where
+      Meth_T136b_1 a_T136b_2 = Apply NotSym0 a_T136b_2
     instance PC Bool where
-      type Meth a = Meth_0123456789876543210 a
+      type Meth a = Meth_T136b_1 a
     instance SC Bool where
-      sMeth (sA_0123456789876543210 :: Sing a_0123456789876543210)
-        = applySing (singFun1 @NotSym0 sNot) sA_0123456789876543210
+      sMeth (sA_T136b_2 :: Sing a_T136b_2)
+        = applySing (singFun1 @NotSym0 sNot) sA_T136b_2

--- a/singletons-base/tests/compile-and-dump/Singletons/T145.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T145.golden
@@ -9,21 +9,21 @@ Singletons/T145.hs:(0,0)-(0,0): Splicing declarations
     data ColSym0 :: (~>) (f a) ((~>) a Bool)
       where
         ColSym0KindInference :: SameKind (Apply ColSym0 arg) (ColSym1 arg) =>
-                                ColSym0 a0123456789876543210
-    type instance Apply @(f a) @((~>) a Bool) ColSym0 a0123456789876543210 = ColSym1 a0123456789876543210
+                                ColSym0 a_Singletons_T145_0
+    type instance Apply @(f a) @((~>) a Bool) ColSym0 a_Singletons_T145_0 = ColSym1 a_Singletons_T145_0
     instance SuppressUnusedWarnings ColSym0 where
       suppressUnusedWarnings = snd ((,) ColSym0KindInference ())
     type ColSym1 :: forall f a. f a -> (~>) a Bool
-    data ColSym1 (a0123456789876543210 :: f a) :: (~>) a Bool
+    data ColSym1 (a_Singletons_T145_0 :: f a) :: (~>) a Bool
       where
-        ColSym1KindInference :: SameKind (Apply (ColSym1 a0123456789876543210) arg) (ColSym2 a0123456789876543210 arg) =>
-                                ColSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @a @Bool (ColSym1 a0123456789876543210) a0123456789876543210 = Col a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ColSym1 a0123456789876543210) where
+        ColSym1KindInference :: SameKind (Apply (ColSym1 a_Singletons_T145_0) arg) (ColSym2 a_Singletons_T145_0 arg) =>
+                                ColSym1 a_Singletons_T145_0 a_Singletons_T145_1
+    type instance Apply @a @Bool (ColSym1 a_Singletons_T145_0) a_Singletons_T145_1 = Col a_Singletons_T145_0 a_Singletons_T145_1
+    instance SuppressUnusedWarnings (ColSym1 a_Singletons_T145_0) where
       suppressUnusedWarnings = snd ((,) ColSym1KindInference ())
     type ColSym2 :: forall f a. f a -> a -> Bool
-    type family ColSym2 @f @a (a0123456789876543210 :: f a) (a0123456789876543210 :: a) :: Bool where
-      ColSym2 a0123456789876543210 a0123456789876543210 = Col a0123456789876543210 a0123456789876543210
+    type family ColSym2 @f @a (a_Singletons_T145_0 :: f a) (a_Singletons_T145_1 :: a) :: Bool where
+      ColSym2 a_Singletons_T145_0 a_Singletons_T145_1 = Col a_Singletons_T145_0 a_Singletons_T145_1
     class PColumn (f :: Type -> Type) where
       type family Col (arg :: f a) (arg :: a) :: Bool
     class SColumn (f :: Type -> Type) where

--- a/singletons-base/tests/compile-and-dump/Singletons/T150.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T150.golden
@@ -77,13 +77,13 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
     data FSSym0 :: (~>) (Fin n) (Fin ('Succ n))
       where
         FSSym0KindInference :: SameKind (Apply FSSym0 arg) (FSSym1 arg) =>
-                               FSSym0 a0123456789876543210
-    type instance Apply @(Fin n) @(Fin ('Succ n)) FSSym0 a0123456789876543210 = FS a0123456789876543210
+                               FSSym0 a_T150_0
+    type instance Apply @(Fin n) @(Fin ('Succ n)) FSSym0 a_T150_0 = FS a_T150_0
     instance SuppressUnusedWarnings FSSym0 where
       suppressUnusedWarnings = snd ((,) FSSym0KindInference ())
     type FSSym1 :: Fin n -> Fin ('Succ n)
-    type family FSSym1 @n (a0123456789876543210 :: Fin n) :: Fin ('Succ n) where
-      FSSym1 a0123456789876543210 = FS a0123456789876543210
+    type family FSSym1 @n (a_T150_0 :: Fin n) :: Fin ('Succ n) where
+      FSSym1 a_T150_0 = FS a_T150_0
     type MkFoo1Sym0 :: Foo Bool
     type family MkFoo1Sym0 :: Foo Bool where
       MkFoo1Sym0 = MkFoo1
@@ -97,21 +97,21 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
     data VConsSym0 :: (~>) a ((~>) (Vec n a) (Vec ('Succ n) a))
       where
         VConsSym0KindInference :: SameKind (Apply VConsSym0 arg) (VConsSym1 arg) =>
-                                  VConsSym0 a0123456789876543210
-    type instance Apply @a @((~>) (Vec n a) (Vec ('Succ n) a)) VConsSym0 a0123456789876543210 = VConsSym1 a0123456789876543210
+                                  VConsSym0 a_T150_1
+    type instance Apply @a @((~>) (Vec n a) (Vec ('Succ n) a)) VConsSym0 a_T150_1 = VConsSym1 a_T150_1
     instance SuppressUnusedWarnings VConsSym0 where
       suppressUnusedWarnings = snd ((,) VConsSym0KindInference ())
     type VConsSym1 :: a -> (~>) (Vec n a) (Vec ('Succ n) a)
-    data VConsSym1 (a0123456789876543210 :: a) :: (~>) (Vec n a) (Vec ('Succ n) a)
+    data VConsSym1 (a_T150_1 :: a) :: (~>) (Vec n a) (Vec ('Succ n) a)
       where
-        VConsSym1KindInference :: SameKind (Apply (VConsSym1 a0123456789876543210) arg) (VConsSym2 a0123456789876543210 arg) =>
-                                  VConsSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Vec n a) @(Vec ('Succ n) a) (VConsSym1 a0123456789876543210) a0123456789876543210 = VCons a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (VConsSym1 a0123456789876543210) where
+        VConsSym1KindInference :: SameKind (Apply (VConsSym1 a_T150_1) arg) (VConsSym2 a_T150_1 arg) =>
+                                  VConsSym1 a_T150_1 a_T150_2
+    type instance Apply @(Vec n a) @(Vec ('Succ n) a) (VConsSym1 a_T150_1) a_T150_2 = VCons a_T150_1 a_T150_2
+    instance SuppressUnusedWarnings (VConsSym1 a_T150_1) where
       suppressUnusedWarnings = snd ((,) VConsSym1KindInference ())
     type VConsSym2 :: a -> Vec n a -> Vec ('Succ n) a
-    type family VConsSym2 @a @n (a0123456789876543210 :: a) (a0123456789876543210 :: Vec n a) :: Vec ('Succ n) a where
-      VConsSym2 a0123456789876543210 a0123456789876543210 = VCons a0123456789876543210 a0123456789876543210
+    type family VConsSym2 @a @n (a_T150_1 :: a) (a_T150_2 :: Vec n a) :: Vec ('Succ n) a where
+      VConsSym2 a_T150_1 a_T150_2 = VCons a_T150_1 a_T150_2
     type ReflexiveSym0 :: Equal a a
     type family ReflexiveSym0 @a :: Equal a a where
       ReflexiveSym0 = Reflexive
@@ -122,133 +122,133 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
     data HConsSym0 :: (~>) x ((~>) (HList xs) (HList ('(:) x xs)))
       where
         HConsSym0KindInference :: SameKind (Apply HConsSym0 arg) (HConsSym1 arg) =>
-                                  HConsSym0 a0123456789876543210
-    type instance Apply @x @((~>) (HList xs) (HList ('(:) x xs))) HConsSym0 a0123456789876543210 = HConsSym1 a0123456789876543210
+                                  HConsSym0 a_T150_3
+    type instance Apply @x @((~>) (HList xs) (HList ('(:) x xs))) HConsSym0 a_T150_3 = HConsSym1 a_T150_3
     instance SuppressUnusedWarnings HConsSym0 where
       suppressUnusedWarnings = snd ((,) HConsSym0KindInference ())
     type HConsSym1 :: x -> (~>) (HList xs) (HList ('(:) x xs))
-    data HConsSym1 (a0123456789876543210 :: x) :: (~>) (HList xs) (HList ('(:) x xs))
+    data HConsSym1 (a_T150_3 :: x) :: (~>) (HList xs) (HList ('(:) x xs))
       where
-        HConsSym1KindInference :: SameKind (Apply (HConsSym1 a0123456789876543210) arg) (HConsSym2 a0123456789876543210 arg) =>
-                                  HConsSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(HList xs) @(HList ('(:) x xs)) (HConsSym1 a0123456789876543210) a0123456789876543210 = HCons a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (HConsSym1 a0123456789876543210) where
+        HConsSym1KindInference :: SameKind (Apply (HConsSym1 a_T150_3) arg) (HConsSym2 a_T150_3 arg) =>
+                                  HConsSym1 a_T150_3 a_T150_4
+    type instance Apply @(HList xs) @(HList ('(:) x xs)) (HConsSym1 a_T150_3) a_T150_4 = HCons a_T150_3 a_T150_4
+    instance SuppressUnusedWarnings (HConsSym1 a_T150_3) where
       suppressUnusedWarnings = snd ((,) HConsSym1KindInference ())
     type HConsSym2 :: x -> HList xs -> HList ('(:) x xs)
-    type family HConsSym2 @x @xs (a0123456789876543210 :: x) (a0123456789876543210 :: HList xs) :: HList ('(:) x xs) where
-      HConsSym2 a0123456789876543210 a0123456789876543210 = HCons a0123456789876543210 a0123456789876543210
+    type family HConsSym2 @x @xs (a_T150_3 :: x) (a_T150_4 :: HList xs) :: HList ('(:) x xs) where
+      HConsSym2 a_T150_3 a_T150_4 = HCons a_T150_3 a_T150_4
     type ObjSym0 :: (~>) a Obj
     data ObjSym0 :: (~>) a Obj
       where
         ObjSym0KindInference :: SameKind (Apply ObjSym0 arg) (ObjSym1 arg) =>
-                                ObjSym0 a0123456789876543210
-    type instance Apply @a @Obj ObjSym0 a0123456789876543210 = Obj a0123456789876543210
+                                ObjSym0 a_T150_5
+    type instance Apply @a @Obj ObjSym0 a_T150_5 = Obj a_T150_5
     instance SuppressUnusedWarnings ObjSym0 where
       suppressUnusedWarnings = snd ((,) ObjSym0KindInference ())
     type ObjSym1 :: a -> Obj
-    type family ObjSym1 @a (a0123456789876543210 :: a) :: Obj where
-      ObjSym1 a0123456789876543210 = Obj a0123456789876543210
-    type family LamCases_0123456789876543210 (n0123456789876543210 :: Fin n0123456789876543210) a_0123456789876543210 where
-    data LamCases_0123456789876543210Sym0 (n0123456789876543210 :: Fin n0123456789876543210) a_01234567898765432100123456789876543210
+    type family ObjSym1 @a (a_T150_5 :: a) :: Obj where
+      ObjSym1 a_T150_5 = Obj a_T150_5
+    type family LamCases_T150_13 (n1 :: Fin n0) a_T150_14 where
+    data LamCases_T150_13Sym0 (n1 :: Fin n0) a_T150_14
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 n0123456789876543210) arg) (LamCases_0123456789876543210Sym1 n0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 n0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 n0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 n0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 n0123456789876543210) where
+        LamCases_T150_13Sym0KindInference :: SameKind (Apply (LamCases_T150_13Sym0 n1) arg) (LamCases_T150_13Sym1 n1 arg) =>
+                                             LamCases_T150_13Sym0 n1 a_T150_14
+    type instance Apply @_ @_ (LamCases_T150_13Sym0 n1) a_T150_14 = LamCases_T150_13 n1 a_T150_14
+    instance SuppressUnusedWarnings (LamCases_T150_13Sym0 n1) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (n0123456789876543210 :: Fin n0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 n0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 n0123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_T150_13Sym0KindInference ())
+    type family LamCases_T150_13Sym1 (n1 :: Fin n0) a_T150_14 where
+      LamCases_T150_13Sym1 n1 a_T150_14 = LamCases_T150_13 n1 a_T150_14
     type TransitivitySym0 :: (~>) (Equal a b) ((~>) (Equal b c) (Equal a c))
     data TransitivitySym0 :: (~>) (Equal a b) ((~>) (Equal b c) (Equal a c))
       where
         TransitivitySym0KindInference :: SameKind (Apply TransitivitySym0 arg) (TransitivitySym1 arg) =>
-                                         TransitivitySym0 a0123456789876543210
-    type instance Apply @(Equal a b) @((~>) (Equal b c) (Equal a c)) TransitivitySym0 a0123456789876543210 = TransitivitySym1 a0123456789876543210
+                                         TransitivitySym0 a_T150_6
+    type instance Apply @(Equal a b) @((~>) (Equal b c) (Equal a c)) TransitivitySym0 a_T150_6 = TransitivitySym1 a_T150_6
     instance SuppressUnusedWarnings TransitivitySym0 where
       suppressUnusedWarnings = snd ((,) TransitivitySym0KindInference ())
     type TransitivitySym1 :: Equal a b -> (~>) (Equal b c) (Equal a c)
-    data TransitivitySym1 (a0123456789876543210 :: Equal a b) :: (~>) (Equal b c) (Equal a c)
+    data TransitivitySym1 (a_T150_6 :: Equal a b) :: (~>) (Equal b c) (Equal a c)
       where
-        TransitivitySym1KindInference :: SameKind (Apply (TransitivitySym1 a0123456789876543210) arg) (TransitivitySym2 a0123456789876543210 arg) =>
-                                         TransitivitySym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Equal b c) @(Equal a c) (TransitivitySym1 a0123456789876543210) a0123456789876543210 = Transitivity a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (TransitivitySym1 a0123456789876543210) where
+        TransitivitySym1KindInference :: SameKind (Apply (TransitivitySym1 a_T150_6) arg) (TransitivitySym2 a_T150_6 arg) =>
+                                         TransitivitySym1 a_T150_6 a_T150_7
+    type instance Apply @(Equal b c) @(Equal a c) (TransitivitySym1 a_T150_6) a_T150_7 = Transitivity a_T150_6 a_T150_7
+    instance SuppressUnusedWarnings (TransitivitySym1 a_T150_6) where
       suppressUnusedWarnings = snd ((,) TransitivitySym1KindInference ())
     type TransitivitySym2 :: Equal a b -> Equal b c -> Equal a c
-    type family TransitivitySym2 @a @b @c (a0123456789876543210 :: Equal a b) (a0123456789876543210 :: Equal b c) :: Equal a c where
-      TransitivitySym2 a0123456789876543210 a0123456789876543210 = Transitivity a0123456789876543210 a0123456789876543210
+    type family TransitivitySym2 @a @b @c (a_T150_6 :: Equal a b) (a_T150_7 :: Equal b c) :: Equal a c where
+      TransitivitySym2 a_T150_6 a_T150_7 = Transitivity a_T150_6 a_T150_7
     type SymmetrySym0 :: (~>) (Equal a b) (Equal b a)
     data SymmetrySym0 :: (~>) (Equal a b) (Equal b a)
       where
         SymmetrySym0KindInference :: SameKind (Apply SymmetrySym0 arg) (SymmetrySym1 arg) =>
-                                     SymmetrySym0 a0123456789876543210
-    type instance Apply @(Equal a b) @(Equal b a) SymmetrySym0 a0123456789876543210 = Symmetry a0123456789876543210
+                                     SymmetrySym0 a_T150_8
+    type instance Apply @(Equal a b) @(Equal b a) SymmetrySym0 a_T150_8 = Symmetry a_T150_8
     instance SuppressUnusedWarnings SymmetrySym0 where
       suppressUnusedWarnings = snd ((,) SymmetrySym0KindInference ())
     type SymmetrySym1 :: Equal a b -> Equal b a
-    type family SymmetrySym1 @a @b (a0123456789876543210 :: Equal a b) :: Equal b a where
-      SymmetrySym1 a0123456789876543210 = Symmetry a0123456789876543210
+    type family SymmetrySym1 @a @b (a_T150_8 :: Equal a b) :: Equal b a where
+      SymmetrySym1 a_T150_8 = Symmetry a_T150_8
     type MapVecSym0 :: (~>) ((~>) a b) ((~>) (Vec n a) (Vec n b))
     data MapVecSym0 :: (~>) ((~>) a b) ((~>) (Vec n a) (Vec n b))
       where
         MapVecSym0KindInference :: SameKind (Apply MapVecSym0 arg) (MapVecSym1 arg) =>
-                                   MapVecSym0 a0123456789876543210
-    type instance Apply @((~>) a b) @((~>) (Vec n a) (Vec n b)) MapVecSym0 a0123456789876543210 = MapVecSym1 a0123456789876543210
+                                   MapVecSym0 a_T150_9
+    type instance Apply @((~>) a b) @((~>) (Vec n a) (Vec n b)) MapVecSym0 a_T150_9 = MapVecSym1 a_T150_9
     instance SuppressUnusedWarnings MapVecSym0 where
       suppressUnusedWarnings = snd ((,) MapVecSym0KindInference ())
     type MapVecSym1 :: (~>) a b -> (~>) (Vec n a) (Vec n b)
-    data MapVecSym1 (a0123456789876543210 :: (~>) a b) :: (~>) (Vec n a) (Vec n b)
+    data MapVecSym1 (a_T150_9 :: (~>) a b) :: (~>) (Vec n a) (Vec n b)
       where
-        MapVecSym1KindInference :: SameKind (Apply (MapVecSym1 a0123456789876543210) arg) (MapVecSym2 a0123456789876543210 arg) =>
-                                   MapVecSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Vec n a) @(Vec n b) (MapVecSym1 a0123456789876543210) a0123456789876543210 = MapVec a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (MapVecSym1 a0123456789876543210) where
+        MapVecSym1KindInference :: SameKind (Apply (MapVecSym1 a_T150_9) arg) (MapVecSym2 a_T150_9 arg) =>
+                                   MapVecSym1 a_T150_9 a_T150_10
+    type instance Apply @(Vec n a) @(Vec n b) (MapVecSym1 a_T150_9) a_T150_10 = MapVec a_T150_9 a_T150_10
+    instance SuppressUnusedWarnings (MapVecSym1 a_T150_9) where
       suppressUnusedWarnings = snd ((,) MapVecSym1KindInference ())
     type MapVecSym2 :: (~>) a b -> Vec n a -> Vec n b
-    type family MapVecSym2 @a @b @n (a0123456789876543210 :: (~>) a b) (a0123456789876543210 :: Vec n a) :: Vec n b where
-      MapVecSym2 a0123456789876543210 a0123456789876543210 = MapVec a0123456789876543210 a0123456789876543210
+    type family MapVecSym2 @a @b @n (a_T150_9 :: (~>) a b) (a_T150_10 :: Vec n a) :: Vec n b where
+      MapVecSym2 a_T150_9 a_T150_10 = MapVec a_T150_9 a_T150_10
     type (!@#@$) :: (~>) (Vec n a) ((~>) (Fin n) a)
     data (!@#@$) :: (~>) (Vec n a) ((~>) (Fin n) a)
       where
         (:!@#@$###) :: SameKind (Apply (!@#@$) arg) ((!@#@$$) arg) =>
-                       (!@#@$) a0123456789876543210
-    type instance Apply @(Vec n a) @((~>) (Fin n) a) (!@#@$) a0123456789876543210 = (!@#@$$) a0123456789876543210
+                       (!@#@$) a_T150_11
+    type instance Apply @(Vec n a) @((~>) (Fin n) a) (!@#@$) a_T150_11 = (!@#@$$) a_T150_11
     instance SuppressUnusedWarnings (!@#@$) where
       suppressUnusedWarnings = snd ((,) (:!@#@$###) ())
     type (!@#@$$) :: Vec n a -> (~>) (Fin n) a
-    data (!@#@$$) (a0123456789876543210 :: Vec n a) :: (~>) (Fin n) a
+    data (!@#@$$) (a_T150_11 :: Vec n a) :: (~>) (Fin n) a
       where
-        (:!@#@$$###) :: SameKind (Apply ((!@#@$$) a0123456789876543210) arg) ((!@#@$$$) a0123456789876543210 arg) =>
-                        (!@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @(Fin n) @a ((!@#@$$) a0123456789876543210) a0123456789876543210 = (!) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((!@#@$$) a0123456789876543210) where
+        (:!@#@$$###) :: SameKind (Apply ((!@#@$$) a_T150_11) arg) ((!@#@$$$) a_T150_11 arg) =>
+                        (!@#@$$) a_T150_11 a_T150_12
+    type instance Apply @(Fin n) @a ((!@#@$$) a_T150_11) a_T150_12 = (!) a_T150_11 a_T150_12
+    instance SuppressUnusedWarnings ((!@#@$$) a_T150_11) where
       suppressUnusedWarnings = snd ((,) (:!@#@$$###) ())
     type (!@#@$$$) :: Vec n a -> Fin n -> a
-    type family (!@#@$$$) @n @a (a0123456789876543210 :: Vec n a) (a0123456789876543210 :: Fin n) :: a where
-      (!@#@$$$) a0123456789876543210 a0123456789876543210 = (!) a0123456789876543210 a0123456789876543210
+    type family (!@#@$$$) @n @a (a_T150_11 :: Vec n a) (a_T150_12 :: Fin n) :: a where
+      (!@#@$$$) a_T150_11 a_T150_12 = (!) a_T150_11 a_T150_12
     type TailVecSym0 :: (~>) (Vec ('Succ n) a) (Vec n a)
     data TailVecSym0 :: (~>) (Vec ('Succ n) a) (Vec n a)
       where
         TailVecSym0KindInference :: SameKind (Apply TailVecSym0 arg) (TailVecSym1 arg) =>
-                                    TailVecSym0 a0123456789876543210
-    type instance Apply @(Vec ('Succ n) a) @(Vec n a) TailVecSym0 a0123456789876543210 = TailVec a0123456789876543210
+                                    TailVecSym0 a_T150_15
+    type instance Apply @(Vec ('Succ n) a) @(Vec n a) TailVecSym0 a_T150_15 = TailVec a_T150_15
     instance SuppressUnusedWarnings TailVecSym0 where
       suppressUnusedWarnings = snd ((,) TailVecSym0KindInference ())
     type TailVecSym1 :: Vec ('Succ n) a -> Vec n a
-    type family TailVecSym1 @n @a (a0123456789876543210 :: Vec ('Succ n) a) :: Vec n a where
-      TailVecSym1 a0123456789876543210 = TailVec a0123456789876543210
+    type family TailVecSym1 @n @a (a_T150_15 :: Vec ('Succ n) a) :: Vec n a where
+      TailVecSym1 a_T150_15 = TailVec a_T150_15
     type HeadVecSym0 :: (~>) (Vec ('Succ n) a) a
     data HeadVecSym0 :: (~>) (Vec ('Succ n) a) a
       where
         HeadVecSym0KindInference :: SameKind (Apply HeadVecSym0 arg) (HeadVecSym1 arg) =>
-                                    HeadVecSym0 a0123456789876543210
-    type instance Apply @(Vec ('Succ n) a) @a HeadVecSym0 a0123456789876543210 = HeadVec a0123456789876543210
+                                    HeadVecSym0 a_T150_16
+    type instance Apply @(Vec ('Succ n) a) @a HeadVecSym0 a_T150_16 = HeadVec a_T150_16
     instance SuppressUnusedWarnings HeadVecSym0 where
       suppressUnusedWarnings = snd ((,) HeadVecSym0KindInference ())
     type HeadVecSym1 :: Vec ('Succ n) a -> a
-    type family HeadVecSym1 @n @a (a0123456789876543210 :: Vec ('Succ n) a) :: a where
-      HeadVecSym1 a0123456789876543210 = HeadVec a0123456789876543210
+    type family HeadVecSym1 @n @a (a_T150_16 :: Vec ('Succ n) a) :: a where
+      HeadVecSym1 a_T150_16 = HeadVec a_T150_16
     type Transitivity :: Equal a b -> Equal b c -> Equal a c
     type family Transitivity @a @b @c (a :: Equal a b) (a :: Equal b c) :: Equal a c where
       Transitivity Reflexive Reflexive = ReflexiveSym0
@@ -263,7 +263,7 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
     type family (!) @n @a (a :: Vec n a) (a :: Fin n) :: a where
       (!) (VCons x _) FZ = x
       (!) (VCons _ xs) (FS n) = Apply (Apply (!@#@$) xs) n
-      (!) VNil n = Apply (LamCases_0123456789876543210Sym0 n) n
+      (!) VNil n = Apply (LamCases_T150_13Sym0 n) n
     type TailVec :: Vec ('Succ n) a -> Vec n a
     type family TailVec @n @a (a :: Vec ('Succ n) a) :: Vec n a where
       TailVec (VCons _ xs) = xs
@@ -299,8 +299,7 @@ Singletons/T150.hs:(0,0)-(0,0): Splicing declarations
     (%!) (SVCons _ (sXs :: Sing xs)) (SFS (sN :: Sing n))
       = applySing (applySing (singFun2 @(!@#@$) (%!)) sXs) sN
     (%!) SVNil (sN :: Sing n)
-      = applySing
-          (singFun1 @(LamCases_0123456789876543210Sym0 n) (\case)) sN
+      = applySing (singFun1 @(LamCases_T150_13Sym0 n) (\case)) sN
     sTailVec (SVCons _ (sXs :: Sing xs)) = sXs
     sHeadVec (SVCons (sX :: Sing x) _) = sX
     instance SingI (TransitivitySym0 :: (~>) (Equal a b) ((~>) (Equal b c) (Equal a c))) where

--- a/singletons-base/tests/compile-and-dump/Singletons/T159.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T159.golden
@@ -62,45 +62,45 @@ Singletons/T159.hs:0:0:: Splicing declarations
     data C1Sym0 :: (~>) T0 ((~>) T1 T1)
       where
         C1Sym0KindInference :: SameKind (Apply C1Sym0 arg) (C1Sym1 arg) =>
-                               C1Sym0 a0123456789876543210
-    type instance Apply @T0 @((~>) T1 T1) C1Sym0 a0123456789876543210 = C1Sym1 a0123456789876543210
+                               C1Sym0 a_T159_0
+    type instance Apply @T0 @((~>) T1 T1) C1Sym0 a_T159_0 = C1Sym1 a_T159_0
     instance SuppressUnusedWarnings C1Sym0 where
       suppressUnusedWarnings = snd ((,) C1Sym0KindInference ())
     infixr 5 type `C1Sym0`
     type C1Sym1 :: T0 -> (~>) T1 T1
-    data C1Sym1 (a0123456789876543210 :: T0) :: (~>) T1 T1
+    data C1Sym1 (a_T159_0 :: T0) :: (~>) T1 T1
       where
-        C1Sym1KindInference :: SameKind (Apply (C1Sym1 a0123456789876543210) arg) (C1Sym2 a0123456789876543210 arg) =>
-                               C1Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @T1 @T1 (C1Sym1 a0123456789876543210) a0123456789876543210 = 'C1 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (C1Sym1 a0123456789876543210) where
+        C1Sym1KindInference :: SameKind (Apply (C1Sym1 a_T159_0) arg) (C1Sym2 a_T159_0 arg) =>
+                               C1Sym1 a_T159_0 a_T159_1
+    type instance Apply @T1 @T1 (C1Sym1 a_T159_0) a_T159_1 = 'C1 a_T159_0 a_T159_1
+    instance SuppressUnusedWarnings (C1Sym1 a_T159_0) where
       suppressUnusedWarnings = snd ((,) C1Sym1KindInference ())
     infixr 5 type `C1Sym1`
     type C1Sym2 :: T0 -> T1 -> T1
-    type family C1Sym2 (a0123456789876543210 :: T0) (a0123456789876543210 :: T1) :: T1 where
-      C1Sym2 a0123456789876543210 a0123456789876543210 = 'C1 a0123456789876543210 a0123456789876543210
+    type family C1Sym2 (a_T159_0 :: T0) (a_T159_1 :: T1) :: T1 where
+      C1Sym2 a_T159_0 a_T159_1 = 'C1 a_T159_0 a_T159_1
     infixr 5 type `C1Sym2`
     type (:&&@#@$) :: (~>) T0 ((~>) T1 T1)
     data (:&&@#@$) :: (~>) T0 ((~>) T1 T1)
       where
         (::&&@#@$###) :: SameKind (Apply (:&&@#@$) arg) ((:&&@#@$$) arg) =>
-                         (:&&@#@$) a0123456789876543210
-    type instance Apply @T0 @((~>) T1 T1) (:&&@#@$) a0123456789876543210 = (:&&@#@$$) a0123456789876543210
+                         (:&&@#@$) a_T159_2
+    type instance Apply @T0 @((~>) T1 T1) (:&&@#@$) a_T159_2 = (:&&@#@$$) a_T159_2
     instance SuppressUnusedWarnings (:&&@#@$) where
       suppressUnusedWarnings = snd ((,) (::&&@#@$###) ())
     infixr 5 type :&&@#@$
     type (:&&@#@$$) :: T0 -> (~>) T1 T1
-    data (:&&@#@$$) (a0123456789876543210 :: T0) :: (~>) T1 T1
+    data (:&&@#@$$) (a_T159_2 :: T0) :: (~>) T1 T1
       where
-        (::&&@#@$$###) :: SameKind (Apply ((:&&@#@$$) a0123456789876543210) arg) ((:&&@#@$$$) a0123456789876543210 arg) =>
-                          (:&&@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @T1 @T1 ((:&&@#@$$) a0123456789876543210) a0123456789876543210 = '(:&&) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((:&&@#@$$) a0123456789876543210) where
+        (::&&@#@$$###) :: SameKind (Apply ((:&&@#@$$) a_T159_2) arg) ((:&&@#@$$$) a_T159_2 arg) =>
+                          (:&&@#@$$) a_T159_2 a_T159_3
+    type instance Apply @T1 @T1 ((:&&@#@$$) a_T159_2) a_T159_3 = '(:&&) a_T159_2 a_T159_3
+    instance SuppressUnusedWarnings ((:&&@#@$$) a_T159_2) where
       suppressUnusedWarnings = snd ((,) (::&&@#@$$###) ())
     infixr 5 type :&&@#@$$
     type (:&&@#@$$$) :: T0 -> T1 -> T1
-    type family (:&&@#@$$$) (a0123456789876543210 :: T0) (a0123456789876543210 :: T1) :: T1 where
-      (:&&@#@$$$) a0123456789876543210 a0123456789876543210 = '(:&&) a0123456789876543210 a0123456789876543210
+    type family (:&&@#@$$$) (a_T159_2 :: T0) (a_T159_3 :: T1) :: T1 where
+      (:&&@#@$$$) a_T159_2 a_T159_3 = '(:&&) a_T159_2 a_T159_3
     infixr 5 type :&&@#@$$$
     type ST1 :: T1 -> Type
     data ST1 :: T1 -> Type
@@ -173,45 +173,45 @@ Singletons/T159.hs:(0,0)-(0,0): Splicing declarations
     data C2Sym0 :: (~>) T0 ((~>) T2 T2)
       where
         C2Sym0KindInference :: SameKind (Apply C2Sym0 arg) (C2Sym1 arg) =>
-                               C2Sym0 a0123456789876543210
-    type instance Apply @T0 @((~>) T2 T2) C2Sym0 a0123456789876543210 = C2Sym1 a0123456789876543210
+                               C2Sym0 a_T159_4
+    type instance Apply @T0 @((~>) T2 T2) C2Sym0 a_T159_4 = C2Sym1 a_T159_4
     instance SuppressUnusedWarnings C2Sym0 where
       suppressUnusedWarnings = snd ((,) C2Sym0KindInference ())
     infixr 5 type `C2Sym0`
     type C2Sym1 :: T0 -> (~>) T2 T2
-    data C2Sym1 (a0123456789876543210 :: T0) :: (~>) T2 T2
+    data C2Sym1 (a_T159_4 :: T0) :: (~>) T2 T2
       where
-        C2Sym1KindInference :: SameKind (Apply (C2Sym1 a0123456789876543210) arg) (C2Sym2 a0123456789876543210 arg) =>
-                               C2Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @T2 @T2 (C2Sym1 a0123456789876543210) a0123456789876543210 = C2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (C2Sym1 a0123456789876543210) where
+        C2Sym1KindInference :: SameKind (Apply (C2Sym1 a_T159_4) arg) (C2Sym2 a_T159_4 arg) =>
+                               C2Sym1 a_T159_4 a_T159_5
+    type instance Apply @T2 @T2 (C2Sym1 a_T159_4) a_T159_5 = C2 a_T159_4 a_T159_5
+    instance SuppressUnusedWarnings (C2Sym1 a_T159_4) where
       suppressUnusedWarnings = snd ((,) C2Sym1KindInference ())
     infixr 5 type `C2Sym1`
     type C2Sym2 :: T0 -> T2 -> T2
-    type family C2Sym2 (a0123456789876543210 :: T0) (a0123456789876543210 :: T2) :: T2 where
-      C2Sym2 a0123456789876543210 a0123456789876543210 = C2 a0123456789876543210 a0123456789876543210
+    type family C2Sym2 (a_T159_4 :: T0) (a_T159_5 :: T2) :: T2 where
+      C2Sym2 a_T159_4 a_T159_5 = C2 a_T159_4 a_T159_5
     infixr 5 type `C2Sym2`
     type (:||@#@$) :: (~>) T0 ((~>) T2 T2)
     data (:||@#@$) :: (~>) T0 ((~>) T2 T2)
       where
         (::||@#@$###) :: SameKind (Apply (:||@#@$) arg) ((:||@#@$$) arg) =>
-                         (:||@#@$) a0123456789876543210
-    type instance Apply @T0 @((~>) T2 T2) (:||@#@$) a0123456789876543210 = (:||@#@$$) a0123456789876543210
+                         (:||@#@$) a_T159_6
+    type instance Apply @T0 @((~>) T2 T2) (:||@#@$) a_T159_6 = (:||@#@$$) a_T159_6
     instance SuppressUnusedWarnings (:||@#@$) where
       suppressUnusedWarnings = snd ((,) (::||@#@$###) ())
     infixr 5 type :||@#@$
     type (:||@#@$$) :: T0 -> (~>) T2 T2
-    data (:||@#@$$) (a0123456789876543210 :: T0) :: (~>) T2 T2
+    data (:||@#@$$) (a_T159_6 :: T0) :: (~>) T2 T2
       where
-        (::||@#@$$###) :: SameKind (Apply ((:||@#@$$) a0123456789876543210) arg) ((:||@#@$$$) a0123456789876543210 arg) =>
-                          (:||@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @T2 @T2 ((:||@#@$$) a0123456789876543210) a0123456789876543210 = (:||) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((:||@#@$$) a0123456789876543210) where
+        (::||@#@$$###) :: SameKind (Apply ((:||@#@$$) a_T159_6) arg) ((:||@#@$$$) a_T159_6 arg) =>
+                          (:||@#@$$) a_T159_6 a_T159_7
+    type instance Apply @T2 @T2 ((:||@#@$$) a_T159_6) a_T159_7 = (:||) a_T159_6 a_T159_7
+    instance SuppressUnusedWarnings ((:||@#@$$) a_T159_6) where
       suppressUnusedWarnings = snd ((,) (::||@#@$$###) ())
     infixr 5 type :||@#@$$
     type (:||@#@$$$) :: T0 -> T2 -> T2
-    type family (:||@#@$$$) (a0123456789876543210 :: T0) (a0123456789876543210 :: T2) :: T2 where
-      (:||@#@$$$) a0123456789876543210 a0123456789876543210 = (:||) a0123456789876543210 a0123456789876543210
+    type family (:||@#@$$$) (a_T159_6 :: T0) (a_T159_7 :: T2) :: T2 where
+      (:||@#@$$$) a_T159_6 a_T159_7 = (:||) a_T159_6 a_T159_7
     infixr 5 type :||@#@$$$
     infixr 5 data :%||
     infixr 5 data `SC2`

--- a/singletons-base/tests/compile-and-dump/Singletons/T160.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T160.golden
@@ -5,40 +5,40 @@ Singletons/T160.hs:(0,0)-(0,0): Splicing declarations
   ======>
     foo :: (Num a, Eq a) => a -> a
     foo x = if (x == 0) then 1 else (typeError $ ShowType x)
-    type family LamCases_0123456789876543210 (x0123456789876543210 :: a0123456789876543210) a_0123456789876543210 where
-      LamCases_0123456789876543210 x 'True = FromInteger 1
-      LamCases_0123456789876543210 x 'False = Apply (Apply ($@#@$) TypeErrorSym0) (Apply ShowTypeSym0 x)
-    data LamCases_0123456789876543210Sym0 (x0123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210
+    type family LamCases_T160_1 (x1 :: a0) a_T160_2 where
+      LamCases_T160_1 x 'True = FromInteger 1
+      LamCases_T160_1 x 'False = Apply (Apply ($@#@$) TypeErrorSym0) (Apply ShowTypeSym0 x)
+    data LamCases_T160_1Sym0 (x1 :: a0) a_T160_2
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210) where
+        LamCases_T160_1Sym0KindInference :: SameKind (Apply (LamCases_T160_1Sym0 x1) arg) (LamCases_T160_1Sym1 x1 arg) =>
+                                            LamCases_T160_1Sym0 x1 a_T160_2
+    type instance Apply @_ @_ (LamCases_T160_1Sym0 x1) a_T160_2 = LamCases_T160_1 x1 a_T160_2
+    instance SuppressUnusedWarnings (LamCases_T160_1Sym0 x1) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (x0123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 x0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_T160_1Sym0KindInference ())
+    type family LamCases_T160_1Sym1 (x1 :: a0) a_T160_2 where
+      LamCases_T160_1Sym1 x1 a_T160_2 = LamCases_T160_1 x1 a_T160_2
     type FooSym0 :: (~>) a a
     data FooSym0 :: (~>) a a
       where
         FooSym0KindInference :: SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
-                                FooSym0 a0123456789876543210
-    type instance Apply @a @a FooSym0 a0123456789876543210 = Foo a0123456789876543210
+                                FooSym0 a_T160_0
+    type instance Apply @a @a FooSym0 a_T160_0 = Foo a_T160_0
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings = snd ((,) FooSym0KindInference ())
     type FooSym1 :: a -> a
-    type family FooSym1 @a (a0123456789876543210 :: a) :: a where
-      FooSym1 a0123456789876543210 = Foo a0123456789876543210
+    type family FooSym1 @a (a_T160_0 :: a) :: a where
+      FooSym1 a_T160_0 = Foo a_T160_0
     type Foo :: a -> a
     type family Foo @a (a :: a) :: a where
-      Foo x = Apply (LamCases_0123456789876543210Sym0 x) (Apply (Apply (==@#@$) x) (FromInteger 0))
+      Foo x = Apply (LamCases_T160_1Sym0 x) (Apply (Apply (==@#@$) x) (FromInteger 0))
     sFoo ::
       (forall (t :: a).
        (SNum a, SEq a) => Sing t -> Sing (Foo t :: a) :: Type)
     sFoo (sX :: Sing x)
       = applySing
           (singFun1
-             @(LamCases_0123456789876543210Sym0 x)
+             @(LamCases_T160_1Sym0 x)
              (\cases
                 STrue -> sFromInteger (sing :: Sing 1)
                 SFalse

--- a/singletons-base/tests/compile-and-dump/Singletons/T163.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T163.golden
@@ -6,24 +6,24 @@ Singletons/T163.hs:0:0:: Splicing declarations
     data LSym0 :: (~>) a ((+) a b)
       where
         LSym0KindInference :: SameKind (Apply LSym0 arg) (LSym1 arg) =>
-                              LSym0 a0123456789876543210
-    type instance Apply @a @((+) a b) LSym0 a0123456789876543210 = L a0123456789876543210
+                              LSym0 a_T163_0
+    type instance Apply @a @((+) a b) LSym0 a_T163_0 = L a_T163_0
     instance SuppressUnusedWarnings LSym0 where
       suppressUnusedWarnings = snd ((,) LSym0KindInference ())
     type LSym1 :: forall a b. a -> (+) a b
-    type family LSym1 @a @b (a0123456789876543210 :: a) :: (+) a b where
-      LSym1 a0123456789876543210 = L a0123456789876543210
+    type family LSym1 @a @b (a_T163_0 :: a) :: (+) a b where
+      LSym1 a_T163_0 = L a_T163_0
     type RSym0 :: forall a b. (~>) b ((+) a b)
     data RSym0 :: (~>) b ((+) a b)
       where
         RSym0KindInference :: SameKind (Apply RSym0 arg) (RSym1 arg) =>
-                              RSym0 a0123456789876543210
-    type instance Apply @b @((+) a b) RSym0 a0123456789876543210 = R a0123456789876543210
+                              RSym0 a_T163_1
+    type instance Apply @b @((+) a b) RSym0 a_T163_1 = R a_T163_1
     instance SuppressUnusedWarnings RSym0 where
       suppressUnusedWarnings = snd ((,) RSym0KindInference ())
     type RSym1 :: forall a b. b -> (+) a b
-    type family RSym1 @a @b (a0123456789876543210 :: b) :: (+) a b where
-      RSym1 a0123456789876543210 = R a0123456789876543210
+    type family RSym1 @a @b (a_T163_1 :: b) :: (+) a b where
+      RSym1 a_T163_1 = R a_T163_1
     data (%+) :: forall a b. (+) a b -> Type
       where
         SL :: forall a b (n :: a). (Sing n) -> (%+) (L n :: (+) a b)

--- a/singletons-base/tests/compile-and-dump/Singletons/T166.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T166.golden
@@ -9,60 +9,60 @@ Singletons/T166.hs:(0,0)-(0,0): Splicing declarations
     data FoosPrecSym0 :: (~>) Natural ((~>) a ((~>) [Bool] [Bool]))
       where
         FoosPrecSym0KindInference :: SameKind (Apply FoosPrecSym0 arg) (FoosPrecSym1 arg) =>
-                                     FoosPrecSym0 a0123456789876543210
-    type instance Apply @Natural @((~>) a ((~>) [Bool] [Bool])) FoosPrecSym0 a0123456789876543210 = FoosPrecSym1 a0123456789876543210
+                                     FoosPrecSym0 a_SingletonsBug_0
+    type instance Apply @Natural @((~>) a ((~>) [Bool] [Bool])) FoosPrecSym0 a_SingletonsBug_0 = FoosPrecSym1 a_SingletonsBug_0
     instance SuppressUnusedWarnings FoosPrecSym0 where
       suppressUnusedWarnings = snd ((,) FoosPrecSym0KindInference ())
     type FoosPrecSym1 :: forall a. Natural
                                    -> (~>) a ((~>) [Bool] [Bool])
-    data FoosPrecSym1 (a0123456789876543210 :: Natural) :: (~>) a ((~>) [Bool] [Bool])
+    data FoosPrecSym1 (a_SingletonsBug_0 :: Natural) :: (~>) a ((~>) [Bool] [Bool])
       where
-        FoosPrecSym1KindInference :: SameKind (Apply (FoosPrecSym1 a0123456789876543210) arg) (FoosPrecSym2 a0123456789876543210 arg) =>
-                                     FoosPrecSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @a @((~>) [Bool] [Bool]) (FoosPrecSym1 a0123456789876543210) a0123456789876543210 = FoosPrecSym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (FoosPrecSym1 a0123456789876543210) where
+        FoosPrecSym1KindInference :: SameKind (Apply (FoosPrecSym1 a_SingletonsBug_0) arg) (FoosPrecSym2 a_SingletonsBug_0 arg) =>
+                                     FoosPrecSym1 a_SingletonsBug_0 a_SingletonsBug_1
+    type instance Apply @a @((~>) [Bool] [Bool]) (FoosPrecSym1 a_SingletonsBug_0) a_SingletonsBug_1 = FoosPrecSym2 a_SingletonsBug_0 a_SingletonsBug_1
+    instance SuppressUnusedWarnings (FoosPrecSym1 a_SingletonsBug_0) where
       suppressUnusedWarnings = snd ((,) FoosPrecSym1KindInference ())
     type FoosPrecSym2 :: forall a. Natural -> a -> (~>) [Bool] [Bool]
-    data FoosPrecSym2 (a0123456789876543210 :: Natural) (a0123456789876543210 :: a) :: (~>) [Bool] [Bool]
+    data FoosPrecSym2 (a_SingletonsBug_0 :: Natural) (a_SingletonsBug_1 :: a) :: (~>) [Bool] [Bool]
       where
-        FoosPrecSym2KindInference :: SameKind (Apply (FoosPrecSym2 a0123456789876543210 a0123456789876543210) arg) (FoosPrecSym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                     FoosPrecSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @[Bool] @[Bool] (FoosPrecSym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = FoosPrec a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (FoosPrecSym2 a0123456789876543210 a0123456789876543210) where
+        FoosPrecSym2KindInference :: SameKind (Apply (FoosPrecSym2 a_SingletonsBug_0 a_SingletonsBug_1) arg) (FoosPrecSym3 a_SingletonsBug_0 a_SingletonsBug_1 arg) =>
+                                     FoosPrecSym2 a_SingletonsBug_0 a_SingletonsBug_1 a_SingletonsBug_2
+    type instance Apply @[Bool] @[Bool] (FoosPrecSym2 a_SingletonsBug_0 a_SingletonsBug_1) a_SingletonsBug_2 = FoosPrec a_SingletonsBug_0 a_SingletonsBug_1 a_SingletonsBug_2
+    instance SuppressUnusedWarnings (FoosPrecSym2 a_SingletonsBug_0 a_SingletonsBug_1) where
       suppressUnusedWarnings = snd ((,) FoosPrecSym2KindInference ())
     type FoosPrecSym3 :: forall a. Natural -> a -> [Bool] -> [Bool]
-    type family FoosPrecSym3 @a (a0123456789876543210 :: Natural) (a0123456789876543210 :: a) (a0123456789876543210 :: [Bool]) :: [Bool] where
-      FoosPrecSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = FoosPrec a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type family FoosPrecSym3 @a (a_SingletonsBug_0 :: Natural) (a_SingletonsBug_1 :: a) (a_SingletonsBug_2 :: [Bool]) :: [Bool] where
+      FoosPrecSym3 a_SingletonsBug_0 a_SingletonsBug_1 a_SingletonsBug_2 = FoosPrec a_SingletonsBug_0 a_SingletonsBug_1 a_SingletonsBug_2
     type FooSym0 :: forall a. (~>) a [Bool]
     data FooSym0 :: (~>) a [Bool]
       where
         FooSym0KindInference :: SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
-                                FooSym0 a0123456789876543210
-    type instance Apply @a @[Bool] FooSym0 a0123456789876543210 = Foo a0123456789876543210
+                                FooSym0 a_SingletonsBug_3
+    type instance Apply @a @[Bool] FooSym0 a_SingletonsBug_3 = Foo a_SingletonsBug_3
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings = snd ((,) FooSym0KindInference ())
     type FooSym1 :: forall a. a -> [Bool]
-    type family FooSym1 @a (a0123456789876543210 :: a) :: [Bool] where
-      FooSym1 a0123456789876543210 = Foo a0123456789876543210
-    type family LamCases_0123456789876543210 a0123456789876543210 (x0123456789876543210 :: a0123456789876543210) a_0123456789876543210 where
-      LamCases_0123456789876543210 a x s = Apply (Apply (Apply FoosPrecSym0 (FromInteger 0)) x) s
-    data LamCases_0123456789876543210Sym0 a0123456789876543210 (x0123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210
+    type family FooSym1 @a (a_SingletonsBug_3 :: a) :: [Bool] where
+      FooSym1 a_SingletonsBug_3 = Foo a_SingletonsBug_3
+    type family LamCases_SingletonsBug_6 a0 (x1 :: a0) a_SingletonsBug_7 where
+      LamCases_SingletonsBug_6 a x s = Apply (Apply (Apply FoosPrecSym0 (FromInteger 0)) x) s
+    data LamCases_SingletonsBug_6Sym0 a0 (x1 :: a0) a_SingletonsBug_7
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 a0123456789876543210 x0123456789876543210) arg) (LamCases_0123456789876543210Sym1 a0123456789876543210 x0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 a0123456789876543210 x0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 a0123456789876543210 x0123456789876543210) where
+        LamCases_SingletonsBug_6Sym0KindInference :: SameKind (Apply (LamCases_SingletonsBug_6Sym0 a0 x1) arg) (LamCases_SingletonsBug_6Sym1 a0 x1 arg) =>
+                                                     LamCases_SingletonsBug_6Sym0 a0 x1 a_SingletonsBug_7
+    type instance Apply @_ @_ (LamCases_SingletonsBug_6Sym0 a0 x1) a_SingletonsBug_7 = LamCases_SingletonsBug_6 a0 x1 a_SingletonsBug_7
+    instance SuppressUnusedWarnings (LamCases_SingletonsBug_6Sym0 a0 x1) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 a0123456789876543210 (x0123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    type Foo_0123456789876543210 :: forall a. a -> [Bool]
-    type family Foo_0123456789876543210 @a (a :: a) :: [Bool] where
-      Foo_0123456789876543210 @a (x :: a) = LamCases_0123456789876543210Sym0 a x
+        = snd ((,) LamCases_SingletonsBug_6Sym0KindInference ())
+    type family LamCases_SingletonsBug_6Sym1 a0 (x1 :: a0) a_SingletonsBug_7 where
+      LamCases_SingletonsBug_6Sym1 a0 x1 a_SingletonsBug_7 = LamCases_SingletonsBug_6 a0 x1 a_SingletonsBug_7
+    type Foo_SingletonsBug_4 :: forall a. a -> [Bool]
+    type family Foo_SingletonsBug_4 @a (a :: a) :: [Bool] where
+      Foo_SingletonsBug_4 @a (x :: a) = LamCases_SingletonsBug_6Sym0 a x
     class PFoo a where
       type family FoosPrec (arg :: Natural) (arg :: a) (arg :: [Bool]) :: [Bool]
       type family Foo (arg :: a) :: [Bool]
-      type Foo a = Foo_0123456789876543210 a
+      type Foo a = Foo_SingletonsBug_4 a
     class SFoo a where
       sFoosPrec ::
         (forall (t :: Natural) (t :: a) (t :: [Bool]).
@@ -71,11 +71,11 @@ Singletons/T166.hs:(0,0)-(0,0): Splicing declarations
       sFoo :: (forall (t :: a). Sing t -> Sing (Foo t :: [Bool]) :: Type)
       default sFoo ::
                 (forall (t :: a).
-                 ((Foo t :: [Bool]) ~ Foo_0123456789876543210 t) =>
+                 ((Foo t :: [Bool]) ~ Foo_SingletonsBug_4 t) =>
                  Sing t -> Sing (Foo t :: [Bool]) :: Type)
       sFoo (sX :: Sing x)
         = singFun1
-            @(LamCases_0123456789876543210Sym0 a x)
+            @(LamCases_SingletonsBug_6Sym0 a x)
             (\cases
                (sS :: Sing s)
                  -> applySing
@@ -115,13 +115,13 @@ Singletons/T166.hs:(0,0)-(0,0): Splicing declarations
     instance SFoo a => SingI (FooSym0 :: (~>) a [Bool]) where
       sing = singFun1 @FooSym0 sFoo
 Singletons/T166.hs:0:0: error: [GHC-83865]
-    • Expecting one more argument to ‘LamCases_0123456789876543210Sym0 a x’
+    • Expecting one more argument to ‘LamCases_SingletonsBug_6Sym0 a x’
       Expected kind ‘[Bool]’,
-        but ‘LamCases_0123456789876543210Sym0 a x’ has kind ‘TyFun
-                                                               [Bool] [Bool]
-                                                             -> Type’
-    • In the type ‘LamCases_0123456789876543210Sym0 a x’
-      In the type family declaration for ‘Foo_0123456789876543210’
+        but ‘LamCases_SingletonsBug_6Sym0 a x’ has kind ‘TyFun
+                                                           [Bool] [Bool]
+                                                         -> Type’
+    • In the type ‘LamCases_SingletonsBug_6Sym0 a x’
+      In the type family declaration for ‘Foo_SingletonsBug_4’
   |
 6 | $(singletonsOnly [d|
   |  ^^^^^^^^^^^^^^^^^^^...

--- a/singletons-base/tests/compile-and-dump/Singletons/T167.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T167.golden
@@ -12,62 +12,62 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
     data FoosPrecSym0 :: (~>) Natural ((~>) a ((~>) [Bool] [Bool]))
       where
         FoosPrecSym0KindInference :: SameKind (Apply FoosPrecSym0 arg) (FoosPrecSym1 arg) =>
-                                     FoosPrecSym0 a0123456789876543210
-    type instance Apply @Natural @((~>) a ((~>) [Bool] [Bool])) FoosPrecSym0 a0123456789876543210 = FoosPrecSym1 a0123456789876543210
+                                     FoosPrecSym0 a_Singletons_T167_0
+    type instance Apply @Natural @((~>) a ((~>) [Bool] [Bool])) FoosPrecSym0 a_Singletons_T167_0 = FoosPrecSym1 a_Singletons_T167_0
     instance SuppressUnusedWarnings FoosPrecSym0 where
       suppressUnusedWarnings = snd ((,) FoosPrecSym0KindInference ())
     type FoosPrecSym1 :: forall a. Natural
                                    -> (~>) a ((~>) [Bool] [Bool])
-    data FoosPrecSym1 (a0123456789876543210 :: Natural) :: (~>) a ((~>) [Bool] [Bool])
+    data FoosPrecSym1 (a_Singletons_T167_0 :: Natural) :: (~>) a ((~>) [Bool] [Bool])
       where
-        FoosPrecSym1KindInference :: SameKind (Apply (FoosPrecSym1 a0123456789876543210) arg) (FoosPrecSym2 a0123456789876543210 arg) =>
-                                     FoosPrecSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @a @((~>) [Bool] [Bool]) (FoosPrecSym1 a0123456789876543210) a0123456789876543210 = FoosPrecSym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (FoosPrecSym1 a0123456789876543210) where
+        FoosPrecSym1KindInference :: SameKind (Apply (FoosPrecSym1 a_Singletons_T167_0) arg) (FoosPrecSym2 a_Singletons_T167_0 arg) =>
+                                     FoosPrecSym1 a_Singletons_T167_0 a_Singletons_T167_1
+    type instance Apply @a @((~>) [Bool] [Bool]) (FoosPrecSym1 a_Singletons_T167_0) a_Singletons_T167_1 = FoosPrecSym2 a_Singletons_T167_0 a_Singletons_T167_1
+    instance SuppressUnusedWarnings (FoosPrecSym1 a_Singletons_T167_0) where
       suppressUnusedWarnings = snd ((,) FoosPrecSym1KindInference ())
     type FoosPrecSym2 :: forall a. Natural -> a -> (~>) [Bool] [Bool]
-    data FoosPrecSym2 (a0123456789876543210 :: Natural) (a0123456789876543210 :: a) :: (~>) [Bool] [Bool]
+    data FoosPrecSym2 (a_Singletons_T167_0 :: Natural) (a_Singletons_T167_1 :: a) :: (~>) [Bool] [Bool]
       where
-        FoosPrecSym2KindInference :: SameKind (Apply (FoosPrecSym2 a0123456789876543210 a0123456789876543210) arg) (FoosPrecSym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                     FoosPrecSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @[Bool] @[Bool] (FoosPrecSym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = FoosPrec a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (FoosPrecSym2 a0123456789876543210 a0123456789876543210) where
+        FoosPrecSym2KindInference :: SameKind (Apply (FoosPrecSym2 a_Singletons_T167_0 a_Singletons_T167_1) arg) (FoosPrecSym3 a_Singletons_T167_0 a_Singletons_T167_1 arg) =>
+                                     FoosPrecSym2 a_Singletons_T167_0 a_Singletons_T167_1 a_Singletons_T167_2
+    type instance Apply @[Bool] @[Bool] (FoosPrecSym2 a_Singletons_T167_0 a_Singletons_T167_1) a_Singletons_T167_2 = FoosPrec a_Singletons_T167_0 a_Singletons_T167_1 a_Singletons_T167_2
+    instance SuppressUnusedWarnings (FoosPrecSym2 a_Singletons_T167_0 a_Singletons_T167_1) where
       suppressUnusedWarnings = snd ((,) FoosPrecSym2KindInference ())
     type FoosPrecSym3 :: forall a. Natural -> a -> [Bool] -> [Bool]
-    type family FoosPrecSym3 @a (a0123456789876543210 :: Natural) (a0123456789876543210 :: a) (a0123456789876543210 :: [Bool]) :: [Bool] where
-      FoosPrecSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = FoosPrec a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type family FoosPrecSym3 @a (a_Singletons_T167_0 :: Natural) (a_Singletons_T167_1 :: a) (a_Singletons_T167_2 :: [Bool]) :: [Bool] where
+      FoosPrecSym3 a_Singletons_T167_0 a_Singletons_T167_1 a_Singletons_T167_2 = FoosPrec a_Singletons_T167_0 a_Singletons_T167_1 a_Singletons_T167_2
     type FooListSym0 :: forall a. (~>) a ((~>) [Bool] [Bool])
     data FooListSym0 :: (~>) a ((~>) [Bool] [Bool])
       where
         FooListSym0KindInference :: SameKind (Apply FooListSym0 arg) (FooListSym1 arg) =>
-                                    FooListSym0 a0123456789876543210
-    type instance Apply @a @((~>) [Bool] [Bool]) FooListSym0 a0123456789876543210 = FooListSym1 a0123456789876543210
+                                    FooListSym0 a_Singletons_T167_3
+    type instance Apply @a @((~>) [Bool] [Bool]) FooListSym0 a_Singletons_T167_3 = FooListSym1 a_Singletons_T167_3
     instance SuppressUnusedWarnings FooListSym0 where
       suppressUnusedWarnings = snd ((,) FooListSym0KindInference ())
     type FooListSym1 :: forall a. a -> (~>) [Bool] [Bool]
-    data FooListSym1 (a0123456789876543210 :: a) :: (~>) [Bool] [Bool]
+    data FooListSym1 (a_Singletons_T167_3 :: a) :: (~>) [Bool] [Bool]
       where
-        FooListSym1KindInference :: SameKind (Apply (FooListSym1 a0123456789876543210) arg) (FooListSym2 a0123456789876543210 arg) =>
-                                    FooListSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @[Bool] @[Bool] (FooListSym1 a0123456789876543210) a0123456789876543210 = FooList a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (FooListSym1 a0123456789876543210) where
+        FooListSym1KindInference :: SameKind (Apply (FooListSym1 a_Singletons_T167_3) arg) (FooListSym2 a_Singletons_T167_3 arg) =>
+                                    FooListSym1 a_Singletons_T167_3 a_Singletons_T167_4
+    type instance Apply @[Bool] @[Bool] (FooListSym1 a_Singletons_T167_3) a_Singletons_T167_4 = FooList a_Singletons_T167_3 a_Singletons_T167_4
+    instance SuppressUnusedWarnings (FooListSym1 a_Singletons_T167_3) where
       suppressUnusedWarnings = snd ((,) FooListSym1KindInference ())
     type FooListSym2 :: forall a. a -> [Bool] -> [Bool]
-    type family FooListSym2 @a (a0123456789876543210 :: a) (a0123456789876543210 :: [Bool]) :: [Bool] where
-      FooListSym2 a0123456789876543210 a0123456789876543210 = FooList a0123456789876543210 a0123456789876543210
-    type FooList_0123456789876543210 :: forall a. a -> [Bool] -> [Bool]
-    type family FooList_0123456789876543210 @a (a :: a) (a :: [Bool]) :: [Bool] where
-      FooList_0123456789876543210 @a (a_0123456789876543210 :: a) (a_0123456789876543210 :: [Bool]) = Apply (Apply UndefinedSym0 a_0123456789876543210) a_0123456789876543210
+    type family FooListSym2 @a (a_Singletons_T167_3 :: a) (a_Singletons_T167_4 :: [Bool]) :: [Bool] where
+      FooListSym2 a_Singletons_T167_3 a_Singletons_T167_4 = FooList a_Singletons_T167_3 a_Singletons_T167_4
+    type FooList_Singletons_T167_5 :: forall a. a -> [Bool] -> [Bool]
+    type family FooList_Singletons_T167_5 @a (a :: a) (a :: [Bool]) :: [Bool] where
+      FooList_Singletons_T167_5 @a (a_Singletons_T167_6 :: a) (a_Singletons_T167_7 :: [Bool]) = Apply (Apply UndefinedSym0 a_Singletons_T167_6) a_Singletons_T167_7
     class PFoo a where
       type family FoosPrec (arg :: Natural) (arg :: a) (arg :: [Bool]) :: [Bool]
       type family FooList (arg :: a) (arg :: [Bool]) :: [Bool]
-      type FooList a a = FooList_0123456789876543210 a a
-    type FoosPrec_0123456789876543210 :: forall a. Natural
-                                                   -> [a] -> [Bool] -> [Bool]
-    type family FoosPrec_0123456789876543210 @a (a :: Natural) (a :: [a]) (a :: [Bool]) :: [Bool] where
-      FoosPrec_0123456789876543210 @a (_ :: Natural) (a_0123456789876543210 :: [a]) (a_0123456789876543210 :: [Bool]) = Apply (Apply FooListSym0 a_0123456789876543210) a_0123456789876543210
+      type FooList a a = FooList_Singletons_T167_5 a a
+    type FoosPrec_Singletons_T167_10 :: forall a. Natural
+                                                  -> [a] -> [Bool] -> [Bool]
+    type family FoosPrec_Singletons_T167_10 @a (a :: Natural) (a :: [a]) (a :: [Bool]) :: [Bool] where
+      FoosPrec_Singletons_T167_10 @a (_ :: Natural) (a_Singletons_T167_11 :: [a]) (a_Singletons_T167_12 :: [Bool]) = Apply (Apply FooListSym0 a_Singletons_T167_11) a_Singletons_T167_12
     instance PFoo [a] where
-      type FoosPrec a a a = FoosPrec_0123456789876543210 a a a
+      type FoosPrec a a a = FoosPrec_Singletons_T167_10 a a a
     class SFoo a where
       sFoosPrec ::
         (forall (t :: Natural) (t :: a) (t :: [Bool]).
@@ -78,22 +78,21 @@ Singletons/T167.hs:(0,0)-(0,0): Splicing declarations
          Sing t -> Sing t -> Sing (FooList t t :: [Bool]) :: Type)
       default sFooList ::
                 (forall (t :: a) (t :: [Bool]).
-                 ((FooList t t :: [Bool]) ~ FooList_0123456789876543210 t t) =>
+                 ((FooList t t :: [Bool]) ~ FooList_Singletons_T167_5 t t) =>
                  Sing t -> Sing t -> Sing (FooList t t :: [Bool]) :: Type)
       sFooList
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_Singletons_T167_6 :: Sing a_Singletons_T167_6)
+        (sA_Singletons_T167_7 :: Sing a_Singletons_T167_7)
         = applySing
-            (applySing sUndefined sA_0123456789876543210)
-            sA_0123456789876543210
+            (applySing sUndefined sA_Singletons_T167_6) sA_Singletons_T167_7
     instance SFoo a => SFoo [a] where
       sFoosPrec
         _
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sA_Singletons_T167_11 :: Sing a_Singletons_T167_11)
+        (sA_Singletons_T167_12 :: Sing a_Singletons_T167_12)
         = applySing
-            (applySing (singFun2 @FooListSym0 sFooList) sA_0123456789876543210)
-            sA_0123456789876543210
+            (applySing (singFun2 @FooListSym0 sFooList) sA_Singletons_T167_11)
+            sA_Singletons_T167_12
     instance SFoo a =>
              SingI (FoosPrecSym0 :: (~>) Natural ((~>) a ((~>) [Bool] [Bool]))) where
       sing = singFun3 @FoosPrecSym0 sFoosPrec

--- a/singletons-base/tests/compile-and-dump/Singletons/T172.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T172.golden
@@ -7,33 +7,30 @@ Singletons/T172.hs:(0,0)-(0,0): Splicing declarations
     data ($>@#@$) :: (~>) Natural ((~>) Natural Natural)
       where
         (:$>@#@$###) :: SameKind (Apply ($>@#@$) arg) (($>@#@$$) arg) =>
-                        ($>@#@$) a0123456789876543210
-    type instance Apply @Natural @((~>) Natural Natural) ($>@#@$) a0123456789876543210 = ($>@#@$$) a0123456789876543210
+                        ($>@#@$) a_T172_2
+    type instance Apply @Natural @((~>) Natural Natural) ($>@#@$) a_T172_2 = ($>@#@$$) a_T172_2
     instance SuppressUnusedWarnings ($>@#@$) where
       suppressUnusedWarnings = snd ((,) (:$>@#@$###) ())
     type ($>@#@$$) :: Natural -> (~>) Natural Natural
-    data ($>@#@$$) (a0123456789876543210 :: Natural) :: (~>) Natural Natural
+    data ($>@#@$$) (a_T172_2 :: Natural) :: (~>) Natural Natural
       where
-        (:$>@#@$$###) :: SameKind (Apply (($>@#@$$) a0123456789876543210) arg) (($>@#@$$$) a0123456789876543210 arg) =>
-                         ($>@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @Natural @Natural (($>@#@$$) a0123456789876543210) a0123456789876543210 = ($>) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (($>@#@$$) a0123456789876543210) where
+        (:$>@#@$$###) :: SameKind (Apply (($>@#@$$) a_T172_2) arg) (($>@#@$$$) a_T172_2 arg) =>
+                         ($>@#@$$) a_T172_2 a_T172_3
+    type instance Apply @Natural @Natural (($>@#@$$) a_T172_2) a_T172_3 = ($>) a_T172_2 a_T172_3
+    instance SuppressUnusedWarnings (($>@#@$$) a_T172_2) where
       suppressUnusedWarnings = snd ((,) (:$>@#@$$###) ())
     type ($>@#@$$$) :: Natural -> Natural -> Natural
-    type family ($>@#@$$$) (a0123456789876543210 :: Natural) (a0123456789876543210 :: Natural) :: Natural where
-      ($>@#@$$$) a0123456789876543210 a0123456789876543210 = ($>) a0123456789876543210 a0123456789876543210
+    type family ($>@#@$$$) (a_T172_2 :: Natural) (a_T172_3 :: Natural) :: Natural where
+      ($>@#@$$$) a_T172_2 a_T172_3 = ($>) a_T172_2 a_T172_3
     type ($>) :: Natural -> Natural -> Natural
     type family ($>) (a :: Natural) (a :: Natural) :: Natural where
-      ($>) a_0123456789876543210 a_0123456789876543210 = Apply (Apply (+@#@$) a_0123456789876543210) a_0123456789876543210
+      ($>) a_T172_0 a_T172_1 = Apply (Apply (+@#@$) a_T172_0) a_T172_1
     (%$>) ::
       (forall (t :: Natural) (t :: Natural).
        Sing t -> Sing t -> Sing (($>) t t :: Natural) :: Type)
-    (%$>)
-      (sA_0123456789876543210 :: Sing a_0123456789876543210)
-      (sA_0123456789876543210 :: Sing a_0123456789876543210)
+    (%$>) (sA_T172_0 :: Sing a_T172_0) (sA_T172_1 :: Sing a_T172_1)
       = applySing
-          (applySing (singFun2 @(+@#@$) (%+)) sA_0123456789876543210)
-          sA_0123456789876543210
+          (applySing (singFun2 @(+@#@$) (%+)) sA_T172_0) sA_T172_1
     instance SingI (($>@#@$) :: (~>) Natural ((~>) Natural Natural)) where
       sing = singFun2 @($>@#@$) (%$>)
     instance SingI d =>

--- a/singletons-base/tests/compile-and-dump/Singletons/T175.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T175.golden
@@ -32,12 +32,12 @@ Singletons/T175.hs:(0,0)-(0,0): Splicing declarations
     type Quux1Sym0 :: forall a. a
     type family Quux1Sym0 @a :: a where
       Quux1Sym0 = Quux1
-    type Quux1_0123456789876543210 :: forall a. a
-    type family Quux1_0123456789876543210 @a :: a where
-      Quux1_0123456789876543210 @a = BazSym0
+    type Quux1_T175_0 :: forall a. a
+    type family Quux1_T175_0 @a :: a where
+      Quux1_T175_0 @a = BazSym0
     class PBar1 a where
       type family Quux1 :: a
-      type Quux1 = Quux1_0123456789876543210
+      type Quux1 = Quux1_T175_0
     class PBar2 a
     sQuux2 :: (SBar2 a => Sing (Quux2 :: a) :: Type)
     sQuux2 = sBaz
@@ -46,7 +46,6 @@ Singletons/T175.hs:(0,0)-(0,0): Splicing declarations
     class SFoo a => SBar1 a where
       sQuux1 :: (Sing (Quux1 :: a) :: Type)
       default sQuux1 ::
-                (((Quux1 :: a) ~ Quux1_0123456789876543210) =>
-                 Sing (Quux1 :: a) :: Type)
+                (((Quux1 :: a) ~ Quux1_T175_0) => Sing (Quux1 :: a) :: Type)
       sQuux1 = sBaz
     class SFoo a => SBar2 a

--- a/singletons-base/tests/compile-and-dump/Singletons/T176.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T176.golden
@@ -22,65 +22,65 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
       baz2 :: a
     quux2 :: Foo2 a => a -> a
     quux2 x = (x `bar2` baz2)
-    type family LamCases_0123456789876543210 (x0123456789876543210 :: a0123456789876543210) a_0123456789876543210 where
-      LamCases_0123456789876543210 x _ = Baz1Sym0
-    data LamCases_0123456789876543210Sym0 (x0123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210
+    type family LamCases_T176_2 (x1 :: a0) a_T176_3 where
+      LamCases_T176_2 x _ = Baz1Sym0
+    data LamCases_T176_2Sym0 (x1 :: a0) a_T176_3
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210) where
+        LamCases_T176_2Sym0KindInference :: SameKind (Apply (LamCases_T176_2Sym0 x1) arg) (LamCases_T176_2Sym1 x1 arg) =>
+                                            LamCases_T176_2Sym0 x1 a_T176_3
+    type instance Apply @_ @_ (LamCases_T176_2Sym0 x1) a_T176_3 = LamCases_T176_2 x1 a_T176_3
+    instance SuppressUnusedWarnings (LamCases_T176_2Sym0 x1) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (x0123456789876543210 :: a0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 x0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_T176_2Sym0KindInference ())
+    type family LamCases_T176_2Sym1 (x1 :: a0) a_T176_3 where
+      LamCases_T176_2Sym1 x1 a_T176_3 = LamCases_T176_2 x1 a_T176_3
     type Quux2Sym0 :: (~>) a a
     data Quux2Sym0 :: (~>) a a
       where
         Quux2Sym0KindInference :: SameKind (Apply Quux2Sym0 arg) (Quux2Sym1 arg) =>
-                                  Quux2Sym0 a0123456789876543210
-    type instance Apply @a @a Quux2Sym0 a0123456789876543210 = Quux2 a0123456789876543210
+                                  Quux2Sym0 a_T176_0
+    type instance Apply @a @a Quux2Sym0 a_T176_0 = Quux2 a_T176_0
     instance SuppressUnusedWarnings Quux2Sym0 where
       suppressUnusedWarnings = snd ((,) Quux2Sym0KindInference ())
     type Quux2Sym1 :: a -> a
-    type family Quux2Sym1 @a (a0123456789876543210 :: a) :: a where
-      Quux2Sym1 a0123456789876543210 = Quux2 a0123456789876543210
+    type family Quux2Sym1 @a (a_T176_0 :: a) :: a where
+      Quux2Sym1 a_T176_0 = Quux2 a_T176_0
     type Quux1Sym0 :: (~>) a a
     data Quux1Sym0 :: (~>) a a
       where
         Quux1Sym0KindInference :: SameKind (Apply Quux1Sym0 arg) (Quux1Sym1 arg) =>
-                                  Quux1Sym0 a0123456789876543210
-    type instance Apply @a @a Quux1Sym0 a0123456789876543210 = Quux1 a0123456789876543210
+                                  Quux1Sym0 a_T176_1
+    type instance Apply @a @a Quux1Sym0 a_T176_1 = Quux1 a_T176_1
     instance SuppressUnusedWarnings Quux1Sym0 where
       suppressUnusedWarnings = snd ((,) Quux1Sym0KindInference ())
     type Quux1Sym1 :: a -> a
-    type family Quux1Sym1 @a (a0123456789876543210 :: a) :: a where
-      Quux1Sym1 a0123456789876543210 = Quux1 a0123456789876543210
+    type family Quux1Sym1 @a (a_T176_1 :: a) :: a where
+      Quux1Sym1 a_T176_1 = Quux1 a_T176_1
     type Quux2 :: a -> a
     type family Quux2 @a (a :: a) :: a where
       Quux2 x = Apply (Apply Bar2Sym0 x) Baz2Sym0
     type Quux1 :: a -> a
     type family Quux1 @a (a :: a) :: a where
-      Quux1 x = Apply (Apply Bar1Sym0 x) (LamCases_0123456789876543210Sym0 x)
+      Quux1 x = Apply (Apply Bar1Sym0 x) (LamCases_T176_2Sym0 x)
     type Bar1Sym0 :: forall a b. (~>) a ((~>) ((~>) a b) b)
     data Bar1Sym0 :: (~>) a ((~>) ((~>) a b) b)
       where
         Bar1Sym0KindInference :: SameKind (Apply Bar1Sym0 arg) (Bar1Sym1 arg) =>
-                                 Bar1Sym0 a0123456789876543210
-    type instance Apply @a @((~>) ((~>) a b) b) Bar1Sym0 a0123456789876543210 = Bar1Sym1 a0123456789876543210
+                                 Bar1Sym0 a_T176_4
+    type instance Apply @a @((~>) ((~>) a b) b) Bar1Sym0 a_T176_4 = Bar1Sym1 a_T176_4
     instance SuppressUnusedWarnings Bar1Sym0 where
       suppressUnusedWarnings = snd ((,) Bar1Sym0KindInference ())
     type Bar1Sym1 :: forall a b. a -> (~>) ((~>) a b) b
-    data Bar1Sym1 (a0123456789876543210 :: a) :: (~>) ((~>) a b) b
+    data Bar1Sym1 (a_T176_4 :: a) :: (~>) ((~>) a b) b
       where
-        Bar1Sym1KindInference :: SameKind (Apply (Bar1Sym1 a0123456789876543210) arg) (Bar1Sym2 a0123456789876543210 arg) =>
-                                 Bar1Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @((~>) a b) @b (Bar1Sym1 a0123456789876543210) a0123456789876543210 = Bar1 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Bar1Sym1 a0123456789876543210) where
+        Bar1Sym1KindInference :: SameKind (Apply (Bar1Sym1 a_T176_4) arg) (Bar1Sym2 a_T176_4 arg) =>
+                                 Bar1Sym1 a_T176_4 a_T176_5
+    type instance Apply @((~>) a b) @b (Bar1Sym1 a_T176_4) a_T176_5 = Bar1 a_T176_4 a_T176_5
+    instance SuppressUnusedWarnings (Bar1Sym1 a_T176_4) where
       suppressUnusedWarnings = snd ((,) Bar1Sym1KindInference ())
     type Bar1Sym2 :: forall a b. a -> (~>) a b -> b
-    type family Bar1Sym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: (~>) a b) :: b where
-      Bar1Sym2 a0123456789876543210 a0123456789876543210 = Bar1 a0123456789876543210 a0123456789876543210
+    type family Bar1Sym2 @a @b (a_T176_4 :: a) (a_T176_5 :: (~>) a b) :: b where
+      Bar1Sym2 a_T176_4 a_T176_5 = Bar1 a_T176_4 a_T176_5
     type Baz1Sym0 :: forall a. a
     type family Baz1Sym0 @a :: a where
       Baz1Sym0 = Baz1
@@ -91,21 +91,21 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
     data Bar2Sym0 :: (~>) a ((~>) b b)
       where
         Bar2Sym0KindInference :: SameKind (Apply Bar2Sym0 arg) (Bar2Sym1 arg) =>
-                                 Bar2Sym0 a0123456789876543210
-    type instance Apply @a @((~>) b b) Bar2Sym0 a0123456789876543210 = Bar2Sym1 a0123456789876543210
+                                 Bar2Sym0 a_T176_6
+    type instance Apply @a @((~>) b b) Bar2Sym0 a_T176_6 = Bar2Sym1 a_T176_6
     instance SuppressUnusedWarnings Bar2Sym0 where
       suppressUnusedWarnings = snd ((,) Bar2Sym0KindInference ())
     type Bar2Sym1 :: forall a b. a -> (~>) b b
-    data Bar2Sym1 (a0123456789876543210 :: a) :: (~>) b b
+    data Bar2Sym1 (a_T176_6 :: a) :: (~>) b b
       where
-        Bar2Sym1KindInference :: SameKind (Apply (Bar2Sym1 a0123456789876543210) arg) (Bar2Sym2 a0123456789876543210 arg) =>
-                                 Bar2Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @b (Bar2Sym1 a0123456789876543210) a0123456789876543210 = Bar2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Bar2Sym1 a0123456789876543210) where
+        Bar2Sym1KindInference :: SameKind (Apply (Bar2Sym1 a_T176_6) arg) (Bar2Sym2 a_T176_6 arg) =>
+                                 Bar2Sym1 a_T176_6 a_T176_7
+    type instance Apply @b @b (Bar2Sym1 a_T176_6) a_T176_7 = Bar2 a_T176_6 a_T176_7
+    instance SuppressUnusedWarnings (Bar2Sym1 a_T176_6) where
       suppressUnusedWarnings = snd ((,) Bar2Sym1KindInference ())
     type Bar2Sym2 :: forall a b. a -> b -> b
-    type family Bar2Sym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: b where
-      Bar2Sym2 a0123456789876543210 a0123456789876543210 = Bar2 a0123456789876543210 a0123456789876543210
+    type family Bar2Sym2 @a @b (a_T176_6 :: a) (a_T176_7 :: b) :: b where
+      Bar2Sym2 a_T176_6 a_T176_7 = Bar2 a_T176_6 a_T176_7
     type Baz2Sym0 :: forall a. a
     type family Baz2Sym0 @a :: a where
       Baz2Sym0 = Baz2
@@ -121,8 +121,7 @@ Singletons/T176.hs:(0,0)-(0,0): Splicing declarations
     sQuux1 (sX :: Sing x)
       = applySing
           (applySing (singFun2 @Bar1Sym0 sBar1) sX)
-          (singFun1
-             @(LamCases_0123456789876543210Sym0 x) (\cases _ -> sBaz1))
+          (singFun1 @(LamCases_T176_2Sym0 x) (\cases _ -> sBaz1))
     instance SFoo2 a => SingI (Quux2Sym0 :: (~>) a a) where
       sing = singFun1 @Quux2Sym0 sQuux2
     instance SFoo1 a => SingI (Quux1Sym0 :: (~>) a a) where

--- a/singletons-base/tests/compile-and-dump/Singletons/T178.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T178.golden
@@ -31,40 +31,39 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
     type Empty :: [(Symbol, Occ)]
     type family Empty :: [(Symbol, Occ)] where
       Empty = NilSym0
-    type TFHelper_0123456789876543210 :: Occ -> Occ -> Bool
-    type family TFHelper_0123456789876543210 (a :: Occ) (a :: Occ) :: Bool where
-      TFHelper_0123456789876543210 Str Str = TrueSym0
-      TFHelper_0123456789876543210 Str Opt = FalseSym0
-      TFHelper_0123456789876543210 Str Many = FalseSym0
-      TFHelper_0123456789876543210 Opt Str = FalseSym0
-      TFHelper_0123456789876543210 Opt Opt = TrueSym0
-      TFHelper_0123456789876543210 Opt Many = FalseSym0
-      TFHelper_0123456789876543210 Many Str = FalseSym0
-      TFHelper_0123456789876543210 Many Opt = FalseSym0
-      TFHelper_0123456789876543210 Many Many = TrueSym0
+    type TFHelper_T178_1 :: Occ -> Occ -> Bool
+    type family TFHelper_T178_1 (a :: Occ) (a :: Occ) :: Bool where
+      TFHelper_T178_1 Str Str = TrueSym0
+      TFHelper_T178_1 Str Opt = FalseSym0
+      TFHelper_T178_1 Str Many = FalseSym0
+      TFHelper_T178_1 Opt Str = FalseSym0
+      TFHelper_T178_1 Opt Opt = TrueSym0
+      TFHelper_T178_1 Opt Many = FalseSym0
+      TFHelper_T178_1 Many Str = FalseSym0
+      TFHelper_T178_1 Many Opt = FalseSym0
+      TFHelper_T178_1 Many Many = TrueSym0
     instance PEq Occ where
-      type (==) a a = TFHelper_0123456789876543210 a a
-    type Compare_0123456789876543210 :: Occ -> Occ -> Ordering
-    type family Compare_0123456789876543210 (a :: Occ) (a :: Occ) :: Ordering where
-      Compare_0123456789876543210 Str Str = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
-      Compare_0123456789876543210 Opt Opt = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
-      Compare_0123456789876543210 Many Many = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
-      Compare_0123456789876543210 Str Opt = LTSym0
-      Compare_0123456789876543210 Str Many = LTSym0
-      Compare_0123456789876543210 Opt Str = GTSym0
-      Compare_0123456789876543210 Opt Many = LTSym0
-      Compare_0123456789876543210 Many Str = GTSym0
-      Compare_0123456789876543210 Many Opt = GTSym0
+      type (==) a a = TFHelper_T178_1 a a
+    type Compare_T178_4 :: Occ -> Occ -> Ordering
+    type family Compare_T178_4 (a :: Occ) (a :: Occ) :: Ordering where
+      Compare_T178_4 Str Str = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
+      Compare_T178_4 Opt Opt = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
+      Compare_T178_4 Many Many = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
+      Compare_T178_4 Str Opt = LTSym0
+      Compare_T178_4 Str Many = LTSym0
+      Compare_T178_4 Opt Str = GTSym0
+      Compare_T178_4 Opt Many = LTSym0
+      Compare_T178_4 Many Str = GTSym0
+      Compare_T178_4 Many Opt = GTSym0
     instance POrd Occ where
-      type Compare a a = Compare_0123456789876543210 a a
-    type ShowsPrec_0123456789876543210 :: Natural
-                                          -> Occ -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210 (a :: Natural) (a :: Occ) (a :: Symbol) :: Symbol where
-      ShowsPrec_0123456789876543210 _ Str a_0123456789876543210 = Apply (Apply ShowStringSym0 "Str") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ Opt a_0123456789876543210 = Apply (Apply ShowStringSym0 "Opt") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ Many a_0123456789876543210 = Apply (Apply ShowStringSym0 "Many") a_0123456789876543210
+      type Compare a a = Compare_T178_4 a a
+    type ShowsPrec_T178_7 :: Natural -> Occ -> Symbol -> Symbol
+    type family ShowsPrec_T178_7 (a :: Natural) (a :: Occ) (a :: Symbol) :: Symbol where
+      ShowsPrec_T178_7 _ Str a_T178_8 = Apply (Apply ShowStringSym0 "Str") a_T178_8
+      ShowsPrec_T178_7 _ Opt a_T178_9 = Apply (Apply ShowStringSym0 "Opt") a_T178_9
+      ShowsPrec_T178_7 _ Many a_T178_10 = Apply (Apply ShowStringSym0 "Many") a_T178_10
     instance PShow Occ where
-      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
+      type ShowsPrec a a a = ShowsPrec_T178_7 a a a
     sEmpty :: (Sing (Empty :: [(Symbol, Occ)]) :: Type)
     sEmpty = SNil
     data SOcc :: Occ -> Type
@@ -117,30 +116,21 @@ Singletons/T178.hs:(0,0)-(0,0): Splicing declarations
       sCompare SMany SStr = SGT
       sCompare SMany SOpt = SGT
     instance SShow Occ where
-      sShowsPrec
-        _
-        SStr
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+      sShowsPrec _ SStr (sA_T178_8 :: Sing a_T178_8)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "Str"))
-            sA_0123456789876543210
-      sShowsPrec
-        _
-        SOpt
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+            sA_T178_8
+      sShowsPrec _ SOpt (sA_T178_9 :: Sing a_T178_9)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "Opt"))
-            sA_0123456789876543210
-      sShowsPrec
-        _
-        SMany
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+            sA_T178_9
+      sShowsPrec _ SMany (sA_T178_10 :: Sing a_T178_10)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "Many"))
-            sA_0123456789876543210
+            sA_T178_10
     instance SDecide Occ where
       (%~) SStr SStr = Proved Refl
       (%~) SStr SOpt = Disproved (\case)

--- a/singletons-base/tests/compile-and-dump/Singletons/T183.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T183.golden
@@ -59,238 +59,234 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
           g :: a -> b -> a
           g y _ = y
         in g x ()
-    data Let0123456789876543210GSym0 a0123456789876543210 (x0123456789876543210 :: a0123456789876543210) :: (~>) a0123456789876543210 ((~>) b0123456789876543210 a0123456789876543210)
+    data Let2GSym0 a0 (x1 :: a0) :: (~>) a0 ((~>) b3 a0)
       where
-        Let0123456789876543210GSym0KindInference :: SameKind (Apply (Let0123456789876543210GSym0 a0123456789876543210 x0123456789876543210) arg) (Let0123456789876543210GSym1 a0123456789876543210 x0123456789876543210 arg) =>
-                                                    Let0123456789876543210GSym0 a0123456789876543210 x0123456789876543210 a0123456789876543210
-    type instance Apply @a0123456789876543210 @((~>) b0123456789876543210 a0123456789876543210) (Let0123456789876543210GSym0 a0123456789876543210 x0123456789876543210) a0123456789876543210 = Let0123456789876543210GSym1 a0123456789876543210 x0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Let0123456789876543210GSym0 a0123456789876543210 x0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Let0123456789876543210GSym0KindInference ())
-    data Let0123456789876543210GSym1 a0123456789876543210 (x0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: a0123456789876543210) :: (~>) b0123456789876543210 a0123456789876543210
+        Let2GSym0KindInference :: SameKind (Apply (Let2GSym0 a0 x1) arg) (Let2GSym1 a0 x1 arg) =>
+                                  Let2GSym0 a0 x1 a2
+    type instance Apply @a0 @((~>) b3 a0) (Let2GSym0 a0 x1) a2 = Let2GSym1 a0 x1 a2
+    instance SuppressUnusedWarnings (Let2GSym0 a0 x1) where
+      suppressUnusedWarnings = snd ((,) Let2GSym0KindInference ())
+    data Let2GSym1 a0 (x1 :: a0) (a2 :: a0) :: (~>) b3 a0
       where
-        Let0123456789876543210GSym1KindInference :: SameKind (Apply (Let0123456789876543210GSym1 a0123456789876543210 x0123456789876543210 a0123456789876543210) arg) (Let0123456789876543210GSym2 a0123456789876543210 x0123456789876543210 a0123456789876543210 arg) =>
-                                                    Let0123456789876543210GSym1 a0123456789876543210 x0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @b0123456789876543210 @a0123456789876543210 (Let0123456789876543210GSym1 a0123456789876543210 x0123456789876543210 a0123456789876543210) a0123456789876543210 = Let0123456789876543210G a0123456789876543210 x0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Let0123456789876543210GSym1 a0123456789876543210 x0123456789876543210 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Let0123456789876543210GSym1KindInference ())
-    type family Let0123456789876543210GSym2 a0123456789876543210 (x0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: b0123456789876543210) :: a0123456789876543210 where
-      Let0123456789876543210GSym2 a0123456789876543210 x0123456789876543210 a0123456789876543210 a0123456789876543210 = Let0123456789876543210G a0123456789876543210 x0123456789876543210 a0123456789876543210 a0123456789876543210
-    type family Let0123456789876543210G a0123456789876543210 (x0123456789876543210 :: a0123456789876543210) (a :: a0123456789876543210) (a :: b) :: a0123456789876543210 where
-      Let0123456789876543210G a x y _ = y
-    type family Let0123456789876543210XSym0 a0123456789876543210 (wild_01234567898765432100123456789876543210 :: a0123456789876543210) where
-      Let0123456789876543210XSym0 a0123456789876543210 wild_01234567898765432100123456789876543210 = Let0123456789876543210X a0123456789876543210 wild_01234567898765432100123456789876543210
-    type family Let0123456789876543210X a0123456789876543210 (wild_01234567898765432100123456789876543210 :: a0123456789876543210) where
-      Let0123456789876543210X a wild_0123456789876543210 = Apply JustSym0 (wild_0123456789876543210 :: a) :: Maybe a
-    type family Let0123456789876543210XSym0 a0123456789876543210 where
-      Let0123456789876543210XSym0 a0123456789876543210 = Let0123456789876543210X a0123456789876543210
-    type family Let0123456789876543210X a0123456789876543210 where
-      Let0123456789876543210X a = NothingSym0 :: Maybe a
-    type family LamCases_0123456789876543210 a0123456789876543210 x0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 a x ('Just (y :: a) :: Maybe a) = Apply JustSym0 (Apply JustSym0 (y :: a) :: Maybe a)
-    data LamCases_0123456789876543210Sym0 a0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
+        Let2GSym1KindInference :: SameKind (Apply (Let2GSym1 a0 x1 a2) arg) (Let2GSym2 a0 x1 a2 arg) =>
+                                  Let2GSym1 a0 x1 a2 a4
+    type instance Apply @b3 @a0 (Let2GSym1 a0 x1 a2) a4 = Let2G a0 x1 a2 a4
+    instance SuppressUnusedWarnings (Let2GSym1 a0 x1 a2) where
+      suppressUnusedWarnings = snd ((,) Let2GSym1KindInference ())
+    type family Let2GSym2 a0 (x1 :: a0) (a2 :: a0) (a4 :: b3) :: a0 where
+      Let2GSym2 a0 x1 a2 a4 = Let2G a0 x1 a2 a4
+    type family Let2G a0 (x1 :: a0) (a :: a0) (a :: b) :: a0 where
+      Let2G a x y _ = y
+    type family Let4XSym0 a0 (wild_T183_01 :: a0) where
+      Let4XSym0 a0 wild_T183_01 = Let4X a0 wild_T183_01
+    type family Let4X a0 (wild_T183_01 :: a0) where
+      Let4X a wild_T183_0 = Apply JustSym0 (wild_T183_0 :: a) :: Maybe a
+    type family Let5XSym0 a0 where
+      Let5XSym0 a0 = Let5X a0
+    type family Let5X a0 where
+      Let5X a = NothingSym0 :: Maybe a
+    type family LamCases_T183_10 a0 x1 a_T183_11 where
+      LamCases_T183_10 a x ('Just (y :: a) :: Maybe a) = Apply JustSym0 (Apply JustSym0 (y :: a) :: Maybe a)
+    data LamCases_T183_10Sym0 a0 x1 a_T183_11
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 a0123456789876543210 x0123456789876543210) arg) (LamCases_0123456789876543210Sym1 a0123456789876543210 x0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 a0123456789876543210 x0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 a0123456789876543210 x0123456789876543210) where
+        LamCases_T183_10Sym0KindInference :: SameKind (Apply (LamCases_T183_10Sym0 a0 x1) arg) (LamCases_T183_10Sym1 a0 x1 arg) =>
+                                             LamCases_T183_10Sym0 a0 x1 a_T183_11
+    type instance Apply @_ @_ (LamCases_T183_10Sym0 a0 x1) a_T183_11 = LamCases_T183_10 a0 x1 a_T183_11
+    instance SuppressUnusedWarnings (LamCases_T183_10Sym0 a0 x1) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 a0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (a_01234567898765432100123456789876543210 :: (a0123456789876543210,
-                                                                                           b0123456789876543210)) a_0123456789876543210 where
-      LamCases_0123456789876543210 a_0123456789876543210 '(x :: a,
-                                                           y :: b) = Apply (Apply Tuple2Sym0 (y :: b)) (x :: a)
-    data LamCases_0123456789876543210Sym0 (a_01234567898765432100123456789876543210 :: (a0123456789876543210,
-                                                                                        b0123456789876543210)) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_T183_10Sym0KindInference ())
+    type family LamCases_T183_10Sym1 a0 x1 a_T183_11 where
+      LamCases_T183_10Sym1 a0 x1 a_T183_11 = LamCases_T183_10 a0 x1 a_T183_11
+    type family LamCases_T183_15 (a_T183_132 :: (a0,
+                                                 b1)) a_T183_16 where
+      LamCases_T183_15 a_T183_13 '(x :: a,
+                                   y :: b) = Apply (Apply Tuple2Sym0 (y :: b)) (x :: a)
+    data LamCases_T183_15Sym0 (a_T183_132 :: (a0, b1)) a_T183_16
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210) where
+        LamCases_T183_15Sym0KindInference :: SameKind (Apply (LamCases_T183_15Sym0 a_T183_132) arg) (LamCases_T183_15Sym1 a_T183_132 arg) =>
+                                             LamCases_T183_15Sym0 a_T183_132 a_T183_16
+    type instance Apply @_ @_ (LamCases_T183_15Sym0 a_T183_132) a_T183_16 = LamCases_T183_15 a_T183_132 a_T183_16
+    instance SuppressUnusedWarnings (LamCases_T183_15Sym0 a_T183_132) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (a_01234567898765432100123456789876543210 :: (a0123456789876543210,
-                                                                                               b0123456789876543210)) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 x0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 x ('Just y :: Maybe Bool) = y :: Bool
-    data LamCases_0123456789876543210Sym0 x0123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_T183_15Sym0KindInference ())
+    type family LamCases_T183_15Sym1 (a_T183_132 :: (a0,
+                                                     b1)) a_T183_16 where
+      LamCases_T183_15Sym1 a_T183_132 a_T183_16 = LamCases_T183_15 a_T183_132 a_T183_16
+    type family LamCases_T183_20 x0 a_T183_21 where
+      LamCases_T183_20 x ('Just y :: Maybe Bool) = y :: Bool
+    data LamCases_T183_20Sym0 x0 a_T183_21
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210) where
+        LamCases_T183_20Sym0KindInference :: SameKind (Apply (LamCases_T183_20Sym0 x0) arg) (LamCases_T183_20Sym1 x0 arg) =>
+                                             LamCases_T183_20Sym0 x0 a_T183_21
+    type instance Apply @_ @_ (LamCases_T183_20Sym0 x0) a_T183_21 = LamCases_T183_20 x0 a_T183_21
+    instance SuppressUnusedWarnings (LamCases_T183_20Sym0 x0) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 x0123456789876543210 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 x0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_T183_20Sym0KindInference ())
+    type family LamCases_T183_20Sym1 x0 a_T183_21 where
+      LamCases_T183_20Sym1 x0 a_T183_21 = LamCases_T183_20 x0 a_T183_21
     type Foo9Sym0 :: (~>) a a
     data Foo9Sym0 :: (~>) a a
       where
         Foo9Sym0KindInference :: SameKind (Apply Foo9Sym0 arg) (Foo9Sym1 arg) =>
-                                 Foo9Sym0 a0123456789876543210
-    type instance Apply @a @a Foo9Sym0 a0123456789876543210 = Foo9 a0123456789876543210
+                                 Foo9Sym0 a_T183_1
+    type instance Apply @a @a Foo9Sym0 a_T183_1 = Foo9 a_T183_1
     instance SuppressUnusedWarnings Foo9Sym0 where
       suppressUnusedWarnings = snd ((,) Foo9Sym0KindInference ())
     type Foo9Sym1 :: a -> a
-    type family Foo9Sym1 @a (a0123456789876543210 :: a) :: a where
-      Foo9Sym1 a0123456789876543210 = Foo9 a0123456789876543210
+    type family Foo9Sym1 @a (a_T183_1 :: a) :: a where
+      Foo9Sym1 a_T183_1 = Foo9 a_T183_1
     type Foo8Sym0 :: forall a. (~>) (Maybe a) (Maybe a)
     data Foo8Sym0 :: (~>) (Maybe a) (Maybe a)
       where
         Foo8Sym0KindInference :: SameKind (Apply Foo8Sym0 arg) (Foo8Sym1 arg) =>
-                                 Foo8Sym0 a0123456789876543210
-    type instance Apply @(Maybe a) @(Maybe a) Foo8Sym0 a0123456789876543210 = Foo8 a0123456789876543210
+                                 Foo8Sym0 a_T183_3
+    type instance Apply @(Maybe a) @(Maybe a) Foo8Sym0 a_T183_3 = Foo8 a_T183_3
     instance SuppressUnusedWarnings Foo8Sym0 where
       suppressUnusedWarnings = snd ((,) Foo8Sym0KindInference ())
     type Foo8Sym1 :: forall a. Maybe a -> Maybe a
-    type family Foo8Sym1 @a (a0123456789876543210 :: Maybe a) :: Maybe a where
-      Foo8Sym1 a0123456789876543210 = Foo8 a0123456789876543210
+    type family Foo8Sym1 @a (a_T183_3 :: Maybe a) :: Maybe a where
+      Foo8Sym1 a_T183_3 = Foo8 a_T183_3
     type Foo7Sym0 :: (~>) a ((~>) b a)
     data Foo7Sym0 :: (~>) a ((~>) b a)
       where
         Foo7Sym0KindInference :: SameKind (Apply Foo7Sym0 arg) (Foo7Sym1 arg) =>
-                                 Foo7Sym0 a0123456789876543210
-    type instance Apply @a @((~>) b a) Foo7Sym0 a0123456789876543210 = Foo7Sym1 a0123456789876543210
+                                 Foo7Sym0 a_T183_6
+    type instance Apply @a @((~>) b a) Foo7Sym0 a_T183_6 = Foo7Sym1 a_T183_6
     instance SuppressUnusedWarnings Foo7Sym0 where
       suppressUnusedWarnings = snd ((,) Foo7Sym0KindInference ())
     type Foo7Sym1 :: a -> (~>) b a
-    data Foo7Sym1 (a0123456789876543210 :: a) :: (~>) b a
+    data Foo7Sym1 (a_T183_6 :: a) :: (~>) b a
       where
-        Foo7Sym1KindInference :: SameKind (Apply (Foo7Sym1 a0123456789876543210) arg) (Foo7Sym2 a0123456789876543210 arg) =>
-                                 Foo7Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @a (Foo7Sym1 a0123456789876543210) a0123456789876543210 = Foo7 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Foo7Sym1 a0123456789876543210) where
+        Foo7Sym1KindInference :: SameKind (Apply (Foo7Sym1 a_T183_6) arg) (Foo7Sym2 a_T183_6 arg) =>
+                                 Foo7Sym1 a_T183_6 a_T183_7
+    type instance Apply @b @a (Foo7Sym1 a_T183_6) a_T183_7 = Foo7 a_T183_6 a_T183_7
+    instance SuppressUnusedWarnings (Foo7Sym1 a_T183_6) where
       suppressUnusedWarnings = snd ((,) Foo7Sym1KindInference ())
     type Foo7Sym2 :: a -> b -> a
-    type family Foo7Sym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: a where
-      Foo7Sym2 a0123456789876543210 a0123456789876543210 = Foo7 a0123456789876543210 a0123456789876543210
+    type family Foo7Sym2 @a @b (a_T183_6 :: a) (a_T183_7 :: b) :: a where
+      Foo7Sym2 a_T183_6 a_T183_7 = Foo7 a_T183_6 a_T183_7
     type Foo6Sym0 :: (~>) (Maybe (Maybe a)) (Maybe (Maybe a))
     data Foo6Sym0 :: (~>) (Maybe (Maybe a)) (Maybe (Maybe a))
       where
         Foo6Sym0KindInference :: SameKind (Apply Foo6Sym0 arg) (Foo6Sym1 arg) =>
-                                 Foo6Sym0 a0123456789876543210
-    type instance Apply @(Maybe (Maybe a)) @(Maybe (Maybe a)) Foo6Sym0 a0123456789876543210 = Foo6 a0123456789876543210
+                                 Foo6Sym0 a_T183_9
+    type instance Apply @(Maybe (Maybe a)) @(Maybe (Maybe a)) Foo6Sym0 a_T183_9 = Foo6 a_T183_9
     instance SuppressUnusedWarnings Foo6Sym0 where
       suppressUnusedWarnings = snd ((,) Foo6Sym0KindInference ())
     type Foo6Sym1 :: Maybe (Maybe a) -> Maybe (Maybe a)
-    type family Foo6Sym1 @a (a0123456789876543210 :: Maybe (Maybe a)) :: Maybe (Maybe a) where
-      Foo6Sym1 a0123456789876543210 = Foo6 a0123456789876543210
+    type family Foo6Sym1 @a (a_T183_9 :: Maybe (Maybe a)) :: Maybe (Maybe a) where
+      Foo6Sym1 a_T183_9 = Foo6 a_T183_9
     type Foo5Sym0 :: (~>) (Maybe (Maybe a)) (Maybe (Maybe a))
     data Foo5Sym0 :: (~>) (Maybe (Maybe a)) (Maybe (Maybe a))
       where
         Foo5Sym0KindInference :: SameKind (Apply Foo5Sym0 arg) (Foo5Sym1 arg) =>
-                                 Foo5Sym0 a0123456789876543210
-    type instance Apply @(Maybe (Maybe a)) @(Maybe (Maybe a)) Foo5Sym0 a0123456789876543210 = Foo5 a0123456789876543210
+                                 Foo5Sym0 a_T183_12
+    type instance Apply @(Maybe (Maybe a)) @(Maybe (Maybe a)) Foo5Sym0 a_T183_12 = Foo5 a_T183_12
     instance SuppressUnusedWarnings Foo5Sym0 where
       suppressUnusedWarnings = snd ((,) Foo5Sym0KindInference ())
     type Foo5Sym1 :: Maybe (Maybe a) -> Maybe (Maybe a)
-    type family Foo5Sym1 @a (a0123456789876543210 :: Maybe (Maybe a)) :: Maybe (Maybe a) where
-      Foo5Sym1 a0123456789876543210 = Foo5 a0123456789876543210
+    type family Foo5Sym1 @a (a_T183_12 :: Maybe (Maybe a)) :: Maybe (Maybe a) where
+      Foo5Sym1 a_T183_12 = Foo5 a_T183_12
     type Foo4Sym0 :: (~>) (a, b) (b, a)
     data Foo4Sym0 :: (~>) (a, b) (b, a)
       where
         Foo4Sym0KindInference :: SameKind (Apply Foo4Sym0 arg) (Foo4Sym1 arg) =>
-                                 Foo4Sym0 a0123456789876543210
+                                 Foo4Sym0 a_T183_14
     type instance Apply @(a, b) @(b,
-                                  a) Foo4Sym0 a0123456789876543210 = Foo4 a0123456789876543210
+                                  a) Foo4Sym0 a_T183_14 = Foo4 a_T183_14
     instance SuppressUnusedWarnings Foo4Sym0 where
       suppressUnusedWarnings = snd ((,) Foo4Sym0KindInference ())
     type Foo4Sym1 :: (a, b) -> (b, a)
-    type family Foo4Sym1 @a @b (a0123456789876543210 :: (a, b)) :: (b,
-                                                                    a) where
-      Foo4Sym1 a0123456789876543210 = Foo4 a0123456789876543210
+    type family Foo4Sym1 @a @b (a_T183_14 :: (a, b)) :: (b, a) where
+      Foo4Sym1 a_T183_14 = Foo4 a_T183_14
     type Foo3Sym0 :: forall a. (~>) (Maybe a) a
     data Foo3Sym0 :: (~>) (Maybe a) a
       where
         Foo3Sym0KindInference :: SameKind (Apply Foo3Sym0 arg) (Foo3Sym1 arg) =>
-                                 Foo3Sym0 a0123456789876543210
-    type instance Apply @(Maybe a) @a Foo3Sym0 a0123456789876543210 = Foo3 a0123456789876543210
+                                 Foo3Sym0 a_T183_17
+    type instance Apply @(Maybe a) @a Foo3Sym0 a_T183_17 = Foo3 a_T183_17
     instance SuppressUnusedWarnings Foo3Sym0 where
       suppressUnusedWarnings = snd ((,) Foo3Sym0KindInference ())
     type Foo3Sym1 :: forall a. Maybe a -> a
-    type family Foo3Sym1 @a (a0123456789876543210 :: Maybe a) :: a where
-      Foo3Sym1 a0123456789876543210 = Foo3 a0123456789876543210
+    type family Foo3Sym1 @a (a_T183_17 :: Maybe a) :: a where
+      Foo3Sym1 a_T183_17 = Foo3 a_T183_17
     type Foo2Sym0 :: forall a. (~>) (Maybe a) a
     data Foo2Sym0 :: (~>) (Maybe a) a
       where
         Foo2Sym0KindInference :: SameKind (Apply Foo2Sym0 arg) (Foo2Sym1 arg) =>
-                                 Foo2Sym0 a0123456789876543210
-    type instance Apply @(Maybe a) @a Foo2Sym0 a0123456789876543210 = Foo2 a0123456789876543210
+                                 Foo2Sym0 a_T183_18
+    type instance Apply @(Maybe a) @a Foo2Sym0 a_T183_18 = Foo2 a_T183_18
     instance SuppressUnusedWarnings Foo2Sym0 where
       suppressUnusedWarnings = snd ((,) Foo2Sym0KindInference ())
     type Foo2Sym1 :: forall a. Maybe a -> a
-    type family Foo2Sym1 @a (a0123456789876543210 :: Maybe a) :: a where
-      Foo2Sym1 a0123456789876543210 = Foo2 a0123456789876543210
+    type family Foo2Sym1 @a (a_T183_18 :: Maybe a) :: a where
+      Foo2Sym1 a_T183_18 = Foo2 a_T183_18
     type Foo1Sym0 :: (~>) (Maybe a) a
     data Foo1Sym0 :: (~>) (Maybe a) a
       where
         Foo1Sym0KindInference :: SameKind (Apply Foo1Sym0 arg) (Foo1Sym1 arg) =>
-                                 Foo1Sym0 a0123456789876543210
-    type instance Apply @(Maybe a) @a Foo1Sym0 a0123456789876543210 = Foo1 a0123456789876543210
+                                 Foo1Sym0 a_T183_19
+    type instance Apply @(Maybe a) @a Foo1Sym0 a_T183_19 = Foo1 a_T183_19
     instance SuppressUnusedWarnings Foo1Sym0 where
       suppressUnusedWarnings = snd ((,) Foo1Sym0KindInference ())
     type Foo1Sym1 :: Maybe a -> a
-    type family Foo1Sym1 @a (a0123456789876543210 :: Maybe a) :: a where
-      Foo1Sym1 a0123456789876543210 = Foo1 a0123456789876543210
-    data GSym0 a0123456789876543210
+    type family Foo1Sym1 @a (a_T183_19 :: Maybe a) :: a where
+      Foo1Sym1 a_T183_19 = Foo1 a_T183_19
+    data GSym0 a0
       where
         GSym0KindInference :: SameKind (Apply GSym0 arg) (GSym1 arg) =>
-                              GSym0 a0123456789876543210
-    type instance Apply @_ @_ GSym0 a0123456789876543210 = G a0123456789876543210
+                              GSym0 a0
+    type instance Apply @_ @_ GSym0 a0 = G a0
     instance SuppressUnusedWarnings GSym0 where
       suppressUnusedWarnings = snd ((,) GSym0KindInference ())
-    type family GSym1 a0123456789876543210 where
-      GSym1 a0123456789876543210 = G a0123456789876543210
-    data F3Sym0 a0123456789876543210
+    type family GSym1 a0 where
+      GSym1 a0 = G a0
+    data F3Sym0 a0
       where
         F3Sym0KindInference :: SameKind (Apply F3Sym0 arg) (F3Sym1 arg) =>
-                               F3Sym0 a0123456789876543210
-    type instance Apply @_ @_ F3Sym0 a0123456789876543210 = F3 a0123456789876543210
+                               F3Sym0 a0
+    type instance Apply @_ @_ F3Sym0 a0 = F3 a0
     instance SuppressUnusedWarnings F3Sym0 where
       suppressUnusedWarnings = snd ((,) F3Sym0KindInference ())
-    type family F3Sym1 a0123456789876543210 where
-      F3Sym1 a0123456789876543210 = F3 a0123456789876543210
-    data F2Sym0 a0123456789876543210
+    type family F3Sym1 a0 where
+      F3Sym1 a0 = F3 a0
+    data F2Sym0 a0
       where
         F2Sym0KindInference :: SameKind (Apply F2Sym0 arg) (F2Sym1 arg) =>
-                               F2Sym0 a0123456789876543210
-    type instance Apply @_ @_ F2Sym0 a0123456789876543210 = F2 a0123456789876543210
+                               F2Sym0 a0
+    type instance Apply @_ @_ F2Sym0 a0 = F2 a0
     instance SuppressUnusedWarnings F2Sym0 where
       suppressUnusedWarnings = snd ((,) F2Sym0KindInference ())
-    type family F2Sym1 a0123456789876543210 where
-      F2Sym1 a0123456789876543210 = F2 a0123456789876543210
-    data F1Sym0 a0123456789876543210
+    type family F2Sym1 a0 where
+      F2Sym1 a0 = F2 a0
+    data F1Sym0 a0
       where
         F1Sym0KindInference :: SameKind (Apply F1Sym0 arg) (F1Sym1 arg) =>
-                               F1Sym0 a0123456789876543210
-    type instance Apply @_ @_ F1Sym0 a0123456789876543210 = F1 a0123456789876543210
+                               F1Sym0 a0
+    type instance Apply @_ @_ F1Sym0 a0 = F1 a0
     instance SuppressUnusedWarnings F1Sym0 where
       suppressUnusedWarnings = snd ((,) F1Sym0KindInference ())
-    type family F1Sym1 a0123456789876543210 where
-      F1Sym1 a0123456789876543210 = F1 a0123456789876543210
+    type family F1Sym1 a0 where
+      F1Sym1 a0 = F1 a0
     type Foo9 :: a -> a
     type family Foo9 @a (a :: a) :: a where
-      Foo9 (x :: a) = Apply (Apply (Let0123456789876543210GSym0 a x) x) Tuple0Sym0
+      Foo9 (x :: a) = Apply (Apply (Let2GSym0 a x) x) Tuple0Sym0
     type Foo8 :: forall a. Maybe a -> Maybe a
     type family Foo8 @a (a :: Maybe a) :: Maybe a where
-      Foo8 @a ('Just (wild_0123456789876543210 :: a) :: Maybe a :: Maybe a) = Let0123456789876543210XSym0 a wild_0123456789876543210
-      Foo8 @a ('Nothing :: Maybe a :: Maybe a) = Let0123456789876543210XSym0 a
+      Foo8 @a ('Just (wild_T183_0 :: a) :: Maybe a :: Maybe a) = Let4XSym0 a wild_T183_0
+      Foo8 @a ('Nothing :: Maybe a :: Maybe a) = Let5XSym0 a
     type Foo7 :: a -> b -> a
     type family Foo7 @a @b (a :: a) (a :: b) :: a where
-      Foo7 (x :: a) (wild_0123456789876543210 :: b) = x :: a
+      Foo7 (x :: a) (wild_T183_8 :: b) = x :: a
     type Foo6 :: Maybe (Maybe a) -> Maybe (Maybe a)
     type family Foo6 @a (a :: Maybe (Maybe a)) :: Maybe (Maybe a) where
-      Foo6 ('Just x :: Maybe (Maybe a)) = Apply (LamCases_0123456789876543210Sym0 a x) (x :: Maybe a)
+      Foo6 ('Just x :: Maybe (Maybe a)) = Apply (LamCases_T183_10Sym0 a x) (x :: Maybe a)
     type Foo5 :: Maybe (Maybe a) -> Maybe (Maybe a)
     type family Foo5 @a (a :: Maybe (Maybe a)) :: Maybe (Maybe a) where
       Foo5 ('Just ('Just (x :: a) :: Maybe a) :: Maybe (Maybe a)) = Apply JustSym0 (Apply JustSym0 (x :: a) :: Maybe a) :: Maybe (Maybe a)
     type Foo4 :: (a, b) -> (b, a)
     type family Foo4 @a @b (a :: (a, b)) :: (b, a) where
-      Foo4 a_0123456789876543210 = Apply (LamCases_0123456789876543210Sym0 a_0123456789876543210) a_0123456789876543210
+      Foo4 a_T183_13 = Apply (LamCases_T183_15Sym0 a_T183_13) a_T183_13
     type Foo3 :: forall a. Maybe a -> a
     type family Foo3 @a (a :: Maybe a) :: a where
       Foo3 @a ('Just x :: Maybe a) = x :: a
@@ -301,7 +297,7 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
     type family Foo1 @a (a :: Maybe a) :: a where
       Foo1 ('Just x :: Maybe a) = x :: a
     type family G a where
-      G x = Apply (LamCases_0123456789876543210Sym0 x) (Apply JustSym0 x)
+      G x = Apply (LamCases_T183_20Sym0 x) (Apply JustSym0 x)
     type family F3 a where
       F3 ('Just a :: Maybe Bool) = "hi"
     type family F2 a where
@@ -336,53 +332,43 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
              -> let
                   sG ::
                     (forall (t :: a) (t :: b).
-                     Sing t
-                     -> Sing t -> Sing (Let0123456789876543210G a x t t :: a) :: Type)
+                     Sing t -> Sing t -> Sing (Let2G a x t t :: a) :: Type)
                   sG (sY :: Sing y) _ = sY
-                in
-                  applySing
-                    (applySing (singFun2 @(Let0123456789876543210GSym0 a x) sG) sX)
-                    STuple0)
+                in applySing (applySing (singFun2 @(Let2GSym0 a x) sG) sX) STuple0)
           (sX :: Sing x)
-    sFoo8
-      (SJust (sWild_0123456789876543210 :: Sing wild_0123456789876543210))
+    sFoo8 (SJust (sWild_T183_0 :: Sing wild_T183_0))
       = (\cases
-           (_ :: Sing (wild_0123456789876543210 :: a))
-             (_ :: Sing ('Just (wild_0123456789876543210 :: a) :: Maybe a))
+           (_ :: Sing (wild_T183_0 :: a))
+             (_ :: Sing ('Just (wild_T183_0 :: a) :: Maybe a))
              -> let
-                  sX :: Sing @_ (Let0123456789876543210X a wild_0123456789876543210)
+                  sX :: Sing @_ (Let4X a wild_T183_0)
                   sX
                     = applySing
                         (singFun1 @JustSym0 SJust)
-                        (sWild_0123456789876543210 ::
-                           Sing (wild_0123456789876543210 :: a)) ::
-                        Sing (Apply JustSym0 (wild_0123456789876543210 :: a) :: Maybe a)
+                        (sWild_T183_0 :: Sing (wild_T183_0 :: a)) ::
+                        Sing (Apply JustSym0 (wild_T183_0 :: a) :: Maybe a)
                 in sX)
-          (sWild_0123456789876543210 :: Sing wild_0123456789876543210)
-          (SJust
-             (sWild_0123456789876543210 :: Sing wild_0123456789876543210))
+          (sWild_T183_0 :: Sing wild_T183_0)
+          (SJust (sWild_T183_0 :: Sing wild_T183_0))
     sFoo8 SNothing
       = (\cases
            (_ :: Sing ('Nothing :: Maybe a))
              -> let
-                  sX :: Sing @_ (Let0123456789876543210X a)
+                  sX :: Sing @_ (Let5X a)
                   sX = SNothing :: Sing (NothingSym0 :: Maybe a)
                 in sX)
           SNothing
-    sFoo7
-      (sX :: Sing x)
-      (sWild_0123456789876543210 :: Sing wild_0123456789876543210)
+    sFoo7 (sX :: Sing x) (sWild_T183_8 :: Sing wild_T183_8)
       = (\cases
-           (_ :: Sing (x :: a)) (_ :: Sing (wild_0123456789876543210 :: b))
+           (_ :: Sing (x :: a)) (_ :: Sing (wild_T183_8 :: b))
              -> sX :: Sing (x :: a))
-          (sX :: Sing x)
-          (sWild_0123456789876543210 :: Sing wild_0123456789876543210)
+          (sX :: Sing x) (sWild_T183_8 :: Sing wild_T183_8)
     sFoo6 (SJust (sX :: Sing x))
       = (\cases
            (_ :: Sing ('Just x :: Maybe (Maybe a)))
              -> applySing
                   (singFun1
-                     @(LamCases_0123456789876543210Sym0 a x)
+                     @(LamCases_T183_10Sym0 a x)
                      (\cases
                         (SJust (sY :: Sing y))
                           -> (\cases
@@ -407,10 +393,10 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
                   Sing (Apply JustSym0 (Apply JustSym0 (x :: a) :: Maybe a) :: Maybe (Maybe a)))
           (sX :: Sing x) (SJust (sX :: Sing x))
           (SJust (SJust (sX :: Sing x)))
-    sFoo4 (sA_0123456789876543210 :: Sing a_0123456789876543210)
+    sFoo4 (sA_T183_13 :: Sing a_T183_13)
       = applySing
           (singFun1
-             @(LamCases_0123456789876543210Sym0 a_0123456789876543210)
+             @(LamCases_T183_15Sym0 a_T183_13)
              (\cases
                 (STuple2 (sX :: Sing x) (sY :: Sing y))
                   -> (\cases
@@ -419,7 +405,7 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
                                (applySing (singFun2 @Tuple2Sym0 STuple2) (sY :: Sing (y :: b)))
                                (sX :: Sing (x :: a)))
                        (sX :: Sing x) (sY :: Sing y)))
-          sA_0123456789876543210
+          sA_T183_13
     sFoo3 (SJust (sX :: Sing x)) = sX :: Sing (x :: a)
     sFoo2 (SJust (sX :: Sing x))
       = (\cases (_ :: Sing ('Just x :: Maybe a)) -> sX :: Sing (x :: a))
@@ -430,7 +416,7 @@ Singletons/T183.hs:(0,0)-(0,0): Splicing declarations
     sG (sX :: Sing x)
       = applySing
           (singFun1
-             @(LamCases_0123456789876543210Sym0 x)
+             @(LamCases_T183_20Sym0 x)
              (\cases
                 (SJust (sY :: Sing y))
                   -> (\cases

--- a/singletons-base/tests/compile-and-dump/Singletons/T184.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T184.golden
@@ -25,190 +25,189 @@ Singletons/T184.hs:(0,0)-(0,0): Splicing declarations
     cartProd xs ys = [(x, y) | x <- xs, y <- ys]
     trues :: [Bool] -> [Bool]
     trues xs = [x | x <- xs, x]
-    type family LamCases_0123456789876543210 (xs0123456789876543210 :: [Bool]) a_0123456789876543210 where
-      LamCases_0123456789876543210 xs x = Apply (Apply (>>@#@$) (Apply GuardSym0 x)) (Apply ReturnSym0 x)
-    data LamCases_0123456789876543210Sym0 (xs0123456789876543210 :: [Bool]) a_01234567898765432100123456789876543210
+    type family LamCases_T184_1 (xs0 :: [Bool]) a_T184_2 where
+      LamCases_T184_1 xs x = Apply (Apply (>>@#@$) (Apply GuardSym0 x)) (Apply ReturnSym0 x)
+    data LamCases_T184_1Sym0 (xs0 :: [Bool]) a_T184_2
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 xs0123456789876543210) arg) (LamCases_0123456789876543210Sym1 xs0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 xs0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 xs0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 xs0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 xs0123456789876543210) where
+        LamCases_T184_1Sym0KindInference :: SameKind (Apply (LamCases_T184_1Sym0 xs0) arg) (LamCases_T184_1Sym1 xs0 arg) =>
+                                            LamCases_T184_1Sym0 xs0 a_T184_2
+    type instance Apply @_ @_ (LamCases_T184_1Sym0 xs0) a_T184_2 = LamCases_T184_1 xs0 a_T184_2
+    instance SuppressUnusedWarnings (LamCases_T184_1Sym0 xs0) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (xs0123456789876543210 :: [Bool]) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 xs0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 xs0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 x0123456789876543210 (xs0123456789876543210 :: [a0123456789876543210]) (ys0123456789876543210 :: [b0123456789876543210]) a_0123456789876543210 where
-      LamCases_0123456789876543210 x xs ys y = Apply ReturnSym0 (Apply (Apply Tuple2Sym0 x) y)
-    data LamCases_0123456789876543210Sym0 x0123456789876543210 (xs0123456789876543210 :: [a0123456789876543210]) (ys0123456789876543210 :: [b0123456789876543210]) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_T184_1Sym0KindInference ())
+    type family LamCases_T184_1Sym1 (xs0 :: [Bool]) a_T184_2 where
+      LamCases_T184_1Sym1 xs0 a_T184_2 = LamCases_T184_1 xs0 a_T184_2
+    type family LamCases_T184_6 x0 (xs2 :: [a1]) (ys4 :: [b3]) a_T184_7 where
+      LamCases_T184_6 x xs ys y = Apply ReturnSym0 (Apply (Apply Tuple2Sym0 x) y)
+    data LamCases_T184_6Sym0 x0 (xs2 :: [a1]) (ys4 :: [b3]) a_T184_7
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 x0123456789876543210 xs0123456789876543210 ys0123456789876543210) arg) (LamCases_0123456789876543210Sym1 x0123456789876543210 xs0123456789876543210 ys0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 x0123456789876543210 xs0123456789876543210 ys0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 x0123456789876543210 xs0123456789876543210 ys0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 xs0123456789876543210 ys0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 x0123456789876543210 xs0123456789876543210 ys0123456789876543210) where
+        LamCases_T184_6Sym0KindInference :: SameKind (Apply (LamCases_T184_6Sym0 x0 xs2 ys4) arg) (LamCases_T184_6Sym1 x0 xs2 ys4 arg) =>
+                                            LamCases_T184_6Sym0 x0 xs2 ys4 a_T184_7
+    type instance Apply @_ @_ (LamCases_T184_6Sym0 x0 xs2 ys4) a_T184_7 = LamCases_T184_6 x0 xs2 ys4 a_T184_7
+    instance SuppressUnusedWarnings (LamCases_T184_6Sym0 x0 xs2 ys4) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 x0123456789876543210 (xs0123456789876543210 :: [a0123456789876543210]) (ys0123456789876543210 :: [b0123456789876543210]) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 x0123456789876543210 xs0123456789876543210 ys0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 x0123456789876543210 xs0123456789876543210 ys0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (xs0123456789876543210 :: [a0123456789876543210]) (ys0123456789876543210 :: [b0123456789876543210]) a_0123456789876543210 where
-      LamCases_0123456789876543210 xs ys x = Apply (Apply (>>=@#@$) ys) (LamCases_0123456789876543210Sym0 x xs ys)
-    data LamCases_0123456789876543210Sym0 (xs0123456789876543210 :: [a0123456789876543210]) (ys0123456789876543210 :: [b0123456789876543210]) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_T184_6Sym0KindInference ())
+    type family LamCases_T184_6Sym1 x0 (xs2 :: [a1]) (ys4 :: [b3]) a_T184_7 where
+      LamCases_T184_6Sym1 x0 xs2 ys4 a_T184_7 = LamCases_T184_6 x0 xs2 ys4 a_T184_7
+    type family LamCases_T184_5 (xs1 :: [a0]) (ys3 :: [b2]) a_T184_8 where
+      LamCases_T184_5 xs ys x = Apply (Apply (>>=@#@$) ys) (LamCases_T184_6Sym0 x xs ys)
+    data LamCases_T184_5Sym0 (xs1 :: [a0]) (ys3 :: [b2]) a_T184_8
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 xs0123456789876543210 ys0123456789876543210) arg) (LamCases_0123456789876543210Sym1 xs0123456789876543210 ys0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 xs0123456789876543210 ys0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 xs0123456789876543210 ys0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 xs0123456789876543210 ys0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 xs0123456789876543210 ys0123456789876543210) where
+        LamCases_T184_5Sym0KindInference :: SameKind (Apply (LamCases_T184_5Sym0 xs1 ys3) arg) (LamCases_T184_5Sym1 xs1 ys3 arg) =>
+                                            LamCases_T184_5Sym0 xs1 ys3 a_T184_8
+    type instance Apply @_ @_ (LamCases_T184_5Sym0 xs1 ys3) a_T184_8 = LamCases_T184_5 xs1 ys3 a_T184_8
+    instance SuppressUnusedWarnings (LamCases_T184_5Sym0 xs1 ys3) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (xs0123456789876543210 :: [a0123456789876543210]) (ys0123456789876543210 :: [b0123456789876543210]) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 xs0123456789876543210 ys0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 xs0123456789876543210 ys0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (xs0123456789876543210 :: [a0123456789876543210]) (ys0123456789876543210 :: [b0123456789876543210]) a_0123456789876543210 where
-      LamCases_0123456789876543210 xs ys x = Apply ReturnSym0 x
-    data LamCases_0123456789876543210Sym0 (xs0123456789876543210 :: [a0123456789876543210]) (ys0123456789876543210 :: [b0123456789876543210]) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_T184_5Sym0KindInference ())
+    type family LamCases_T184_5Sym1 (xs1 :: [a0]) (ys3 :: [b2]) a_T184_8 where
+      LamCases_T184_5Sym1 xs1 ys3 a_T184_8 = LamCases_T184_5 xs1 ys3 a_T184_8
+    type family LamCases_T184_11 (xs1 :: [a0]) (ys3 :: [b2]) a_T184_12 where
+      LamCases_T184_11 xs ys x = Apply ReturnSym0 x
+    data LamCases_T184_11Sym0 (xs1 :: [a0]) (ys3 :: [b2]) a_T184_12
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 xs0123456789876543210 ys0123456789876543210) arg) (LamCases_0123456789876543210Sym1 xs0123456789876543210 ys0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 xs0123456789876543210 ys0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 xs0123456789876543210 ys0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 xs0123456789876543210 ys0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 xs0123456789876543210 ys0123456789876543210) where
+        LamCases_T184_11Sym0KindInference :: SameKind (Apply (LamCases_T184_11Sym0 xs1 ys3) arg) (LamCases_T184_11Sym1 xs1 ys3 arg) =>
+                                             LamCases_T184_11Sym0 xs1 ys3 a_T184_12
+    type instance Apply @_ @_ (LamCases_T184_11Sym0 xs1 ys3) a_T184_12 = LamCases_T184_11 xs1 ys3 a_T184_12
+    instance SuppressUnusedWarnings (LamCases_T184_11Sym0 xs1 ys3) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (xs0123456789876543210 :: [a0123456789876543210]) (ys0123456789876543210 :: [b0123456789876543210]) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 xs0123456789876543210 ys0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 xs0123456789876543210 ys0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (xs0123456789876543210 :: [a0123456789876543210]) (ys0123456789876543210 :: [b0123456789876543210]) a_0123456789876543210 where
-      LamCases_0123456789876543210 xs ys y = Apply ReturnSym0 y
-    data LamCases_0123456789876543210Sym0 (xs0123456789876543210 :: [a0123456789876543210]) (ys0123456789876543210 :: [b0123456789876543210]) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_T184_11Sym0KindInference ())
+    type family LamCases_T184_11Sym1 (xs1 :: [a0]) (ys3 :: [b2]) a_T184_12 where
+      LamCases_T184_11Sym1 xs1 ys3 a_T184_12 = LamCases_T184_11 xs1 ys3 a_T184_12
+    type family LamCases_T184_13 (xs1 :: [a0]) (ys3 :: [b2]) a_T184_14 where
+      LamCases_T184_13 xs ys y = Apply ReturnSym0 y
+    data LamCases_T184_13Sym0 (xs1 :: [a0]) (ys3 :: [b2]) a_T184_14
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 xs0123456789876543210 ys0123456789876543210) arg) (LamCases_0123456789876543210Sym1 xs0123456789876543210 ys0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 xs0123456789876543210 ys0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 xs0123456789876543210 ys0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 xs0123456789876543210 ys0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 xs0123456789876543210 ys0123456789876543210) where
+        LamCases_T184_13Sym0KindInference :: SameKind (Apply (LamCases_T184_13Sym0 xs1 ys3) arg) (LamCases_T184_13Sym1 xs1 ys3 arg) =>
+                                             LamCases_T184_13Sym0 xs1 ys3 a_T184_14
+    type instance Apply @_ @_ (LamCases_T184_13Sym0 xs1 ys3) a_T184_14 = LamCases_T184_13 xs1 ys3 a_T184_14
+    instance SuppressUnusedWarnings (LamCases_T184_13Sym0 xs1 ys3) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (xs0123456789876543210 :: [a0123456789876543210]) (ys0123456789876543210 :: [b0123456789876543210]) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 xs0123456789876543210 ys0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 xs0123456789876543210 ys0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (xs0123456789876543210 :: [a0123456789876543210]) (ys0123456789876543210 :: [b0123456789876543210]) a_0123456789876543210 where
-      LamCases_0123456789876543210 xs ys '(x,
-                                           y) = Apply ReturnSym0 (Apply (Apply Tuple2Sym0 x) y)
-    data LamCases_0123456789876543210Sym0 (xs0123456789876543210 :: [a0123456789876543210]) (ys0123456789876543210 :: [b0123456789876543210]) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_T184_13Sym0KindInference ())
+    type family LamCases_T184_13Sym1 (xs1 :: [a0]) (ys3 :: [b2]) a_T184_14 where
+      LamCases_T184_13Sym1 xs1 ys3 a_T184_14 = LamCases_T184_13 xs1 ys3 a_T184_14
+    type family LamCases_T184_15 (xs1 :: [a0]) (ys3 :: [b2]) a_T184_16 where
+      LamCases_T184_15 xs ys '(x,
+                               y) = Apply ReturnSym0 (Apply (Apply Tuple2Sym0 x) y)
+    data LamCases_T184_15Sym0 (xs1 :: [a0]) (ys3 :: [b2]) a_T184_16
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 xs0123456789876543210 ys0123456789876543210) arg) (LamCases_0123456789876543210Sym1 xs0123456789876543210 ys0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 xs0123456789876543210 ys0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 xs0123456789876543210 ys0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 xs0123456789876543210 ys0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 xs0123456789876543210 ys0123456789876543210) where
+        LamCases_T184_15Sym0KindInference :: SameKind (Apply (LamCases_T184_15Sym0 xs1 ys3) arg) (LamCases_T184_15Sym1 xs1 ys3 arg) =>
+                                             LamCases_T184_15Sym0 xs1 ys3 a_T184_16
+    type instance Apply @_ @_ (LamCases_T184_15Sym0 xs1 ys3) a_T184_16 = LamCases_T184_15 xs1 ys3 a_T184_16
+    instance SuppressUnusedWarnings (LamCases_T184_15Sym0 xs1 ys3) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (xs0123456789876543210 :: [a0123456789876543210]) (ys0123456789876543210 :: [b0123456789876543210]) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 xs0123456789876543210 ys0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 xs0123456789876543210 ys0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 a0123456789876543210 (ma0123456789876543210 :: Maybe a0123456789876543210) (mb0123456789876543210 :: Maybe Bool) a_0123456789876543210 where
-      LamCases_0123456789876543210 a ma mb b = Apply (Apply (>>@#@$) (Apply GuardSym0 b)) (Apply ReturnSym0 a)
-    data LamCases_0123456789876543210Sym0 a0123456789876543210 (ma0123456789876543210 :: Maybe a0123456789876543210) (mb0123456789876543210 :: Maybe Bool) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_T184_15Sym0KindInference ())
+    type family LamCases_T184_15Sym1 (xs1 :: [a0]) (ys3 :: [b2]) a_T184_16 where
+      LamCases_T184_15Sym1 xs1 ys3 a_T184_16 = LamCases_T184_15 xs1 ys3 a_T184_16
+    type family LamCases_T184_20 a0 (ma2 :: Maybe a1) (mb3 :: Maybe Bool) a_T184_21 where
+      LamCases_T184_20 a ma mb b = Apply (Apply (>>@#@$) (Apply GuardSym0 b)) (Apply ReturnSym0 a)
+    data LamCases_T184_20Sym0 a0 (ma2 :: Maybe a1) (mb3 :: Maybe Bool) a_T184_21
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 a0123456789876543210 ma0123456789876543210 mb0123456789876543210) arg) (LamCases_0123456789876543210Sym1 a0123456789876543210 ma0123456789876543210 mb0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a0123456789876543210 ma0123456789876543210 mb0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 a0123456789876543210 ma0123456789876543210 mb0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a0123456789876543210 ma0123456789876543210 mb0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 a0123456789876543210 ma0123456789876543210 mb0123456789876543210) where
+        LamCases_T184_20Sym0KindInference :: SameKind (Apply (LamCases_T184_20Sym0 a0 ma2 mb3) arg) (LamCases_T184_20Sym1 a0 ma2 mb3 arg) =>
+                                             LamCases_T184_20Sym0 a0 ma2 mb3 a_T184_21
+    type instance Apply @_ @_ (LamCases_T184_20Sym0 a0 ma2 mb3) a_T184_21 = LamCases_T184_20 a0 ma2 mb3 a_T184_21
+    instance SuppressUnusedWarnings (LamCases_T184_20Sym0 a0 ma2 mb3) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 a0123456789876543210 (ma0123456789876543210 :: Maybe a0123456789876543210) (mb0123456789876543210 :: Maybe Bool) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a0123456789876543210 ma0123456789876543210 mb0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a0123456789876543210 ma0123456789876543210 mb0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (ma0123456789876543210 :: Maybe a0123456789876543210) (mb0123456789876543210 :: Maybe Bool) a_0123456789876543210 where
-      LamCases_0123456789876543210 ma mb a = Apply (Apply (>>=@#@$) mb) (LamCases_0123456789876543210Sym0 a ma mb)
-    data LamCases_0123456789876543210Sym0 (ma0123456789876543210 :: Maybe a0123456789876543210) (mb0123456789876543210 :: Maybe Bool) a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_T184_20Sym0KindInference ())
+    type family LamCases_T184_20Sym1 a0 (ma2 :: Maybe a1) (mb3 :: Maybe Bool) a_T184_21 where
+      LamCases_T184_20Sym1 a0 ma2 mb3 a_T184_21 = LamCases_T184_20 a0 ma2 mb3 a_T184_21
+    type family LamCases_T184_19 (ma1 :: Maybe a0) (mb2 :: Maybe Bool) a_T184_22 where
+      LamCases_T184_19 ma mb a = Apply (Apply (>>=@#@$) mb) (LamCases_T184_20Sym0 a ma mb)
+    data LamCases_T184_19Sym0 (ma1 :: Maybe a0) (mb2 :: Maybe Bool) a_T184_22
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 ma0123456789876543210 mb0123456789876543210) arg) (LamCases_0123456789876543210Sym1 ma0123456789876543210 mb0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 ma0123456789876543210 mb0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 ma0123456789876543210 mb0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 ma0123456789876543210 mb0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 ma0123456789876543210 mb0123456789876543210) where
+        LamCases_T184_19Sym0KindInference :: SameKind (Apply (LamCases_T184_19Sym0 ma1 mb2) arg) (LamCases_T184_19Sym1 ma1 mb2 arg) =>
+                                             LamCases_T184_19Sym0 ma1 mb2 a_T184_22
+    type instance Apply @_ @_ (LamCases_T184_19Sym0 ma1 mb2) a_T184_22 = LamCases_T184_19 ma1 mb2 a_T184_22
+    instance SuppressUnusedWarnings (LamCases_T184_19Sym0 ma1 mb2) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (ma0123456789876543210 :: Maybe a0123456789876543210) (mb0123456789876543210 :: Maybe Bool) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 ma0123456789876543210 mb0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 ma0123456789876543210 mb0123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_T184_19Sym0KindInference ())
+    type family LamCases_T184_19Sym1 (ma1 :: Maybe a0) (mb2 :: Maybe Bool) a_T184_22 where
+      LamCases_T184_19Sym1 ma1 mb2 a_T184_22 = LamCases_T184_19 ma1 mb2 a_T184_22
     type TruesSym0 :: (~>) [Bool] [Bool]
     data TruesSym0 :: (~>) [Bool] [Bool]
       where
         TruesSym0KindInference :: SameKind (Apply TruesSym0 arg) (TruesSym1 arg) =>
-                                  TruesSym0 a0123456789876543210
-    type instance Apply @[Bool] @[Bool] TruesSym0 a0123456789876543210 = Trues a0123456789876543210
+                                  TruesSym0 a_T184_0
+    type instance Apply @[Bool] @[Bool] TruesSym0 a_T184_0 = Trues a_T184_0
     instance SuppressUnusedWarnings TruesSym0 where
       suppressUnusedWarnings = snd ((,) TruesSym0KindInference ())
     type TruesSym1 :: [Bool] -> [Bool]
-    type family TruesSym1 (a0123456789876543210 :: [Bool]) :: [Bool] where
-      TruesSym1 a0123456789876543210 = Trues a0123456789876543210
+    type family TruesSym1 (a_T184_0 :: [Bool]) :: [Bool] where
+      TruesSym1 a_T184_0 = Trues a_T184_0
     type CartProdSym0 :: (~>) [a] ((~>) [b] [(a, b)])
     data CartProdSym0 :: (~>) [a] ((~>) [b] [(a, b)])
       where
         CartProdSym0KindInference :: SameKind (Apply CartProdSym0 arg) (CartProdSym1 arg) =>
-                                     CartProdSym0 a0123456789876543210
+                                     CartProdSym0 a_T184_3
     type instance Apply @[a] @((~>) [b] [(a,
-                                          b)]) CartProdSym0 a0123456789876543210 = CartProdSym1 a0123456789876543210
+                                          b)]) CartProdSym0 a_T184_3 = CartProdSym1 a_T184_3
     instance SuppressUnusedWarnings CartProdSym0 where
       suppressUnusedWarnings = snd ((,) CartProdSym0KindInference ())
     type CartProdSym1 :: [a] -> (~>) [b] [(a, b)]
-    data CartProdSym1 (a0123456789876543210 :: [a]) :: (~>) [b] [(a,
-                                                                  b)]
+    data CartProdSym1 (a_T184_3 :: [a]) :: (~>) [b] [(a, b)]
       where
-        CartProdSym1KindInference :: SameKind (Apply (CartProdSym1 a0123456789876543210) arg) (CartProdSym2 a0123456789876543210 arg) =>
-                                     CartProdSym1 a0123456789876543210 a0123456789876543210
+        CartProdSym1KindInference :: SameKind (Apply (CartProdSym1 a_T184_3) arg) (CartProdSym2 a_T184_3 arg) =>
+                                     CartProdSym1 a_T184_3 a_T184_4
     type instance Apply @[b] @[(a,
-                                b)] (CartProdSym1 a0123456789876543210) a0123456789876543210 = CartProd a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (CartProdSym1 a0123456789876543210) where
+                                b)] (CartProdSym1 a_T184_3) a_T184_4 = CartProd a_T184_3 a_T184_4
+    instance SuppressUnusedWarnings (CartProdSym1 a_T184_3) where
       suppressUnusedWarnings = snd ((,) CartProdSym1KindInference ())
     type CartProdSym2 :: [a] -> [b] -> [(a, b)]
-    type family CartProdSym2 @a @b (a0123456789876543210 :: [a]) (a0123456789876543210 :: [b]) :: [(a,
-                                                                                                    b)] where
-      CartProdSym2 a0123456789876543210 a0123456789876543210 = CartProd a0123456789876543210 a0123456789876543210
+    type family CartProdSym2 @a @b (a_T184_3 :: [a]) (a_T184_4 :: [b]) :: [(a,
+                                                                            b)] where
+      CartProdSym2 a_T184_3 a_T184_4 = CartProd a_T184_3 a_T184_4
     type Zip'Sym0 :: (~>) [a] ((~>) [b] [(a, b)])
     data Zip'Sym0 :: (~>) [a] ((~>) [b] [(a, b)])
       where
         Zip'Sym0KindInference :: SameKind (Apply Zip'Sym0 arg) (Zip'Sym1 arg) =>
-                                 Zip'Sym0 a0123456789876543210
+                                 Zip'Sym0 a_T184_9
     type instance Apply @[a] @((~>) [b] [(a,
-                                          b)]) Zip'Sym0 a0123456789876543210 = Zip'Sym1 a0123456789876543210
+                                          b)]) Zip'Sym0 a_T184_9 = Zip'Sym1 a_T184_9
     instance SuppressUnusedWarnings Zip'Sym0 where
       suppressUnusedWarnings = snd ((,) Zip'Sym0KindInference ())
     type Zip'Sym1 :: [a] -> (~>) [b] [(a, b)]
-    data Zip'Sym1 (a0123456789876543210 :: [a]) :: (~>) [b] [(a, b)]
+    data Zip'Sym1 (a_T184_9 :: [a]) :: (~>) [b] [(a, b)]
       where
-        Zip'Sym1KindInference :: SameKind (Apply (Zip'Sym1 a0123456789876543210) arg) (Zip'Sym2 a0123456789876543210 arg) =>
-                                 Zip'Sym1 a0123456789876543210 a0123456789876543210
+        Zip'Sym1KindInference :: SameKind (Apply (Zip'Sym1 a_T184_9) arg) (Zip'Sym2 a_T184_9 arg) =>
+                                 Zip'Sym1 a_T184_9 a_T184_10
     type instance Apply @[b] @[(a,
-                                b)] (Zip'Sym1 a0123456789876543210) a0123456789876543210 = Zip' a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Zip'Sym1 a0123456789876543210) where
+                                b)] (Zip'Sym1 a_T184_9) a_T184_10 = Zip' a_T184_9 a_T184_10
+    instance SuppressUnusedWarnings (Zip'Sym1 a_T184_9) where
       suppressUnusedWarnings = snd ((,) Zip'Sym1KindInference ())
     type Zip'Sym2 :: [a] -> [b] -> [(a, b)]
-    type family Zip'Sym2 @a @b (a0123456789876543210 :: [a]) (a0123456789876543210 :: [b]) :: [(a,
-                                                                                                b)] where
-      Zip'Sym2 a0123456789876543210 a0123456789876543210 = Zip' a0123456789876543210 a0123456789876543210
+    type family Zip'Sym2 @a @b (a_T184_9 :: [a]) (a_T184_10 :: [b]) :: [(a,
+                                                                         b)] where
+      Zip'Sym2 a_T184_9 a_T184_10 = Zip' a_T184_9 a_T184_10
     type BoogieSym0 :: (~>) (Maybe a) ((~>) (Maybe Bool) (Maybe a))
     data BoogieSym0 :: (~>) (Maybe a) ((~>) (Maybe Bool) (Maybe a))
       where
         BoogieSym0KindInference :: SameKind (Apply BoogieSym0 arg) (BoogieSym1 arg) =>
-                                   BoogieSym0 a0123456789876543210
-    type instance Apply @(Maybe a) @((~>) (Maybe Bool) (Maybe a)) BoogieSym0 a0123456789876543210 = BoogieSym1 a0123456789876543210
+                                   BoogieSym0 a_T184_17
+    type instance Apply @(Maybe a) @((~>) (Maybe Bool) (Maybe a)) BoogieSym0 a_T184_17 = BoogieSym1 a_T184_17
     instance SuppressUnusedWarnings BoogieSym0 where
       suppressUnusedWarnings = snd ((,) BoogieSym0KindInference ())
     type BoogieSym1 :: Maybe a -> (~>) (Maybe Bool) (Maybe a)
-    data BoogieSym1 (a0123456789876543210 :: Maybe a) :: (~>) (Maybe Bool) (Maybe a)
+    data BoogieSym1 (a_T184_17 :: Maybe a) :: (~>) (Maybe Bool) (Maybe a)
       where
-        BoogieSym1KindInference :: SameKind (Apply (BoogieSym1 a0123456789876543210) arg) (BoogieSym2 a0123456789876543210 arg) =>
-                                   BoogieSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Maybe Bool) @(Maybe a) (BoogieSym1 a0123456789876543210) a0123456789876543210 = Boogie a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (BoogieSym1 a0123456789876543210) where
+        BoogieSym1KindInference :: SameKind (Apply (BoogieSym1 a_T184_17) arg) (BoogieSym2 a_T184_17 arg) =>
+                                   BoogieSym1 a_T184_17 a_T184_18
+    type instance Apply @(Maybe Bool) @(Maybe a) (BoogieSym1 a_T184_17) a_T184_18 = Boogie a_T184_17 a_T184_18
+    instance SuppressUnusedWarnings (BoogieSym1 a_T184_17) where
       suppressUnusedWarnings = snd ((,) BoogieSym1KindInference ())
     type BoogieSym2 :: Maybe a -> Maybe Bool -> Maybe a
-    type family BoogieSym2 @a (a0123456789876543210 :: Maybe a) (a0123456789876543210 :: Maybe Bool) :: Maybe a where
-      BoogieSym2 a0123456789876543210 a0123456789876543210 = Boogie a0123456789876543210 a0123456789876543210
+    type family BoogieSym2 @a (a_T184_17 :: Maybe a) (a_T184_18 :: Maybe Bool) :: Maybe a where
+      BoogieSym2 a_T184_17 a_T184_18 = Boogie a_T184_17 a_T184_18
     type Trues :: [Bool] -> [Bool]
     type family Trues (a :: [Bool]) :: [Bool] where
-      Trues xs = Apply (Apply (>>=@#@$) xs) (LamCases_0123456789876543210Sym0 xs)
+      Trues xs = Apply (Apply (>>=@#@$) xs) (LamCases_T184_1Sym0 xs)
     type CartProd :: [a] -> [b] -> [(a, b)]
     type family CartProd @a @b (a :: [a]) (a :: [b]) :: [(a, b)] where
-      CartProd xs ys = Apply (Apply (>>=@#@$) xs) (LamCases_0123456789876543210Sym0 xs ys)
+      CartProd xs ys = Apply (Apply (>>=@#@$) xs) (LamCases_T184_5Sym0 xs ys)
     type Zip' :: [a] -> [b] -> [(a, b)]
     type family Zip' @a @b (a :: [a]) (a :: [b]) :: [(a, b)] where
-      Zip' xs ys = Apply (Apply (>>=@#@$) (Apply (Apply MzipSym0 (Apply (Apply (>>=@#@$) xs) (LamCases_0123456789876543210Sym0 xs ys))) (Apply (Apply (>>=@#@$) ys) (LamCases_0123456789876543210Sym0 xs ys)))) (LamCases_0123456789876543210Sym0 xs ys)
+      Zip' xs ys = Apply (Apply (>>=@#@$) (Apply (Apply MzipSym0 (Apply (Apply (>>=@#@$) xs) (LamCases_T184_11Sym0 xs ys))) (Apply (Apply (>>=@#@$) ys) (LamCases_T184_13Sym0 xs ys)))) (LamCases_T184_15Sym0 xs ys)
     type Boogie :: Maybe a -> Maybe Bool -> Maybe a
     type family Boogie @a (a :: Maybe a) (a :: Maybe Bool) :: Maybe a where
-      Boogie ma mb = Apply (Apply (>>=@#@$) ma) (LamCases_0123456789876543210Sym0 ma mb)
+      Boogie ma mb = Apply (Apply (>>=@#@$) ma) (LamCases_T184_19Sym0 ma mb)
     sTrues ::
       (forall (t :: [Bool]). Sing t -> Sing (Trues t :: [Bool]) :: Type)
     sCartProd ::
@@ -224,7 +223,7 @@ Singletons/T184.hs:(0,0)-(0,0): Splicing declarations
       = applySing
           (applySing (singFun2 @(>>=@#@$) (%>>=)) sXs)
           (singFun1
-             @(LamCases_0123456789876543210Sym0 xs)
+             @(LamCases_T184_1Sym0 xs)
              (\cases
                 (sX :: Sing x)
                   -> applySing
@@ -236,13 +235,13 @@ Singletons/T184.hs:(0,0)-(0,0): Splicing declarations
       = applySing
           (applySing (singFun2 @(>>=@#@$) (%>>=)) sXs)
           (singFun1
-             @(LamCases_0123456789876543210Sym0 xs ys)
+             @(LamCases_T184_5Sym0 xs ys)
              (\cases
                 (sX :: Sing x)
                   -> applySing
                        (applySing (singFun2 @(>>=@#@$) (%>>=)) sYs)
                        (singFun1
-                          @(LamCases_0123456789876543210Sym0 x xs ys)
+                          @(LamCases_T184_6Sym0 x xs ys)
                           (\cases
                              (sY :: Sing y)
                                -> applySing
@@ -258,17 +257,17 @@ Singletons/T184.hs:(0,0)-(0,0): Splicing declarations
                    (applySing
                       (applySing (singFun2 @(>>=@#@$) (%>>=)) sXs)
                       (singFun1
-                         @(LamCases_0123456789876543210Sym0 xs ys)
+                         @(LamCases_T184_11Sym0 xs ys)
                          (\cases
                             (sX :: Sing x) -> applySing (singFun1 @ReturnSym0 sReturn) sX))))
                 (applySing
                    (applySing (singFun2 @(>>=@#@$) (%>>=)) sYs)
                    (singFun1
-                      @(LamCases_0123456789876543210Sym0 xs ys)
+                      @(LamCases_T184_13Sym0 xs ys)
                       (\cases
                          (sY :: Sing y) -> applySing (singFun1 @ReturnSym0 sReturn) sY)))))
           (singFun1
-             @(LamCases_0123456789876543210Sym0 xs ys)
+             @(LamCases_T184_15Sym0 xs ys)
              (\cases
                 (STuple2 (sX :: Sing x) (sY :: Sing y))
                   -> applySing
@@ -278,13 +277,13 @@ Singletons/T184.hs:(0,0)-(0,0): Splicing declarations
       = applySing
           (applySing (singFun2 @(>>=@#@$) (%>>=)) sMa)
           (singFun1
-             @(LamCases_0123456789876543210Sym0 ma mb)
+             @(LamCases_T184_19Sym0 ma mb)
              (\cases
                 (sA :: Sing a)
                   -> applySing
                        (applySing (singFun2 @(>>=@#@$) (%>>=)) sMb)
                        (singFun1
-                          @(LamCases_0123456789876543210Sym0 a ma mb)
+                          @(LamCases_T184_20Sym0 a ma mb)
                           (\cases
                              (sB :: Sing b)
                                -> applySing

--- a/singletons-base/tests/compile-and-dump/Singletons/T187.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T187.golden
@@ -8,16 +8,16 @@ Singletons/T187.hs:(0,0)-(0,0): Splicing declarations
     data Empty
     deriving instance Eq Empty
     deriving instance Ord Empty
-    type TFHelper_0123456789876543210 :: Empty -> Empty -> Bool
-    type family TFHelper_0123456789876543210 (a :: Empty) (a :: Empty) :: Bool where
-      TFHelper_0123456789876543210 _ _ = TrueSym0
+    type TFHelper_T187_0 :: Empty -> Empty -> Bool
+    type family TFHelper_T187_0 (a :: Empty) (a :: Empty) :: Bool where
+      TFHelper_T187_0 _ _ = TrueSym0
     instance PEq Empty where
-      type (==) a a = TFHelper_0123456789876543210 a a
-    type Compare_0123456789876543210 :: Empty -> Empty -> Ordering
-    type family Compare_0123456789876543210 (a :: Empty) (a :: Empty) :: Ordering where
-      Compare_0123456789876543210 _ _ = EQSym0
+      type (==) a a = TFHelper_T187_0 a a
+    type Compare_T187_3 :: Empty -> Empty -> Ordering
+    type family Compare_T187_3 (a :: Empty) (a :: Empty) :: Ordering where
+      Compare_T187_3 _ _ = EQSym0
     instance POrd Empty where
-      type Compare a a = Compare_0123456789876543210 a a
+      type Compare a a = Compare_T187_3 a a
     data SEmpty :: Empty -> Type
     type instance Sing @Empty = SEmpty
     instance SingKind Empty where

--- a/singletons-base/tests/compile-and-dump/Singletons/T190.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T190.golden
@@ -10,57 +10,53 @@ Singletons/T190.hs:0:0:: Splicing declarations
     type TSym0 :: T
     type family TSym0 :: T where
       TSym0 = T
-    type TFHelper_0123456789876543210 :: T -> T -> Bool
-    type family TFHelper_0123456789876543210 (a :: T) (a :: T) :: Bool where
-      TFHelper_0123456789876543210 T T = TrueSym0
+    type TFHelper_T190_1 :: T -> T -> Bool
+    type family TFHelper_T190_1 (a :: T) (a :: T) :: Bool where
+      TFHelper_T190_1 T T = TrueSym0
     instance PEq T where
-      type (==) a a = TFHelper_0123456789876543210 a a
-    type Compare_0123456789876543210 :: T -> T -> Ordering
-    type family Compare_0123456789876543210 (a :: T) (a :: T) :: Ordering where
-      Compare_0123456789876543210 T T = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
+      type (==) a a = TFHelper_T190_1 a a
+    type Compare_T190_4 :: T -> T -> Ordering
+    type family Compare_T190_4 (a :: T) (a :: T) :: Ordering where
+      Compare_T190_4 T T = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
     instance POrd T where
-      type Compare a a = Compare_0123456789876543210 a a
-    type family LamCases_0123456789876543210 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_0123456789876543210 where
-      LamCases_0123456789876543210 n 'True = TSym0
-      LamCases_0123456789876543210 n 'False = Apply ErrorSym0 "toEnum: bad argument"
-    data LamCases_0123456789876543210Sym0 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_01234567898765432100123456789876543210
+      type Compare a a = Compare_T190_4 a a
+    type family LamCases_T190_9 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_T190_10 where
+      LamCases_T190_9 n 'True = TSym0
+      LamCases_T190_9 n 'False = Apply ErrorSym0 "toEnum: bad argument"
+    data LamCases_T190_9Sym0 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_T190_10
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 n0123456789876543210) arg) (LamCases_0123456789876543210Sym1 n0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 n0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 n0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 n0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 n0123456789876543210) where
+        LamCases_T190_9Sym0KindInference :: SameKind (Apply (LamCases_T190_9Sym0 n0) arg) (LamCases_T190_9Sym1 n0 arg) =>
+                                            LamCases_T190_9Sym0 n0 a_T190_10
+    type instance Apply @_ @_ (LamCases_T190_9Sym0 n0) a_T190_10 = LamCases_T190_9 n0 a_T190_10
+    instance SuppressUnusedWarnings (LamCases_T190_9Sym0 n0) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 n0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 n0123456789876543210 a_01234567898765432100123456789876543210
-    type ToEnum_0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural
-                                       -> T
-    type family ToEnum_0123456789876543210 (a :: GHC.Internal.Bignum.Natural.Natural) :: T where
-      ToEnum_0123456789876543210 n = Apply (LamCases_0123456789876543210Sym0 n) (Apply (Apply (==@#@$) n) (FromInteger 0))
-    type FromEnum_0123456789876543210 :: T
-                                         -> GHC.Internal.Bignum.Natural.Natural
-    type family FromEnum_0123456789876543210 (a :: T) :: GHC.Internal.Bignum.Natural.Natural where
-      FromEnum_0123456789876543210 T = FromInteger 0
+        = snd ((,) LamCases_T190_9Sym0KindInference ())
+    type family LamCases_T190_9Sym1 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_T190_10 where
+      LamCases_T190_9Sym1 n0 a_T190_10 = LamCases_T190_9 n0 a_T190_10
+    type ToEnum_T190_7 :: GHC.Internal.Bignum.Natural.Natural -> T
+    type family ToEnum_T190_7 (a :: GHC.Internal.Bignum.Natural.Natural) :: T where
+      ToEnum_T190_7 n = Apply (LamCases_T190_9Sym0 n) (Apply (Apply (==@#@$) n) (FromInteger 0))
+    type FromEnum_T190_11 :: T -> GHC.Internal.Bignum.Natural.Natural
+    type family FromEnum_T190_11 (a :: T) :: GHC.Internal.Bignum.Natural.Natural where
+      FromEnum_T190_11 T = FromInteger 0
     instance PEnum T where
-      type ToEnum a = ToEnum_0123456789876543210 a
-      type FromEnum a = FromEnum_0123456789876543210 a
-    type MinBound_0123456789876543210 :: T
-    type family MinBound_0123456789876543210 :: T where
-      MinBound_0123456789876543210 = TSym0
-    type MaxBound_0123456789876543210 :: T
-    type family MaxBound_0123456789876543210 :: T where
-      MaxBound_0123456789876543210 = TSym0
+      type ToEnum a = ToEnum_T190_7 a
+      type FromEnum a = FromEnum_T190_11 a
+    type MinBound_T190_13 :: T
+    type family MinBound_T190_13 :: T where
+      MinBound_T190_13 = TSym0
+    type MaxBound_T190_14 :: T
+    type family MaxBound_T190_14 :: T where
+      MaxBound_T190_14 = TSym0
     instance PBounded T where
-      type MinBound = MinBound_0123456789876543210
-      type MaxBound = MaxBound_0123456789876543210
-    type ShowsPrec_0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural
-                                          -> T
-                                             -> GHC.Internal.Types.Symbol
-                                                -> GHC.Internal.Types.Symbol
-    type family ShowsPrec_0123456789876543210 (a :: GHC.Internal.Bignum.Natural.Natural) (a :: T) (a :: GHC.Internal.Types.Symbol) :: GHC.Internal.Types.Symbol where
-      ShowsPrec_0123456789876543210 _ T a_0123456789876543210 = Apply (Apply ShowStringSym0 "T") a_0123456789876543210
+      type MinBound = MinBound_T190_13
+      type MaxBound = MaxBound_T190_14
+    type ShowsPrec_T190_15 :: GHC.Internal.Bignum.Natural.Natural
+                              -> T -> GHC.Internal.Types.Symbol -> GHC.Internal.Types.Symbol
+    type family ShowsPrec_T190_15 (a :: GHC.Internal.Bignum.Natural.Natural) (a :: T) (a :: GHC.Internal.Types.Symbol) :: GHC.Internal.Types.Symbol where
+      ShowsPrec_T190_15 _ T a_T190_16 = Apply (Apply ShowStringSym0 "T") a_T190_16
     instance PShow T where
-      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
+      type ShowsPrec a a a = ShowsPrec_T190_15 a a a
     data ST :: T -> Type where ST :: ST (T :: T)
     type instance Sing @T = ST
     instance SingKind T where
@@ -80,7 +76,7 @@ Singletons/T190.hs:0:0:: Splicing declarations
       sToEnum (sN :: Sing n)
         = applySing
             (singFun1
-               @(LamCases_0123456789876543210Sym0 n)
+               @(LamCases_T190_9Sym0 n)
                (\cases
                   STrue -> ST
                   SFalse
@@ -95,14 +91,11 @@ Singletons/T190.hs:0:0:: Splicing declarations
       sMinBound = ST
       sMaxBound = ST
     instance SShow T where
-      sShowsPrec
-        _
-        ST
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+      sShowsPrec _ ST (sA_T190_16 :: Sing a_T190_16)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "T"))
-            sA_0123456789876543210
+            sA_T190_16
     instance SDecide T where
       (%~) ST ST = Proved Refl
     instance Eq (ST (z :: T)) where

--- a/singletons-base/tests/compile-and-dump/Singletons/T197.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T197.golden
@@ -12,23 +12,23 @@ Singletons/T197.hs:(0,0)-(0,0): Splicing declarations
     data ($$:@#@$) :: (~>) Bool ((~>) Bool Bool)
       where
         (:$$:@#@$###) :: SameKind (Apply ($$:@#@$) arg) (($$:@#@$$) arg) =>
-                         ($$:@#@$) a0123456789876543210
-    type instance Apply @Bool @((~>) Bool Bool) ($$:@#@$) a0123456789876543210 = ($$:@#@$$) a0123456789876543210
+                         ($$:@#@$) a_T197_0
+    type instance Apply @Bool @((~>) Bool Bool) ($$:@#@$) a_T197_0 = ($$:@#@$$) a_T197_0
     instance SuppressUnusedWarnings ($$:@#@$) where
       suppressUnusedWarnings = snd ((,) (:$$:@#@$###) ())
     infixl 5 type $$:@#@$
     type ($$:@#@$$) :: Bool -> (~>) Bool Bool
-    data ($$:@#@$$) (a0123456789876543210 :: Bool) :: (~>) Bool Bool
+    data ($$:@#@$$) (a_T197_0 :: Bool) :: (~>) Bool Bool
       where
-        (:$$:@#@$$###) :: SameKind (Apply (($$:@#@$$) a0123456789876543210) arg) (($$:@#@$$$) a0123456789876543210 arg) =>
-                          ($$:@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @Bool @Bool (($$:@#@$$) a0123456789876543210) a0123456789876543210 = ($$:) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (($$:@#@$$) a0123456789876543210) where
+        (:$$:@#@$$###) :: SameKind (Apply (($$:@#@$$) a_T197_0) arg) (($$:@#@$$$) a_T197_0 arg) =>
+                          ($$:@#@$$) a_T197_0 a_T197_1
+    type instance Apply @Bool @Bool (($$:@#@$$) a_T197_0) a_T197_1 = ($$:) a_T197_0 a_T197_1
+    instance SuppressUnusedWarnings (($$:@#@$$) a_T197_0) where
       suppressUnusedWarnings = snd ((,) (:$$:@#@$$###) ())
     infixl 5 type $$:@#@$$
     type ($$:@#@$$$) :: Bool -> Bool -> Bool
-    type family ($$:@#@$$$) (a0123456789876543210 :: Bool) (a0123456789876543210 :: Bool) :: Bool where
-      ($$:@#@$$$) a0123456789876543210 a0123456789876543210 = ($$:) a0123456789876543210 a0123456789876543210
+    type family ($$:@#@$$$) (a_T197_0 :: Bool) (a_T197_1 :: Bool) :: Bool where
+      ($$:@#@$$$) a_T197_0 a_T197_1 = ($$:) a_T197_0 a_T197_1
     infixl 5 type $$:@#@$$$
     type ($$:) :: Bool -> Bool -> Bool
     type family ($$:) (a :: Bool) (a :: Bool) :: Bool where

--- a/singletons-base/tests/compile-and-dump/Singletons/T197b.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T197b.golden
@@ -13,42 +13,42 @@ Singletons/T197b.hs:(0,0)-(0,0): Splicing declarations
     data (:*:@#@$) :: (~>) a ((~>) b ((:*:) a b))
       where
         (::*:@#@$###) :: SameKind (Apply (:*:@#@$) arg) ((:*:@#@$$) arg) =>
-                         (:*:@#@$) a0123456789876543210
-    type instance Apply @a @((~>) b ((:*:) a b)) (:*:@#@$) a0123456789876543210 = (:*:@#@$$) a0123456789876543210
+                         (:*:@#@$) a_T197b_0
+    type instance Apply @a @((~>) b ((:*:) a b)) (:*:@#@$) a_T197b_0 = (:*:@#@$$) a_T197b_0
     instance SuppressUnusedWarnings (:*:@#@$) where
       suppressUnusedWarnings = snd ((,) (::*:@#@$###) ())
     type (:*:@#@$$) :: forall a b. a -> (~>) b ((:*:) a b)
-    data (:*:@#@$$) (a0123456789876543210 :: a) :: (~>) b ((:*:) a b)
+    data (:*:@#@$$) (a_T197b_0 :: a) :: (~>) b ((:*:) a b)
       where
-        (::*:@#@$$###) :: SameKind (Apply ((:*:@#@$$) a0123456789876543210) arg) ((:*:@#@$$$) a0123456789876543210 arg) =>
-                          (:*:@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @b @((:*:) a b) ((:*:@#@$$) a0123456789876543210) a0123456789876543210 = (:*:) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((:*:@#@$$) a0123456789876543210) where
+        (::*:@#@$$###) :: SameKind (Apply ((:*:@#@$$) a_T197b_0) arg) ((:*:@#@$$$) a_T197b_0 arg) =>
+                          (:*:@#@$$) a_T197b_0 a_T197b_1
+    type instance Apply @b @((:*:) a b) ((:*:@#@$$) a_T197b_0) a_T197b_1 = (:*:) a_T197b_0 a_T197b_1
+    instance SuppressUnusedWarnings ((:*:@#@$$) a_T197b_0) where
       suppressUnusedWarnings = snd ((,) (::*:@#@$$###) ())
     type (:*:@#@$$$) :: forall a b. a -> b -> (:*:) a b
-    type family (:*:@#@$$$) @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: (:*:) a b where
-      (:*:@#@$$$) a0123456789876543210 a0123456789876543210 = (:*:) a0123456789876543210 a0123456789876543210
+    type family (:*:@#@$$$) @a @b (a_T197b_0 :: a) (a_T197b_1 :: b) :: (:*:) a b where
+      (:*:@#@$$$) a_T197b_0 a_T197b_1 = (:*:) a_T197b_0 a_T197b_1
     type MkPairSym0 :: forall a b. (~>) a ((~>) b (Pair a b))
     data MkPairSym0 :: (~>) a ((~>) b (Pair a b))
       where
         MkPairSym0KindInference :: SameKind (Apply MkPairSym0 arg) (MkPairSym1 arg) =>
-                                   MkPairSym0 a0123456789876543210
-    type instance Apply @a @((~>) b (Pair a b)) MkPairSym0 a0123456789876543210 = MkPairSym1 a0123456789876543210
+                                   MkPairSym0 a_T197b_2
+    type instance Apply @a @((~>) b (Pair a b)) MkPairSym0 a_T197b_2 = MkPairSym1 a_T197b_2
     instance SuppressUnusedWarnings MkPairSym0 where
       suppressUnusedWarnings = snd ((,) MkPairSym0KindInference ())
     infixr 9 type `MkPairSym0`
     type MkPairSym1 :: forall a b. a -> (~>) b (Pair a b)
-    data MkPairSym1 (a0123456789876543210 :: a) :: (~>) b (Pair a b)
+    data MkPairSym1 (a_T197b_2 :: a) :: (~>) b (Pair a b)
       where
-        MkPairSym1KindInference :: SameKind (Apply (MkPairSym1 a0123456789876543210) arg) (MkPairSym2 a0123456789876543210 arg) =>
-                                   MkPairSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @(Pair a b) (MkPairSym1 a0123456789876543210) a0123456789876543210 = MkPair a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (MkPairSym1 a0123456789876543210) where
+        MkPairSym1KindInference :: SameKind (Apply (MkPairSym1 a_T197b_2) arg) (MkPairSym2 a_T197b_2 arg) =>
+                                   MkPairSym1 a_T197b_2 a_T197b_3
+    type instance Apply @b @(Pair a b) (MkPairSym1 a_T197b_2) a_T197b_3 = MkPair a_T197b_2 a_T197b_3
+    instance SuppressUnusedWarnings (MkPairSym1 a_T197b_2) where
       suppressUnusedWarnings = snd ((,) MkPairSym1KindInference ())
     infixr 9 type `MkPairSym1`
     type MkPairSym2 :: forall a b. a -> b -> Pair a b
-    type family MkPairSym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: Pair a b where
-      MkPairSym2 a0123456789876543210 a0123456789876543210 = MkPair a0123456789876543210 a0123456789876543210
+    type family MkPairSym2 @a @b (a_T197b_2 :: a) (a_T197b_3 :: b) :: Pair a b where
+      MkPairSym2 a_T197b_2 a_T197b_3 = MkPair a_T197b_2 a_T197b_3
     infixr 9 type `MkPairSym2`
     infixr 9 data `SMkPair`
     data (%:*:) :: forall a b. (:*:) a b -> Type

--- a/singletons-base/tests/compile-and-dump/Singletons/T200.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T200.golden
@@ -22,89 +22,89 @@ Singletons/T200.hs:(0,0)-(0,0): Splicing declarations
     data (:$$:@#@$) :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)
       where
         (::$$:@#@$###) :: SameKind (Apply (:$$:@#@$) arg) ((:$$:@#@$$) arg) =>
-                          (:$$:@#@$) a0123456789876543210
-    type instance Apply @ErrorMessage @((~>) ErrorMessage ErrorMessage) (:$$:@#@$) a0123456789876543210 = (:$$:@#@$$) a0123456789876543210
+                          (:$$:@#@$) a_T200_0
+    type instance Apply @ErrorMessage @((~>) ErrorMessage ErrorMessage) (:$$:@#@$) a_T200_0 = (:$$:@#@$$) a_T200_0
     instance SuppressUnusedWarnings (:$$:@#@$) where
       suppressUnusedWarnings = snd ((,) (::$$:@#@$###) ())
     type (:$$:@#@$$) :: ErrorMessage -> (~>) ErrorMessage ErrorMessage
-    data (:$$:@#@$$) (a0123456789876543210 :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage
+    data (:$$:@#@$$) (a_T200_0 :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage
       where
-        (::$$:@#@$$###) :: SameKind (Apply ((:$$:@#@$$) a0123456789876543210) arg) ((:$$:@#@$$$) a0123456789876543210 arg) =>
-                           (:$$:@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @ErrorMessage @ErrorMessage ((:$$:@#@$$) a0123456789876543210) a0123456789876543210 = (:$$:) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((:$$:@#@$$) a0123456789876543210) where
+        (::$$:@#@$$###) :: SameKind (Apply ((:$$:@#@$$) a_T200_0) arg) ((:$$:@#@$$$) a_T200_0 arg) =>
+                           (:$$:@#@$$) a_T200_0 a_T200_1
+    type instance Apply @ErrorMessage @ErrorMessage ((:$$:@#@$$) a_T200_0) a_T200_1 = (:$$:) a_T200_0 a_T200_1
+    instance SuppressUnusedWarnings ((:$$:@#@$$) a_T200_0) where
       suppressUnusedWarnings = snd ((,) (::$$:@#@$$###) ())
     type (:$$:@#@$$$) :: ErrorMessage -> ErrorMessage -> ErrorMessage
-    type family (:$$:@#@$$$) (a0123456789876543210 :: ErrorMessage) (a0123456789876543210 :: ErrorMessage) :: ErrorMessage where
-      (:$$:@#@$$$) a0123456789876543210 a0123456789876543210 = (:$$:) a0123456789876543210 a0123456789876543210
+    type family (:$$:@#@$$$) (a_T200_0 :: ErrorMessage) (a_T200_1 :: ErrorMessage) :: ErrorMessage where
+      (:$$:@#@$$$) a_T200_0 a_T200_1 = (:$$:) a_T200_0 a_T200_1
     type (:<>:@#@$) :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)
     data (:<>:@#@$) :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)
       where
         (::<>:@#@$###) :: SameKind (Apply (:<>:@#@$) arg) ((:<>:@#@$$) arg) =>
-                          (:<>:@#@$) a0123456789876543210
-    type instance Apply @ErrorMessage @((~>) ErrorMessage ErrorMessage) (:<>:@#@$) a0123456789876543210 = (:<>:@#@$$) a0123456789876543210
+                          (:<>:@#@$) a_T200_2
+    type instance Apply @ErrorMessage @((~>) ErrorMessage ErrorMessage) (:<>:@#@$) a_T200_2 = (:<>:@#@$$) a_T200_2
     instance SuppressUnusedWarnings (:<>:@#@$) where
       suppressUnusedWarnings = snd ((,) (::<>:@#@$###) ())
     type (:<>:@#@$$) :: ErrorMessage -> (~>) ErrorMessage ErrorMessage
-    data (:<>:@#@$$) (a0123456789876543210 :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage
+    data (:<>:@#@$$) (a_T200_2 :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage
       where
-        (::<>:@#@$$###) :: SameKind (Apply ((:<>:@#@$$) a0123456789876543210) arg) ((:<>:@#@$$$) a0123456789876543210 arg) =>
-                           (:<>:@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @ErrorMessage @ErrorMessage ((:<>:@#@$$) a0123456789876543210) a0123456789876543210 = (:<>:) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((:<>:@#@$$) a0123456789876543210) where
+        (::<>:@#@$$###) :: SameKind (Apply ((:<>:@#@$$) a_T200_2) arg) ((:<>:@#@$$$) a_T200_2 arg) =>
+                           (:<>:@#@$$) a_T200_2 a_T200_3
+    type instance Apply @ErrorMessage @ErrorMessage ((:<>:@#@$$) a_T200_2) a_T200_3 = (:<>:) a_T200_2 a_T200_3
+    instance SuppressUnusedWarnings ((:<>:@#@$$) a_T200_2) where
       suppressUnusedWarnings = snd ((,) (::<>:@#@$$###) ())
     type (:<>:@#@$$$) :: ErrorMessage -> ErrorMessage -> ErrorMessage
-    type family (:<>:@#@$$$) (a0123456789876543210 :: ErrorMessage) (a0123456789876543210 :: ErrorMessage) :: ErrorMessage where
-      (:<>:@#@$$$) a0123456789876543210 a0123456789876543210 = (:<>:) a0123456789876543210 a0123456789876543210
+    type family (:<>:@#@$$$) (a_T200_2 :: ErrorMessage) (a_T200_3 :: ErrorMessage) :: ErrorMessage where
+      (:<>:@#@$$$) a_T200_2 a_T200_3 = (:<>:) a_T200_2 a_T200_3
     type EMSym0 :: (~>) [Bool] ErrorMessage
     data EMSym0 :: (~>) [Bool] ErrorMessage
       where
         EMSym0KindInference :: SameKind (Apply EMSym0 arg) (EMSym1 arg) =>
-                               EMSym0 a0123456789876543210
-    type instance Apply @[Bool] @ErrorMessage EMSym0 a0123456789876543210 = EM a0123456789876543210
+                               EMSym0 a_T200_4
+    type instance Apply @[Bool] @ErrorMessage EMSym0 a_T200_4 = EM a_T200_4
     instance SuppressUnusedWarnings EMSym0 where
       suppressUnusedWarnings = snd ((,) EMSym0KindInference ())
     type EMSym1 :: [Bool] -> ErrorMessage
-    type family EMSym1 (a0123456789876543210 :: [Bool]) :: ErrorMessage where
-      EMSym1 a0123456789876543210 = EM a0123456789876543210
+    type family EMSym1 (a_T200_4 :: [Bool]) :: ErrorMessage where
+      EMSym1 a_T200_4 = EM a_T200_4
     type (<>:@#@$) :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)
     data (<>:@#@$) :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)
       where
         (:<>:@#@$###) :: SameKind (Apply (<>:@#@$) arg) ((<>:@#@$$) arg) =>
-                         (<>:@#@$) a0123456789876543210
-    type instance Apply @ErrorMessage @((~>) ErrorMessage ErrorMessage) (<>:@#@$) a0123456789876543210 = (<>:@#@$$) a0123456789876543210
+                         (<>:@#@$) a_T200_5
+    type instance Apply @ErrorMessage @((~>) ErrorMessage ErrorMessage) (<>:@#@$) a_T200_5 = (<>:@#@$$) a_T200_5
     instance SuppressUnusedWarnings (<>:@#@$) where
       suppressUnusedWarnings = snd ((,) (:<>:@#@$###) ())
     type (<>:@#@$$) :: ErrorMessage -> (~>) ErrorMessage ErrorMessage
-    data (<>:@#@$$) (a0123456789876543210 :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage
+    data (<>:@#@$$) (a_T200_5 :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage
       where
-        (:<>:@#@$$###) :: SameKind (Apply ((<>:@#@$$) a0123456789876543210) arg) ((<>:@#@$$$) a0123456789876543210 arg) =>
-                          (<>:@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @ErrorMessage @ErrorMessage ((<>:@#@$$) a0123456789876543210) a0123456789876543210 = (<>:) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((<>:@#@$$) a0123456789876543210) where
+        (:<>:@#@$$###) :: SameKind (Apply ((<>:@#@$$) a_T200_5) arg) ((<>:@#@$$$) a_T200_5 arg) =>
+                          (<>:@#@$$) a_T200_5 a_T200_6
+    type instance Apply @ErrorMessage @ErrorMessage ((<>:@#@$$) a_T200_5) a_T200_6 = (<>:) a_T200_5 a_T200_6
+    instance SuppressUnusedWarnings ((<>:@#@$$) a_T200_5) where
       suppressUnusedWarnings = snd ((,) (:<>:@#@$$###) ())
     type (<>:@#@$$$) :: ErrorMessage -> ErrorMessage -> ErrorMessage
-    type family (<>:@#@$$$) (a0123456789876543210 :: ErrorMessage) (a0123456789876543210 :: ErrorMessage) :: ErrorMessage where
-      (<>:@#@$$$) a0123456789876543210 a0123456789876543210 = (<>:) a0123456789876543210 a0123456789876543210
+    type family (<>:@#@$$$) (a_T200_5 :: ErrorMessage) (a_T200_6 :: ErrorMessage) :: ErrorMessage where
+      (<>:@#@$$$) a_T200_5 a_T200_6 = (<>:) a_T200_5 a_T200_6
     type ($$:@#@$) :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)
     data ($$:@#@$) :: (~>) ErrorMessage ((~>) ErrorMessage ErrorMessage)
       where
         (:$$:@#@$###) :: SameKind (Apply ($$:@#@$) arg) (($$:@#@$$) arg) =>
-                         ($$:@#@$) a0123456789876543210
-    type instance Apply @ErrorMessage @((~>) ErrorMessage ErrorMessage) ($$:@#@$) a0123456789876543210 = ($$:@#@$$) a0123456789876543210
+                         ($$:@#@$) a_T200_7
+    type instance Apply @ErrorMessage @((~>) ErrorMessage ErrorMessage) ($$:@#@$) a_T200_7 = ($$:@#@$$) a_T200_7
     instance SuppressUnusedWarnings ($$:@#@$) where
       suppressUnusedWarnings = snd ((,) (:$$:@#@$###) ())
     type ($$:@#@$$) :: ErrorMessage -> (~>) ErrorMessage ErrorMessage
-    data ($$:@#@$$) (a0123456789876543210 :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage
+    data ($$:@#@$$) (a_T200_7 :: ErrorMessage) :: (~>) ErrorMessage ErrorMessage
       where
-        (:$$:@#@$$###) :: SameKind (Apply (($$:@#@$$) a0123456789876543210) arg) (($$:@#@$$$) a0123456789876543210 arg) =>
-                          ($$:@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @ErrorMessage @ErrorMessage (($$:@#@$$) a0123456789876543210) a0123456789876543210 = ($$:) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (($$:@#@$$) a0123456789876543210) where
+        (:$$:@#@$$###) :: SameKind (Apply (($$:@#@$$) a_T200_7) arg) (($$:@#@$$$) a_T200_7 arg) =>
+                          ($$:@#@$$) a_T200_7 a_T200_8
+    type instance Apply @ErrorMessage @ErrorMessage (($$:@#@$$) a_T200_7) a_T200_8 = ($$:) a_T200_7 a_T200_8
+    instance SuppressUnusedWarnings (($$:@#@$$) a_T200_7) where
       suppressUnusedWarnings = snd ((,) (:$$:@#@$$###) ())
     type ($$:@#@$$$) :: ErrorMessage -> ErrorMessage -> ErrorMessage
-    type family ($$:@#@$$$) (a0123456789876543210 :: ErrorMessage) (a0123456789876543210 :: ErrorMessage) :: ErrorMessage where
-      ($$:@#@$$$) a0123456789876543210 a0123456789876543210 = ($$:) a0123456789876543210 a0123456789876543210
+    type family ($$:@#@$$$) (a_T200_7 :: ErrorMessage) (a_T200_8 :: ErrorMessage) :: ErrorMessage where
+      ($$:@#@$$$) a_T200_7 a_T200_8 = ($$:) a_T200_7 a_T200_8
     type (<>:) :: ErrorMessage -> ErrorMessage -> ErrorMessage
     type family (<>:) (a :: ErrorMessage) (a :: ErrorMessage) :: ErrorMessage where
       (<>:) x y = Apply (Apply (:<>:@#@$) x) y

--- a/singletons-base/tests/compile-and-dump/Singletons/T204.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T204.golden
@@ -19,40 +19,40 @@ Singletons/T204.hs:(0,0)-(0,0): Splicing declarations
     data (:%@#@$) :: (~>) a ((~>) a (Ratio1 a))
       where
         (::%@#@$###) :: SameKind (Apply (:%@#@$) arg) ((:%@#@$$) arg) =>
-                        (:%@#@$) a0123456789876543210
-    type instance Apply @a @((~>) a (Ratio1 a)) (:%@#@$) a0123456789876543210 = (:%@#@$$) a0123456789876543210
+                        (:%@#@$) a_T204_0
+    type instance Apply @a @((~>) a (Ratio1 a)) (:%@#@$) a_T204_0 = (:%@#@$$) a_T204_0
     instance SuppressUnusedWarnings (:%@#@$) where
       suppressUnusedWarnings = snd ((,) (::%@#@$###) ())
     type (:%@#@$$) :: forall a. a -> (~>) a (Ratio1 a)
-    data (:%@#@$$) (a0123456789876543210 :: a) :: (~>) a (Ratio1 a)
+    data (:%@#@$$) (a_T204_0 :: a) :: (~>) a (Ratio1 a)
       where
-        (::%@#@$$###) :: SameKind (Apply ((:%@#@$$) a0123456789876543210) arg) ((:%@#@$$$) a0123456789876543210 arg) =>
-                         (:%@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @a @(Ratio1 a) ((:%@#@$$) a0123456789876543210) a0123456789876543210 = (:%) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((:%@#@$$) a0123456789876543210) where
+        (::%@#@$$###) :: SameKind (Apply ((:%@#@$$) a_T204_0) arg) ((:%@#@$$$) a_T204_0 arg) =>
+                         (:%@#@$$) a_T204_0 a_T204_1
+    type instance Apply @a @(Ratio1 a) ((:%@#@$$) a_T204_0) a_T204_1 = (:%) a_T204_0 a_T204_1
+    instance SuppressUnusedWarnings ((:%@#@$$) a_T204_0) where
       suppressUnusedWarnings = snd ((,) (::%@#@$$###) ())
     type (:%@#@$$$) :: forall a. a -> a -> Ratio1 a
-    type family (:%@#@$$$) @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Ratio1 a where
-      (:%@#@$$$) a0123456789876543210 a0123456789876543210 = (:%) a0123456789876543210 a0123456789876543210
+    type family (:%@#@$$$) @a (a_T204_0 :: a) (a_T204_1 :: a) :: Ratio1 a where
+      (:%@#@$$$) a_T204_0 a_T204_1 = (:%) a_T204_0 a_T204_1
     type (:%%@#@$) :: forall a. (~>) a ((~>) a (Ratio2 a))
     data (:%%@#@$) :: (~>) a ((~>) a (Ratio2 a))
       where
         (::%%@#@$###) :: SameKind (Apply (:%%@#@$) arg) ((:%%@#@$$) arg) =>
-                         (:%%@#@$) a0123456789876543210
-    type instance Apply @a @((~>) a (Ratio2 a)) (:%%@#@$) a0123456789876543210 = (:%%@#@$$) a0123456789876543210
+                         (:%%@#@$) a_T204_2
+    type instance Apply @a @((~>) a (Ratio2 a)) (:%%@#@$) a_T204_2 = (:%%@#@$$) a_T204_2
     instance SuppressUnusedWarnings (:%%@#@$) where
       suppressUnusedWarnings = snd ((,) (::%%@#@$###) ())
     type (:%%@#@$$) :: forall a. a -> (~>) a (Ratio2 a)
-    data (:%%@#@$$) (a0123456789876543210 :: a) :: (~>) a (Ratio2 a)
+    data (:%%@#@$$) (a_T204_2 :: a) :: (~>) a (Ratio2 a)
       where
-        (::%%@#@$$###) :: SameKind (Apply ((:%%@#@$$) a0123456789876543210) arg) ((:%%@#@$$$) a0123456789876543210 arg) =>
-                          (:%%@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @a @(Ratio2 a) ((:%%@#@$$) a0123456789876543210) a0123456789876543210 = (:%%) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((:%%@#@$$) a0123456789876543210) where
+        (::%%@#@$$###) :: SameKind (Apply ((:%%@#@$$) a_T204_2) arg) ((:%%@#@$$$) a_T204_2 arg) =>
+                          (:%%@#@$$) a_T204_2 a_T204_3
+    type instance Apply @a @(Ratio2 a) ((:%%@#@$$) a_T204_2) a_T204_3 = (:%%) a_T204_2 a_T204_3
+    instance SuppressUnusedWarnings ((:%%@#@$$) a_T204_2) where
       suppressUnusedWarnings = snd ((,) (::%%@#@$$###) ())
     type (:%%@#@$$$) :: forall a. a -> a -> Ratio2 a
-    type family (:%%@#@$$$) @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Ratio2 a where
-      (:%%@#@$$$) a0123456789876543210 a0123456789876543210 = (:%%) a0123456789876543210 a0123456789876543210
+    type family (:%%@#@$$$) @a (a_T204_2 :: a) (a_T204_3 :: a) :: Ratio2 a where
+      (:%%@#@$$$) a_T204_2 a_T204_3 = (:%%) a_T204_2 a_T204_3
     data SRatio1 :: forall a. Ratio1 a -> GHC.Internal.Types.Type
       where
         (:^%) :: forall a (n :: a) (n :: a).

--- a/singletons-base/tests/compile-and-dump/Singletons/T209.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T209.golden
@@ -24,29 +24,29 @@ Singletons/T209.hs:(0,0)-(0,0): Splicing declarations
     data MSym0 :: (~>) a ((~>) b ((~>) Bool Bool))
       where
         MSym0KindInference :: SameKind (Apply MSym0 arg) (MSym1 arg) =>
-                              MSym0 a0123456789876543210
-    type instance Apply @a @((~>) b ((~>) Bool Bool)) MSym0 a0123456789876543210 = MSym1 a0123456789876543210
+                              MSym0 a_T209_0
+    type instance Apply @a @((~>) b ((~>) Bool Bool)) MSym0 a_T209_0 = MSym1 a_T209_0
     instance SuppressUnusedWarnings MSym0 where
       suppressUnusedWarnings = snd ((,) MSym0KindInference ())
     type MSym1 :: a -> (~>) b ((~>) Bool Bool)
-    data MSym1 (a0123456789876543210 :: a) :: (~>) b ((~>) Bool Bool)
+    data MSym1 (a_T209_0 :: a) :: (~>) b ((~>) Bool Bool)
       where
-        MSym1KindInference :: SameKind (Apply (MSym1 a0123456789876543210) arg) (MSym2 a0123456789876543210 arg) =>
-                              MSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @((~>) Bool Bool) (MSym1 a0123456789876543210) a0123456789876543210 = MSym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (MSym1 a0123456789876543210) where
+        MSym1KindInference :: SameKind (Apply (MSym1 a_T209_0) arg) (MSym2 a_T209_0 arg) =>
+                              MSym1 a_T209_0 a_T209_1
+    type instance Apply @b @((~>) Bool Bool) (MSym1 a_T209_0) a_T209_1 = MSym2 a_T209_0 a_T209_1
+    instance SuppressUnusedWarnings (MSym1 a_T209_0) where
       suppressUnusedWarnings = snd ((,) MSym1KindInference ())
     type MSym2 :: a -> b -> (~>) Bool Bool
-    data MSym2 (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: (~>) Bool Bool
+    data MSym2 (a_T209_0 :: a) (a_T209_1 :: b) :: (~>) Bool Bool
       where
-        MSym2KindInference :: SameKind (Apply (MSym2 a0123456789876543210 a0123456789876543210) arg) (MSym3 a0123456789876543210 a0123456789876543210 arg) =>
-                              MSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @Bool @Bool (MSym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = M a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (MSym2 a0123456789876543210 a0123456789876543210) where
+        MSym2KindInference :: SameKind (Apply (MSym2 a_T209_0 a_T209_1) arg) (MSym3 a_T209_0 a_T209_1 arg) =>
+                              MSym2 a_T209_0 a_T209_1 a_T209_2
+    type instance Apply @Bool @Bool (MSym2 a_T209_0 a_T209_1) a_T209_2 = M a_T209_0 a_T209_1 a_T209_2
+    instance SuppressUnusedWarnings (MSym2 a_T209_0 a_T209_1) where
       suppressUnusedWarnings = snd ((,) MSym2KindInference ())
     type MSym3 :: a -> b -> Bool -> Bool
-    type family MSym3 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) (a0123456789876543210 :: Bool) :: Bool where
-      MSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = M a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type family MSym3 @a @b (a_T209_0 :: a) (a_T209_1 :: b) (a_T209_2 :: Bool) :: Bool where
+      MSym3 a_T209_0 a_T209_1 a_T209_2 = M a_T209_0 a_T209_1 a_T209_2
     type M :: a -> b -> Bool -> Bool
     type family M @a @b (a :: a) (a :: b) (a :: Bool) :: Bool where
       M _ _ x = x

--- a/singletons-base/tests/compile-and-dump/Singletons/T216.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T216.golden
@@ -1,42 +1,42 @@
 Singletons/T216.hs:0:0:: Splicing declarations
     genDefunSymbols [''MyProxy, ''Symmetry]
   ======>
-    data MyProxySym0 :: (~>) Type ((~>) k0123456789876543210 Type)
+    data MyProxySym0 :: (~>) Type ((~>) k0 Type)
       where
         MyProxySym0KindInference :: SameKind (Apply MyProxySym0 arg) (MyProxySym1 arg) =>
-                                    MyProxySym0 k0123456789876543210
-    type instance Apply @Type @((~>) k0123456789876543210 Type) MyProxySym0 k0123456789876543210 = MyProxySym1 k0123456789876543210
+                                    MyProxySym0 k0
+    type instance Apply @Type @((~>) k0 Type) MyProxySym0 k0 = MyProxySym1 k0
     instance SuppressUnusedWarnings MyProxySym0 where
       suppressUnusedWarnings = snd ((,) MyProxySym0KindInference ())
-    data MyProxySym1 (k0123456789876543210 :: Type) :: (~>) k0123456789876543210 Type
+    data MyProxySym1 (k0 :: Type) :: (~>) k0 Type
       where
-        MyProxySym1KindInference :: SameKind (Apply (MyProxySym1 k0123456789876543210) arg) (MyProxySym2 k0123456789876543210 arg) =>
-                                    MyProxySym1 k0123456789876543210 e0123456789876543210
-    type instance Apply @k0123456789876543210 @Type (MyProxySym1 k0123456789876543210) e0123456789876543210 = MyProxy k0123456789876543210 e0123456789876543210
-    instance SuppressUnusedWarnings (MyProxySym1 k0123456789876543210) where
+        MyProxySym1KindInference :: SameKind (Apply (MyProxySym1 k0) arg) (MyProxySym2 k0 arg) =>
+                                    MyProxySym1 k0 e_T216_0
+    type instance Apply @k0 @Type (MyProxySym1 k0) e_T216_0 = MyProxy k0 e_T216_0
+    instance SuppressUnusedWarnings (MyProxySym1 k0) where
       suppressUnusedWarnings = snd ((,) MyProxySym1KindInference ())
-    type family MyProxySym2 (k0123456789876543210 :: Type) (e0123456789876543210 :: k0123456789876543210) :: Type where
-      MyProxySym2 k0123456789876543210 e0123456789876543210 = MyProxy k0123456789876543210 e0123456789876543210
-    data SymmetrySym0 :: (~>) t0123456789876543210 ((~>) t0123456789876543210 ((~>) ((:~:) a0123456789876543210 y0123456789876543210) Type))
+    type family MyProxySym2 (k0 :: Type) (e_T216_0 :: k0) :: Type where
+      MyProxySym2 k0 e_T216_0 = MyProxy k0 e_T216_0
+    data SymmetrySym0 :: (~>) t0 ((~>) t0 ((~>) ((:~:) a1 y2) Type))
       where
         SymmetrySym0KindInference :: SameKind (Apply SymmetrySym0 arg) (SymmetrySym1 arg) =>
-                                     SymmetrySym0 a0123456789876543210
-    type instance Apply @t0123456789876543210 @((~>) t0123456789876543210 ((~>) ((:~:) a0123456789876543210 y0123456789876543210) Type)) SymmetrySym0 a0123456789876543210 = SymmetrySym1 a0123456789876543210
+                                     SymmetrySym0 a1
+    type instance Apply @t0 @((~>) t0 ((~>) ((:~:) a1 y2) Type)) SymmetrySym0 a1 = SymmetrySym1 a1
     instance SuppressUnusedWarnings SymmetrySym0 where
       suppressUnusedWarnings = snd ((,) SymmetrySym0KindInference ())
-    data SymmetrySym1 (a0123456789876543210 :: t0123456789876543210) :: (~>) t0123456789876543210 ((~>) ((:~:) a0123456789876543210 y0123456789876543210) Type)
+    data SymmetrySym1 (a1 :: t0) :: (~>) t0 ((~>) ((:~:) a1 y2) Type)
       where
-        SymmetrySym1KindInference :: SameKind (Apply (SymmetrySym1 a0123456789876543210) arg) (SymmetrySym2 a0123456789876543210 arg) =>
-                                     SymmetrySym1 a0123456789876543210 y0123456789876543210
-    type instance Apply @t0123456789876543210 @((~>) ((:~:) a0123456789876543210 y0123456789876543210) Type) (SymmetrySym1 a0123456789876543210) y0123456789876543210 = SymmetrySym2 a0123456789876543210 y0123456789876543210
-    instance SuppressUnusedWarnings (SymmetrySym1 a0123456789876543210) where
+        SymmetrySym1KindInference :: SameKind (Apply (SymmetrySym1 a1) arg) (SymmetrySym2 a1 arg) =>
+                                     SymmetrySym1 a1 y2
+    type instance Apply @t0 @((~>) ((:~:) a1 y2) Type) (SymmetrySym1 a1) y2 = SymmetrySym2 a1 y2
+    instance SuppressUnusedWarnings (SymmetrySym1 a1) where
       suppressUnusedWarnings = snd ((,) SymmetrySym1KindInference ())
-    data SymmetrySym2 (a0123456789876543210 :: t0123456789876543210) (y0123456789876543210 :: t0123456789876543210) :: (~>) ((:~:) a0123456789876543210 y0123456789876543210) Type
+    data SymmetrySym2 (a1 :: t0) (y2 :: t0) :: (~>) ((:~:) a1 y2) Type
       where
-        SymmetrySym2KindInference :: SameKind (Apply (SymmetrySym2 a0123456789876543210 y0123456789876543210) arg) (SymmetrySym3 a0123456789876543210 y0123456789876543210 arg) =>
-                                     SymmetrySym2 a0123456789876543210 y0123456789876543210 e0123456789876543210
-    type instance Apply @((:~:) a0123456789876543210 y0123456789876543210) @Type (SymmetrySym2 a0123456789876543210 y0123456789876543210) e0123456789876543210 = Symmetry a0123456789876543210 y0123456789876543210 e0123456789876543210
-    instance SuppressUnusedWarnings (SymmetrySym2 a0123456789876543210 y0123456789876543210) where
+        SymmetrySym2KindInference :: SameKind (Apply (SymmetrySym2 a1 y2) arg) (SymmetrySym3 a1 y2 arg) =>
+                                     SymmetrySym2 a1 y2 e_T216_1
+    type instance Apply @((:~:) a1 y2) @Type (SymmetrySym2 a1 y2) e_T216_1 = Symmetry a1 y2 e_T216_1
+    instance SuppressUnusedWarnings (SymmetrySym2 a1 y2) where
       suppressUnusedWarnings = snd ((,) SymmetrySym2KindInference ())
-    type family SymmetrySym3 (a0123456789876543210 :: t0123456789876543210) (y0123456789876543210 :: t0123456789876543210) (e0123456789876543210 :: (:~:) a0123456789876543210 y0123456789876543210) :: Type where
-      SymmetrySym3 a0123456789876543210 y0123456789876543210 e0123456789876543210 = Symmetry a0123456789876543210 y0123456789876543210 e0123456789876543210
+    type family SymmetrySym3 (a1 :: t0) (y2 :: t0) (e_T216_1 :: (:~:) a1 y2) :: Type where
+      SymmetrySym3 a1 y2 e_T216_1 = Symmetry a1 y2 e_T216_1

--- a/singletons-base/tests/compile-and-dump/Singletons/T229.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T229.golden
@@ -9,13 +9,13 @@ Singletons/T229.hs:(0,0)-(0,0): Splicing declarations
     data US___fooSym0 :: (~>) Bool Bool
       where
         US___fooSym0KindInference :: SameKind (Apply US___fooSym0 arg) (US___fooSym1 arg) =>
-                                     US___fooSym0 a0123456789876543210
-    type instance Apply @Bool @Bool US___fooSym0 a0123456789876543210 = US___foo a0123456789876543210
+                                     US___fooSym0 a_T229_0
+    type instance Apply @Bool @Bool US___fooSym0 a_T229_0 = US___foo a_T229_0
     instance SuppressUnusedWarnings US___fooSym0 where
       suppressUnusedWarnings = snd ((,) US___fooSym0KindInference ())
     type US___fooSym1 :: Bool -> Bool
-    type family US___fooSym1 (a0123456789876543210 :: Bool) :: Bool where
-      US___fooSym1 a0123456789876543210 = US___foo a0123456789876543210
+    type family US___fooSym1 (a_T229_0 :: Bool) :: Bool where
+      US___fooSym1 a_T229_0 = US___foo a_T229_0
     type US___foo :: Bool -> Bool
     type family US___foo (a :: Bool) :: Bool where
       US___foo _ = TrueSym0

--- a/singletons-base/tests/compile-and-dump/Singletons/T249.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T249.golden
@@ -11,35 +11,35 @@ Singletons/T249.hs:(0,0)-(0,0): Splicing declarations
     data MkFoo1Sym0 :: (~>) a (Foo1 a)
       where
         MkFoo1Sym0KindInference :: SameKind (Apply MkFoo1Sym0 arg) (MkFoo1Sym1 arg) =>
-                                   MkFoo1Sym0 a0123456789876543210
-    type instance Apply @a @(Foo1 a) MkFoo1Sym0 a0123456789876543210 = MkFoo1 a0123456789876543210
+                                   MkFoo1Sym0 a_T249_0
+    type instance Apply @a @(Foo1 a) MkFoo1Sym0 a_T249_0 = MkFoo1 a_T249_0
     instance SuppressUnusedWarnings MkFoo1Sym0 where
       suppressUnusedWarnings = snd ((,) MkFoo1Sym0KindInference ())
     type MkFoo1Sym1 :: forall a. a -> Foo1 a
-    type family MkFoo1Sym1 @a (a0123456789876543210 :: a) :: Foo1 a where
-      MkFoo1Sym1 a0123456789876543210 = MkFoo1 a0123456789876543210
+    type family MkFoo1Sym1 @a (a_T249_0 :: a) :: Foo1 a where
+      MkFoo1Sym1 a_T249_0 = MkFoo1 a_T249_0
     type MkFoo2Sym0 :: (~>) x (Foo2 x)
     data MkFoo2Sym0 :: (~>) x (Foo2 x)
       where
         MkFoo2Sym0KindInference :: SameKind (Apply MkFoo2Sym0 arg) (MkFoo2Sym1 arg) =>
-                                   MkFoo2Sym0 a0123456789876543210
-    type instance Apply @x @(Foo2 x) MkFoo2Sym0 a0123456789876543210 = MkFoo2 a0123456789876543210
+                                   MkFoo2Sym0 a_T249_1
+    type instance Apply @x @(Foo2 x) MkFoo2Sym0 a_T249_1 = MkFoo2 a_T249_1
     instance SuppressUnusedWarnings MkFoo2Sym0 where
       suppressUnusedWarnings = snd ((,) MkFoo2Sym0KindInference ())
     type MkFoo2Sym1 :: x -> Foo2 x
-    type family MkFoo2Sym1 @x (a0123456789876543210 :: x) :: Foo2 x where
-      MkFoo2Sym1 a0123456789876543210 = MkFoo2 a0123456789876543210
+    type family MkFoo2Sym1 @x (a_T249_1 :: x) :: Foo2 x where
+      MkFoo2Sym1 a_T249_1 = MkFoo2 a_T249_1
     type MkFoo3Sym0 :: forall x. (~>) x (Foo3 x)
     data MkFoo3Sym0 :: (~>) x (Foo3 x)
       where
         MkFoo3Sym0KindInference :: SameKind (Apply MkFoo3Sym0 arg) (MkFoo3Sym1 arg) =>
-                                   MkFoo3Sym0 a0123456789876543210
-    type instance Apply @x @(Foo3 x) MkFoo3Sym0 a0123456789876543210 = MkFoo3 a0123456789876543210
+                                   MkFoo3Sym0 a_T249_2
+    type instance Apply @x @(Foo3 x) MkFoo3Sym0 a_T249_2 = MkFoo3 a_T249_2
     instance SuppressUnusedWarnings MkFoo3Sym0 where
       suppressUnusedWarnings = snd ((,) MkFoo3Sym0KindInference ())
     type MkFoo3Sym1 :: forall x. x -> Foo3 x
-    type family MkFoo3Sym1 @x (a0123456789876543210 :: x) :: Foo3 x where
-      MkFoo3Sym1 a0123456789876543210 = MkFoo3 a0123456789876543210
+    type family MkFoo3Sym1 @x (a_T249_2 :: x) :: Foo3 x where
+      MkFoo3Sym1 a_T249_2 = MkFoo3 a_T249_2
     data SFoo1 :: forall a. Foo1 a -> Type
       where
         SMkFoo1 :: forall a (n :: a).

--- a/singletons-base/tests/compile-and-dump/Singletons/T271.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T271.golden
@@ -18,49 +18,48 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
     data ConstantSym0 :: (~>) a (Constant a b)
       where
         ConstantSym0KindInference :: SameKind (Apply ConstantSym0 arg) (ConstantSym1 arg) =>
-                                     ConstantSym0 a0123456789876543210
-    type instance Apply @a @(Constant a b) ConstantSym0 a0123456789876543210 = Constant a0123456789876543210
+                                     ConstantSym0 a_T271_8
+    type instance Apply @a @(Constant a b) ConstantSym0 a_T271_8 = Constant a_T271_8
     instance SuppressUnusedWarnings ConstantSym0 where
       suppressUnusedWarnings = snd ((,) ConstantSym0KindInference ())
     type ConstantSym1 :: forall (a :: Type) (b :: Type). a
                                                          -> Constant a b
-    type family ConstantSym1 @(a :: Type) @(b :: Type) (a0123456789876543210 :: a) :: Constant a b where
-      ConstantSym1 a0123456789876543210 = Constant a0123456789876543210
+    type family ConstantSym1 @(a :: Type) @(b :: Type) (a_T271_8 :: a) :: Constant a b where
+      ConstantSym1 a_T271_8 = Constant a_T271_8
     type IdentitySym0 :: (~>) a (Identity a)
     data IdentitySym0 :: (~>) a (Identity a)
       where
         IdentitySym0KindInference :: SameKind (Apply IdentitySym0 arg) (IdentitySym1 arg) =>
-                                     IdentitySym0 a0123456789876543210
-    type instance Apply @a @(Identity a) IdentitySym0 a0123456789876543210 = Identity a0123456789876543210
+                                     IdentitySym0 a_T271_9
+    type instance Apply @a @(Identity a) IdentitySym0 a_T271_9 = Identity a_T271_9
     instance SuppressUnusedWarnings IdentitySym0 where
       suppressUnusedWarnings = snd ((,) IdentitySym0KindInference ())
     type IdentitySym1 :: a -> Identity a
-    type family IdentitySym1 @a (a0123456789876543210 :: a) :: Identity a where
-      IdentitySym1 a0123456789876543210 = Identity a0123456789876543210
-    type TFHelper_0123456789876543210 :: forall a b. Constant a b
-                                                     -> Constant a b -> Bool
-    type family TFHelper_0123456789876543210 @a @b (a :: Constant a b) (a :: Constant a b) :: Bool where
-      TFHelper_0123456789876543210 @a @b (Constant a_0123456789876543210 :: Constant a b) (Constant b_0123456789876543210 :: Constant a b) = Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210
+    type family IdentitySym1 @a (a_T271_9 :: a) :: Identity a where
+      IdentitySym1 a_T271_9 = Identity a_T271_9
+    type TFHelper_T271_10 :: forall a b. Constant a b
+                                         -> Constant a b -> Bool
+    type family TFHelper_T271_10 @a @b (a :: Constant a b) (a :: Constant a b) :: Bool where
+      TFHelper_T271_10 @a @b (Constant a_T271_0 :: Constant a b) (Constant b_T271_1 :: Constant a b) = Apply (Apply (==@#@$) a_T271_0) b_T271_1
     instance PEq (Constant a b) where
-      type (==) a a = TFHelper_0123456789876543210 a a
-    type Compare_0123456789876543210 :: forall a b. Constant a b
-                                                    -> Constant a b -> Ordering
-    type family Compare_0123456789876543210 @a @b (a :: Constant a b) (a :: Constant a b) :: Ordering where
-      Compare_0123456789876543210 @a @b (Constant a_0123456789876543210 :: Constant a b) (Constant b_0123456789876543210 :: Constant a b) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0)
+      type (==) a a = TFHelper_T271_10 a a
+    type Compare_T271_13 :: forall a b. Constant a b
+                                        -> Constant a b -> Ordering
+    type family Compare_T271_13 @a @b (a :: Constant a b) (a :: Constant a b) :: Ordering where
+      Compare_T271_13 @a @b (Constant a_T271_2 :: Constant a b) (Constant b_T271_3 :: Constant a b) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_T271_2) b_T271_3)) NilSym0)
     instance POrd (Constant a b) where
-      type Compare a a = Compare_0123456789876543210 a a
-    type TFHelper_0123456789876543210 :: forall a. Identity a
-                                                   -> Identity a -> Bool
-    type family TFHelper_0123456789876543210 @a (a :: Identity a) (a :: Identity a) :: Bool where
-      TFHelper_0123456789876543210 @a (Identity a_0123456789876543210 :: Identity a) (Identity b_0123456789876543210 :: Identity a) = Apply (Apply (==@#@$) a_0123456789876543210) b_0123456789876543210
+      type Compare a a = Compare_T271_13 a a
+    type TFHelper_T271_16 :: forall a. Identity a -> Identity a -> Bool
+    type family TFHelper_T271_16 @a (a :: Identity a) (a :: Identity a) :: Bool where
+      TFHelper_T271_16 @a (Identity a_T271_4 :: Identity a) (Identity b_T271_5 :: Identity a) = Apply (Apply (==@#@$) a_T271_4) b_T271_5
     instance PEq (Identity a) where
-      type (==) a a = TFHelper_0123456789876543210 a a
-    type Compare_0123456789876543210 :: forall a. Identity a
-                                                  -> Identity a -> Ordering
-    type family Compare_0123456789876543210 @a (a :: Identity a) (a :: Identity a) :: Ordering where
-      Compare_0123456789876543210 @a (Identity a_0123456789876543210 :: Identity a) (Identity b_0123456789876543210 :: Identity a) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_0123456789876543210) b_0123456789876543210)) NilSym0)
+      type (==) a a = TFHelper_T271_16 a a
+    type Compare_T271_19 :: forall a. Identity a
+                                      -> Identity a -> Ordering
+    type family Compare_T271_19 @a (a :: Identity a) (a :: Identity a) :: Ordering where
+      Compare_T271_19 @a (Identity a_T271_6 :: Identity a) (Identity b_T271_7 :: Identity a) = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) (Apply (Apply (:@#@$) (Apply (Apply CompareSym0 a_T271_6) b_T271_7)) NilSym0)
     instance POrd (Identity a) where
-      type Compare a a = Compare_0123456789876543210 a a
+      type Compare a a = Compare_T271_19 a a
     data SConstant :: forall (a :: Type) (b :: Type).
                       Constant a b -> Type
       where
@@ -86,15 +85,14 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
             (toSing b :: SomeSing a)
     instance SEq a => SEq (Constant a b) where
       (%==)
-        (SConstant (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SConstant (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SConstant (sA_T271_0 :: Sing a_T271_0))
+        (SConstant (sB_T271_1 :: Sing b_T271_1))
         = applySing
-            (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-            sB_0123456789876543210
+            (applySing (singFun2 @(==@#@$) (%==)) sA_T271_0) sB_T271_1
     instance SOrd a => SOrd (Constant a b) where
       sCompare
-        (SConstant (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SConstant (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SConstant (sA_T271_2 :: Sing a_T271_2))
+        (SConstant (sB_T271_3 :: Sing b_T271_3))
         = applySing
             (applySing
                (applySing (singFun3 @FoldlSym0 sFoldl) (singFun2 @(<>@#@$) (%<>)))
@@ -103,20 +101,18 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
                (applySing
                   (singFun2 @(:@#@$) SCons)
                   (applySing
-                     (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                     sB_0123456789876543210))
+                     (applySing (singFun2 @CompareSym0 sCompare) sA_T271_2) sB_T271_3))
                SNil)
     instance SEq a => SEq (Identity a) where
       (%==)
-        (SIdentity (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SIdentity (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SIdentity (sA_T271_4 :: Sing a_T271_4))
+        (SIdentity (sB_T271_5 :: Sing b_T271_5))
         = applySing
-            (applySing (singFun2 @(==@#@$) (%==)) sA_0123456789876543210)
-            sB_0123456789876543210
+            (applySing (singFun2 @(==@#@$) (%==)) sA_T271_4) sB_T271_5
     instance SOrd a => SOrd (Identity a) where
       sCompare
-        (SIdentity (sA_0123456789876543210 :: Sing a_0123456789876543210))
-        (SIdentity (sB_0123456789876543210 :: Sing b_0123456789876543210))
+        (SIdentity (sA_T271_6 :: Sing a_T271_6))
+        (SIdentity (sB_T271_7 :: Sing b_T271_7))
         = applySing
             (applySing
                (applySing (singFun3 @FoldlSym0 sFoldl) (singFun2 @(<>@#@$) (%<>)))
@@ -125,8 +121,7 @@ Singletons/T271.hs:(0,0)-(0,0): Splicing declarations
                (applySing
                   (singFun2 @(:@#@$) SCons)
                   (applySing
-                     (applySing (singFun2 @CompareSym0 sCompare) sA_0123456789876543210)
-                     sB_0123456789876543210))
+                     (applySing (singFun2 @CompareSym0 sCompare) sA_T271_6) sB_T271_7))
                SNil)
     instance SDecide a => SDecide (Constant a b) where
       (%~) (SConstant a) (SConstant b)

--- a/singletons-base/tests/compile-and-dump/Singletons/T287.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T287.golden
@@ -14,41 +14,41 @@ Singletons/T287.hs:(0,0)-(0,0): Splicing declarations
     data (<<>>@#@$) :: (~>) a ((~>) a a)
       where
         (:<<>>@#@$###) :: SameKind (Apply (<<>>@#@$) arg) ((<<>>@#@$$) arg) =>
-                          (<<>>@#@$) a0123456789876543210
-    type instance Apply @a @((~>) a a) (<<>>@#@$) a0123456789876543210 = (<<>>@#@$$) a0123456789876543210
+                          (<<>>@#@$) a_T287_0
+    type instance Apply @a @((~>) a a) (<<>>@#@$) a_T287_0 = (<<>>@#@$$) a_T287_0
     instance SuppressUnusedWarnings (<<>>@#@$) where
       suppressUnusedWarnings = snd ((,) (:<<>>@#@$###) ())
     type (<<>>@#@$$) :: forall a. a -> (~>) a a
-    data (<<>>@#@$$) (a0123456789876543210 :: a) :: (~>) a a
+    data (<<>>@#@$$) (a_T287_0 :: a) :: (~>) a a
       where
-        (:<<>>@#@$$###) :: SameKind (Apply ((<<>>@#@$$) a0123456789876543210) arg) ((<<>>@#@$$$) a0123456789876543210 arg) =>
-                           (<<>>@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @a @a ((<<>>@#@$$) a0123456789876543210) a0123456789876543210 = (<<>>) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((<<>>@#@$$) a0123456789876543210) where
+        (:<<>>@#@$$###) :: SameKind (Apply ((<<>>@#@$$) a_T287_0) arg) ((<<>>@#@$$$) a_T287_0 arg) =>
+                           (<<>>@#@$$) a_T287_0 a_T287_1
+    type instance Apply @a @a ((<<>>@#@$$) a_T287_0) a_T287_1 = (<<>>) a_T287_0 a_T287_1
+    instance SuppressUnusedWarnings ((<<>>@#@$$) a_T287_0) where
       suppressUnusedWarnings = snd ((,) (:<<>>@#@$$###) ())
     type (<<>>@#@$$$) :: forall a. a -> a -> a
-    type family (<<>>@#@$$$) @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: a where
-      (<<>>@#@$$$) a0123456789876543210 a0123456789876543210 = (<<>>) a0123456789876543210 a0123456789876543210
+    type family (<<>>@#@$$$) @a (a_T287_0 :: a) (a_T287_1 :: a) :: a where
+      (<<>>@#@$$$) a_T287_0 a_T287_1 = (<<>>) a_T287_0 a_T287_1
     class PS a where
       type family (<<>>) (arg :: a) (arg :: a) :: a
-    type family LamCases_0123456789876543210 a0123456789876543210 b0123456789876543210 (f0123456789876543210 :: (~>) a0123456789876543210 b0123456789876543210) (g0123456789876543210 :: (~>) a0123456789876543210 b0123456789876543210) a_0123456789876543210 where
-      LamCases_0123456789876543210 a b f g x = Apply (Apply (<<>>@#@$) (Apply f x)) (Apply g x)
-    data LamCases_0123456789876543210Sym0 a0123456789876543210 b0123456789876543210 (f0123456789876543210 :: (~>) a0123456789876543210 b0123456789876543210) (g0123456789876543210 :: (~>) a0123456789876543210 b0123456789876543210) a_01234567898765432100123456789876543210
+    type family LamCases_T287_5 a0 b1 (f2 :: (~>) a0 b1) (g3 :: (~>) a0 b1) a_T287_6 where
+      LamCases_T287_5 a b f g x = Apply (Apply (<<>>@#@$) (Apply f x)) (Apply g x)
+    data LamCases_T287_5Sym0 a0 b1 (f2 :: (~>) a0 b1) (g3 :: (~>) a0 b1) a_T287_6
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 a0123456789876543210 b0123456789876543210 f0123456789876543210 g0123456789876543210) arg) (LamCases_0123456789876543210Sym1 a0123456789876543210 b0123456789876543210 f0123456789876543210 g0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a0123456789876543210 b0123456789876543210 f0123456789876543210 g0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 a0123456789876543210 b0123456789876543210 f0123456789876543210 g0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a0123456789876543210 b0123456789876543210 f0123456789876543210 g0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 a0123456789876543210 b0123456789876543210 f0123456789876543210 g0123456789876543210) where
+        LamCases_T287_5Sym0KindInference :: SameKind (Apply (LamCases_T287_5Sym0 a0 b1 f2 g3) arg) (LamCases_T287_5Sym1 a0 b1 f2 g3 arg) =>
+                                            LamCases_T287_5Sym0 a0 b1 f2 g3 a_T287_6
+    type instance Apply @_ @_ (LamCases_T287_5Sym0 a0 b1 f2 g3) a_T287_6 = LamCases_T287_5 a0 b1 f2 g3 a_T287_6
+    instance SuppressUnusedWarnings (LamCases_T287_5Sym0 a0 b1 f2 g3) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 a0123456789876543210 b0123456789876543210 (f0123456789876543210 :: (~>) a0123456789876543210 b0123456789876543210) (g0123456789876543210 :: (~>) a0123456789876543210 b0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a0123456789876543210 b0123456789876543210 f0123456789876543210 g0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a0123456789876543210 b0123456789876543210 f0123456789876543210 g0123456789876543210 a_01234567898765432100123456789876543210
-    type TFHelper_0123456789876543210 :: forall a b. (~>) a b
-                                                     -> (~>) a b -> (~>) a b
-    type family TFHelper_0123456789876543210 @a @b (a :: (~>) a b) (a :: (~>) a b) :: (~>) a b where
-      TFHelper_0123456789876543210 @a @b (f :: (~>) a b) (g :: (~>) a b) = LamCases_0123456789876543210Sym0 a b f g
+        = snd ((,) LamCases_T287_5Sym0KindInference ())
+    type family LamCases_T287_5Sym1 a0 b1 (f2 :: (~>) a0 b1) (g3 :: (~>) a0 b1) a_T287_6 where
+      LamCases_T287_5Sym1 a0 b1 f2 g3 a_T287_6 = LamCases_T287_5 a0 b1 f2 g3 a_T287_6
+    type TFHelper_T287_2 :: forall a b. (~>) a b
+                                        -> (~>) a b -> (~>) a b
+    type family TFHelper_T287_2 @a @b (a :: (~>) a b) (a :: (~>) a b) :: (~>) a b where
+      TFHelper_T287_2 @a @b (f :: (~>) a b) (g :: (~>) a b) = LamCases_T287_5Sym0 a b f g
     instance PS ((~>) a b) where
-      type (<<>>) a a = TFHelper_0123456789876543210 a a
+      type (<<>>) a a = TFHelper_T287_2 a a
     class SS a where
       (%<<>>) ::
         (forall (t :: a) (t :: a).
@@ -56,7 +56,7 @@ Singletons/T287.hs:(0,0)-(0,0): Splicing declarations
     instance SS b => SS ((~>) a b) where
       (%<<>>) (sF :: Sing f) (sG :: Sing g)
         = singFun1
-            @(LamCases_0123456789876543210Sym0 a b f g)
+            @(LamCases_T287_5Sym0 a b f g)
             (\cases
                (sX :: Sing x)
                  -> applySing

--- a/singletons-base/tests/compile-and-dump/Singletons/T29.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T29.golden
@@ -21,46 +21,46 @@ Singletons/T29.hs:(0,0)-(0,0): Splicing declarations
     data BanSym0 :: (~>) Bool Bool
       where
         BanSym0KindInference :: SameKind (Apply BanSym0 arg) (BanSym1 arg) =>
-                                BanSym0 a0123456789876543210
-    type instance Apply @Bool @Bool BanSym0 a0123456789876543210 = Ban a0123456789876543210
+                                BanSym0 a_Singletons_T29_0
+    type instance Apply @Bool @Bool BanSym0 a_Singletons_T29_0 = Ban a_Singletons_T29_0
     instance SuppressUnusedWarnings BanSym0 where
       suppressUnusedWarnings = snd ((,) BanSym0KindInference ())
     type BanSym1 :: Bool -> Bool
-    type family BanSym1 (a0123456789876543210 :: Bool) :: Bool where
-      BanSym1 a0123456789876543210 = Ban a0123456789876543210
+    type family BanSym1 (a_Singletons_T29_0 :: Bool) :: Bool where
+      BanSym1 a_Singletons_T29_0 = Ban a_Singletons_T29_0
     type BazSym0 :: (~>) Bool Bool
     data BazSym0 :: (~>) Bool Bool
       where
         BazSym0KindInference :: SameKind (Apply BazSym0 arg) (BazSym1 arg) =>
-                                BazSym0 a0123456789876543210
-    type instance Apply @Bool @Bool BazSym0 a0123456789876543210 = Baz a0123456789876543210
+                                BazSym0 a_Singletons_T29_1
+    type instance Apply @Bool @Bool BazSym0 a_Singletons_T29_1 = Baz a_Singletons_T29_1
     instance SuppressUnusedWarnings BazSym0 where
       suppressUnusedWarnings = snd ((,) BazSym0KindInference ())
     type BazSym1 :: Bool -> Bool
-    type family BazSym1 (a0123456789876543210 :: Bool) :: Bool where
-      BazSym1 a0123456789876543210 = Baz a0123456789876543210
+    type family BazSym1 (a_Singletons_T29_1 :: Bool) :: Bool where
+      BazSym1 a_Singletons_T29_1 = Baz a_Singletons_T29_1
     type BarSym0 :: (~>) Bool Bool
     data BarSym0 :: (~>) Bool Bool
       where
         BarSym0KindInference :: SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
-                                BarSym0 a0123456789876543210
-    type instance Apply @Bool @Bool BarSym0 a0123456789876543210 = Bar a0123456789876543210
+                                BarSym0 a_Singletons_T29_2
+    type instance Apply @Bool @Bool BarSym0 a_Singletons_T29_2 = Bar a_Singletons_T29_2
     instance SuppressUnusedWarnings BarSym0 where
       suppressUnusedWarnings = snd ((,) BarSym0KindInference ())
     type BarSym1 :: Bool -> Bool
-    type family BarSym1 (a0123456789876543210 :: Bool) :: Bool where
-      BarSym1 a0123456789876543210 = Bar a0123456789876543210
+    type family BarSym1 (a_Singletons_T29_2 :: Bool) :: Bool where
+      BarSym1 a_Singletons_T29_2 = Bar a_Singletons_T29_2
     type FooSym0 :: (~>) Bool Bool
     data FooSym0 :: (~>) Bool Bool
       where
         FooSym0KindInference :: SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
-                                FooSym0 a0123456789876543210
-    type instance Apply @Bool @Bool FooSym0 a0123456789876543210 = Foo a0123456789876543210
+                                FooSym0 a_Singletons_T29_3
+    type instance Apply @Bool @Bool FooSym0 a_Singletons_T29_3 = Foo a_Singletons_T29_3
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings = snd ((,) FooSym0KindInference ())
     type FooSym1 :: Bool -> Bool
-    type family FooSym1 (a0123456789876543210 :: Bool) :: Bool where
-      FooSym1 a0123456789876543210 = Foo a0123456789876543210
+    type family FooSym1 (a_Singletons_T29_3 :: Bool) :: Bool where
+      FooSym1 a_Singletons_T29_3 = Foo a_Singletons_T29_3
     type Ban :: Bool -> Bool
     type family Ban (a :: Bool) :: Bool where
       Ban x = Apply (Apply ($!@#@$) (Apply (Apply (.@#@$) NotSym0) (Apply (Apply (.@#@$) NotSym0) NotSym0))) x

--- a/singletons-base/tests/compile-and-dump/Singletons/T296.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T296.golden
@@ -23,35 +23,35 @@ Singletons/T296.hs:(0,0)-(0,0): Splicing declarations
     type MyProxySym0 :: forall (a :: Type). MyProxy a
     type family MyProxySym0 @(a :: Type) :: MyProxy a where
       MyProxySym0 = MyProxy
-    type family Let0123456789876543210ZSym0 a0123456789876543210 :: MyProxy a0123456789876543210 where
-      Let0123456789876543210ZSym0 a0123456789876543210 = Let0123456789876543210Z a0123456789876543210
-    type family Let0123456789876543210Z a0123456789876543210 :: MyProxy a0123456789876543210 where
-      Let0123456789876543210Z a = MyProxySym0
-    type family Let0123456789876543210XSym0 a0123456789876543210 where
-      Let0123456789876543210XSym0 a0123456789876543210 = Let0123456789876543210X a0123456789876543210
-    type family Let0123456789876543210X a0123456789876543210 where
-      Let0123456789876543210X a = Let0123456789876543210ZSym0 a
+    type family Let2ZSym0 a0 :: MyProxy a0 where
+      Let2ZSym0 a0 = Let2Z a0
+    type family Let2Z a0 :: MyProxy a0 where
+      Let2Z a = MyProxySym0
+    type family Let1XSym0 a0 where
+      Let1XSym0 a0 = Let1X a0
+    type family Let1X a0 where
+      Let1X a = Let2ZSym0 a
     type FSym0 :: forall a. (~>) (MyProxy a) (MyProxy a)
     data FSym0 :: (~>) (MyProxy a) (MyProxy a)
       where
         FSym0KindInference :: SameKind (Apply FSym0 arg) (FSym1 arg) =>
-                              FSym0 a0123456789876543210
-    type instance Apply @(MyProxy a) @(MyProxy a) FSym0 a0123456789876543210 = F a0123456789876543210
+                              FSym0 a_T296_0
+    type instance Apply @(MyProxy a) @(MyProxy a) FSym0 a_T296_0 = F a_T296_0
     instance SuppressUnusedWarnings FSym0 where
       suppressUnusedWarnings = snd ((,) FSym0KindInference ())
     type FSym1 :: forall a. MyProxy a -> MyProxy a
-    type family FSym1 @a (a0123456789876543210 :: MyProxy a) :: MyProxy a where
-      FSym1 a0123456789876543210 = F a0123456789876543210
+    type family FSym1 @a (a_T296_0 :: MyProxy a) :: MyProxy a where
+      FSym1 a_T296_0 = F a_T296_0
     type F :: forall a. MyProxy a -> MyProxy a
     type family F @a (a :: MyProxy a) :: MyProxy a where
-      F @a (MyProxy :: MyProxy a) = Let0123456789876543210XSym0 a
+      F @a (MyProxy :: MyProxy a) = Let1XSym0 a
     sF :: forall a (t :: MyProxy a). Sing t -> Sing (F t :: MyProxy a)
     sF SMyProxy
       = let
-          sX :: Sing @_ (Let0123456789876543210X a)
+          sX :: Sing @_ (Let1X a)
           sX
             = let
-                sZ :: (Sing (Let0123456789876543210Z a :: MyProxy a) :: Type)
+                sZ :: (Sing (Let2Z a :: MyProxy a) :: Type)
                 sZ = SMyProxy
               in sZ
         in sX

--- a/singletons-base/tests/compile-and-dump/Singletons/T297.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T297.golden
@@ -21,34 +21,34 @@ Singletons/T297.hs:(0,0)-(0,0): Splicing declarations
     type MyProxySym0 :: forall (a :: Type). MyProxy a
     type family MyProxySym0 @(a :: Type) :: MyProxy a where
       MyProxySym0 = MyProxy
-    type Let0123456789876543210ZSym0 :: MyProxy a
-    type family Let0123456789876543210ZSym0 @a :: MyProxy a where
-      Let0123456789876543210ZSym0 = Let0123456789876543210Z
-    type Let0123456789876543210Z :: MyProxy a
-    type family Let0123456789876543210Z @a :: MyProxy a where
-      Let0123456789876543210Z = MyProxySym0
-    type family Let0123456789876543210XSym0 where
-      Let0123456789876543210XSym0 = Let0123456789876543210X
-    type family Let0123456789876543210X where
-      Let0123456789876543210X = Let0123456789876543210ZSym0
-    data FSym0 a0123456789876543210
+    type Let1ZSym0 :: MyProxy a
+    type family Let1ZSym0 @a :: MyProxy a where
+      Let1ZSym0 = Let1Z
+    type Let1Z :: MyProxy a
+    type family Let1Z @a :: MyProxy a where
+      Let1Z = MyProxySym0
+    type family Let0XSym0 where
+      Let0XSym0 = Let0X
+    type family Let0X where
+      Let0X = Let1ZSym0
+    data FSym0 a0
       where
         FSym0KindInference :: SameKind (Apply FSym0 arg) (FSym1 arg) =>
-                              FSym0 a0123456789876543210
-    type instance Apply @_ @_ FSym0 a0123456789876543210 = F a0123456789876543210
+                              FSym0 a0
+    type instance Apply @_ @_ FSym0 a0 = F a0
     instance SuppressUnusedWarnings FSym0 where
       suppressUnusedWarnings = snd ((,) FSym0KindInference ())
-    type family FSym1 a0123456789876543210 where
-      FSym1 a0123456789876543210 = F a0123456789876543210
+    type family FSym1 a0 where
+      FSym1 a0 = F a0
     type family F a where
-      F MyProxy = Let0123456789876543210XSym0
+      F MyProxy = Let0XSym0
     sF :: forall arg. Sing arg -> Sing (F arg)
     sF SMyProxy
       = let
-          sX :: Sing @_ Let0123456789876543210X
+          sX :: Sing @_ Let0X
           sX
             = let
-                sZ :: (Sing (Let0123456789876543210Z :: MyProxy a) :: Type)
+                sZ :: (Sing (Let1Z :: MyProxy a) :: Type)
                 sZ = SMyProxy
               in sZ
         in sX

--- a/singletons-base/tests/compile-and-dump/Singletons/T312.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T312.golden
@@ -23,71 +23,69 @@ Singletons/T312.hs:(0,0)-(0,0): Splicing declarations
     data BarSym0 :: (~>) a ((~>) b b)
       where
         BarSym0KindInference :: SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
-                                BarSym0 a0123456789876543210
-    type instance Apply @a @((~>) b b) BarSym0 a0123456789876543210 = BarSym1 a0123456789876543210
+                                BarSym0 a_T312_0
+    type instance Apply @a @((~>) b b) BarSym0 a_T312_0 = BarSym1 a_T312_0
     instance SuppressUnusedWarnings BarSym0 where
       suppressUnusedWarnings = snd ((,) BarSym0KindInference ())
     type BarSym1 :: forall a b. a -> (~>) b b
-    data BarSym1 (a0123456789876543210 :: a) :: (~>) b b
+    data BarSym1 (a_T312_0 :: a) :: (~>) b b
       where
-        BarSym1KindInference :: SameKind (Apply (BarSym1 a0123456789876543210) arg) (BarSym2 a0123456789876543210 arg) =>
-                                BarSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @b (BarSym1 a0123456789876543210) a0123456789876543210 = Bar a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (BarSym1 a0123456789876543210) where
+        BarSym1KindInference :: SameKind (Apply (BarSym1 a_T312_0) arg) (BarSym2 a_T312_0 arg) =>
+                                BarSym1 a_T312_0 a_T312_1
+    type instance Apply @b @b (BarSym1 a_T312_0) a_T312_1 = Bar a_T312_0 a_T312_1
+    instance SuppressUnusedWarnings (BarSym1 a_T312_0) where
       suppressUnusedWarnings = snd ((,) BarSym1KindInference ())
     type BarSym2 :: forall a b. a -> b -> b
-    type family BarSym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: b where
-      BarSym2 a0123456789876543210 a0123456789876543210 = Bar a0123456789876543210 a0123456789876543210
+    type family BarSym2 @a @b (a_T312_0 :: a) (a_T312_1 :: b) :: b where
+      BarSym2 a_T312_0 a_T312_1 = Bar a_T312_0 a_T312_1
     type BazSym0 :: forall a b. (~>) a ((~>) b b)
     data BazSym0 :: (~>) a ((~>) b b)
       where
         BazSym0KindInference :: SameKind (Apply BazSym0 arg) (BazSym1 arg) =>
-                                BazSym0 a0123456789876543210
-    type instance Apply @a @((~>) b b) BazSym0 a0123456789876543210 = BazSym1 a0123456789876543210
+                                BazSym0 a_T312_2
+    type instance Apply @a @((~>) b b) BazSym0 a_T312_2 = BazSym1 a_T312_2
     instance SuppressUnusedWarnings BazSym0 where
       suppressUnusedWarnings = snd ((,) BazSym0KindInference ())
     type BazSym1 :: forall a b. a -> (~>) b b
-    data BazSym1 (a0123456789876543210 :: a) :: (~>) b b
+    data BazSym1 (a_T312_2 :: a) :: (~>) b b
       where
-        BazSym1KindInference :: SameKind (Apply (BazSym1 a0123456789876543210) arg) (BazSym2 a0123456789876543210 arg) =>
-                                BazSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @b (BazSym1 a0123456789876543210) a0123456789876543210 = Baz a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (BazSym1 a0123456789876543210) where
+        BazSym1KindInference :: SameKind (Apply (BazSym1 a_T312_2) arg) (BazSym2 a_T312_2 arg) =>
+                                BazSym1 a_T312_2 a_T312_3
+    type instance Apply @b @b (BazSym1 a_T312_2) a_T312_3 = Baz a_T312_2 a_T312_3
+    instance SuppressUnusedWarnings (BazSym1 a_T312_2) where
       suppressUnusedWarnings = snd ((,) BazSym1KindInference ())
     type BazSym2 :: forall a b. a -> b -> b
-    type family BazSym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: b where
-      BazSym2 a0123456789876543210 a0123456789876543210 = Baz a0123456789876543210 a0123456789876543210
-    type Bar_0123456789876543210 :: forall a b. a -> b -> b
-    type family Bar_0123456789876543210 @a @b (a :: a) (a :: b) :: b where
-      Bar_0123456789876543210 @a @b (_ :: a) (x :: b) = x
-    data Let0123456789876543210HSym0 a0123456789876543210 b0123456789876543210 (a_01234567898765432100123456789876543210 :: a0123456789876543210) (a_01234567898765432100123456789876543210 :: b0123456789876543210) :: (~>) c0123456789876543210 ((~>) b0123456789876543210 b0123456789876543210)
+    type family BazSym2 @a @b (a_T312_2 :: a) (a_T312_3 :: b) :: b where
+      BazSym2 a_T312_2 a_T312_3 = Baz a_T312_2 a_T312_3
+    type Bar_T312_4 :: forall a b. a -> b -> b
+    type family Bar_T312_4 @a @b (a :: a) (a :: b) :: b where
+      Bar_T312_4 @a @b (_ :: a) (x :: b) = x
+    data Let12HSym0 a0 b1 (a_T312_82 :: a0) (a_T312_93 :: b1) :: (~>) c4 ((~>) b1 b1)
       where
-        Let0123456789876543210HSym0KindInference :: SameKind (Apply (Let0123456789876543210HSym0 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) arg) (Let0123456789876543210HSym1 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 arg) =>
-                                                    Let0123456789876543210HSym0 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a0123456789876543210
-    type instance Apply @c0123456789876543210 @((~>) b0123456789876543210 b0123456789876543210) (Let0123456789876543210HSym0 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) a0123456789876543210 = Let0123456789876543210HSym1 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Let0123456789876543210HSym0 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Let0123456789876543210HSym0KindInference ())
-    data Let0123456789876543210HSym1 a0123456789876543210 b0123456789876543210 (a_01234567898765432100123456789876543210 :: a0123456789876543210) (a_01234567898765432100123456789876543210 :: b0123456789876543210) (a0123456789876543210 :: c0123456789876543210) :: (~>) b0123456789876543210 b0123456789876543210
+        Let12HSym0KindInference :: SameKind (Apply (Let12HSym0 a0 b1 a_T312_82 a_T312_93) arg) (Let12HSym1 a0 b1 a_T312_82 a_T312_93 arg) =>
+                                   Let12HSym0 a0 b1 a_T312_82 a_T312_93 a5
+    type instance Apply @c4 @((~>) b1 b1) (Let12HSym0 a0 b1 a_T312_82 a_T312_93) a5 = Let12HSym1 a0 b1 a_T312_82 a_T312_93 a5
+    instance SuppressUnusedWarnings (Let12HSym0 a0 b1 a_T312_82 a_T312_93) where
+      suppressUnusedWarnings = snd ((,) Let12HSym0KindInference ())
+    data Let12HSym1 a0 b1 (a_T312_82 :: a0) (a_T312_93 :: b1) (a5 :: c4) :: (~>) b1 b1
       where
-        Let0123456789876543210HSym1KindInference :: SameKind (Apply (Let0123456789876543210HSym1 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a0123456789876543210) arg) (Let0123456789876543210HSym2 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a0123456789876543210 arg) =>
-                                                    Let0123456789876543210HSym1 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @b0123456789876543210 @b0123456789876543210 (Let0123456789876543210HSym1 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a0123456789876543210) a0123456789876543210 = Let0123456789876543210H a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Let0123456789876543210HSym1 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Let0123456789876543210HSym1KindInference ())
-    type family Let0123456789876543210HSym2 a0123456789876543210 b0123456789876543210 (a_01234567898765432100123456789876543210 :: a0123456789876543210) (a_01234567898765432100123456789876543210 :: b0123456789876543210) (a0123456789876543210 :: c0123456789876543210) (a0123456789876543210 :: b0123456789876543210) :: b0123456789876543210 where
-      Let0123456789876543210HSym2 a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a0123456789876543210 a0123456789876543210 = Let0123456789876543210H a0123456789876543210 b0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 a0123456789876543210 a0123456789876543210
-    type family Let0123456789876543210H a0123456789876543210 b0123456789876543210 (a_01234567898765432100123456789876543210 :: a0123456789876543210) (a_01234567898765432100123456789876543210 :: b0123456789876543210) (a :: c) (a :: b0123456789876543210) :: b0123456789876543210 where
-      Let0123456789876543210H a b a_0123456789876543210 a_0123456789876543210 (_ :: c) (x :: b) = x
-    type Baz_0123456789876543210 :: forall a b. a -> b -> b
-    type family Baz_0123456789876543210 @a @b (a :: a) (a :: b) :: b where
-      Baz_0123456789876543210 @a @b (a_0123456789876543210 :: a) (a_0123456789876543210 :: b) = Apply (Apply (Let0123456789876543210HSym0 a b a_0123456789876543210 a_0123456789876543210) a_0123456789876543210) a_0123456789876543210
+        Let12HSym1KindInference :: SameKind (Apply (Let12HSym1 a0 b1 a_T312_82 a_T312_93 a5) arg) (Let12HSym2 a0 b1 a_T312_82 a_T312_93 a5 arg) =>
+                                   Let12HSym1 a0 b1 a_T312_82 a_T312_93 a5 a6
+    type instance Apply @b1 @b1 (Let12HSym1 a0 b1 a_T312_82 a_T312_93 a5) a6 = Let12H a0 b1 a_T312_82 a_T312_93 a5 a6
+    instance SuppressUnusedWarnings (Let12HSym1 a0 b1 a_T312_82 a_T312_93 a5) where
+      suppressUnusedWarnings = snd ((,) Let12HSym1KindInference ())
+    type family Let12HSym2 a0 b1 (a_T312_82 :: a0) (a_T312_93 :: b1) (a5 :: c4) (a6 :: b1) :: b1 where
+      Let12HSym2 a0 b1 a_T312_82 a_T312_93 a5 a6 = Let12H a0 b1 a_T312_82 a_T312_93 a5 a6
+    type family Let12H a0 b1 (a_T312_82 :: a0) (a_T312_93 :: b1) (a :: c) (a :: b1) :: b1 where
+      Let12H a b a_T312_8 a_T312_9 (_ :: c) (x :: b) = x
+    type Baz_T312_7 :: forall a b. a -> b -> b
+    type family Baz_T312_7 @a @b (a :: a) (a :: b) :: b where
+      Baz_T312_7 @a @b (a_T312_8 :: a) (a_T312_9 :: b) = Apply (Apply (Let12HSym0 a b a_T312_8 a_T312_9) a_T312_8) a_T312_9
     class PFoo a where
       type family Bar (arg :: a) (arg :: b) :: b
       type family Baz (arg :: a) (arg :: b) :: b
-      type Bar a a = Bar_0123456789876543210 a a
-      type Baz a a = Baz_0123456789876543210 a a
+      type Bar a a = Bar_T312_4 a a
+      type Baz a a = Baz_T312_7 a a
     class SFoo a where
       sBar ::
         (forall (t :: a) (t :: b).
@@ -96,30 +94,24 @@ Singletons/T312.hs:(0,0)-(0,0): Splicing declarations
         forall b (t :: a) (t :: b). Sing t -> Sing t -> Sing (Baz t t :: b)
       default sBar ::
                 (forall (t :: a) (t :: b).
-                 ((Bar t t :: b) ~ Bar_0123456789876543210 t t) =>
+                 ((Bar t t :: b) ~ Bar_T312_4 t t) =>
                  Sing t -> Sing t -> Sing (Bar t t :: b) :: Type)
       default sBaz ::
-                forall b (t :: a) (t :: b). ((Baz t t :: b)
-                                             ~ Baz_0123456789876543210 t t) =>
+                forall b (t :: a) (t :: b). ((Baz t t :: b) ~ Baz_T312_7 t t) =>
                                             Sing t -> Sing t -> Sing (Baz t t :: b)
       sBar _ (sX :: Sing x) = sX
-      sBaz
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+      sBaz (sA_T312_8 :: Sing a_T312_8) (sA_T312_9 :: Sing a_T312_9)
         = applySing
             (applySing
                (let
                   sH ::
                     forall c (t :: c) (t :: b). Sing t
                                                 -> Sing t
-                                                   -> Sing (Let0123456789876543210H a b a_0123456789876543210 a_0123456789876543210 t t :: b)
+                                                   -> Sing (Let12H a b a_T312_8 a_T312_9 t t :: b)
                   sH _ (sX :: Sing x) = sX
-                in
-                  singFun2
-                    @(Let0123456789876543210HSym0 a b a_0123456789876543210 a_0123456789876543210)
-                    sH)
-               sA_0123456789876543210)
-            sA_0123456789876543210
+                in singFun2 @(Let12HSym0 a b a_T312_8 a_T312_9) sH)
+               sA_T312_8)
+            sA_T312_9
     instance SFoo a => SingI (BarSym0 :: (~>) a ((~>) b b)) where
       sing = singFun2 @BarSym0 sBar
     instance (SFoo a, SingI d) =>

--- a/singletons-base/tests/compile-and-dump/Singletons/T313.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T313.golden
@@ -22,42 +22,42 @@ Singletons/T313.hs:(0,0)-(0,0): Splicing declarations
       type PFoo4 a = Maybe a
     instance PC a where
       type PFoo4 a = Maybe a
-    data PFoo1Sym0 a0123456789876543210
+    data PFoo1Sym0 a0
       where
         PFoo1Sym0KindInference :: SameKind (Apply PFoo1Sym0 arg) (PFoo1Sym1 arg) =>
-                                  PFoo1Sym0 a0123456789876543210
-    type instance Apply @_ @_ PFoo1Sym0 a0123456789876543210 = PFoo1 a0123456789876543210
+                                  PFoo1Sym0 a0
+    type instance Apply @_ @_ PFoo1Sym0 a0 = PFoo1 a0
     instance SuppressUnusedWarnings PFoo1Sym0 where
       suppressUnusedWarnings = snd ((,) PFoo1Sym0KindInference ())
-    type family PFoo1Sym1 a0123456789876543210 where
-      PFoo1Sym1 a0123456789876543210 = PFoo1 a0123456789876543210
-    data PFoo3Sym0 a0123456789876543210
+    type family PFoo1Sym1 a0 where
+      PFoo1Sym1 a0 = PFoo1 a0
+    data PFoo3Sym0 a0
       where
         PFoo3Sym0KindInference :: SameKind (Apply PFoo3Sym0 arg) (PFoo3Sym1 arg) =>
-                                  PFoo3Sym0 a0123456789876543210
-    type instance Apply @_ @_ PFoo3Sym0 a0123456789876543210 = PFoo3 a0123456789876543210
+                                  PFoo3Sym0 a0
+    type instance Apply @_ @_ PFoo3Sym0 a0 = PFoo3 a0
     instance SuppressUnusedWarnings PFoo3Sym0 where
       suppressUnusedWarnings = snd ((,) PFoo3Sym0KindInference ())
-    type family PFoo3Sym1 a0123456789876543210 where
-      PFoo3Sym1 a0123456789876543210 = PFoo3 a0123456789876543210
+    type family PFoo3Sym1 a0 where
+      PFoo3Sym1 a0 = PFoo3 a0
     data PFoo2Sym0 :: (~>) Type Type
       where
         PFoo2Sym0KindInference :: SameKind (Apply PFoo2Sym0 arg) (PFoo2Sym1 arg) =>
-                                  PFoo2Sym0 a0123456789876543210
-    type instance Apply @Type @Type PFoo2Sym0 a0123456789876543210 = PFoo2 a0123456789876543210
+                                  PFoo2Sym0 a0
+    type instance Apply @Type @Type PFoo2Sym0 a0 = PFoo2 a0
     instance SuppressUnusedWarnings PFoo2Sym0 where
       suppressUnusedWarnings = snd ((,) PFoo2Sym0KindInference ())
-    type family PFoo2Sym1 (a0123456789876543210 :: Type) :: Type where
-      PFoo2Sym1 a0123456789876543210 = PFoo2 a0123456789876543210
-    data PFoo4Sym0 a0123456789876543210
+    type family PFoo2Sym1 (a0 :: Type) :: Type where
+      PFoo2Sym1 a0 = PFoo2 a0
+    data PFoo4Sym0 a0
       where
         PFoo4Sym0KindInference :: SameKind (Apply PFoo4Sym0 arg) (PFoo4Sym1 arg) =>
-                                  PFoo4Sym0 a0123456789876543210
-    type instance Apply @Type @_ PFoo4Sym0 a0123456789876543210 = PFoo4 a0123456789876543210
+                                  PFoo4Sym0 a0
+    type instance Apply @Type @_ PFoo4Sym0 a0 = PFoo4 a0
     instance SuppressUnusedWarnings PFoo4Sym0 where
       suppressUnusedWarnings = snd ((,) PFoo4Sym0KindInference ())
-    type family PFoo4Sym1 (a0123456789876543210 :: Type) where
-      PFoo4Sym1 a0123456789876543210 = PFoo4 a0123456789876543210
+    type family PFoo4Sym1 (a0 :: Type) where
+      PFoo4Sym1 a0 = PFoo4 a0
     class PPC (a :: Type)
     instance PPC a
 Singletons/T313.hs:(0,0)-(0,0): Splicing declarations
@@ -84,42 +84,42 @@ Singletons/T313.hs:(0,0)-(0,0): Splicing declarations
       type SFoo4 a = Maybe a
     instance SC a where
       type SFoo4 a = Maybe a
-    data SFoo1Sym0 a0123456789876543210
+    data SFoo1Sym0 a0
       where
         SFoo1Sym0KindInference :: SameKind (Apply SFoo1Sym0 arg) (SFoo1Sym1 arg) =>
-                                  SFoo1Sym0 a0123456789876543210
-    type instance Apply @_ @_ SFoo1Sym0 a0123456789876543210 = SFoo1 a0123456789876543210
+                                  SFoo1Sym0 a0
+    type instance Apply @_ @_ SFoo1Sym0 a0 = SFoo1 a0
     instance SuppressUnusedWarnings SFoo1Sym0 where
       suppressUnusedWarnings = snd ((,) SFoo1Sym0KindInference ())
-    type family SFoo1Sym1 a0123456789876543210 where
-      SFoo1Sym1 a0123456789876543210 = SFoo1 a0123456789876543210
-    data SFoo3Sym0 a0123456789876543210
+    type family SFoo1Sym1 a0 where
+      SFoo1Sym1 a0 = SFoo1 a0
+    data SFoo3Sym0 a0
       where
         SFoo3Sym0KindInference :: SameKind (Apply SFoo3Sym0 arg) (SFoo3Sym1 arg) =>
-                                  SFoo3Sym0 a0123456789876543210
-    type instance Apply @_ @_ SFoo3Sym0 a0123456789876543210 = SFoo3 a0123456789876543210
+                                  SFoo3Sym0 a0
+    type instance Apply @_ @_ SFoo3Sym0 a0 = SFoo3 a0
     instance SuppressUnusedWarnings SFoo3Sym0 where
       suppressUnusedWarnings = snd ((,) SFoo3Sym0KindInference ())
-    type family SFoo3Sym1 a0123456789876543210 where
-      SFoo3Sym1 a0123456789876543210 = SFoo3 a0123456789876543210
+    type family SFoo3Sym1 a0 where
+      SFoo3Sym1 a0 = SFoo3 a0
     data SFoo2Sym0 :: (~>) Type Type
       where
         SFoo2Sym0KindInference :: SameKind (Apply SFoo2Sym0 arg) (SFoo2Sym1 arg) =>
-                                  SFoo2Sym0 a0123456789876543210
-    type instance Apply @Type @Type SFoo2Sym0 a0123456789876543210 = SFoo2 a0123456789876543210
+                                  SFoo2Sym0 a0
+    type instance Apply @Type @Type SFoo2Sym0 a0 = SFoo2 a0
     instance SuppressUnusedWarnings SFoo2Sym0 where
       suppressUnusedWarnings = snd ((,) SFoo2Sym0KindInference ())
-    type family SFoo2Sym1 (a0123456789876543210 :: Type) :: Type where
-      SFoo2Sym1 a0123456789876543210 = SFoo2 a0123456789876543210
-    data SFoo4Sym0 a0123456789876543210
+    type family SFoo2Sym1 (a0 :: Type) :: Type where
+      SFoo2Sym1 a0 = SFoo2 a0
+    data SFoo4Sym0 a0
       where
         SFoo4Sym0KindInference :: SameKind (Apply SFoo4Sym0 arg) (SFoo4Sym1 arg) =>
-                                  SFoo4Sym0 a0123456789876543210
-    type instance Apply @Type @_ SFoo4Sym0 a0123456789876543210 = SFoo4 a0123456789876543210
+                                  SFoo4Sym0 a0
+    type instance Apply @Type @_ SFoo4Sym0 a0 = SFoo4 a0
     instance SuppressUnusedWarnings SFoo4Sym0 where
       suppressUnusedWarnings = snd ((,) SFoo4Sym0KindInference ())
-    type family SFoo4Sym1 (a0123456789876543210 :: Type) where
-      SFoo4Sym1 a0123456789876543210 = SFoo4 a0123456789876543210
+    type family SFoo4Sym1 (a0 :: Type) where
+      SFoo4Sym1 a0 = SFoo4 a0
     class PSC (a :: Type)
     instance PSC a
     class SSC (a :: Type)

--- a/singletons-base/tests/compile-and-dump/Singletons/T316.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T316.golden
@@ -7,35 +7,35 @@ Singletons/T316.hs:(0,0)-(0,0): Splicing declarations
     data ReplaceAllGTypesSym0 :: (~>) ((~>) a ((~>) Type a)) ((~>) [Type] ((~>) [a] [a]))
       where
         ReplaceAllGTypesSym0KindInference :: SameKind (Apply ReplaceAllGTypesSym0 arg) (ReplaceAllGTypesSym1 arg) =>
-                                             ReplaceAllGTypesSym0 a0123456789876543210
-    type instance Apply @((~>) a ((~>) Type a)) @((~>) [Type] ((~>) [a] [a])) ReplaceAllGTypesSym0 a0123456789876543210 = ReplaceAllGTypesSym1 a0123456789876543210
+                                             ReplaceAllGTypesSym0 a_T316_0
+    type instance Apply @((~>) a ((~>) Type a)) @((~>) [Type] ((~>) [a] [a])) ReplaceAllGTypesSym0 a_T316_0 = ReplaceAllGTypesSym1 a_T316_0
     instance SuppressUnusedWarnings ReplaceAllGTypesSym0 where
       suppressUnusedWarnings
         = snd ((,) ReplaceAllGTypesSym0KindInference ())
     type ReplaceAllGTypesSym1 :: (~>) a ((~>) Type a)
                                  -> (~>) [Type] ((~>) [a] [a])
-    data ReplaceAllGTypesSym1 (a0123456789876543210 :: (~>) a ((~>) Type a)) :: (~>) [Type] ((~>) [a] [a])
+    data ReplaceAllGTypesSym1 (a_T316_0 :: (~>) a ((~>) Type a)) :: (~>) [Type] ((~>) [a] [a])
       where
-        ReplaceAllGTypesSym1KindInference :: SameKind (Apply (ReplaceAllGTypesSym1 a0123456789876543210) arg) (ReplaceAllGTypesSym2 a0123456789876543210 arg) =>
-                                             ReplaceAllGTypesSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @[Type] @((~>) [a] [a]) (ReplaceAllGTypesSym1 a0123456789876543210) a0123456789876543210 = ReplaceAllGTypesSym2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ReplaceAllGTypesSym1 a0123456789876543210) where
+        ReplaceAllGTypesSym1KindInference :: SameKind (Apply (ReplaceAllGTypesSym1 a_T316_0) arg) (ReplaceAllGTypesSym2 a_T316_0 arg) =>
+                                             ReplaceAllGTypesSym1 a_T316_0 a_T316_1
+    type instance Apply @[Type] @((~>) [a] [a]) (ReplaceAllGTypesSym1 a_T316_0) a_T316_1 = ReplaceAllGTypesSym2 a_T316_0 a_T316_1
+    instance SuppressUnusedWarnings (ReplaceAllGTypesSym1 a_T316_0) where
       suppressUnusedWarnings
         = snd ((,) ReplaceAllGTypesSym1KindInference ())
     type ReplaceAllGTypesSym2 :: (~>) a ((~>) Type a)
                                  -> [Type] -> (~>) [a] [a]
-    data ReplaceAllGTypesSym2 (a0123456789876543210 :: (~>) a ((~>) Type a)) (a0123456789876543210 :: [Type]) :: (~>) [a] [a]
+    data ReplaceAllGTypesSym2 (a_T316_0 :: (~>) a ((~>) Type a)) (a_T316_1 :: [Type]) :: (~>) [a] [a]
       where
-        ReplaceAllGTypesSym2KindInference :: SameKind (Apply (ReplaceAllGTypesSym2 a0123456789876543210 a0123456789876543210) arg) (ReplaceAllGTypesSym3 a0123456789876543210 a0123456789876543210 arg) =>
-                                             ReplaceAllGTypesSym2 a0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @[a] @[a] (ReplaceAllGTypesSym2 a0123456789876543210 a0123456789876543210) a0123456789876543210 = ReplaceAllGTypes a0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ReplaceAllGTypesSym2 a0123456789876543210 a0123456789876543210) where
+        ReplaceAllGTypesSym2KindInference :: SameKind (Apply (ReplaceAllGTypesSym2 a_T316_0 a_T316_1) arg) (ReplaceAllGTypesSym3 a_T316_0 a_T316_1 arg) =>
+                                             ReplaceAllGTypesSym2 a_T316_0 a_T316_1 a_T316_2
+    type instance Apply @[a] @[a] (ReplaceAllGTypesSym2 a_T316_0 a_T316_1) a_T316_2 = ReplaceAllGTypes a_T316_0 a_T316_1 a_T316_2
+    instance SuppressUnusedWarnings (ReplaceAllGTypesSym2 a_T316_0 a_T316_1) where
       suppressUnusedWarnings
         = snd ((,) ReplaceAllGTypesSym2KindInference ())
     type ReplaceAllGTypesSym3 :: (~>) a ((~>) Type a)
                                  -> [Type] -> [a] -> [a]
-    type family ReplaceAllGTypesSym3 @a (a0123456789876543210 :: (~>) a ((~>) Type a)) (a0123456789876543210 :: [Type]) (a0123456789876543210 :: [a]) :: [a] where
-      ReplaceAllGTypesSym3 a0123456789876543210 a0123456789876543210 a0123456789876543210 = ReplaceAllGTypes a0123456789876543210 a0123456789876543210 a0123456789876543210
+    type family ReplaceAllGTypesSym3 @a (a_T316_0 :: (~>) a ((~>) Type a)) (a_T316_1 :: [Type]) (a_T316_2 :: [a]) :: [a] where
+      ReplaceAllGTypesSym3 a_T316_0 a_T316_1 a_T316_2 = ReplaceAllGTypes a_T316_0 a_T316_1 a_T316_2
     type ReplaceAllGTypes :: (~>) a ((~>) Type a)
                              -> [Type] -> [a] -> [a]
     type family ReplaceAllGTypes @a (a :: (~>) a ((~>) Type a)) (a :: [Type]) (a :: [a]) :: [a] where

--- a/singletons-base/tests/compile-and-dump/Singletons/T322.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T322.golden
@@ -12,37 +12,34 @@ Singletons/T322.hs:(0,0)-(0,0): Splicing declarations
     data (!@#@$) :: (~>) Bool ((~>) Bool Bool)
       where
         (:!@#@$###) :: SameKind (Apply (!@#@$) arg) ((!@#@$$) arg) =>
-                       (!@#@$) a0123456789876543210
-    type instance Apply @Bool @((~>) Bool Bool) (!@#@$) a0123456789876543210 = (!@#@$$) a0123456789876543210
+                       (!@#@$) a_T322_2
+    type instance Apply @Bool @((~>) Bool Bool) (!@#@$) a_T322_2 = (!@#@$$) a_T322_2
     instance SuppressUnusedWarnings (!@#@$) where
       suppressUnusedWarnings = snd ((,) (:!@#@$###) ())
     infixr 2 type !@#@$
     type (!@#@$$) :: Bool -> (~>) Bool Bool
-    data (!@#@$$) (a0123456789876543210 :: Bool) :: (~>) Bool Bool
+    data (!@#@$$) (a_T322_2 :: Bool) :: (~>) Bool Bool
       where
-        (:!@#@$$###) :: SameKind (Apply ((!@#@$$) a0123456789876543210) arg) ((!@#@$$$) a0123456789876543210 arg) =>
-                        (!@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @Bool @Bool ((!@#@$$) a0123456789876543210) a0123456789876543210 = (!) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((!@#@$$) a0123456789876543210) where
+        (:!@#@$$###) :: SameKind (Apply ((!@#@$$) a_T322_2) arg) ((!@#@$$$) a_T322_2 arg) =>
+                        (!@#@$$) a_T322_2 a_T322_3
+    type instance Apply @Bool @Bool ((!@#@$$) a_T322_2) a_T322_3 = (!) a_T322_2 a_T322_3
+    instance SuppressUnusedWarnings ((!@#@$$) a_T322_2) where
       suppressUnusedWarnings = snd ((,) (:!@#@$$###) ())
     infixr 2 type !@#@$$
     type (!@#@$$$) :: Bool -> Bool -> Bool
-    type family (!@#@$$$) (a0123456789876543210 :: Bool) (a0123456789876543210 :: Bool) :: Bool where
-      (!@#@$$$) a0123456789876543210 a0123456789876543210 = (!) a0123456789876543210 a0123456789876543210
+    type family (!@#@$$$) (a_T322_2 :: Bool) (a_T322_3 :: Bool) :: Bool where
+      (!@#@$$$) a_T322_2 a_T322_3 = (!) a_T322_2 a_T322_3
     infixr 2 type !@#@$$$
     type (!) :: Bool -> Bool -> Bool
     type family (!) (a :: Bool) (a :: Bool) :: Bool where
-      (!) a_0123456789876543210 a_0123456789876543210 = Apply (Apply (||@#@$) a_0123456789876543210) a_0123456789876543210
+      (!) a_T322_0 a_T322_1 = Apply (Apply (||@#@$) a_T322_0) a_T322_1
     infixr 2 data %!
     (%!) ::
       (forall (t :: Bool) (t :: Bool).
        Sing t -> Sing t -> Sing ((!) t t :: Bool) :: Type)
-    (%!)
-      (sA_0123456789876543210 :: Sing a_0123456789876543210)
-      (sA_0123456789876543210 :: Sing a_0123456789876543210)
+    (%!) (sA_T322_0 :: Sing a_T322_0) (sA_T322_1 :: Sing a_T322_1)
       = applySing
-          (applySing (singFun2 @(||@#@$) (%||)) sA_0123456789876543210)
-          sA_0123456789876543210
+          (applySing (singFun2 @(||@#@$) (%||)) sA_T322_0) sA_T322_1
     instance SingI ((!@#@$) :: (~>) Bool ((~>) Bool Bool)) where
       sing = singFun2 @(!@#@$) (%!)
     instance SingI d =>

--- a/singletons-base/tests/compile-and-dump/Singletons/T326.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T326.golden
@@ -5,23 +5,23 @@ Singletons/T326.hs:0:0:: Splicing declarations
     data (<%>@#@$) :: (~>) a ((~>) a a)
       where
         (:<%>@#@$###) :: SameKind (Apply (<%>@#@$) arg) ((<%>@#@$$) arg) =>
-                         (<%>@#@$) a0123456789876543210
-    type instance Apply @a @((~>) a a) (<%>@#@$) a0123456789876543210 = (<%>@#@$$) a0123456789876543210
+                         (<%>@#@$) a_T326_0
+    type instance Apply @a @((~>) a a) (<%>@#@$) a_T326_0 = (<%>@#@$$) a_T326_0
     instance SuppressUnusedWarnings (<%>@#@$) where
       suppressUnusedWarnings = snd ((,) (:<%>@#@$###) ())
     infixl 9 type <%>@#@$
     type (<%>@#@$$) :: forall (a :: Type). a -> (~>) a a
-    data (<%>@#@$$) (a0123456789876543210 :: a) :: (~>) a a
+    data (<%>@#@$$) (a_T326_0 :: a) :: (~>) a a
       where
-        (:<%>@#@$$###) :: SameKind (Apply ((<%>@#@$$) a0123456789876543210) arg) ((<%>@#@$$$) a0123456789876543210 arg) =>
-                          (<%>@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @a @a ((<%>@#@$$) a0123456789876543210) a0123456789876543210 = (<%>) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((<%>@#@$$) a0123456789876543210) where
+        (:<%>@#@$$###) :: SameKind (Apply ((<%>@#@$$) a_T326_0) arg) ((<%>@#@$$$) a_T326_0 arg) =>
+                          (<%>@#@$$) a_T326_0 a_T326_1
+    type instance Apply @a @a ((<%>@#@$$) a_T326_0) a_T326_1 = (<%>) a_T326_0 a_T326_1
+    instance SuppressUnusedWarnings ((<%>@#@$$) a_T326_0) where
       suppressUnusedWarnings = snd ((,) (:<%>@#@$$###) ())
     infixl 9 type <%>@#@$$
     type (<%>@#@$$$) :: forall (a :: Type). a -> a -> a
-    type family (<%>@#@$$$) @(a :: Type) (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: a where
-      (<%>@#@$$$) a0123456789876543210 a0123456789876543210 = (<%>) a0123456789876543210 a0123456789876543210
+    type family (<%>@#@$$$) @(a :: Type) (a_T326_0 :: a) (a_T326_1 :: a) :: a where
+      (<%>@#@$$$) a_T326_0 a_T326_1 = (<%>) a_T326_0 a_T326_1
     infixl 9 type <%>@#@$$$
     type PC1 :: Type -> Constraint
     class PC1 (a :: Type) where
@@ -34,23 +34,23 @@ Singletons/T326.hs:0:0:: Splicing declarations
     data (<%%>@#@$) :: (~>) a ((~>) a a)
       where
         (:<%%>@#@$###) :: SameKind (Apply (<%%>@#@$) arg) ((<%%>@#@$$) arg) =>
-                          (<%%>@#@$) a0123456789876543210
-    type instance Apply @a @((~>) a a) (<%%>@#@$) a0123456789876543210 = (<%%>@#@$$) a0123456789876543210
+                          (<%%>@#@$) a_T326_2
+    type instance Apply @a @((~>) a a) (<%%>@#@$) a_T326_2 = (<%%>@#@$$) a_T326_2
     instance SuppressUnusedWarnings (<%%>@#@$) where
       suppressUnusedWarnings = snd ((,) (:<%%>@#@$###) ())
     infixl 9 type <%%>@#@$
     type (<%%>@#@$$) :: forall (a :: Type). a -> (~>) a a
-    data (<%%>@#@$$) (a0123456789876543210 :: a) :: (~>) a a
+    data (<%%>@#@$$) (a_T326_2 :: a) :: (~>) a a
       where
-        (:<%%>@#@$$###) :: SameKind (Apply ((<%%>@#@$$) a0123456789876543210) arg) ((<%%>@#@$$$) a0123456789876543210 arg) =>
-                           (<%%>@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @a @a ((<%%>@#@$$) a0123456789876543210) a0123456789876543210 = (<%%>) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((<%%>@#@$$) a0123456789876543210) where
+        (:<%%>@#@$$###) :: SameKind (Apply ((<%%>@#@$$) a_T326_2) arg) ((<%%>@#@$$$) a_T326_2 arg) =>
+                           (<%%>@#@$$) a_T326_2 a_T326_3
+    type instance Apply @a @a ((<%%>@#@$$) a_T326_2) a_T326_3 = (<%%>) a_T326_2 a_T326_3
+    instance SuppressUnusedWarnings ((<%%>@#@$$) a_T326_2) where
       suppressUnusedWarnings = snd ((,) (:<%%>@#@$$###) ())
     infixl 9 type <%%>@#@$$
     type (<%%>@#@$$$) :: forall (a :: Type). a -> a -> a
-    type family (<%%>@#@$$$) @(a :: Type) (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: a where
-      (<%%>@#@$$$) a0123456789876543210 a0123456789876543210 = (<%%>) a0123456789876543210 a0123456789876543210
+    type family (<%%>@#@$$$) @(a :: Type) (a_T326_2 :: a) (a_T326_3 :: a) :: a where
+      (<%%>@#@$$$) a_T326_2 a_T326_3 = (<%%>) a_T326_2 a_T326_3
     infixl 9 type <%%>@#@$$$
     type PC2 :: Type -> Constraint
     class PC2 (a :: Type) where

--- a/singletons-base/tests/compile-and-dump/Singletons/T33.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T33.golden
@@ -9,15 +9,15 @@ Singletons/T33.hs:(0,0)-(0,0): Splicing declarations
     data FooSym0 :: (~>) (Bool, Bool) ()
       where
         FooSym0KindInference :: SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
-                                FooSym0 a0123456789876543210
+                                FooSym0 a_Singletons_T33_0
     type instance Apply @(Bool,
-                          Bool) @() FooSym0 a0123456789876543210 = Foo a0123456789876543210
+                          Bool) @() FooSym0 a_Singletons_T33_0 = Foo a_Singletons_T33_0
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings = snd ((,) FooSym0KindInference ())
     type FooSym1 :: (Bool, Bool) -> ()
-    type family FooSym1 (a0123456789876543210 :: (Bool,
-                                                  Bool)) :: () where
-      FooSym1 a0123456789876543210 = Foo a0123456789876543210
+    type family FooSym1 (a_Singletons_T33_0 :: (Bool,
+                                                Bool)) :: () where
+      FooSym1 a_Singletons_T33_0 = Foo a_Singletons_T33_0
     type Foo :: (Bool, Bool) -> ()
     type family Foo (a :: (Bool, Bool)) :: () where
       Foo '(_, _) = Tuple0Sym0

--- a/singletons-base/tests/compile-and-dump/Singletons/T332.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T332.golden
@@ -15,13 +15,13 @@ Singletons/T332.hs:(0,0)-(0,0): Splicing declarations
     data FSym0 :: (~>) Foo ()
       where
         FSym0KindInference :: SameKind (Apply FSym0 arg) (FSym1 arg) =>
-                              FSym0 a0123456789876543210
-    type instance Apply @Foo @() FSym0 a0123456789876543210 = F a0123456789876543210
+                              FSym0 a_T332_0
+    type instance Apply @Foo @() FSym0 a_T332_0 = F a_T332_0
     instance SuppressUnusedWarnings FSym0 where
       suppressUnusedWarnings = snd ((,) FSym0KindInference ())
     type FSym1 :: Foo -> ()
-    type family FSym1 (a0123456789876543210 :: Foo) :: () where
-      FSym1 a0123456789876543210 = F a0123456789876543210
+    type family FSym1 (a_T332_0 :: Foo) :: () where
+      FSym1 a_T332_0 = F a_T332_0
     type F :: Foo -> ()
     type family F (a :: Foo) :: () where
       F MkFoo = Tuple0Sym0
@@ -42,13 +42,13 @@ Singletons/T332.hs:(0,0)-(0,0): Splicing declarations
     data BSym0 :: (~>) Bar ()
       where
         BSym0KindInference :: SameKind (Apply BSym0 arg) (BSym1 arg) =>
-                              BSym0 a0123456789876543210
-    type instance Apply @Bar @() BSym0 a0123456789876543210 = B a0123456789876543210
+                              BSym0 a_T332_1
+    type instance Apply @Bar @() BSym0 a_T332_1 = B a_T332_1
     instance SuppressUnusedWarnings BSym0 where
       suppressUnusedWarnings = snd ((,) BSym0KindInference ())
     type BSym1 :: Bar -> ()
-    type family BSym1 (a0123456789876543210 :: Bar) :: () where
-      BSym1 a0123456789876543210 = B a0123456789876543210
+    type family BSym1 (a_T332_1 :: Bar) :: () where
+      BSym1 a_T332_1 = B a_T332_1
     type B :: Bar -> ()
     type family B (a :: Bar) :: () where
       B MkBar = Tuple0Sym0

--- a/singletons-base/tests/compile-and-dump/Singletons/T342.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T342.golden
@@ -7,12 +7,12 @@ Singletons/T342.hs:(0,0)-(0,0): Splicing declarations
        pure $ syn : defuns
   ======>
     type MyId a = a
-    data MyIdSym0 a0123456789876543210
+    data MyIdSym0 a0
       where
         MyIdSym0KindInference :: SameKind (Apply MyIdSym0 arg) (MyIdSym1 arg) =>
-                                 MyIdSym0 a0123456789876543210
-    type instance Apply @_ @_ MyIdSym0 a0123456789876543210 = MyId a0123456789876543210
+                                 MyIdSym0 a0
+    type instance Apply @_ @_ MyIdSym0 a0 = MyId a0
     instance SuppressUnusedWarnings MyIdSym0 where
       suppressUnusedWarnings = snd ((,) MyIdSym0KindInference ())
-    type family MyIdSym1 a0123456789876543210 where
-      MyIdSym1 a0123456789876543210 = MyId a0123456789876543210
+    type family MyIdSym1 a0 where
+      MyIdSym1 a0 = MyId a0

--- a/singletons-base/tests/compile-and-dump/Singletons/T353.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T353.golden
@@ -7,29 +7,29 @@ Singletons/T353.hs:(0,0)-(0,0): Splicing declarations
   ======>
     type family Symmetry (a :: Proxy t) (y :: Proxy t) (e :: (:~:) (a :: Proxy (t :: k)) (y :: Proxy (t :: k))) :: Type where
       Symmetry a y _ = (:~:) y a
-    data SymmetrySym0 :: (~>) (Proxy t0123456789876543210) ((~>) (Proxy t0123456789876543210) ((~>) ((:~:) (a0123456789876543210 :: Proxy (t0123456789876543210 :: k0123456789876543210)) (y0123456789876543210 :: Proxy (t0123456789876543210 :: k0123456789876543210))) Type))
+    data SymmetrySym0 :: (~>) (Proxy t0) ((~>) (Proxy t0) ((~>) ((:~:) (a1 :: Proxy (t0 :: k3)) (y2 :: Proxy (t0 :: k3))) Type))
       where
         SymmetrySym0KindInference :: SameKind (Apply SymmetrySym0 arg) (SymmetrySym1 arg) =>
-                                     SymmetrySym0 a0123456789876543210
-    type instance Apply @(Proxy t0123456789876543210) @((~>) (Proxy t0123456789876543210) ((~>) ((:~:) (a0123456789876543210 :: Proxy (t0123456789876543210 :: k0123456789876543210)) (y0123456789876543210 :: Proxy (t0123456789876543210 :: k0123456789876543210))) Type)) SymmetrySym0 a0123456789876543210 = SymmetrySym1 a0123456789876543210
+                                     SymmetrySym0 a1
+    type instance Apply @(Proxy t0) @((~>) (Proxy t0) ((~>) ((:~:) (a1 :: Proxy (t0 :: k3)) (y2 :: Proxy (t0 :: k3))) Type)) SymmetrySym0 a1 = SymmetrySym1 a1
     instance SuppressUnusedWarnings SymmetrySym0 where
       suppressUnusedWarnings = snd ((,) SymmetrySym0KindInference ())
-    data SymmetrySym1 (a0123456789876543210 :: Proxy t0123456789876543210) :: (~>) (Proxy t0123456789876543210) ((~>) ((:~:) (a0123456789876543210 :: Proxy (t0123456789876543210 :: k0123456789876543210)) (y0123456789876543210 :: Proxy (t0123456789876543210 :: k0123456789876543210))) Type)
+    data SymmetrySym1 (a1 :: Proxy t0) :: (~>) (Proxy t0) ((~>) ((:~:) (a1 :: Proxy (t0 :: k3)) (y2 :: Proxy (t0 :: k3))) Type)
       where
-        SymmetrySym1KindInference :: SameKind (Apply (SymmetrySym1 a0123456789876543210) arg) (SymmetrySym2 a0123456789876543210 arg) =>
-                                     SymmetrySym1 a0123456789876543210 y0123456789876543210
-    type instance Apply @(Proxy t0123456789876543210) @((~>) ((:~:) (a0123456789876543210 :: Proxy (t0123456789876543210 :: k0123456789876543210)) (y0123456789876543210 :: Proxy (t0123456789876543210 :: k0123456789876543210))) Type) (SymmetrySym1 a0123456789876543210) y0123456789876543210 = SymmetrySym2 a0123456789876543210 y0123456789876543210
-    instance SuppressUnusedWarnings (SymmetrySym1 a0123456789876543210) where
+        SymmetrySym1KindInference :: SameKind (Apply (SymmetrySym1 a1) arg) (SymmetrySym2 a1 arg) =>
+                                     SymmetrySym1 a1 y2
+    type instance Apply @(Proxy t0) @((~>) ((:~:) (a1 :: Proxy (t0 :: k3)) (y2 :: Proxy (t0 :: k3))) Type) (SymmetrySym1 a1) y2 = SymmetrySym2 a1 y2
+    instance SuppressUnusedWarnings (SymmetrySym1 a1) where
       suppressUnusedWarnings = snd ((,) SymmetrySym1KindInference ())
-    data SymmetrySym2 (a0123456789876543210 :: Proxy t0123456789876543210) (y0123456789876543210 :: Proxy t0123456789876543210) :: (~>) ((:~:) (a0123456789876543210 :: Proxy (t0123456789876543210 :: k0123456789876543210)) (y0123456789876543210 :: Proxy (t0123456789876543210 :: k0123456789876543210))) Type
+    data SymmetrySym2 (a1 :: Proxy t0) (y2 :: Proxy t0) :: (~>) ((:~:) (a1 :: Proxy (t0 :: k3)) (y2 :: Proxy (t0 :: k3))) Type
       where
-        SymmetrySym2KindInference :: SameKind (Apply (SymmetrySym2 a0123456789876543210 y0123456789876543210) arg) (SymmetrySym3 a0123456789876543210 y0123456789876543210 arg) =>
-                                     SymmetrySym2 a0123456789876543210 y0123456789876543210 e0123456789876543210
-    type instance Apply @((:~:) (a0123456789876543210 :: Proxy (t0123456789876543210 :: k0123456789876543210)) (y0123456789876543210 :: Proxy (t0123456789876543210 :: k0123456789876543210))) @Type (SymmetrySym2 a0123456789876543210 y0123456789876543210) e0123456789876543210 = Symmetry a0123456789876543210 y0123456789876543210 e0123456789876543210
-    instance SuppressUnusedWarnings (SymmetrySym2 a0123456789876543210 y0123456789876543210) where
+        SymmetrySym2KindInference :: SameKind (Apply (SymmetrySym2 a1 y2) arg) (SymmetrySym3 a1 y2 arg) =>
+                                     SymmetrySym2 a1 y2 e4
+    type instance Apply @((:~:) (a1 :: Proxy (t0 :: k3)) (y2 :: Proxy (t0 :: k3))) @Type (SymmetrySym2 a1 y2) e4 = Symmetry a1 y2 e4
+    instance SuppressUnusedWarnings (SymmetrySym2 a1 y2) where
       suppressUnusedWarnings = snd ((,) SymmetrySym2KindInference ())
-    type family SymmetrySym3 (a0123456789876543210 :: Proxy t0123456789876543210) (y0123456789876543210 :: Proxy t0123456789876543210) (e0123456789876543210 :: (:~:) (a0123456789876543210 :: Proxy (t0123456789876543210 :: k0123456789876543210)) (y0123456789876543210 :: Proxy (t0123456789876543210 :: k0123456789876543210))) :: Type where
-      SymmetrySym3 a0123456789876543210 y0123456789876543210 e0123456789876543210 = Symmetry a0123456789876543210 y0123456789876543210 e0123456789876543210
+    type family SymmetrySym3 (a1 :: Proxy t0) (y2 :: Proxy t0) (e4 :: (:~:) (a1 :: Proxy (t0 :: k3)) (y2 :: Proxy (t0 :: k3))) :: Type where
+      SymmetrySym3 a1 y2 e4 = Symmetry a1 y2 e4
 Singletons/T353.hs:0:0:: Splicing declarations
     genDefunSymbols [''Prod]
   ======>
@@ -40,28 +40,28 @@ Singletons/T353.hs:0:0:: Splicing declarations
     data MkProdSym0 :: (~>) (f p) ((~>) (g p) (Prod f g p))
       where
         MkProdSym0KindInference :: SameKind (Apply MkProdSym0 arg) (MkProdSym1 arg) =>
-                                   MkProdSym0 a0123456789876543210
-    type instance Apply @(f p) @((~>) (g p) (Prod f g p)) MkProdSym0 a0123456789876543210 = MkProdSym1 a0123456789876543210
+                                   MkProdSym0 a_T353_0
+    type instance Apply @(f p) @((~>) (g p) (Prod f g p)) MkProdSym0 a_T353_0 = MkProdSym1 a_T353_0
     instance SuppressUnusedWarnings MkProdSym0 where
       suppressUnusedWarnings = snd ((,) MkProdSym0KindInference ())
     type MkProdSym1 :: forall {k :: Type}
                               (f :: k -> Type)
                               (g :: k -> Type)
                               (p :: k). f p -> (~>) (g p) (Prod f g p)
-    data MkProdSym1 (a0123456789876543210 :: f p) :: (~>) (g p) (Prod f g p)
+    data MkProdSym1 (a_T353_0 :: f p) :: (~>) (g p) (Prod f g p)
       where
-        MkProdSym1KindInference :: SameKind (Apply (MkProdSym1 a0123456789876543210) arg) (MkProdSym2 a0123456789876543210 arg) =>
-                                   MkProdSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(g p) @(Prod f g p) (MkProdSym1 a0123456789876543210) a0123456789876543210 = 'MkProd a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (MkProdSym1 a0123456789876543210) where
+        MkProdSym1KindInference :: SameKind (Apply (MkProdSym1 a_T353_0) arg) (MkProdSym2 a_T353_0 arg) =>
+                                   MkProdSym1 a_T353_0 a_T353_1
+    type instance Apply @(g p) @(Prod f g p) (MkProdSym1 a_T353_0) a_T353_1 = 'MkProd a_T353_0 a_T353_1
+    instance SuppressUnusedWarnings (MkProdSym1 a_T353_0) where
       suppressUnusedWarnings = snd ((,) MkProdSym1KindInference ())
     type MkProdSym2 :: forall {k :: Type}
                               (f :: k -> Type)
                               (g :: k -> Type)
                               (p :: k). f p -> g p -> Prod f g p
     type family MkProdSym2 @(f :: k -> Type) @(g :: k
-                                                    -> Type) @(p :: k) (a0123456789876543210 :: f p) (a0123456789876543210 :: g p) :: Prod f g p where
-      MkProdSym2 a0123456789876543210 a0123456789876543210 = 'MkProd a0123456789876543210 a0123456789876543210
+                                                    -> Type) @(p :: k) (a_T353_0 :: f p) (a_T353_1 :: g p) :: Prod f g p where
+      MkProdSym2 a_T353_0 a_T353_1 = 'MkProd a_T353_0 a_T353_1
 Singletons/T353.hs:0:0:: Splicing declarations
     genDefunSymbols [''Foo]
   ======>
@@ -72,24 +72,24 @@ Singletons/T353.hs:0:0:: Splicing declarations
     data MkFooSym0 :: (~>) (Proxy a) ((~>) (Proxy b) (Foo a b))
       where
         MkFooSym0KindInference :: SameKind (Apply MkFooSym0 arg) (MkFooSym1 arg) =>
-                                  MkFooSym0 a0123456789876543210
-    type instance Apply @(Proxy a) @((~>) (Proxy b) (Foo a b)) MkFooSym0 a0123456789876543210 = MkFooSym1 a0123456789876543210
+                                  MkFooSym0 a_T353_2
+    type instance Apply @(Proxy a) @((~>) (Proxy b) (Foo a b)) MkFooSym0 a_T353_2 = MkFooSym1 a_T353_2
     instance SuppressUnusedWarnings MkFooSym0 where
       suppressUnusedWarnings = snd ((,) MkFooSym0KindInference ())
     type MkFooSym1 :: forall {k :: Type}
                              {k :: Type}
                              (a :: k)
                              (b :: k). Proxy a -> (~>) (Proxy b) (Foo a b)
-    data MkFooSym1 (a0123456789876543210 :: Proxy a) :: (~>) (Proxy b) (Foo a b)
+    data MkFooSym1 (a_T353_2 :: Proxy a) :: (~>) (Proxy b) (Foo a b)
       where
-        MkFooSym1KindInference :: SameKind (Apply (MkFooSym1 a0123456789876543210) arg) (MkFooSym2 a0123456789876543210 arg) =>
-                                  MkFooSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Proxy b) @(Foo a b) (MkFooSym1 a0123456789876543210) a0123456789876543210 = 'MkFoo a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (MkFooSym1 a0123456789876543210) where
+        MkFooSym1KindInference :: SameKind (Apply (MkFooSym1 a_T353_2) arg) (MkFooSym2 a_T353_2 arg) =>
+                                  MkFooSym1 a_T353_2 a_T353_3
+    type instance Apply @(Proxy b) @(Foo a b) (MkFooSym1 a_T353_2) a_T353_3 = 'MkFoo a_T353_2 a_T353_3
+    instance SuppressUnusedWarnings (MkFooSym1 a_T353_2) where
       suppressUnusedWarnings = snd ((,) MkFooSym1KindInference ())
     type MkFooSym2 :: forall {k :: Type}
                              {k :: Type}
                              (a :: k)
                              (b :: k). Proxy a -> Proxy b -> Foo a b
-    type family MkFooSym2 @(a :: k) @(b :: k) (a0123456789876543210 :: Proxy a) (a0123456789876543210 :: Proxy b) :: Foo a b where
-      MkFooSym2 a0123456789876543210 a0123456789876543210 = 'MkFoo a0123456789876543210 a0123456789876543210
+    type family MkFooSym2 @(a :: k) @(b :: k) (a_T353_2 :: Proxy a) (a_T353_3 :: Proxy b) :: Foo a b where
+      MkFooSym2 a_T353_2 a_T353_3 = 'MkFoo a_T353_2 a_T353_3

--- a/singletons-base/tests/compile-and-dump/Singletons/T358.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T358.golden
@@ -34,41 +34,41 @@ Singletons/T358.hs:(0,0)-(0,0): Splicing declarations
     data Method2aSym0 :: (~>) b a
       where
         Method2aSym0KindInference :: SameKind (Apply Method2aSym0 arg) (Method2aSym1 arg) =>
-                                     Method2aSym0 a0123456789876543210
-    type instance Apply @b @a Method2aSym0 a0123456789876543210 = Method2a a0123456789876543210
+                                     Method2aSym0 a_T358_0
+    type instance Apply @b @a Method2aSym0 a_T358_0 = Method2a a_T358_0
     instance SuppressUnusedWarnings Method2aSym0 where
       suppressUnusedWarnings = snd ((,) Method2aSym0KindInference ())
     type Method2aSym1 :: forall b a. b -> a
-    type family Method2aSym1 @b @a (a0123456789876543210 :: b) :: a where
-      Method2aSym1 a0123456789876543210 = Method2a a0123456789876543210
+    type family Method2aSym1 @b @a (a_T358_0 :: b) :: a where
+      Method2aSym1 a_T358_0 = Method2a a_T358_0
     type Method2bSym0 :: forall b a. (~>) b a
     data Method2bSym0 :: (~>) b a
       where
         Method2bSym0KindInference :: SameKind (Apply Method2bSym0 arg) (Method2bSym1 arg) =>
-                                     Method2bSym0 a0123456789876543210
-    type instance Apply @b @a Method2bSym0 a0123456789876543210 = Method2b a0123456789876543210
+                                     Method2bSym0 a_T358_1
+    type instance Apply @b @a Method2bSym0 a_T358_1 = Method2b a_T358_1
     instance SuppressUnusedWarnings Method2bSym0 where
       suppressUnusedWarnings = snd ((,) Method2bSym0KindInference ())
     type Method2bSym1 :: forall b a. b -> a
-    type family Method2bSym1 @b @a (a0123456789876543210 :: b) :: a where
-      Method2bSym1 a0123456789876543210 = Method2b a0123456789876543210
+    type family Method2bSym1 @b @a (a_T358_1 :: b) :: a where
+      Method2bSym1 a_T358_1 = Method2b a_T358_1
     class PC2 a where
       type family Method2a (arg :: b) :: a
       type family Method2b (arg :: b) :: a
-    type Method1_0123456789876543210 :: forall a. [a]
-    type family Method1_0123456789876543210 @a :: [a] where
-      Method1_0123456789876543210 @a = NilSym0
+    type Method1_T358_2 :: forall a. [a]
+    type family Method1_T358_2 @a :: [a] where
+      Method1_T358_2 @a = NilSym0
     instance PC1 [] where
-      type Method1 = Method1_0123456789876543210
-    type Method2a_0123456789876543210 :: forall a b. b -> [a]
-    type family Method2a_0123456789876543210 @a @b (a :: b) :: [a] where
-      Method2a_0123456789876543210 @a @b (_ :: b) = NilSym0
-    type Method2b_0123456789876543210 :: forall a b. b -> [a]
-    type family Method2b_0123456789876543210 @a @b (a :: b) :: [a] where
-      Method2b_0123456789876543210 @a @b (_ :: b) = NilSym0
+      type Method1 = Method1_T358_2
+    type Method2a_T358_3 :: forall a b. b -> [a]
+    type family Method2a_T358_3 @a @b (a :: b) :: [a] where
+      Method2a_T358_3 @a @b (_ :: b) = NilSym0
+    type Method2b_T358_5 :: forall a b. b -> [a]
+    type family Method2b_T358_5 @a @b (a :: b) :: [a] where
+      Method2b_T358_5 @a @b (_ :: b) = NilSym0
     instance PC2 [a] where
-      type Method2a a = Method2a_0123456789876543210 a
-      type Method2b a = Method2b_0123456789876543210 a
+      type Method2a a = Method2a_T358_3 a
+      type Method2b a = Method2b_T358_5 a
     class SC1 (f :: k -> Type) where
       sMethod1 :: (Sing (Method1 :: f a) :: Type)
     class SC2 a where

--- a/singletons-base/tests/compile-and-dump/Singletons/T367.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T367.golden
@@ -7,23 +7,23 @@ Singletons/T367.hs:(0,0)-(0,0): Splicing declarations
     data Const'Sym0 :: (~>) a ((~>) b a)
       where
         Const'Sym0KindInference :: SameKind (Apply Const'Sym0 arg) (Const'Sym1 arg) =>
-                                   Const'Sym0 a0123456789876543210
-    type instance Apply @a @((~>) b a) Const'Sym0 a0123456789876543210 = Const'Sym1 a0123456789876543210
+                                   Const'Sym0 a_T367_0
+    type instance Apply @a @((~>) b a) Const'Sym0 a_T367_0 = Const'Sym1 a_T367_0
     instance Data.Singletons.TH.SuppressUnusedWarnings.SuppressUnusedWarnings Const'Sym0 where
       Data.Singletons.TH.SuppressUnusedWarnings.suppressUnusedWarnings
         = snd ((,) Const'Sym0KindInference ())
     type Const'Sym1 :: a -> (~>) b a
-    data Const'Sym1 (a0123456789876543210 :: a) :: (~>) b a
+    data Const'Sym1 (a_T367_0 :: a) :: (~>) b a
       where
-        Const'Sym1KindInference :: SameKind (Apply (Const'Sym1 a0123456789876543210) arg) (Const'Sym2 a0123456789876543210 arg) =>
-                                   Const'Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @a (Const'Sym1 a0123456789876543210) a0123456789876543210 = Const' a0123456789876543210 a0123456789876543210
-    instance Data.Singletons.TH.SuppressUnusedWarnings.SuppressUnusedWarnings (Const'Sym1 a0123456789876543210) where
+        Const'Sym1KindInference :: SameKind (Apply (Const'Sym1 a_T367_0) arg) (Const'Sym2 a_T367_0 arg) =>
+                                   Const'Sym1 a_T367_0 a_T367_1
+    type instance Apply @b @a (Const'Sym1 a_T367_0) a_T367_1 = Const' a_T367_0 a_T367_1
+    instance Data.Singletons.TH.SuppressUnusedWarnings.SuppressUnusedWarnings (Const'Sym1 a_T367_0) where
       Data.Singletons.TH.SuppressUnusedWarnings.suppressUnusedWarnings
         = snd ((,) Const'Sym1KindInference ())
     type Const'Sym2 :: a -> b -> a
-    type family Const'Sym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: a where
-      Const'Sym2 a0123456789876543210 a0123456789876543210 = Const' a0123456789876543210 a0123456789876543210
+    type family Const'Sym2 @a @b (a_T367_0 :: a) (a_T367_1 :: b) :: a where
+      Const'Sym2 a_T367_0 a_T367_1 = Const' a_T367_0 a_T367_1
     type Const' :: a -> b -> a
     type family Const' @a @b (a :: a) (a :: b) :: a where
       Const' x _ = x

--- a/singletons-base/tests/compile-and-dump/Singletons/T371.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T371.golden
@@ -20,13 +20,13 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
     data X2Sym0 :: (~>) (Y a) (X a)
       where
         X2Sym0KindInference :: SameKind (Apply X2Sym0 arg) (X2Sym1 arg) =>
-                               X2Sym0 a0123456789876543210
-    type instance Apply @(Y a) @(X a) X2Sym0 a0123456789876543210 = X2 a0123456789876543210
+                               X2Sym0 a_T371_4
+    type instance Apply @(Y a) @(X a) X2Sym0 a_T371_4 = X2 a_T371_4
     instance SuppressUnusedWarnings X2Sym0 where
       suppressUnusedWarnings = snd ((,) X2Sym0KindInference ())
     type X2Sym1 :: forall (a :: Type). Y a -> X a
-    type family X2Sym1 @(a :: Type) (a0123456789876543210 :: Y a) :: X a where
-      X2Sym1 a0123456789876543210 = X2 a0123456789876543210
+    type family X2Sym1 @(a :: Type) (a_T371_4 :: Y a) :: X a where
+      X2Sym1 a_T371_4 = X2 a_T371_4
     type Y1Sym0 :: forall (a :: Type). Y a
     type family Y1Sym0 @(a :: Type) :: Y a where
       Y1Sym0 = Y1
@@ -34,31 +34,29 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
     data Y2Sym0 :: (~>) (X a) (Y a)
       where
         Y2Sym0KindInference :: SameKind (Apply Y2Sym0 arg) (Y2Sym1 arg) =>
-                               Y2Sym0 a0123456789876543210
-    type instance Apply @(X a) @(Y a) Y2Sym0 a0123456789876543210 = Y2 a0123456789876543210
+                               Y2Sym0 a_T371_5
+    type instance Apply @(X a) @(Y a) Y2Sym0 a_T371_5 = Y2 a_T371_5
     instance SuppressUnusedWarnings Y2Sym0 where
       suppressUnusedWarnings = snd ((,) Y2Sym0KindInference ())
     type Y2Sym1 :: forall (a :: Type). X a -> Y a
-    type family Y2Sym1 @(a :: Type) (a0123456789876543210 :: X a) :: Y a where
-      Y2Sym1 a0123456789876543210 = Y2 a0123456789876543210
-    type ShowsPrec_0123456789876543210 :: forall a. GHC.Internal.Bignum.Natural.Natural
-                                                    -> X a
-                                                       -> GHC.Internal.Types.Symbol
-                                                          -> GHC.Internal.Types.Symbol
-    type family ShowsPrec_0123456789876543210 @a (a :: GHC.Internal.Bignum.Natural.Natural) (a :: X a) (a :: GHC.Internal.Types.Symbol) :: GHC.Internal.Types.Symbol where
-      ShowsPrec_0123456789876543210 @a (_ :: GHC.Internal.Bignum.Natural.Natural) (X1 :: X a) (a_0123456789876543210 :: GHC.Internal.Types.Symbol) = Apply (Apply ShowStringSym0 "X1") a_0123456789876543210
-      ShowsPrec_0123456789876543210 @a (p_0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) (X2 arg_0123456789876543210 :: X a) (a_0123456789876543210 :: GHC.Internal.Types.Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "X2 ")) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
+    type family Y2Sym1 @(a :: Type) (a_T371_5 :: X a) :: Y a where
+      Y2Sym1 a_T371_5 = Y2 a_T371_5
+    type ShowsPrec_T371_6 :: forall a. GHC.Internal.Bignum.Natural.Natural
+                                       -> X a
+                                          -> GHC.Internal.Types.Symbol -> GHC.Internal.Types.Symbol
+    type family ShowsPrec_T371_6 @a (a :: GHC.Internal.Bignum.Natural.Natural) (a :: X a) (a :: GHC.Internal.Types.Symbol) :: GHC.Internal.Types.Symbol where
+      ShowsPrec_T371_6 @a (_ :: GHC.Internal.Bignum.Natural.Natural) (X1 :: X a) (a_T371_7 :: GHC.Internal.Types.Symbol) = Apply (Apply ShowStringSym0 "X1") a_T371_7
+      ShowsPrec_T371_6 @a (p_T371_0 :: GHC.Internal.Bignum.Natural.Natural) (X2 arg_T371_1 :: X a) (a_T371_8 :: GHC.Internal.Types.Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_T371_0) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "X2 ")) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_T371_1))) a_T371_8
     instance PShow (X a) where
-      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
-    type ShowsPrec_0123456789876543210 :: forall a. GHC.Internal.Bignum.Natural.Natural
-                                                    -> Y a
-                                                       -> GHC.Internal.Types.Symbol
-                                                          -> GHC.Internal.Types.Symbol
-    type family ShowsPrec_0123456789876543210 @a (a :: GHC.Internal.Bignum.Natural.Natural) (a :: Y a) (a :: GHC.Internal.Types.Symbol) :: GHC.Internal.Types.Symbol where
-      ShowsPrec_0123456789876543210 @a (_ :: GHC.Internal.Bignum.Natural.Natural) (Y1 :: Y a) (a_0123456789876543210 :: GHC.Internal.Types.Symbol) = Apply (Apply ShowStringSym0 "Y1") a_0123456789876543210
-      ShowsPrec_0123456789876543210 @a (p_0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) (Y2 arg_0123456789876543210 :: Y a) (a_0123456789876543210 :: GHC.Internal.Types.Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_0123456789876543210) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Y2 ")) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_0123456789876543210))) a_0123456789876543210
+      type ShowsPrec a a a = ShowsPrec_T371_6 a a a
+    type ShowsPrec_T371_12 :: forall a. GHC.Internal.Bignum.Natural.Natural
+                                        -> Y a
+                                           -> GHC.Internal.Types.Symbol -> GHC.Internal.Types.Symbol
+    type family ShowsPrec_T371_12 @a (a :: GHC.Internal.Bignum.Natural.Natural) (a :: Y a) (a :: GHC.Internal.Types.Symbol) :: GHC.Internal.Types.Symbol where
+      ShowsPrec_T371_12 @a (_ :: GHC.Internal.Bignum.Natural.Natural) (Y1 :: Y a) (a_T371_13 :: GHC.Internal.Types.Symbol) = Apply (Apply ShowStringSym0 "Y1") a_T371_13
+      ShowsPrec_T371_12 @a (p_T371_2 :: GHC.Internal.Bignum.Natural.Natural) (Y2 arg_T371_3 :: Y a) (a_T371_14 :: GHC.Internal.Types.Symbol) = Apply (Apply (Apply ShowParenSym0 (Apply (Apply (>@#@$) p_T371_2) (FromInteger 10))) (Apply (Apply (.@#@$) (Apply ShowStringSym0 "Y2 ")) (Apply (Apply ShowsPrecSym0 (FromInteger 11)) arg_T371_3))) a_T371_14
     instance PShow (Y a) where
-      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
+      type ShowsPrec a a a = ShowsPrec_T371_12 a a a
     data SX :: forall (a :: Type). X a -> Type
       where
         SX1 :: forall (a :: Type). SX (X1 :: X a)
@@ -86,24 +84,21 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
         = (\cases (SomeSing c) -> SomeSing (SY2 c))
             (toSing b :: SomeSing (X a))
     instance SShow (Y a) => SShow (X a) where
-      sShowsPrec
-        _
-        SX1
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+      sShowsPrec _ SX1 (sA_T371_7 :: Sing a_T371_7)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "X1"))
-            sA_0123456789876543210
+            sA_T371_7
       sShowsPrec
-        (sP_0123456789876543210 :: Sing p_0123456789876543210)
-        (SX2 (sArg_0123456789876543210 :: Sing arg_0123456789876543210))
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sP_T371_0 :: Sing p_T371_0)
+        (SX2 (sArg_T371_1 :: Sing arg_T371_1))
+        (sA_T371_8 :: Sing a_T371_8)
         = applySing
             (applySing
                (applySing
                   (singFun3 @ShowParenSym0 sShowParen)
                   (applySing
-                     (applySing (singFun2 @(>@#@$) (%>)) sP_0123456789876543210)
+                     (applySing (singFun2 @(>@#@$) (%>)) sP_T371_0)
                      (sFromInteger (sing :: Sing 10))))
                (applySing
                   (applySing
@@ -114,27 +109,24 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
                      (applySing
                         (singFun3 @ShowsPrecSym0 sShowsPrec)
                         (sFromInteger (sing :: Sing 11)))
-                     sArg_0123456789876543210)))
-            sA_0123456789876543210
+                     sArg_T371_1)))
+            sA_T371_8
     instance SShow (X a) => SShow (Y a) where
-      sShowsPrec
-        _
-        SY1
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+      sShowsPrec _ SY1 (sA_T371_13 :: Sing a_T371_13)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "Y1"))
-            sA_0123456789876543210
+            sA_T371_13
       sShowsPrec
-        (sP_0123456789876543210 :: Sing p_0123456789876543210)
-        (SY2 (sArg_0123456789876543210 :: Sing arg_0123456789876543210))
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+        (sP_T371_2 :: Sing p_T371_2)
+        (SY2 (sArg_T371_3 :: Sing arg_T371_3))
+        (sA_T371_14 :: Sing a_T371_14)
         = applySing
             (applySing
                (applySing
                   (singFun3 @ShowParenSym0 sShowParen)
                   (applySing
-                     (applySing (singFun2 @(>@#@$) (%>)) sP_0123456789876543210)
+                     (applySing (singFun2 @(>@#@$) (%>)) sP_T371_2)
                      (sFromInteger (sing :: Sing 10))))
                (applySing
                   (applySing
@@ -145,8 +137,8 @@ Singletons/T371.hs:(0,0)-(0,0): Splicing declarations
                      (applySing
                         (singFun3 @ShowsPrecSym0 sShowsPrec)
                         (sFromInteger (sing :: Sing 11)))
-                     sArg_0123456789876543210)))
-            sA_0123456789876543210
+                     sArg_T371_3)))
+            sA_T371_14
     deriving instance Data.Singletons.ShowSing.ShowSing (Y a) =>
                       Show (SX (z :: X a))
     deriving instance Data.Singletons.ShowSing.ShowSing (X a) =>

--- a/singletons-base/tests/compile-and-dump/Singletons/T376.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T376.golden
@@ -9,31 +9,29 @@ Singletons/T376.hs:(0,0)-(0,0): Splicing declarations
     data FSym0 :: (~>) ((~>) () ()) ((~>) () ())
       where
         FSym0KindInference :: SameKind (Apply FSym0 arg) (FSym1 arg) =>
-                              FSym0 a0123456789876543210
-    type instance Apply @((~>) () ()) @((~>) () ()) FSym0 a0123456789876543210 = FSym1 a0123456789876543210
+                              FSym0 a_T376_1
+    type instance Apply @((~>) () ()) @((~>) () ()) FSym0 a_T376_1 = FSym1 a_T376_1
     instance SuppressUnusedWarnings FSym0 where
       suppressUnusedWarnings = snd ((,) FSym0KindInference ())
     type FSym1 :: (~>) () () -> (~>) () ()
-    data FSym1 (a0123456789876543210 :: (~>) () ()) :: (~>) () ()
+    data FSym1 (a_T376_1 :: (~>) () ()) :: (~>) () ()
       where
-        FSym1KindInference :: SameKind (Apply (FSym1 a0123456789876543210) arg) (FSym2 a0123456789876543210 arg) =>
-                              FSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @() @() (FSym1 a0123456789876543210) a0123456789876543210 = F a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (FSym1 a0123456789876543210) where
+        FSym1KindInference :: SameKind (Apply (FSym1 a_T376_1) arg) (FSym2 a_T376_1 arg) =>
+                              FSym1 a_T376_1 a_T376_2
+    type instance Apply @() @() (FSym1 a_T376_1) a_T376_2 = F a_T376_1 a_T376_2
+    instance SuppressUnusedWarnings (FSym1 a_T376_1) where
       suppressUnusedWarnings = snd ((,) FSym1KindInference ())
     type FSym2 :: (~>) () () -> () -> ()
-    type family FSym2 (a0123456789876543210 :: (~>) () ()) (a0123456789876543210 :: ()) :: () where
-      FSym2 a0123456789876543210 a0123456789876543210 = F a0123456789876543210 a0123456789876543210
+    type family FSym2 (a_T376_1 :: (~>) () ()) (a_T376_2 :: ()) :: () where
+      FSym2 a_T376_1 a_T376_2 = F a_T376_1 a_T376_2
     type F :: (~>) () () -> () -> ()
     type family F (a :: (~>) () ()) (a :: ()) :: () where
-      F g a_0123456789876543210 = Apply (g :: (~>) () ()) a_0123456789876543210
+      F g a_T376_0 = Apply (g :: (~>) () ()) a_T376_0
     sF ::
       (forall (t :: (~>) () ()) (t :: ()).
        Sing t -> Sing t -> Sing (F t t :: ()) :: Type)
-    sF
-      (sG :: Sing g)
-      (sA_0123456789876543210 :: Sing a_0123456789876543210)
-      = applySing (sG :: Sing (g :: (~>) () ())) sA_0123456789876543210
+    sF (sG :: Sing g) (sA_T376_0 :: Sing a_T376_0)
+      = applySing (sG :: Sing (g :: (~>) () ())) sA_T376_0
     instance SingI (FSym0 :: (~>) ((~>) () ()) ((~>) () ())) where
       sing = singFun2 @FSym0 sF
     instance SingI d =>

--- a/singletons-base/tests/compile-and-dump/Singletons/T378a.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T378a.golden
@@ -34,21 +34,21 @@ Singletons/T378a.hs:(0,0)-(0,0): Splicing declarations
     data ConstBASym0 :: (~>) a ((~>) b a)
       where
         ConstBASym0KindInference :: SameKind (Apply ConstBASym0 arg) (ConstBASym1 arg) =>
-                                    ConstBASym0 a0123456789876543210
-    type instance Apply @a @((~>) b a) ConstBASym0 a0123456789876543210 = ConstBASym1 a0123456789876543210
+                                    ConstBASym0 a_T378a_0
+    type instance Apply @a @((~>) b a) ConstBASym0 a_T378a_0 = ConstBASym1 a_T378a_0
     instance SuppressUnusedWarnings ConstBASym0 where
       suppressUnusedWarnings = snd ((,) ConstBASym0KindInference ())
     type ConstBASym1 :: forall b a. a -> (~>) b a
-    data ConstBASym1 (a0123456789876543210 :: a) :: (~>) b a
+    data ConstBASym1 (a_T378a_0 :: a) :: (~>) b a
       where
-        ConstBASym1KindInference :: SameKind (Apply (ConstBASym1 a0123456789876543210) arg) (ConstBASym2 a0123456789876543210 arg) =>
-                                    ConstBASym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @a (ConstBASym1 a0123456789876543210) a0123456789876543210 = ConstBA a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ConstBASym1 a0123456789876543210) where
+        ConstBASym1KindInference :: SameKind (Apply (ConstBASym1 a_T378a_0) arg) (ConstBASym2 a_T378a_0 arg) =>
+                                    ConstBASym1 a_T378a_0 a_T378a_1
+    type instance Apply @b @a (ConstBASym1 a_T378a_0) a_T378a_1 = ConstBA a_T378a_0 a_T378a_1
+    instance SuppressUnusedWarnings (ConstBASym1 a_T378a_0) where
       suppressUnusedWarnings = snd ((,) ConstBASym1KindInference ())
     type ConstBASym2 :: forall b a. a -> b -> a
-    type family ConstBASym2 @b @a (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: a where
-      ConstBASym2 a0123456789876543210 a0123456789876543210 = ConstBA a0123456789876543210 a0123456789876543210
+    type family ConstBASym2 @b @a (a_T378a_0 :: a) (a_T378a_1 :: b) :: a where
+      ConstBASym2 a_T378a_0 a_T378a_1 = ConstBA a_T378a_0 a_T378a_1
     type ConstBA :: forall b a. a -> b -> a
     type family ConstBA @b @a (a :: a) (a :: b) :: a where
       ConstBA @b @a (x :: a) (_ :: b) = x

--- a/singletons-base/tests/compile-and-dump/Singletons/T378b.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T378b.golden
@@ -23,53 +23,53 @@ Singletons/T378b.hs:(0,0)-(0,0): Splicing declarations
     natMinus Zero _ = Zero
     natMinus (Succ a) (Succ b) = natMinus a b
     natMinus a@(Succ _) Zero = a
-    type family Let0123456789876543210ASym0 wild_01234567898765432100123456789876543210 where
-      Let0123456789876543210ASym0 wild_01234567898765432100123456789876543210 = Let0123456789876543210A wild_01234567898765432100123456789876543210
-    type family Let0123456789876543210A wild_01234567898765432100123456789876543210 where
-      Let0123456789876543210A wild_0123456789876543210 = Apply SuccSym0 wild_0123456789876543210
+    type family Let3ASym0 wild_T378b_00 where
+      Let3ASym0 wild_T378b_00 = Let3A wild_T378b_00
+    type family Let3A wild_T378b_00 where
+      Let3A wild_T378b_0 = Apply SuccSym0 wild_T378b_0
     type NatMinusSym0 :: (~>) Nat ((~>) Nat Nat)
     data NatMinusSym0 :: (~>) Nat ((~>) Nat Nat)
       where
         NatMinusSym0KindInference :: SameKind (Apply NatMinusSym0 arg) (NatMinusSym1 arg) =>
-                                     NatMinusSym0 a0123456789876543210
-    type instance Apply @Nat @((~>) Nat Nat) NatMinusSym0 a0123456789876543210 = NatMinusSym1 a0123456789876543210
+                                     NatMinusSym0 a_T378b_1
+    type instance Apply @Nat @((~>) Nat Nat) NatMinusSym0 a_T378b_1 = NatMinusSym1 a_T378b_1
     instance SuppressUnusedWarnings NatMinusSym0 where
       suppressUnusedWarnings = snd ((,) NatMinusSym0KindInference ())
     type NatMinusSym1 :: Nat -> (~>) Nat Nat
-    data NatMinusSym1 (a0123456789876543210 :: Nat) :: (~>) Nat Nat
+    data NatMinusSym1 (a_T378b_1 :: Nat) :: (~>) Nat Nat
       where
-        NatMinusSym1KindInference :: SameKind (Apply (NatMinusSym1 a0123456789876543210) arg) (NatMinusSym2 a0123456789876543210 arg) =>
-                                     NatMinusSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Nat @Nat (NatMinusSym1 a0123456789876543210) a0123456789876543210 = NatMinus a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (NatMinusSym1 a0123456789876543210) where
+        NatMinusSym1KindInference :: SameKind (Apply (NatMinusSym1 a_T378b_1) arg) (NatMinusSym2 a_T378b_1 arg) =>
+                                     NatMinusSym1 a_T378b_1 a_T378b_2
+    type instance Apply @Nat @Nat (NatMinusSym1 a_T378b_1) a_T378b_2 = NatMinus a_T378b_1 a_T378b_2
+    instance SuppressUnusedWarnings (NatMinusSym1 a_T378b_1) where
       suppressUnusedWarnings = snd ((,) NatMinusSym1KindInference ())
     type NatMinusSym2 :: Nat -> Nat -> Nat
-    type family NatMinusSym2 (a0123456789876543210 :: Nat) (a0123456789876543210 :: Nat) :: Nat where
-      NatMinusSym2 a0123456789876543210 a0123456789876543210 = NatMinus a0123456789876543210 a0123456789876543210
+    type family NatMinusSym2 (a_T378b_1 :: Nat) (a_T378b_2 :: Nat) :: Nat where
+      NatMinusSym2 a_T378b_1 a_T378b_2 = NatMinus a_T378b_1 a_T378b_2
     type FSym0 :: forall b a. (~>) a ((~>) b ())
     data FSym0 :: (~>) a ((~>) b ())
       where
         FSym0KindInference :: SameKind (Apply FSym0 arg) (FSym1 arg) =>
-                              FSym0 a0123456789876543210
-    type instance Apply @a @((~>) b ()) FSym0 a0123456789876543210 = FSym1 a0123456789876543210
+                              FSym0 a_T378b_4
+    type instance Apply @a @((~>) b ()) FSym0 a_T378b_4 = FSym1 a_T378b_4
     instance SuppressUnusedWarnings FSym0 where
       suppressUnusedWarnings = snd ((,) FSym0KindInference ())
     type FSym1 :: forall b a. a -> (~>) b ()
-    data FSym1 (a0123456789876543210 :: a) :: (~>) b ()
+    data FSym1 (a_T378b_4 :: a) :: (~>) b ()
       where
-        FSym1KindInference :: SameKind (Apply (FSym1 a0123456789876543210) arg) (FSym2 a0123456789876543210 arg) =>
-                              FSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @() (FSym1 a0123456789876543210) a0123456789876543210 = F a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (FSym1 a0123456789876543210) where
+        FSym1KindInference :: SameKind (Apply (FSym1 a_T378b_4) arg) (FSym2 a_T378b_4 arg) =>
+                              FSym1 a_T378b_4 a_T378b_5
+    type instance Apply @b @() (FSym1 a_T378b_4) a_T378b_5 = F a_T378b_4 a_T378b_5
+    instance SuppressUnusedWarnings (FSym1 a_T378b_4) where
       suppressUnusedWarnings = snd ((,) FSym1KindInference ())
     type FSym2 :: forall b a. a -> b -> ()
-    type family FSym2 @b @a (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: () where
-      FSym2 a0123456789876543210 a0123456789876543210 = F a0123456789876543210 a0123456789876543210
+    type family FSym2 @b @a (a_T378b_4 :: a) (a_T378b_5 :: b) :: () where
+      FSym2 a_T378b_4 a_T378b_5 = F a_T378b_4 a_T378b_5
     type NatMinus :: Nat -> Nat -> Nat
     type family NatMinus (a :: Nat) (a :: Nat) :: Nat where
       NatMinus 'Zero _ = ZeroSym0
       NatMinus ('Succ a) ('Succ b) = Apply (Apply NatMinusSym0 a) b
-      NatMinus ('Succ wild_0123456789876543210) 'Zero = Let0123456789876543210ASym0 wild_0123456789876543210
+      NatMinus ('Succ wild_T378b_0) 'Zero = Let3ASym0 wild_T378b_0
     type F :: forall b a. a -> b -> ()
     type family F @b @a (a :: a) (a :: b) :: () where
       F @b @a (_ :: a) (_ :: b) = Tuple0Sym0
@@ -84,12 +84,10 @@ Singletons/T378b.hs:(0,0)-(0,0): Splicing declarations
     sNatMinus SZero _ = SZero
     sNatMinus (SSucc (sA :: Sing a)) (SSucc (sB :: Sing b))
       = applySing (applySing (singFun2 @NatMinusSym0 sNatMinus) sA) sB
-    sNatMinus
-      (SSucc (sWild_0123456789876543210 :: Sing wild_0123456789876543210))
-      SZero
+    sNatMinus (SSucc (sWild_T378b_0 :: Sing wild_T378b_0)) SZero
       = let
-          sA :: Sing @_ (Let0123456789876543210A wild_0123456789876543210)
-          sA = applySing (singFun1 @SuccSym0 SSucc) sWild_0123456789876543210
+          sA :: Sing @_ (Let3A wild_T378b_0)
+          sA = applySing (singFun1 @SuccSym0 SSucc) sWild_T378b_0
         in sA
     sF _ _ = STuple0
     instance SingI (NatMinusSym0 :: (~>) Nat ((~>) Nat Nat)) where

--- a/singletons-base/tests/compile-and-dump/Singletons/T402.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T402.golden
@@ -2,12 +2,12 @@ Singletons/T402.hs:0:0:: Splicing declarations
     singletons [d| type AnyOfKind (k :: Type) = Any :: k |]
   ======>
     type AnyOfKind (k :: Type) = Any :: k
-    data AnyOfKindSym0 :: (~>) Type k0123456789876543210
+    data AnyOfKindSym0 :: (~>) Type k0
       where
         AnyOfKindSym0KindInference :: SameKind (Apply AnyOfKindSym0 arg) (AnyOfKindSym1 arg) =>
-                                      AnyOfKindSym0 k0123456789876543210
-    type instance Apply @Type @k0123456789876543210 AnyOfKindSym0 k0123456789876543210 = AnyOfKind k0123456789876543210
+                                      AnyOfKindSym0 k0
+    type instance Apply @Type @k0 AnyOfKindSym0 k0 = AnyOfKind k0
     instance SuppressUnusedWarnings AnyOfKindSym0 where
       suppressUnusedWarnings = snd ((,) AnyOfKindSym0KindInference ())
-    type family AnyOfKindSym1 (k0123456789876543210 :: Type) :: k0123456789876543210 where
-      AnyOfKindSym1 k0123456789876543210 = AnyOfKind k0123456789876543210
+    type family AnyOfKindSym1 (k0 :: Type) :: k0 where
+      AnyOfKindSym1 k0 = AnyOfKind k0

--- a/singletons-base/tests/compile-and-dump/Singletons/T410.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T410.golden
@@ -14,27 +14,27 @@ Singletons/T410.hs:(0,0)-(0,0): Splicing declarations
     data EqualsSym0 :: (~>) a ((~>) a Bool)
       where
         EqualsSym0KindInference :: SameKind (Apply EqualsSym0 arg) (EqualsSym1 arg) =>
-                                   EqualsSym0 a0123456789876543210
-    type instance Apply @a @((~>) a Bool) EqualsSym0 a0123456789876543210 = EqualsSym1 a0123456789876543210
+                                   EqualsSym0 a_T410_0
+    type instance Apply @a @((~>) a Bool) EqualsSym0 a_T410_0 = EqualsSym1 a_T410_0
     instance Data.Singletons.TH.SuppressUnusedWarnings.SuppressUnusedWarnings EqualsSym0 where
       Data.Singletons.TH.SuppressUnusedWarnings.suppressUnusedWarnings
         = snd ((,) EqualsSym0KindInference ())
     type EqualsSym1 :: forall a. a -> (~>) a Bool
-    data EqualsSym1 (a0123456789876543210 :: a) :: (~>) a Bool
+    data EqualsSym1 (a_T410_0 :: a) :: (~>) a Bool
       where
-        EqualsSym1KindInference :: SameKind (Apply (EqualsSym1 a0123456789876543210) arg) (EqualsSym2 a0123456789876543210 arg) =>
-                                   EqualsSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @a @Bool (EqualsSym1 a0123456789876543210) a0123456789876543210 = Equals a0123456789876543210 a0123456789876543210
-    instance Data.Singletons.TH.SuppressUnusedWarnings.SuppressUnusedWarnings (EqualsSym1 a0123456789876543210) where
+        EqualsSym1KindInference :: SameKind (Apply (EqualsSym1 a_T410_0) arg) (EqualsSym2 a_T410_0 arg) =>
+                                   EqualsSym1 a_T410_0 a_T410_1
+    type instance Apply @a @Bool (EqualsSym1 a_T410_0) a_T410_1 = Equals a_T410_0 a_T410_1
+    instance Data.Singletons.TH.SuppressUnusedWarnings.SuppressUnusedWarnings (EqualsSym1 a_T410_0) where
       Data.Singletons.TH.SuppressUnusedWarnings.suppressUnusedWarnings
         = snd ((,) EqualsSym1KindInference ())
     type EqualsSym2 :: forall a. a -> a -> Bool
-    type family EqualsSym2 @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: Bool where
-      EqualsSym2 a0123456789876543210 a0123456789876543210 = Equals a0123456789876543210 a0123456789876543210
+    type family EqualsSym2 @a (a_T410_0 :: a) (a_T410_1 :: a) :: Bool where
+      EqualsSym2 a_T410_0 a_T410_1 = Equals a_T410_0 a_T410_1
     class PEq a where
       type family Equals (arg :: a) (arg :: a) :: Bool
-    type Equals_0123456789876543210 :: () -> () -> Bool
-    type family Equals_0123456789876543210 (a :: ()) (a :: ()) :: Bool where
-      Equals_0123456789876543210 '() '() = TrueSym0
+    type Equals_T410_2 :: () -> () -> Bool
+    type family Equals_T410_2 (a :: ()) (a :: ()) :: Bool where
+      Equals_T410_2 '() '() = TrueSym0
     instance PEq () where
-      type Equals a a = Equals_0123456789876543210 a a
+      type Equals a a = Equals_T410_2 a a

--- a/singletons-base/tests/compile-and-dump/Singletons/T412.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T412.golden
@@ -26,91 +26,91 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
     infixr 5 `d1A`
     infixr 5 `d1B`
     data D1 a b = MkD1 {d1A :: a, d1B :: b}
-    data T1aSym0 a0123456789876543210
+    data T1aSym0 a0
       where
         T1aSym0KindInference :: SameKind (Apply T1aSym0 arg) (T1aSym1 arg) =>
-                                T1aSym0 a0123456789876543210
-    type instance Apply @_ @_ T1aSym0 a0123456789876543210 = T1aSym1 a0123456789876543210
+                                T1aSym0 a0
+    type instance Apply @_ @_ T1aSym0 a0 = T1aSym1 a0
     instance SuppressUnusedWarnings T1aSym0 where
       suppressUnusedWarnings = snd ((,) T1aSym0KindInference ())
     infixl 5 type `T1aSym0`
-    data T1aSym1 a0123456789876543210 b0123456789876543210
+    data T1aSym1 a0 b1
       where
-        T1aSym1KindInference :: SameKind (Apply (T1aSym1 a0123456789876543210) arg) (T1aSym2 a0123456789876543210 arg) =>
-                                T1aSym1 a0123456789876543210 b0123456789876543210
-    type instance Apply @_ @_ (T1aSym1 a0123456789876543210) b0123456789876543210 = T1a a0123456789876543210 b0123456789876543210
-    instance SuppressUnusedWarnings (T1aSym1 a0123456789876543210) where
+        T1aSym1KindInference :: SameKind (Apply (T1aSym1 a0) arg) (T1aSym2 a0 arg) =>
+                                T1aSym1 a0 b1
+    type instance Apply @_ @_ (T1aSym1 a0) b1 = T1a a0 b1
+    instance SuppressUnusedWarnings (T1aSym1 a0) where
       suppressUnusedWarnings = snd ((,) T1aSym1KindInference ())
     infixl 5 type `T1aSym1`
-    type family T1aSym2 a0123456789876543210 b0123456789876543210 where
-      T1aSym2 a0123456789876543210 b0123456789876543210 = T1a a0123456789876543210 b0123456789876543210
+    type family T1aSym2 a0 b1 where
+      T1aSym2 a0 b1 = T1a a0 b1
     infixl 5 type `T1aSym2`
-    data T1bSym0 a0123456789876543210
+    data T1bSym0 a0
       where
         T1bSym0KindInference :: SameKind (Apply T1bSym0 arg) (T1bSym1 arg) =>
-                                T1bSym0 a0123456789876543210
-    type instance Apply @_ @_ T1bSym0 a0123456789876543210 = T1bSym1 a0123456789876543210
+                                T1bSym0 a0
+    type instance Apply @_ @_ T1bSym0 a0 = T1bSym1 a0
     instance SuppressUnusedWarnings T1bSym0 where
       suppressUnusedWarnings = snd ((,) T1bSym0KindInference ())
     infixl 5 type `T1bSym0`
-    data T1bSym1 a0123456789876543210 b0123456789876543210
+    data T1bSym1 a0 b1
       where
-        T1bSym1KindInference :: SameKind (Apply (T1bSym1 a0123456789876543210) arg) (T1bSym2 a0123456789876543210 arg) =>
-                                T1bSym1 a0123456789876543210 b0123456789876543210
-    type instance Apply @_ @_ (T1bSym1 a0123456789876543210) b0123456789876543210 = T1b a0123456789876543210 b0123456789876543210
-    instance SuppressUnusedWarnings (T1bSym1 a0123456789876543210) where
+        T1bSym1KindInference :: SameKind (Apply (T1bSym1 a0) arg) (T1bSym2 a0 arg) =>
+                                T1bSym1 a0 b1
+    type instance Apply @_ @_ (T1bSym1 a0) b1 = T1b a0 b1
+    instance SuppressUnusedWarnings (T1bSym1 a0) where
       suppressUnusedWarnings = snd ((,) T1bSym1KindInference ())
     infixl 5 type `T1bSym1`
-    type family T1bSym2 a0123456789876543210 b0123456789876543210 where
-      T1bSym2 a0123456789876543210 b0123456789876543210 = T1b a0123456789876543210 b0123456789876543210
+    type family T1bSym2 a0 b1 where
+      T1bSym2 a0 b1 = T1b a0 b1
     infixl 5 type `T1bSym2`
     type MkD1Sym0 :: forall a b. (~>) a ((~>) b (D1 a b))
     data MkD1Sym0 :: (~>) a ((~>) b (D1 a b))
       where
         MkD1Sym0KindInference :: SameKind (Apply MkD1Sym0 arg) (MkD1Sym1 arg) =>
-                                 MkD1Sym0 a0123456789876543210
-    type instance Apply @a @((~>) b (D1 a b)) MkD1Sym0 a0123456789876543210 = MkD1Sym1 a0123456789876543210
+                                 MkD1Sym0 a_T412_0
+    type instance Apply @a @((~>) b (D1 a b)) MkD1Sym0 a_T412_0 = MkD1Sym1 a_T412_0
     instance SuppressUnusedWarnings MkD1Sym0 where
       suppressUnusedWarnings = snd ((,) MkD1Sym0KindInference ())
     infixr 5 type `MkD1Sym0`
     type MkD1Sym1 :: forall a b. a -> (~>) b (D1 a b)
-    data MkD1Sym1 (a0123456789876543210 :: a) :: (~>) b (D1 a b)
+    data MkD1Sym1 (a_T412_0 :: a) :: (~>) b (D1 a b)
       where
-        MkD1Sym1KindInference :: SameKind (Apply (MkD1Sym1 a0123456789876543210) arg) (MkD1Sym2 a0123456789876543210 arg) =>
-                                 MkD1Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @(D1 a b) (MkD1Sym1 a0123456789876543210) a0123456789876543210 = MkD1 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (MkD1Sym1 a0123456789876543210) where
+        MkD1Sym1KindInference :: SameKind (Apply (MkD1Sym1 a_T412_0) arg) (MkD1Sym2 a_T412_0 arg) =>
+                                 MkD1Sym1 a_T412_0 a_T412_1
+    type instance Apply @b @(D1 a b) (MkD1Sym1 a_T412_0) a_T412_1 = MkD1 a_T412_0 a_T412_1
+    instance SuppressUnusedWarnings (MkD1Sym1 a_T412_0) where
       suppressUnusedWarnings = snd ((,) MkD1Sym1KindInference ())
     infixr 5 type `MkD1Sym1`
     type MkD1Sym2 :: forall a b. a -> b -> D1 a b
-    type family MkD1Sym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: D1 a b where
-      MkD1Sym2 a0123456789876543210 a0123456789876543210 = MkD1 a0123456789876543210 a0123456789876543210
+    type family MkD1Sym2 @a @b (a_T412_0 :: a) (a_T412_1 :: b) :: D1 a b where
+      MkD1Sym2 a_T412_0 a_T412_1 = MkD1 a_T412_0 a_T412_1
     infixr 5 type `MkD1Sym2`
     type D1BSym0 :: forall a b. (~>) (D1 a b) b
     data D1BSym0 :: (~>) (D1 a b) b
       where
         D1BSym0KindInference :: SameKind (Apply D1BSym0 arg) (D1BSym1 arg) =>
-                                D1BSym0 a0123456789876543210
-    type instance Apply @(D1 a b) @b D1BSym0 a0123456789876543210 = D1B a0123456789876543210
+                                D1BSym0 a_T412_2
+    type instance Apply @(D1 a b) @b D1BSym0 a_T412_2 = D1B a_T412_2
     instance SuppressUnusedWarnings D1BSym0 where
       suppressUnusedWarnings = snd ((,) D1BSym0KindInference ())
     infixr 5 type `D1BSym0`
     type D1BSym1 :: forall a b. D1 a b -> b
-    type family D1BSym1 @a @b (a0123456789876543210 :: D1 a b) :: b where
-      D1BSym1 a0123456789876543210 = D1B a0123456789876543210
+    type family D1BSym1 @a @b (a_T412_2 :: D1 a b) :: b where
+      D1BSym1 a_T412_2 = D1B a_T412_2
     infixr 5 type `D1BSym1`
     type D1ASym0 :: forall a b. (~>) (D1 a b) a
     data D1ASym0 :: (~>) (D1 a b) a
       where
         D1ASym0KindInference :: SameKind (Apply D1ASym0 arg) (D1ASym1 arg) =>
-                                D1ASym0 a0123456789876543210
-    type instance Apply @(D1 a b) @a D1ASym0 a0123456789876543210 = D1A a0123456789876543210
+                                D1ASym0 a_T412_3
+    type instance Apply @(D1 a b) @a D1ASym0 a_T412_3 = D1A a_T412_3
     instance SuppressUnusedWarnings D1ASym0 where
       suppressUnusedWarnings = snd ((,) D1ASym0KindInference ())
     infixr 5 type `D1ASym0`
     type D1ASym1 :: forall a b. D1 a b -> a
-    type family D1ASym1 @a @b (a0123456789876543210 :: D1 a b) :: a where
-      D1ASym1 a0123456789876543210 = D1A a0123456789876543210
+    type family D1ASym1 @a @b (a_T412_3 :: D1 a b) :: a where
+      D1ASym1 a_T412_3 = D1A a_T412_3
     infixr 5 type `D1ASym1`
     type D1B :: forall a b. D1 a b -> b
     type family D1B @a @b (a :: D1 a b) :: b where
@@ -125,23 +125,23 @@ Singletons/T412.hs:(0,0)-(0,0): Splicing declarations
     data M1Sym0 :: (~>) a ((~>) b Bool)
       where
         M1Sym0KindInference :: SameKind (Apply M1Sym0 arg) (M1Sym1 arg) =>
-                               M1Sym0 a0123456789876543210
-    type instance Apply @a @((~>) b Bool) M1Sym0 a0123456789876543210 = M1Sym1 a0123456789876543210
+                               M1Sym0 a_T412_4
+    type instance Apply @a @((~>) b Bool) M1Sym0 a_T412_4 = M1Sym1 a_T412_4
     instance SuppressUnusedWarnings M1Sym0 where
       suppressUnusedWarnings = snd ((,) M1Sym0KindInference ())
     infix 6 type `M1Sym0`
     type M1Sym1 :: forall a b. a -> (~>) b Bool
-    data M1Sym1 (a0123456789876543210 :: a) :: (~>) b Bool
+    data M1Sym1 (a_T412_4 :: a) :: (~>) b Bool
       where
-        M1Sym1KindInference :: SameKind (Apply (M1Sym1 a0123456789876543210) arg) (M1Sym2 a0123456789876543210 arg) =>
-                               M1Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @Bool (M1Sym1 a0123456789876543210) a0123456789876543210 = M1 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (M1Sym1 a0123456789876543210) where
+        M1Sym1KindInference :: SameKind (Apply (M1Sym1 a_T412_4) arg) (M1Sym2 a_T412_4 arg) =>
+                               M1Sym1 a_T412_4 a_T412_5
+    type instance Apply @b @Bool (M1Sym1 a_T412_4) a_T412_5 = M1 a_T412_4 a_T412_5
+    instance SuppressUnusedWarnings (M1Sym1 a_T412_4) where
       suppressUnusedWarnings = snd ((,) M1Sym1KindInference ())
     infix 6 type `M1Sym1`
     type M1Sym2 :: forall a b. a -> b -> Bool
-    type family M1Sym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: Bool where
-      M1Sym2 a0123456789876543210 a0123456789876543210 = M1 a0123456789876543210 a0123456789876543210
+    type family M1Sym2 @a @b (a_T412_4 :: a) (a_T412_5 :: b) :: Bool where
+      M1Sym2 a_T412_4 a_T412_5 = M1 a_T412_4 a_T412_5
     infix 6 type `M1Sym2`
     class PC1 a b where
       type family M1 (arg :: a) (arg :: b) :: Bool
@@ -202,23 +202,23 @@ Singletons/T412.hs:0:0:: Splicing declarations
     data M2Sym0 :: (~>) a ((~>) b Bool)
       where
         M2Sym0KindInference :: SameKind (Apply M2Sym0 arg) (M2Sym1 arg) =>
-                               M2Sym0 a0123456789876543210
-    type instance Apply @a @((~>) b Bool) M2Sym0 a0123456789876543210 = M2Sym1 a0123456789876543210
+                               M2Sym0 a_T412_6
+    type instance Apply @a @((~>) b Bool) M2Sym0 a_T412_6 = M2Sym1 a_T412_6
     instance SuppressUnusedWarnings M2Sym0 where
       suppressUnusedWarnings = snd ((,) M2Sym0KindInference ())
     infix 6 type `M2Sym0`
     type M2Sym1 :: forall (a :: Type) (b :: Type). a -> (~>) b Bool
-    data M2Sym1 (a0123456789876543210 :: a) :: (~>) b Bool
+    data M2Sym1 (a_T412_6 :: a) :: (~>) b Bool
       where
-        M2Sym1KindInference :: SameKind (Apply (M2Sym1 a0123456789876543210) arg) (M2Sym2 a0123456789876543210 arg) =>
-                               M2Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @Bool (M2Sym1 a0123456789876543210) a0123456789876543210 = M2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (M2Sym1 a0123456789876543210) where
+        M2Sym1KindInference :: SameKind (Apply (M2Sym1 a_T412_6) arg) (M2Sym2 a_T412_6 arg) =>
+                               M2Sym1 a_T412_6 a_T412_7
+    type instance Apply @b @Bool (M2Sym1 a_T412_6) a_T412_7 = M2 a_T412_6 a_T412_7
+    instance SuppressUnusedWarnings (M2Sym1 a_T412_6) where
       suppressUnusedWarnings = snd ((,) M2Sym1KindInference ())
     infix 6 type `M2Sym1`
     type M2Sym2 :: forall (a :: Type) (b :: Type). a -> b -> Bool
-    type family M2Sym2 @(a :: Type) @(b :: Type) (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: Bool where
-      M2Sym2 a0123456789876543210 a0123456789876543210 = M2 a0123456789876543210 a0123456789876543210
+    type family M2Sym2 @(a :: Type) @(b :: Type) (a_T412_6 :: a) (a_T412_7 :: b) :: Bool where
+      M2Sym2 a_T412_6 a_T412_7 = M2 a_T412_6 a_T412_7
     infix 6 type `M2Sym2`
     type PC2 :: Type -> Type -> Constraint
     class PC2 (a :: Type) (b :: Type) where
@@ -243,69 +243,69 @@ Singletons/T412.hs:0:0:: Splicing declarations
     data T2aSym0 :: (~>) Type ((~>) Type Type)
       where
         T2aSym0KindInference :: SameKind (Apply T2aSym0 arg) (T2aSym1 arg) =>
-                                T2aSym0 a0123456789876543210
-    type instance Apply @Type @((~>) Type Type) T2aSym0 a0123456789876543210 = T2aSym1 a0123456789876543210
+                                T2aSym0 a_T412_8
+    type instance Apply @Type @((~>) Type Type) T2aSym0 a_T412_8 = T2aSym1 a_T412_8
     instance SuppressUnusedWarnings T2aSym0 where
       suppressUnusedWarnings = snd ((,) T2aSym0KindInference ())
     infixl 5 type `T2aSym0`
     type T2aSym1 :: Type -> (~>) Type Type
-    data T2aSym1 (a0123456789876543210 :: Type) :: (~>) Type Type
+    data T2aSym1 (a_T412_8 :: Type) :: (~>) Type Type
       where
-        T2aSym1KindInference :: SameKind (Apply (T2aSym1 a0123456789876543210) arg) (T2aSym2 a0123456789876543210 arg) =>
-                                T2aSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Type @Type (T2aSym1 a0123456789876543210) a0123456789876543210 = T2a a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (T2aSym1 a0123456789876543210) where
+        T2aSym1KindInference :: SameKind (Apply (T2aSym1 a_T412_8) arg) (T2aSym2 a_T412_8 arg) =>
+                                T2aSym1 a_T412_8 a_T412_9
+    type instance Apply @Type @Type (T2aSym1 a_T412_8) a_T412_9 = T2a a_T412_8 a_T412_9
+    instance SuppressUnusedWarnings (T2aSym1 a_T412_8) where
       suppressUnusedWarnings = snd ((,) T2aSym1KindInference ())
     infixl 5 type `T2aSym1`
     type T2aSym2 :: Type -> Type -> Type
-    type family T2aSym2 (a0123456789876543210 :: Type) (a0123456789876543210 :: Type) :: Type where
-      T2aSym2 a0123456789876543210 a0123456789876543210 = T2a a0123456789876543210 a0123456789876543210
+    type family T2aSym2 (a_T412_8 :: Type) (a_T412_9 :: Type) :: Type where
+      T2aSym2 a_T412_8 a_T412_9 = T2a a_T412_8 a_T412_9
     infixl 5 type `T2aSym2`
     type T2bSym0 :: (~>) Type ((~>) Type Type)
     data T2bSym0 :: (~>) Type ((~>) Type Type)
       where
         T2bSym0KindInference :: SameKind (Apply T2bSym0 arg) (T2bSym1 arg) =>
-                                T2bSym0 a0123456789876543210
-    type instance Apply @Type @((~>) Type Type) T2bSym0 a0123456789876543210 = T2bSym1 a0123456789876543210
+                                T2bSym0 a_T412_10
+    type instance Apply @Type @((~>) Type Type) T2bSym0 a_T412_10 = T2bSym1 a_T412_10
     instance SuppressUnusedWarnings T2bSym0 where
       suppressUnusedWarnings = snd ((,) T2bSym0KindInference ())
     infixl 5 type `T2bSym0`
     type T2bSym1 :: Type -> (~>) Type Type
-    data T2bSym1 (a0123456789876543210 :: Type) :: (~>) Type Type
+    data T2bSym1 (a_T412_10 :: Type) :: (~>) Type Type
       where
-        T2bSym1KindInference :: SameKind (Apply (T2bSym1 a0123456789876543210) arg) (T2bSym2 a0123456789876543210 arg) =>
-                                T2bSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Type @Type (T2bSym1 a0123456789876543210) a0123456789876543210 = T2b a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (T2bSym1 a0123456789876543210) where
+        T2bSym1KindInference :: SameKind (Apply (T2bSym1 a_T412_10) arg) (T2bSym2 a_T412_10 arg) =>
+                                T2bSym1 a_T412_10 a_T412_11
+    type instance Apply @Type @Type (T2bSym1 a_T412_10) a_T412_11 = T2b a_T412_10 a_T412_11
+    instance SuppressUnusedWarnings (T2bSym1 a_T412_10) where
       suppressUnusedWarnings = snd ((,) T2bSym1KindInference ())
     infixl 5 type `T2bSym1`
     type T2bSym2 :: Type -> Type -> Type
-    type family T2bSym2 (a0123456789876543210 :: Type) (a0123456789876543210 :: Type) :: Type where
-      T2bSym2 a0123456789876543210 a0123456789876543210 = T2b a0123456789876543210 a0123456789876543210
+    type family T2bSym2 (a_T412_10 :: Type) (a_T412_11 :: Type) :: Type where
+      T2bSym2 a_T412_10 a_T412_11 = T2b a_T412_10 a_T412_11
     infixl 5 type `T2bSym2`
     type MkD2Sym0 :: forall (a :: Type)
                             (b :: Type). (~>) a ((~>) b (D2 a b))
     data MkD2Sym0 :: (~>) a ((~>) b (D2 a b))
       where
         MkD2Sym0KindInference :: SameKind (Apply MkD2Sym0 arg) (MkD2Sym1 arg) =>
-                                 MkD2Sym0 a0123456789876543210
-    type instance Apply @a @((~>) b (D2 a b)) MkD2Sym0 a0123456789876543210 = MkD2Sym1 a0123456789876543210
+                                 MkD2Sym0 a_T412_12
+    type instance Apply @a @((~>) b (D2 a b)) MkD2Sym0 a_T412_12 = MkD2Sym1 a_T412_12
     instance SuppressUnusedWarnings MkD2Sym0 where
       suppressUnusedWarnings = snd ((,) MkD2Sym0KindInference ())
     infixr 5 type `MkD2Sym0`
     type MkD2Sym1 :: forall (a :: Type) (b :: Type). a
                                                      -> (~>) b (D2 a b)
-    data MkD2Sym1 (a0123456789876543210 :: a) :: (~>) b (D2 a b)
+    data MkD2Sym1 (a_T412_12 :: a) :: (~>) b (D2 a b)
       where
-        MkD2Sym1KindInference :: SameKind (Apply (MkD2Sym1 a0123456789876543210) arg) (MkD2Sym2 a0123456789876543210 arg) =>
-                                 MkD2Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @(D2 a b) (MkD2Sym1 a0123456789876543210) a0123456789876543210 = 'MkD2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (MkD2Sym1 a0123456789876543210) where
+        MkD2Sym1KindInference :: SameKind (Apply (MkD2Sym1 a_T412_12) arg) (MkD2Sym2 a_T412_12 arg) =>
+                                 MkD2Sym1 a_T412_12 a_T412_13
+    type instance Apply @b @(D2 a b) (MkD2Sym1 a_T412_12) a_T412_13 = 'MkD2 a_T412_12 a_T412_13
+    instance SuppressUnusedWarnings (MkD2Sym1 a_T412_12) where
       suppressUnusedWarnings = snd ((,) MkD2Sym1KindInference ())
     infixr 5 type `MkD2Sym1`
     type MkD2Sym2 :: forall (a :: Type) (b :: Type). a -> b -> D2 a b
-    type family MkD2Sym2 @(a :: Type) @(b :: Type) (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: D2 a b where
-      MkD2Sym2 a0123456789876543210 a0123456789876543210 = 'MkD2 a0123456789876543210 a0123456789876543210
+    type family MkD2Sym2 @(a :: Type) @(b :: Type) (a_T412_12 :: a) (a_T412_13 :: b) :: D2 a b where
+      MkD2Sym2 a_T412_12 a_T412_13 = 'MkD2 a_T412_12 a_T412_13
     infixr 5 type `MkD2Sym2`
     infixr 5 type `D2A`
     infixr 5 type `D2B`
@@ -313,24 +313,24 @@ Singletons/T412.hs:0:0:: Splicing declarations
     data D2BSym0 :: (~>) (D2 a b) b
       where
         D2BSym0KindInference :: SameKind (Apply D2BSym0 arg) (D2BSym1 arg) =>
-                                D2BSym0 a0123456789876543210
-    type instance Apply @(D2 a b) @b D2BSym0 a0123456789876543210 = D2B a0123456789876543210
+                                D2BSym0 a_T412_14
+    type instance Apply @(D2 a b) @b D2BSym0 a_T412_14 = D2B a_T412_14
     instance SuppressUnusedWarnings D2BSym0 where
       suppressUnusedWarnings = snd ((,) D2BSym0KindInference ())
     type D2BSym1 :: forall (a :: Type) (b :: Type). D2 a b -> b
-    type family D2BSym1 @(a :: Type) @(b :: Type) (a0123456789876543210 :: D2 a b) :: b where
-      D2BSym1 a0123456789876543210 = D2B a0123456789876543210
+    type family D2BSym1 @(a :: Type) @(b :: Type) (a_T412_14 :: D2 a b) :: b where
+      D2BSym1 a_T412_14 = D2B a_T412_14
     type D2ASym0 :: forall (a :: Type) (b :: Type). (~>) (D2 a b) a
     data D2ASym0 :: (~>) (D2 a b) a
       where
         D2ASym0KindInference :: SameKind (Apply D2ASym0 arg) (D2ASym1 arg) =>
-                                D2ASym0 a0123456789876543210
-    type instance Apply @(D2 a b) @a D2ASym0 a0123456789876543210 = D2A a0123456789876543210
+                                D2ASym0 a_T412_15
+    type instance Apply @(D2 a b) @a D2ASym0 a_T412_15 = D2A a_T412_15
     instance SuppressUnusedWarnings D2ASym0 where
       suppressUnusedWarnings = snd ((,) D2ASym0KindInference ())
     type D2ASym1 :: forall (a :: Type) (b :: Type). D2 a b -> a
-    type family D2ASym1 @(a :: Type) @(b :: Type) (a0123456789876543210 :: D2 a b) :: a where
-      D2ASym1 a0123456789876543210 = D2A a0123456789876543210
+    type family D2ASym1 @(a :: Type) @(b :: Type) (a_T412_15 :: D2 a b) :: a where
+      D2ASym1 a_T412_15 = D2A a_T412_15
     type D2B :: forall (a :: Type) (b :: Type). D2 a b -> b
     type family D2B @(a :: Type) @(b :: Type) (a :: D2 a b) :: b where
       D2B @a @b ('MkD2 _ field :: D2 a b) = field

--- a/singletons-base/tests/compile-and-dump/Singletons/T414.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T414.golden
@@ -16,59 +16,59 @@ Singletons/T414.hs:(0,0)-(0,0): Splicing declarations
     type C3 :: Bool -> Constraint
     class C3 a where
       type family T3 a b
-    data T1Sym0 a0123456789876543210
+    data T1Sym0 a0
       where
         T1Sym0KindInference :: SameKind (Apply T1Sym0 arg) (T1Sym1 arg) =>
-                               T1Sym0 a0123456789876543210
-    type instance Apply @Bool @_ T1Sym0 a0123456789876543210 = T1Sym1 a0123456789876543210
+                               T1Sym0 a0
+    type instance Apply @Bool @_ T1Sym0 a0 = T1Sym1 a0
     instance SuppressUnusedWarnings T1Sym0 where
       suppressUnusedWarnings = snd ((,) T1Sym0KindInference ())
-    data T1Sym1 (a0123456789876543210 :: Bool) b0123456789876543210
+    data T1Sym1 (a0 :: Bool) b1
       where
-        T1Sym1KindInference :: SameKind (Apply (T1Sym1 a0123456789876543210) arg) (T1Sym2 a0123456789876543210 arg) =>
-                               T1Sym1 a0123456789876543210 b0123456789876543210
-    type instance Apply @_ @_ (T1Sym1 a0123456789876543210) b0123456789876543210 = T1 a0123456789876543210 b0123456789876543210
-    instance SuppressUnusedWarnings (T1Sym1 a0123456789876543210) where
+        T1Sym1KindInference :: SameKind (Apply (T1Sym1 a0) arg) (T1Sym2 a0 arg) =>
+                               T1Sym1 a0 b1
+    type instance Apply @_ @_ (T1Sym1 a0) b1 = T1 a0 b1
+    instance SuppressUnusedWarnings (T1Sym1 a0) where
       suppressUnusedWarnings = snd ((,) T1Sym1KindInference ())
-    type family T1Sym2 (a0123456789876543210 :: Bool) b0123456789876543210 where
-      T1Sym2 a0123456789876543210 b0123456789876543210 = T1 a0123456789876543210 b0123456789876543210
+    type family T1Sym2 (a0 :: Bool) b1 where
+      T1Sym2 a0 b1 = T1 a0 b1
     class PC1 (a :: Bool)
-    data T2Sym0 a0123456789876543210
+    data T2Sym0 a0
       where
         T2Sym0KindInference :: SameKind (Apply T2Sym0 arg) (T2Sym1 arg) =>
-                               T2Sym0 a0123456789876543210
-    type instance Apply @_ @_ T2Sym0 a0123456789876543210 = T2Sym1 a0123456789876543210
+                               T2Sym0 a0
+    type instance Apply @_ @_ T2Sym0 a0 = T2Sym1 a0
     instance SuppressUnusedWarnings T2Sym0 where
       suppressUnusedWarnings = snd ((,) T2Sym0KindInference ())
-    data T2Sym1 a0123456789876543210 b0123456789876543210
+    data T2Sym1 a0 b1
       where
-        T2Sym1KindInference :: SameKind (Apply (T2Sym1 a0123456789876543210) arg) (T2Sym2 a0123456789876543210 arg) =>
-                               T2Sym1 a0123456789876543210 b0123456789876543210
-    type instance Apply @_ @_ (T2Sym1 a0123456789876543210) b0123456789876543210 = T2 a0123456789876543210 b0123456789876543210
-    instance SuppressUnusedWarnings (T2Sym1 a0123456789876543210) where
+        T2Sym1KindInference :: SameKind (Apply (T2Sym1 a0) arg) (T2Sym2 a0 arg) =>
+                               T2Sym1 a0 b1
+    type instance Apply @_ @_ (T2Sym1 a0) b1 = T2 a0 b1
+    instance SuppressUnusedWarnings (T2Sym1 a0) where
       suppressUnusedWarnings = snd ((,) T2Sym1KindInference ())
-    type family T2Sym2 a0123456789876543210 b0123456789876543210 where
-      T2Sym2 a0123456789876543210 b0123456789876543210 = T2 a0123456789876543210 b0123456789876543210
+    type family T2Sym2 a0 b1 where
+      T2Sym2 a0 b1 = T2 a0 b1
     class PC2 a
     type T3Sym0 :: (~>) Bool ((~>) Type Type)
     data T3Sym0 :: (~>) Bool ((~>) Type Type)
       where
         T3Sym0KindInference :: SameKind (Apply T3Sym0 arg) (T3Sym1 arg) =>
-                               T3Sym0 a0123456789876543210
-    type instance Apply @Bool @((~>) Type Type) T3Sym0 a0123456789876543210 = T3Sym1 a0123456789876543210
+                               T3Sym0 a_T414_0
+    type instance Apply @Bool @((~>) Type Type) T3Sym0 a_T414_0 = T3Sym1 a_T414_0
     instance SuppressUnusedWarnings T3Sym0 where
       suppressUnusedWarnings = snd ((,) T3Sym0KindInference ())
     type T3Sym1 :: Bool -> (~>) Type Type
-    data T3Sym1 (a0123456789876543210 :: Bool) :: (~>) Type Type
+    data T3Sym1 (a_T414_0 :: Bool) :: (~>) Type Type
       where
-        T3Sym1KindInference :: SameKind (Apply (T3Sym1 a0123456789876543210) arg) (T3Sym2 a0123456789876543210 arg) =>
-                               T3Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Type @Type (T3Sym1 a0123456789876543210) a0123456789876543210 = T3 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (T3Sym1 a0123456789876543210) where
+        T3Sym1KindInference :: SameKind (Apply (T3Sym1 a_T414_0) arg) (T3Sym2 a_T414_0 arg) =>
+                               T3Sym1 a_T414_0 a_T414_1
+    type instance Apply @Type @Type (T3Sym1 a_T414_0) a_T414_1 = T3 a_T414_0 a_T414_1
+    instance SuppressUnusedWarnings (T3Sym1 a_T414_0) where
       suppressUnusedWarnings = snd ((,) T3Sym1KindInference ())
     type T3Sym2 :: Bool -> Type -> Type
-    type family T3Sym2 (a0123456789876543210 :: Bool) (a0123456789876543210 :: Type) :: Type where
-      T3Sym2 a0123456789876543210 a0123456789876543210 = T3 a0123456789876543210 a0123456789876543210
+    type family T3Sym2 (a_T414_0 :: Bool) (a_T414_1 :: Type) :: Type where
+      T3Sym2 a_T414_0 a_T414_1 = T3 a_T414_0 a_T414_1
     type PC3 :: Bool -> Constraint
     class PC3 a
     class SC1 (a :: Bool)

--- a/singletons-base/tests/compile-and-dump/Singletons/T433.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T433.golden
@@ -75,194 +75,191 @@ Singletons/T433.hs:(0,0)-(0,0): Splicing declarations
       where
           g :: b -> a -> b
           g y _ = y
-    data Let0123456789876543210GSym0 (x0123456789876543210 :: a0123456789876543210) :: (~>) b0123456789876543210 ((~>) a0123456789876543210 b0123456789876543210)
+    data Let1GSym0 (x1 :: a0) :: (~>) b2 ((~>) a4 b2)
       where
-        Let0123456789876543210GSym0KindInference :: SameKind (Apply (Let0123456789876543210GSym0 x0123456789876543210) arg) (Let0123456789876543210GSym1 x0123456789876543210 arg) =>
-                                                    Let0123456789876543210GSym0 x0123456789876543210 a0123456789876543210
-    type instance Apply @b0123456789876543210 @((~>) a0123456789876543210 b0123456789876543210) (Let0123456789876543210GSym0 x0123456789876543210) a0123456789876543210 = Let0123456789876543210GSym1 x0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Let0123456789876543210GSym0 x0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Let0123456789876543210GSym0KindInference ())
-    data Let0123456789876543210GSym1 (x0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: b0123456789876543210) :: (~>) a0123456789876543210 b0123456789876543210
+        Let1GSym0KindInference :: SameKind (Apply (Let1GSym0 x1) arg) (Let1GSym1 x1 arg) =>
+                                  Let1GSym0 x1 a3
+    type instance Apply @b2 @((~>) a4 b2) (Let1GSym0 x1) a3 = Let1GSym1 x1 a3
+    instance SuppressUnusedWarnings (Let1GSym0 x1) where
+      suppressUnusedWarnings = snd ((,) Let1GSym0KindInference ())
+    data Let1GSym1 (x1 :: a0) (a3 :: b2) :: (~>) a4 b2
       where
-        Let0123456789876543210GSym1KindInference :: SameKind (Apply (Let0123456789876543210GSym1 x0123456789876543210 a0123456789876543210) arg) (Let0123456789876543210GSym2 x0123456789876543210 a0123456789876543210 arg) =>
-                                                    Let0123456789876543210GSym1 x0123456789876543210 a0123456789876543210 a0123456789876543210
-    type instance Apply @a0123456789876543210 @b0123456789876543210 (Let0123456789876543210GSym1 x0123456789876543210 a0123456789876543210) a0123456789876543210 = Let0123456789876543210G x0123456789876543210 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Let0123456789876543210GSym1 x0123456789876543210 a0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Let0123456789876543210GSym1KindInference ())
-    type family Let0123456789876543210GSym2 (x0123456789876543210 :: a0123456789876543210) (a0123456789876543210 :: b0123456789876543210) (a0123456789876543210 :: a0123456789876543210) :: b0123456789876543210 where
-      Let0123456789876543210GSym2 x0123456789876543210 a0123456789876543210 a0123456789876543210 = Let0123456789876543210G x0123456789876543210 a0123456789876543210 a0123456789876543210
-    type family Let0123456789876543210G (x0123456789876543210 :: a0123456789876543210) (a :: b) (a :: a) :: b where
-      Let0123456789876543210G x y _ = y
-    type family Let0123456789876543210GSym0 b0123456789876543210 (x0123456789876543210 :: b0123456789876543210) where
-      Let0123456789876543210GSym0 b0123456789876543210 x0123456789876543210 = Let0123456789876543210G b0123456789876543210 x0123456789876543210
-    type family Let0123456789876543210G b0123456789876543210 (x0123456789876543210 :: b0123456789876543210) where
-      Let0123456789876543210G b x = x :: b
-    type family Let0123456789876543210GSym0 b0123456789876543210 (x0123456789876543210 :: b0123456789876543210) where
-      Let0123456789876543210GSym0 b0123456789876543210 x0123456789876543210 = Let0123456789876543210G b0123456789876543210 x0123456789876543210
-    type family Let0123456789876543210G b0123456789876543210 (x0123456789876543210 :: b0123456789876543210) where
-      Let0123456789876543210G b x = x :: b
-    type family Let0123456789876543210GSym0 a0123456789876543210 (a_01234567898765432100123456789876543210 :: a0123456789876543210) where
-      Let0123456789876543210GSym0 a0123456789876543210 a_01234567898765432100123456789876543210 = Let0123456789876543210G a0123456789876543210 a_01234567898765432100123456789876543210
-    type family Let0123456789876543210G a0123456789876543210 (a_01234567898765432100123456789876543210 :: a0123456789876543210) where
-      Let0123456789876543210G a a_0123456789876543210 = IdSym0 :: (~>) a a
-    data Let0123456789876543210GSym0 local0123456789876543210 :: (~>) a0123456789876543210 a0123456789876543210
+        Let1GSym1KindInference :: SameKind (Apply (Let1GSym1 x1 a3) arg) (Let1GSym2 x1 a3 arg) =>
+                                  Let1GSym1 x1 a3 a5
+    type instance Apply @a4 @b2 (Let1GSym1 x1 a3) a5 = Let1G x1 a3 a5
+    instance SuppressUnusedWarnings (Let1GSym1 x1 a3) where
+      suppressUnusedWarnings = snd ((,) Let1GSym1KindInference ())
+    type family Let1GSym2 (x1 :: a0) (a3 :: b2) (a5 :: a4) :: b2 where
+      Let1GSym2 x1 a3 a5 = Let1G x1 a3 a5
+    type family Let1G (x1 :: a0) (a :: b) (a :: a) :: b where
+      Let1G x y _ = y
+    type family Let2GSym0 b0 (x1 :: b0) where
+      Let2GSym0 b0 x1 = Let2G b0 x1
+    type family Let2G b0 (x1 :: b0) where
+      Let2G b x = x :: b
+    type family Let4GSym0 b0 (x1 :: b0) where
+      Let4GSym0 b0 x1 = Let4G b0 x1
+    type family Let4G b0 (x1 :: b0) where
+      Let4G b x = x :: b
+    type family Let7GSym0 a0 (a_T433_51 :: a0) where
+      Let7GSym0 a0 a_T433_51 = Let7G a0 a_T433_51
+    type family Let7G a0 (a_T433_51 :: a0) where
+      Let7G a a_T433_5 = IdSym0 :: (~>) a a
+    data Let12GSym0 local0 :: (~>) a1 a1
       where
-        Let0123456789876543210GSym0KindInference :: SameKind (Apply (Let0123456789876543210GSym0 local0123456789876543210) arg) (Let0123456789876543210GSym1 local0123456789876543210 arg) =>
-                                                    Let0123456789876543210GSym0 local0123456789876543210 a0123456789876543210
-    type instance Apply @a0123456789876543210 @a0123456789876543210 (Let0123456789876543210GSym0 local0123456789876543210) a0123456789876543210 = Let0123456789876543210G local0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Let0123456789876543210GSym0 local0123456789876543210) where
-      suppressUnusedWarnings
-        = snd ((,) Let0123456789876543210GSym0KindInference ())
-    type family Let0123456789876543210GSym1 local0123456789876543210 (a0123456789876543210 :: a0123456789876543210) :: a0123456789876543210 where
-      Let0123456789876543210GSym1 local0123456789876543210 a0123456789876543210 = Let0123456789876543210G local0123456789876543210 a0123456789876543210
-    type family Let0123456789876543210G local0123456789876543210 (a :: a) :: a where
-      Let0123456789876543210G local (x :: a) = Apply (Apply Konst1Sym0 (x :: a)) local
+        Let12GSym0KindInference :: SameKind (Apply (Let12GSym0 local0) arg) (Let12GSym1 local0 arg) =>
+                                   Let12GSym0 local0 a2
+    type instance Apply @a1 @a1 (Let12GSym0 local0) a2 = Let12G local0 a2
+    instance SuppressUnusedWarnings (Let12GSym0 local0) where
+      suppressUnusedWarnings = snd ((,) Let12GSym0KindInference ())
+    type family Let12GSym1 local0 (a2 :: a1) :: a1 where
+      Let12GSym1 local0 a2 = Let12G local0 a2
+    type family Let12G local0 (a :: a) :: a where
+      Let12G local (x :: a) = Apply (Apply Konst1Sym0 (x :: a)) local
     type Id8Sym0 :: (~>) a a
     data Id8Sym0 :: (~>) a a
       where
         Id8Sym0KindInference :: SameKind (Apply Id8Sym0 arg) (Id8Sym1 arg) =>
-                                Id8Sym0 a0123456789876543210
-    type instance Apply @a @a Id8Sym0 a0123456789876543210 = Id8 a0123456789876543210
+                                Id8Sym0 a_T433_0
+    type instance Apply @a @a Id8Sym0 a_T433_0 = Id8 a_T433_0
     instance SuppressUnusedWarnings Id8Sym0 where
       suppressUnusedWarnings = snd ((,) Id8Sym0KindInference ())
     type Id8Sym1 :: a -> a
-    type family Id8Sym1 @a (a0123456789876543210 :: a) :: a where
-      Id8Sym1 a0123456789876543210 = Id8 a0123456789876543210
-    data Id7Sym0 a0123456789876543210
+    type family Id8Sym1 @a (a_T433_0 :: a) :: a where
+      Id8Sym1 a_T433_0 = Id8 a_T433_0
+    data Id7Sym0 a0
       where
         Id7Sym0KindInference :: SameKind (Apply Id7Sym0 arg) (Id7Sym1 arg) =>
-                                Id7Sym0 a0123456789876543210
-    type instance Apply @_ @_ Id7Sym0 a0123456789876543210 = Id7 a0123456789876543210
+                                Id7Sym0 a0
+    type instance Apply @_ @_ Id7Sym0 a0 = Id7 a0
     instance SuppressUnusedWarnings Id7Sym0 where
       suppressUnusedWarnings = snd ((,) Id7Sym0KindInference ())
-    type family Id7Sym1 a0123456789876543210 where
-      Id7Sym1 a0123456789876543210 = Id7 a0123456789876543210
+    type family Id7Sym1 a0 where
+      Id7Sym1 a0 = Id7 a0
     type Id6Sym0 :: (~>) a a
     data Id6Sym0 :: (~>) a a
       where
         Id6Sym0KindInference :: SameKind (Apply Id6Sym0 arg) (Id6Sym1 arg) =>
-                                Id6Sym0 a0123456789876543210
-    type instance Apply @a @a Id6Sym0 a0123456789876543210 = Id6 a0123456789876543210
+                                Id6Sym0 a_T433_3
+    type instance Apply @a @a Id6Sym0 a_T433_3 = Id6 a_T433_3
     instance SuppressUnusedWarnings Id6Sym0 where
       suppressUnusedWarnings = snd ((,) Id6Sym0KindInference ())
     type Id6Sym1 :: a -> a
-    type family Id6Sym1 @a (a0123456789876543210 :: a) :: a where
-      Id6Sym1 a0123456789876543210 = Id6 a0123456789876543210
+    type family Id6Sym1 @a (a_T433_3 :: a) :: a where
+      Id6Sym1 a_T433_3 = Id6 a_T433_3
     type Id5Sym0 :: forall a. (~>) a a
     data Id5Sym0 :: (~>) a a
       where
         Id5Sym0KindInference :: SameKind (Apply Id5Sym0 arg) (Id5Sym1 arg) =>
-                                Id5Sym0 a0123456789876543210
-    type instance Apply @a @a Id5Sym0 a0123456789876543210 = Id5 a0123456789876543210
+                                Id5Sym0 a_T433_6
+    type instance Apply @a @a Id5Sym0 a_T433_6 = Id5 a_T433_6
     instance SuppressUnusedWarnings Id5Sym0 where
       suppressUnusedWarnings = snd ((,) Id5Sym0KindInference ())
     type Id5Sym1 :: forall a. a -> a
-    type family Id5Sym1 @a (a0123456789876543210 :: a) :: a where
-      Id5Sym1 a0123456789876543210 = Id5 a0123456789876543210
+    type family Id5Sym1 @a (a_T433_6 :: a) :: a where
+      Id5Sym1 a_T433_6 = Id5 a_T433_6
     type Id4Sym0 :: forall a. (~>) a a
     data Id4Sym0 :: (~>) a a
       where
         Id4Sym0KindInference :: SameKind (Apply Id4Sym0 arg) (Id4Sym1 arg) =>
-                                Id4Sym0 a0123456789876543210
-    type instance Apply @a @a Id4Sym0 a0123456789876543210 = Id4 a0123456789876543210
+                                Id4Sym0 a_T433_8
+    type instance Apply @a @a Id4Sym0 a_T433_8 = Id4 a_T433_8
     instance SuppressUnusedWarnings Id4Sym0 where
       suppressUnusedWarnings = snd ((,) Id4Sym0KindInference ())
     type Id4Sym1 :: forall a. a -> a
-    type family Id4Sym1 @a (a0123456789876543210 :: a) :: a where
-      Id4Sym1 a0123456789876543210 = Id4 a0123456789876543210
+    type family Id4Sym1 @a (a_T433_8 :: a) :: a where
+      Id4Sym1 a_T433_8 = Id4 a_T433_8
     type Id3Sym0 :: (~>) a a
     data Id3Sym0 :: (~>) a a
       where
         Id3Sym0KindInference :: SameKind (Apply Id3Sym0 arg) (Id3Sym1 arg) =>
-                                Id3Sym0 a0123456789876543210
-    type instance Apply @a @a Id3Sym0 a0123456789876543210 = Id3 a0123456789876543210
+                                Id3Sym0 a_T433_9
+    type instance Apply @a @a Id3Sym0 a_T433_9 = Id3 a_T433_9
     instance SuppressUnusedWarnings Id3Sym0 where
       suppressUnusedWarnings = snd ((,) Id3Sym0KindInference ())
     type Id3Sym1 :: a -> a
-    type family Id3Sym1 @a (a0123456789876543210 :: a) :: a where
-      Id3Sym1 a0123456789876543210 = Id3 a0123456789876543210
+    type family Id3Sym1 @a (a_T433_9 :: a) :: a where
+      Id3Sym1 a_T433_9 = Id3 a_T433_9
     type Id2Sym0 :: forall a. (~>) a a
     data Id2Sym0 :: (~>) a a
       where
         Id2Sym0KindInference :: SameKind (Apply Id2Sym0 arg) (Id2Sym1 arg) =>
-                                Id2Sym0 a0123456789876543210
-    type instance Apply @a @a Id2Sym0 a0123456789876543210 = Id2 a0123456789876543210
+                                Id2Sym0 a_T433_10
+    type instance Apply @a @a Id2Sym0 a_T433_10 = Id2 a_T433_10
     instance SuppressUnusedWarnings Id2Sym0 where
       suppressUnusedWarnings = snd ((,) Id2Sym0KindInference ())
     type Id2Sym1 :: forall a. a -> a
-    type family Id2Sym1 @a (a0123456789876543210 :: a) :: a where
-      Id2Sym1 a0123456789876543210 = Id2 a0123456789876543210
+    type family Id2Sym1 @a (a_T433_10 :: a) :: a where
+      Id2Sym1 a_T433_10 = Id2 a_T433_10
     type FooSym0 :: forall a. (~>) a ()
     data FooSym0 :: (~>) a ()
       where
         FooSym0KindInference :: SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
-                                FooSym0 a0123456789876543210
-    type instance Apply @a @() FooSym0 a0123456789876543210 = Foo a0123456789876543210
+                                FooSym0 a_T433_11
+    type instance Apply @a @() FooSym0 a_T433_11 = Foo a_T433_11
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings = snd ((,) FooSym0KindInference ())
     type FooSym1 :: forall a. a -> ()
-    type family FooSym1 @a (a0123456789876543210 :: a) :: () where
-      FooSym1 a0123456789876543210 = Foo a0123456789876543210
-    data FSym0 a0123456789876543210
+    type family FooSym1 @a (a_T433_11 :: a) :: () where
+      FooSym1 a_T433_11 = Foo a_T433_11
+    data FSym0 a0
       where
         FSym0KindInference :: SameKind (Apply FSym0 arg) (FSym1 arg) =>
-                              FSym0 a0123456789876543210
-    type instance Apply @_ @_ FSym0 a0123456789876543210 = F a0123456789876543210
+                              FSym0 a0
+    type instance Apply @_ @_ FSym0 a0 = F a0
     instance SuppressUnusedWarnings FSym0 where
       suppressUnusedWarnings = snd ((,) FSym0KindInference ())
-    type family FSym1 a0123456789876543210 where
-      FSym1 a0123456789876543210 = F a0123456789876543210
+    type family FSym1 a0 where
+      FSym1 a0 = F a0
     type Konst2Sym0 :: (~>) a ((~>) (Maybe Bool) a)
     data Konst2Sym0 :: (~>) a ((~>) (Maybe Bool) a)
       where
         Konst2Sym0KindInference :: SameKind (Apply Konst2Sym0 arg) (Konst2Sym1 arg) =>
-                                   Konst2Sym0 a0123456789876543210
-    type instance Apply @a @((~>) (Maybe Bool) a) Konst2Sym0 a0123456789876543210 = Konst2Sym1 a0123456789876543210
+                                   Konst2Sym0 a_T433_13
+    type instance Apply @a @((~>) (Maybe Bool) a) Konst2Sym0 a_T433_13 = Konst2Sym1 a_T433_13
     instance SuppressUnusedWarnings Konst2Sym0 where
       suppressUnusedWarnings = snd ((,) Konst2Sym0KindInference ())
     type Konst2Sym1 :: a -> (~>) (Maybe Bool) a
-    data Konst2Sym1 (a0123456789876543210 :: a) :: (~>) (Maybe Bool) a
+    data Konst2Sym1 (a_T433_13 :: a) :: (~>) (Maybe Bool) a
       where
-        Konst2Sym1KindInference :: SameKind (Apply (Konst2Sym1 a0123456789876543210) arg) (Konst2Sym2 a0123456789876543210 arg) =>
-                                   Konst2Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Maybe Bool) @a (Konst2Sym1 a0123456789876543210) a0123456789876543210 = Konst2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Konst2Sym1 a0123456789876543210) where
+        Konst2Sym1KindInference :: SameKind (Apply (Konst2Sym1 a_T433_13) arg) (Konst2Sym2 a_T433_13 arg) =>
+                                   Konst2Sym1 a_T433_13 a_T433_14
+    type instance Apply @(Maybe Bool) @a (Konst2Sym1 a_T433_13) a_T433_14 = Konst2 a_T433_13 a_T433_14
+    instance SuppressUnusedWarnings (Konst2Sym1 a_T433_13) where
       suppressUnusedWarnings = snd ((,) Konst2Sym1KindInference ())
     type Konst2Sym2 :: a -> Maybe Bool -> a
-    type family Konst2Sym2 @a (a0123456789876543210 :: a) (a0123456789876543210 :: Maybe Bool) :: a where
-      Konst2Sym2 a0123456789876543210 a0123456789876543210 = Konst2 a0123456789876543210 a0123456789876543210
+    type family Konst2Sym2 @a (a_T433_13 :: a) (a_T433_14 :: Maybe Bool) :: a where
+      Konst2Sym2 a_T433_13 a_T433_14 = Konst2 a_T433_13 a_T433_14
     type Konst1Sym0 :: (~>) a ((~>) Bool a)
     data Konst1Sym0 :: (~>) a ((~>) Bool a)
       where
         Konst1Sym0KindInference :: SameKind (Apply Konst1Sym0 arg) (Konst1Sym1 arg) =>
-                                   Konst1Sym0 a0123456789876543210
-    type instance Apply @a @((~>) Bool a) Konst1Sym0 a0123456789876543210 = Konst1Sym1 a0123456789876543210
+                                   Konst1Sym0 a_T433_15
+    type instance Apply @a @((~>) Bool a) Konst1Sym0 a_T433_15 = Konst1Sym1 a_T433_15
     instance SuppressUnusedWarnings Konst1Sym0 where
       suppressUnusedWarnings = snd ((,) Konst1Sym0KindInference ())
     type Konst1Sym1 :: a -> (~>) Bool a
-    data Konst1Sym1 (a0123456789876543210 :: a) :: (~>) Bool a
+    data Konst1Sym1 (a_T433_15 :: a) :: (~>) Bool a
       where
-        Konst1Sym1KindInference :: SameKind (Apply (Konst1Sym1 a0123456789876543210) arg) (Konst1Sym2 a0123456789876543210 arg) =>
-                                   Konst1Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Bool @a (Konst1Sym1 a0123456789876543210) a0123456789876543210 = Konst1 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (Konst1Sym1 a0123456789876543210) where
+        Konst1Sym1KindInference :: SameKind (Apply (Konst1Sym1 a_T433_15) arg) (Konst1Sym2 a_T433_15 arg) =>
+                                   Konst1Sym1 a_T433_15 a_T433_16
+    type instance Apply @Bool @a (Konst1Sym1 a_T433_15) a_T433_16 = Konst1 a_T433_15 a_T433_16
+    instance SuppressUnusedWarnings (Konst1Sym1 a_T433_15) where
       suppressUnusedWarnings = snd ((,) Konst1Sym1KindInference ())
     type Konst1Sym2 :: a -> Bool -> a
-    type family Konst1Sym2 @a (a0123456789876543210 :: a) (a0123456789876543210 :: Bool) :: a where
-      Konst1Sym2 a0123456789876543210 a0123456789876543210 = Konst1 a0123456789876543210 a0123456789876543210
+    type family Konst1Sym2 @a (a_T433_15 :: a) (a_T433_16 :: Bool) :: a where
+      Konst1Sym2 a_T433_15 a_T433_16 = Konst1 a_T433_15 a_T433_16
     type Id8 :: a -> a
     type family Id8 @a (a :: a) :: a where
-      Id8 x = Apply (Apply (Let0123456789876543210GSym0 x) x) TrueSym0
+      Id8 x = Apply (Apply (Let1GSym0 x) x) TrueSym0
     type family Id7 a where
-      Id7 (x :: b) = Let0123456789876543210GSym0 b x
+      Id7 (x :: b) = Let2GSym0 b x
     type Id6 :: a -> a
     type family Id6 @a (a :: a) :: a where
-      Id6 (x :: b) = Let0123456789876543210GSym0 b x
+      Id6 (x :: b) = Let4GSym0 b x
     type Id5 :: forall a. a -> a
     type family Id5 @a (a :: a) :: a where
-      Id5 @a (a_0123456789876543210 :: a) = Apply (Let0123456789876543210GSym0 a a_0123456789876543210) a_0123456789876543210
+      Id5 @a (a_T433_5 :: a) = Apply (Let7GSym0 a a_T433_5) a_T433_5
     type Id4 :: forall a. a -> a
     type family Id4 @a (a :: a) :: a where
       Id4 @a (x :: a :: a) = Apply IdSym0 (x :: a)
@@ -276,7 +273,7 @@ Singletons/T433.hs:(0,0)-(0,0): Splicing declarations
     type family Foo @a (a :: a) :: () where
       Foo @a (x :: a) = Apply (Apply ConstSym0 Tuple0Sym0) (NothingSym0 :: Maybe a)
     type family F a where
-      F local = Let0123456789876543210GSym0 local
+      F local = Let12GSym0 local
     type Konst2 :: a -> Maybe Bool -> a
     type family Konst2 @a (a :: a) (a :: Maybe Bool) :: a where
       Konst2 x _ = x

--- a/singletons-base/tests/compile-and-dump/Singletons/T443.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T443.golden
@@ -19,13 +19,13 @@ Singletons/T443.hs:(0,0)-(0,0): Splicing declarations
     data SSym0 :: (~>) Nat Nat
       where
         SSym0KindInference :: SameKind (Apply SSym0 arg) (SSym1 arg) =>
-                              SSym0 a0123456789876543210
-    type instance Apply @Nat @Nat SSym0 a0123456789876543210 = S a0123456789876543210
+                              SSym0 a_T443_0
+    type instance Apply @Nat @Nat SSym0 a_T443_0 = S a_T443_0
     instance SuppressUnusedWarnings SSym0 where
       suppressUnusedWarnings = snd ((,) SSym0KindInference ())
     type SSym1 :: Nat -> Nat
-    type family SSym1 (a0123456789876543210 :: Nat) :: Nat where
-      SSym1 a0123456789876543210 = S a0123456789876543210
+    type family SSym1 (a_T443_0 :: Nat) :: Nat where
+      SSym1 a_T443_0 = S a_T443_0
     type VNilSym0 :: Vec Z a
     type family VNilSym0 @a :: Vec Z a where
       VNilSym0 = VNil
@@ -33,43 +33,43 @@ Singletons/T443.hs:(0,0)-(0,0): Splicing declarations
     data (:>@#@$) :: (~>) a ((~>) (Vec n a) (Vec (S n) a))
       where
         (::>@#@$###) :: SameKind (Apply (:>@#@$) arg) ((:>@#@$$) arg) =>
-                        (:>@#@$) a0123456789876543210
-    type instance Apply @a @((~>) (Vec n a) (Vec (S n) a)) (:>@#@$) a0123456789876543210 = (:>@#@$$) a0123456789876543210
+                        (:>@#@$) a_T443_1
+    type instance Apply @a @((~>) (Vec n a) (Vec (S n) a)) (:>@#@$) a_T443_1 = (:>@#@$$) a_T443_1
     instance SuppressUnusedWarnings (:>@#@$) where
       suppressUnusedWarnings = snd ((,) (::>@#@$###) ())
     type (:>@#@$$) :: a -> (~>) (Vec n a) (Vec (S n) a)
-    data (:>@#@$$) (a0123456789876543210 :: a) :: (~>) (Vec n a) (Vec (S n) a)
+    data (:>@#@$$) (a_T443_1 :: a) :: (~>) (Vec n a) (Vec (S n) a)
       where
-        (::>@#@$$###) :: SameKind (Apply ((:>@#@$$) a0123456789876543210) arg) ((:>@#@$$$) a0123456789876543210 arg) =>
-                         (:>@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @(Vec n a) @(Vec (S n) a) ((:>@#@$$) a0123456789876543210) a0123456789876543210 = (:>) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((:>@#@$$) a0123456789876543210) where
+        (::>@#@$$###) :: SameKind (Apply ((:>@#@$$) a_T443_1) arg) ((:>@#@$$$) a_T443_1 arg) =>
+                         (:>@#@$$) a_T443_1 a_T443_2
+    type instance Apply @(Vec n a) @(Vec (S n) a) ((:>@#@$$) a_T443_1) a_T443_2 = (:>) a_T443_1 a_T443_2
+    instance SuppressUnusedWarnings ((:>@#@$$) a_T443_1) where
       suppressUnusedWarnings = snd ((,) (::>@#@$$###) ())
     type (:>@#@$$$) :: a -> Vec n a -> Vec (S n) a
-    type family (:>@#@$$$) @a @n (a0123456789876543210 :: a) (a0123456789876543210 :: Vec n a) :: Vec (S n) a where
-      (:>@#@$$$) a0123456789876543210 a0123456789876543210 = (:>) a0123456789876543210 a0123456789876543210
+    type family (:>@#@$$$) @a @n (a_T443_1 :: a) (a_T443_2 :: Vec n a) :: Vec (S n) a where
+      (:>@#@$$$) a_T443_1 a_T443_2 = (:>) a_T443_1 a_T443_2
     type TailSym0 :: (~>) (Vec (S n) a) (Vec n a)
     data TailSym0 :: (~>) (Vec (S n) a) (Vec n a)
       where
         TailSym0KindInference :: SameKind (Apply TailSym0 arg) (TailSym1 arg) =>
-                                 TailSym0 a0123456789876543210
-    type instance Apply @(Vec (S n) a) @(Vec n a) TailSym0 a0123456789876543210 = Tail a0123456789876543210
+                                 TailSym0 a_T443_3
+    type instance Apply @(Vec (S n) a) @(Vec n a) TailSym0 a_T443_3 = Tail a_T443_3
     instance SuppressUnusedWarnings TailSym0 where
       suppressUnusedWarnings = snd ((,) TailSym0KindInference ())
     type TailSym1 :: Vec (S n) a -> Vec n a
-    type family TailSym1 @n @a (a0123456789876543210 :: Vec (S n) a) :: Vec n a where
-      TailSym1 a0123456789876543210 = Tail a0123456789876543210
+    type family TailSym1 @n @a (a_T443_3 :: Vec (S n) a) :: Vec n a where
+      TailSym1 a_T443_3 = Tail a_T443_3
     type HeadSym0 :: (~>) (Vec (S n) a) a
     data HeadSym0 :: (~>) (Vec (S n) a) a
       where
         HeadSym0KindInference :: SameKind (Apply HeadSym0 arg) (HeadSym1 arg) =>
-                                 HeadSym0 a0123456789876543210
-    type instance Apply @(Vec (S n) a) @a HeadSym0 a0123456789876543210 = Head a0123456789876543210
+                                 HeadSym0 a_T443_4
+    type instance Apply @(Vec (S n) a) @a HeadSym0 a_T443_4 = Head a_T443_4
     instance SuppressUnusedWarnings HeadSym0 where
       suppressUnusedWarnings = snd ((,) HeadSym0KindInference ())
     type HeadSym1 :: Vec (S n) a -> a
-    type family HeadSym1 @n @a (a0123456789876543210 :: Vec (S n) a) :: a where
-      HeadSym1 a0123456789876543210 = Head a0123456789876543210
+    type family HeadSym1 @n @a (a_T443_4 :: Vec (S n) a) :: a where
+      HeadSym1 a_T443_4 = Head a_T443_4
     type Tail :: Vec (S n) a -> Vec n a
     type family Tail @n @a (a :: Vec (S n) a) :: Vec n a where
       Tail ((:>) _ field) = field

--- a/singletons-base/tests/compile-and-dump/Singletons/T445.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T445.golden
@@ -5,13 +5,13 @@ Singletons/T445.hs:0:0:: Splicing declarations
     data LitSym0 :: (~>) Natural Nat
       where
         LitSym0KindInference :: SameKind (Apply LitSym0 arg) (LitSym1 arg) =>
-                                LitSym0 a0123456789876543210
-    type instance Apply @Natural @Nat LitSym0 a0123456789876543210 = Lit a0123456789876543210
+                                LitSym0 a_T445_0
+    type instance Apply @Natural @Nat LitSym0 a_T445_0 = Lit a_T445_0
     instance SuppressUnusedWarnings LitSym0 where
       suppressUnusedWarnings = snd ((,) LitSym0KindInference ())
     type LitSym1 :: Natural -> Nat
-    type family LitSym1 (a0123456789876543210 :: Natural) :: Nat where
-      LitSym1 a0123456789876543210 = Lit a0123456789876543210
+    type family LitSym1 (a_T445_0 :: Natural) :: Nat where
+      LitSym1 a_T445_0 = Lit a_T445_0
 Singletons/T445.hs:(0,0)-(0,0): Splicing declarations
     promoteOnly
       [d| evenb :: Nat -> Bool
@@ -21,44 +21,44 @@ Singletons/T445.hs:(0,0)-(0,0): Splicing declarations
           filterEvenGt7 :: [Nat] -> [Nat]
           filterEvenGt7 = filter (\ x -> evenb x && x > lit 7) |]
   ======>
-    type family LamCases_0123456789876543210 (a_01234567898765432100123456789876543210 :: [Nat]) a_0123456789876543210 where
-      LamCases_0123456789876543210 a_0123456789876543210 x = Apply (Apply (&&@#@$) (Apply EvenbSym0 x)) (Apply (Apply (>@#@$) x) (Apply LitSym0 (FromInteger 7)))
-    data LamCases_0123456789876543210Sym0 (a_01234567898765432100123456789876543210 :: [Nat]) a_01234567898765432100123456789876543210
+    type family LamCases_T445_3 (a_T445_10 :: [Nat]) a_T445_4 where
+      LamCases_T445_3 a_T445_1 x = Apply (Apply (&&@#@$) (Apply EvenbSym0 x)) (Apply (Apply (>@#@$) x) (Apply LitSym0 (FromInteger 7)))
+    data LamCases_T445_3Sym0 (a_T445_10 :: [Nat]) a_T445_4
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210) where
+        LamCases_T445_3Sym0KindInference :: SameKind (Apply (LamCases_T445_3Sym0 a_T445_10) arg) (LamCases_T445_3Sym1 a_T445_10 arg) =>
+                                            LamCases_T445_3Sym0 a_T445_10 a_T445_4
+    type instance Apply @_ @_ (LamCases_T445_3Sym0 a_T445_10) a_T445_4 = LamCases_T445_3 a_T445_10 a_T445_4
+    instance SuppressUnusedWarnings (LamCases_T445_3Sym0 a_T445_10) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (a_01234567898765432100123456789876543210 :: [Nat]) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_T445_3Sym0KindInference ())
+    type family LamCases_T445_3Sym1 (a_T445_10 :: [Nat]) a_T445_4 where
+      LamCases_T445_3Sym1 a_T445_10 a_T445_4 = LamCases_T445_3 a_T445_10 a_T445_4
     type FilterEvenGt7Sym0 :: (~>) [Nat] [Nat]
     data FilterEvenGt7Sym0 :: (~>) [Nat] [Nat]
       where
         FilterEvenGt7Sym0KindInference :: SameKind (Apply FilterEvenGt7Sym0 arg) (FilterEvenGt7Sym1 arg) =>
-                                          FilterEvenGt7Sym0 a0123456789876543210
-    type instance Apply @[Nat] @[Nat] FilterEvenGt7Sym0 a0123456789876543210 = FilterEvenGt7 a0123456789876543210
+                                          FilterEvenGt7Sym0 a_T445_2
+    type instance Apply @[Nat] @[Nat] FilterEvenGt7Sym0 a_T445_2 = FilterEvenGt7 a_T445_2
     instance SuppressUnusedWarnings FilterEvenGt7Sym0 where
       suppressUnusedWarnings
         = snd ((,) FilterEvenGt7Sym0KindInference ())
     type FilterEvenGt7Sym1 :: [Nat] -> [Nat]
-    type family FilterEvenGt7Sym1 (a0123456789876543210 :: [Nat]) :: [Nat] where
-      FilterEvenGt7Sym1 a0123456789876543210 = FilterEvenGt7 a0123456789876543210
+    type family FilterEvenGt7Sym1 (a_T445_2 :: [Nat]) :: [Nat] where
+      FilterEvenGt7Sym1 a_T445_2 = FilterEvenGt7 a_T445_2
     type EvenbSym0 :: (~>) Nat Bool
     data EvenbSym0 :: (~>) Nat Bool
       where
         EvenbSym0KindInference :: SameKind (Apply EvenbSym0 arg) (EvenbSym1 arg) =>
-                                  EvenbSym0 a0123456789876543210
-    type instance Apply @Nat @Bool EvenbSym0 a0123456789876543210 = Evenb a0123456789876543210
+                                  EvenbSym0 a_T445_5
+    type instance Apply @Nat @Bool EvenbSym0 a_T445_5 = Evenb a_T445_5
     instance SuppressUnusedWarnings EvenbSym0 where
       suppressUnusedWarnings = snd ((,) EvenbSym0KindInference ())
     type EvenbSym1 :: Nat -> Bool
-    type family EvenbSym1 (a0123456789876543210 :: Nat) :: Bool where
-      EvenbSym1 a0123456789876543210 = Evenb a0123456789876543210
+    type family EvenbSym1 (a_T445_5 :: Nat) :: Bool where
+      EvenbSym1 a_T445_5 = Evenb a_T445_5
     type FilterEvenGt7 :: [Nat] -> [Nat]
     type family FilterEvenGt7 (a :: [Nat]) :: [Nat] where
-      FilterEvenGt7 a_0123456789876543210 = Apply (Apply FilterSym0 (LamCases_0123456789876543210Sym0 a_0123456789876543210)) a_0123456789876543210
+      FilterEvenGt7 a_T445_1 = Apply (Apply FilterSym0 (LamCases_T445_3Sym0 a_T445_1)) a_T445_1
     type Evenb :: Nat -> Bool
     type family Evenb (a :: Nat) :: Bool where
       Evenb 'Zero = TrueSym0

--- a/singletons-base/tests/compile-and-dump/Singletons/T450.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T450.golden
@@ -40,13 +40,13 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
     data PMkMessageSym0 :: (~>) Symbol PMessage
       where
         PMkMessageSym0KindInference :: SameKind (Apply PMkMessageSym0 arg) (PMkMessageSym1 arg) =>
-                                       PMkMessageSym0 a0123456789876543210
-    type instance Apply @Symbol @PMessage PMkMessageSym0 a0123456789876543210 = 'PMkMessage a0123456789876543210
+                                       PMkMessageSym0 a_T450_0
+    type instance Apply @Symbol @PMessage PMkMessageSym0 a_T450_0 = 'PMkMessage a_T450_0
     instance SuppressUnusedWarnings PMkMessageSym0 where
       suppressUnusedWarnings = snd ((,) PMkMessageSym0KindInference ())
     type PMkMessageSym1 :: Symbol -> PMessage
-    type family PMkMessageSym1 (a0123456789876543210 :: Symbol) :: PMessage where
-      PMkMessageSym1 a0123456789876543210 = 'PMkMessage a0123456789876543210
+    type family PMkMessageSym1 (a_T450_0 :: Symbol) :: PMessage where
+      PMkMessageSym1 a_T450_0 = 'PMkMessage a_T450_0
     type SMessage :: PMessage -> Type
     data SMessage :: PMessage -> Type
       where
@@ -72,23 +72,23 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
     data AppendMessageSym0 :: (~>) PMessage ((~>) PMessage PMessage)
       where
         AppendMessageSym0KindInference :: SameKind (Apply AppendMessageSym0 arg) (AppendMessageSym1 arg) =>
-                                          AppendMessageSym0 a0123456789876543210
-    type instance Apply @PMessage @((~>) PMessage PMessage) AppendMessageSym0 a0123456789876543210 = AppendMessageSym1 a0123456789876543210
+                                          AppendMessageSym0 a_T450_1
+    type instance Apply @PMessage @((~>) PMessage PMessage) AppendMessageSym0 a_T450_1 = AppendMessageSym1 a_T450_1
     instance SuppressUnusedWarnings AppendMessageSym0 where
       suppressUnusedWarnings
         = snd ((,) AppendMessageSym0KindInference ())
     type AppendMessageSym1 :: PMessage -> (~>) PMessage PMessage
-    data AppendMessageSym1 (a0123456789876543210 :: PMessage) :: (~>) PMessage PMessage
+    data AppendMessageSym1 (a_T450_1 :: PMessage) :: (~>) PMessage PMessage
       where
-        AppendMessageSym1KindInference :: SameKind (Apply (AppendMessageSym1 a0123456789876543210) arg) (AppendMessageSym2 a0123456789876543210 arg) =>
-                                          AppendMessageSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @PMessage @PMessage (AppendMessageSym1 a0123456789876543210) a0123456789876543210 = AppendMessage a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (AppendMessageSym1 a0123456789876543210) where
+        AppendMessageSym1KindInference :: SameKind (Apply (AppendMessageSym1 a_T450_1) arg) (AppendMessageSym2 a_T450_1 arg) =>
+                                          AppendMessageSym1 a_T450_1 a_T450_2
+    type instance Apply @PMessage @PMessage (AppendMessageSym1 a_T450_1) a_T450_2 = AppendMessage a_T450_1 a_T450_2
+    instance SuppressUnusedWarnings (AppendMessageSym1 a_T450_1) where
       suppressUnusedWarnings
         = snd ((,) AppendMessageSym1KindInference ())
     type AppendMessageSym2 :: PMessage -> PMessage -> PMessage
-    type family AppendMessageSym2 (a0123456789876543210 :: PMessage) (a0123456789876543210 :: PMessage) :: PMessage where
-      AppendMessageSym2 a0123456789876543210 a0123456789876543210 = AppendMessage a0123456789876543210 a0123456789876543210
+    type family AppendMessageSym2 (a_T450_1 :: PMessage) (a_T450_2 :: PMessage) :: PMessage where
+      AppendMessageSym2 a_T450_1 a_T450_2 = AppendMessage a_T450_1 a_T450_2
     type AppendMessage :: PMessage -> PMessage -> PMessage
     type family AppendMessage (a :: PMessage) (a :: PMessage) :: PMessage where
       AppendMessage ('PMkMessage (x :: Symbol)) ('PMkMessage (y :: Symbol)) = Apply PMkMessageSym0 (Apply (Apply (<>@#@$) x) y :: Symbol)
@@ -121,14 +121,14 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
     data PMkFunctionSym0 :: (~>) ((~>) a b) (PFunction a b)
       where
         PMkFunctionSym0KindInference :: SameKind (Apply PMkFunctionSym0 arg) (PMkFunctionSym1 arg) =>
-                                        PMkFunctionSym0 a0123456789876543210
-    type instance Apply @((~>) a b) @(PFunction a b) PMkFunctionSym0 a0123456789876543210 = 'PMkFunction a0123456789876543210
+                                        PMkFunctionSym0 a_T450_3
+    type instance Apply @((~>) a b) @(PFunction a b) PMkFunctionSym0 a_T450_3 = 'PMkFunction a_T450_3
     instance SuppressUnusedWarnings PMkFunctionSym0 where
       suppressUnusedWarnings = snd ((,) PMkFunctionSym0KindInference ())
     type PMkFunctionSym1 :: forall (a :: Type) (b :: Type). (~>) a b
                                                             -> PFunction a b
-    type family PMkFunctionSym1 @(a :: Type) @(b :: Type) (a0123456789876543210 :: (~>) a b) :: PFunction a b where
-      PMkFunctionSym1 a0123456789876543210 = 'PMkFunction a0123456789876543210
+    type family PMkFunctionSym1 @(a :: Type) @(b :: Type) (a_T450_3 :: (~>) a b) :: PFunction a b where
+      PMkFunctionSym1 a_T450_3 = 'PMkFunction a_T450_3
     type SFunction :: forall (a :: Type) (b :: Type). PFunction a b
                                                       -> Type
     data SFunction :: forall (a :: Type) (b :: Type).
@@ -158,25 +158,25 @@ Singletons/T450.hs:(0,0)-(0,0): Splicing declarations
     data ComposeFunctionSym0 :: (~>) (PFunction b c) ((~>) (PFunction a b) (PFunction a c))
       where
         ComposeFunctionSym0KindInference :: SameKind (Apply ComposeFunctionSym0 arg) (ComposeFunctionSym1 arg) =>
-                                            ComposeFunctionSym0 a0123456789876543210
-    type instance Apply @(PFunction b c) @((~>) (PFunction a b) (PFunction a c)) ComposeFunctionSym0 a0123456789876543210 = ComposeFunctionSym1 a0123456789876543210
+                                            ComposeFunctionSym0 a_T450_4
+    type instance Apply @(PFunction b c) @((~>) (PFunction a b) (PFunction a c)) ComposeFunctionSym0 a_T450_4 = ComposeFunctionSym1 a_T450_4
     instance SuppressUnusedWarnings ComposeFunctionSym0 where
       suppressUnusedWarnings
         = snd ((,) ComposeFunctionSym0KindInference ())
     type ComposeFunctionSym1 :: PFunction b c
                                 -> (~>) (PFunction a b) (PFunction a c)
-    data ComposeFunctionSym1 (a0123456789876543210 :: PFunction b c) :: (~>) (PFunction a b) (PFunction a c)
+    data ComposeFunctionSym1 (a_T450_4 :: PFunction b c) :: (~>) (PFunction a b) (PFunction a c)
       where
-        ComposeFunctionSym1KindInference :: SameKind (Apply (ComposeFunctionSym1 a0123456789876543210) arg) (ComposeFunctionSym2 a0123456789876543210 arg) =>
-                                            ComposeFunctionSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(PFunction a b) @(PFunction a c) (ComposeFunctionSym1 a0123456789876543210) a0123456789876543210 = ComposeFunction a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (ComposeFunctionSym1 a0123456789876543210) where
+        ComposeFunctionSym1KindInference :: SameKind (Apply (ComposeFunctionSym1 a_T450_4) arg) (ComposeFunctionSym2 a_T450_4 arg) =>
+                                            ComposeFunctionSym1 a_T450_4 a_T450_5
+    type instance Apply @(PFunction a b) @(PFunction a c) (ComposeFunctionSym1 a_T450_4) a_T450_5 = ComposeFunction a_T450_4 a_T450_5
+    instance SuppressUnusedWarnings (ComposeFunctionSym1 a_T450_4) where
       suppressUnusedWarnings
         = snd ((,) ComposeFunctionSym1KindInference ())
     type ComposeFunctionSym2 :: PFunction b c
                                 -> PFunction a b -> PFunction a c
-    type family ComposeFunctionSym2 @b @c @a (a0123456789876543210 :: PFunction b c) (a0123456789876543210 :: PFunction a b) :: PFunction a c where
-      ComposeFunctionSym2 a0123456789876543210 a0123456789876543210 = ComposeFunction a0123456789876543210 a0123456789876543210
+    type family ComposeFunctionSym2 @b @c @a (a_T450_4 :: PFunction b c) (a_T450_5 :: PFunction a b) :: PFunction a c where
+      ComposeFunctionSym2 a_T450_4 a_T450_5 = ComposeFunction a_T450_4 a_T450_5
     type ComposeFunction :: PFunction b c
                             -> PFunction a b -> PFunction a c
     type family ComposeFunction @b @c @a (a :: PFunction b c) (a :: PFunction a b) :: PFunction a c where

--- a/singletons-base/tests/compile-and-dump/Singletons/T470.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T470.golden
@@ -18,35 +18,35 @@ Singletons/T470.hs:(0,0)-(0,0): Splicing declarations
     data MkT1Sym0 :: (~>) a (T a)
       where
         MkT1Sym0KindInference :: SameKind (Apply MkT1Sym0 arg) (MkT1Sym1 arg) =>
-                                 MkT1Sym0 a0123456789876543210
-    type instance Apply @a @(T a) MkT1Sym0 a0123456789876543210 = MkT1 a0123456789876543210
+                                 MkT1Sym0 a_T470_0
+    type instance Apply @a @(T a) MkT1Sym0 a_T470_0 = MkT1 a_T470_0
     instance SuppressUnusedWarnings MkT1Sym0 where
       suppressUnusedWarnings = snd ((,) MkT1Sym0KindInference ())
     type MkT1Sym1 :: a -> T a
-    type family MkT1Sym1 @a (a0123456789876543210 :: a) :: T a where
-      MkT1Sym1 a0123456789876543210 = MkT1 a0123456789876543210
+    type family MkT1Sym1 @a (a_T470_0 :: a) :: T a where
+      MkT1Sym1 a_T470_0 = MkT1 a_T470_0
     type MkT2Sym0 :: (~>) Void (T a)
     data MkT2Sym0 :: (~>) Void (T a)
       where
         MkT2Sym0KindInference :: SameKind (Apply MkT2Sym0 arg) (MkT2Sym1 arg) =>
-                                 MkT2Sym0 a0123456789876543210
-    type instance Apply @Void @(T a) MkT2Sym0 a0123456789876543210 = MkT2 a0123456789876543210
+                                 MkT2Sym0 a_T470_1
+    type instance Apply @Void @(T a) MkT2Sym0 a_T470_1 = MkT2 a_T470_1
     instance SuppressUnusedWarnings MkT2Sym0 where
       suppressUnusedWarnings = snd ((,) MkT2Sym0KindInference ())
     type MkT2Sym1 :: Void -> T a
-    type family MkT2Sym1 @a (a0123456789876543210 :: Void) :: T a where
-      MkT2Sym1 a0123456789876543210 = MkT2 a0123456789876543210
+    type family MkT2Sym1 @a (a_T470_1 :: Void) :: T a where
+      MkT2Sym1 a_T470_1 = MkT2 a_T470_1
     type MkSSym0 :: (~>) Bool S
     data MkSSym0 :: (~>) Bool S
       where
         MkSSym0KindInference :: SameKind (Apply MkSSym0 arg) (MkSSym1 arg) =>
-                                MkSSym0 a0123456789876543210
-    type instance Apply @Bool @S MkSSym0 a0123456789876543210 = MkS a0123456789876543210
+                                MkSSym0 a_T470_2
+    type instance Apply @Bool @S MkSSym0 a_T470_2 = MkS a_T470_2
     instance SuppressUnusedWarnings MkSSym0 where
       suppressUnusedWarnings = snd ((,) MkSSym0KindInference ())
     type MkSSym1 :: Bool -> S
-    type family MkSSym1 (a0123456789876543210 :: Bool) :: S where
-      MkSSym1 a0123456789876543210 = MkS a0123456789876543210
+    type family MkSSym1 (a_T470_2 :: Bool) :: S where
+      MkSSym1 a_T470_2 = MkS a_T470_2
     type ST :: forall (a :: Type). T a -> Type
     data ST :: forall (a :: Type). T a -> Type
       where

--- a/singletons-base/tests/compile-and-dump/Singletons/T487.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T487.golden
@@ -24,13 +24,13 @@ Singletons/T487.hs:(0,0)-(0,0): Splicing declarations
     data ConsExSym0 :: (~>) Char Symbol
       where
         ConsExSym0KindInference :: SameKind (Apply ConsExSym0 arg) (ConsExSym1 arg) =>
-                                   ConsExSym0 a0123456789876543210
-    type instance Apply @Char @Symbol ConsExSym0 a0123456789876543210 = ConsEx a0123456789876543210
+                                   ConsExSym0 a_T487_0
+    type instance Apply @Char @Symbol ConsExSym0 a_T487_0 = ConsEx a_T487_0
     instance SuppressUnusedWarnings ConsExSym0 where
       suppressUnusedWarnings = snd ((,) ConsExSym0KindInference ())
     type ConsExSym1 :: Char -> Symbol
-    type family ConsExSym1 (a0123456789876543210 :: Char) :: Symbol where
-      ConsExSym1 a0123456789876543210 = ConsEx a0123456789876543210
+    type family ConsExSym1 (a_T487_0 :: Char) :: Symbol where
+      ConsExSym1 a_T487_0 = ConsEx a_T487_0
     type ExprExSym0 :: Char
     type family ExprExSym0 :: Char where
       ExprExSym0 = ExprEx

--- a/singletons-base/tests/compile-and-dump/Singletons/T489.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T489.golden
@@ -17,24 +17,24 @@ Singletons/T489.hs:(0,0)-(0,0): Splicing declarations
     data FlurmpSym0 :: (~>) (Maybe ()) ()
       where
         FlurmpSym0KindInference :: SameKind (Apply FlurmpSym0 arg) (FlurmpSym1 arg) =>
-                                   FlurmpSym0 a0123456789876543210
-    type instance Apply @(Maybe ()) @() FlurmpSym0 a0123456789876543210 = Flurmp a0123456789876543210
+                                   FlurmpSym0 a_T489_0
+    type instance Apply @(Maybe ()) @() FlurmpSym0 a_T489_0 = Flurmp a_T489_0
     instance SuppressUnusedWarnings FlurmpSym0 where
       suppressUnusedWarnings = snd ((,) FlurmpSym0KindInference ())
     type FlurmpSym1 :: Maybe () -> ()
-    type family FlurmpSym1 (a0123456789876543210 :: Maybe ()) :: () where
-      FlurmpSym1 a0123456789876543210 = Flurmp a0123456789876543210
+    type family FlurmpSym1 (a_T489_0 :: Maybe ()) :: () where
+      FlurmpSym1 a_T489_0 = Flurmp a_T489_0
     type BlahSym0 :: (~>) (Maybe a) [a]
     data BlahSym0 :: (~>) (Maybe a) [a]
       where
         BlahSym0KindInference :: SameKind (Apply BlahSym0 arg) (BlahSym1 arg) =>
-                                 BlahSym0 a0123456789876543210
-    type instance Apply @(Maybe a) @[a] BlahSym0 a0123456789876543210 = Blah a0123456789876543210
+                                 BlahSym0 a_T489_1
+    type instance Apply @(Maybe a) @[a] BlahSym0 a_T489_1 = Blah a_T489_1
     instance SuppressUnusedWarnings BlahSym0 where
       suppressUnusedWarnings = snd ((,) BlahSym0KindInference ())
     type BlahSym1 :: Maybe a -> [a]
-    type family BlahSym1 @a (a0123456789876543210 :: Maybe a) :: [a] where
-      BlahSym1 a0123456789876543210 = Blah a0123456789876543210
+    type family BlahSym1 @a (a_T489_1 :: Maybe a) :: [a] where
+      BlahSym1 a_T489_1 = Blah a_T489_1
     type Flurmp :: Maybe () -> ()
     type family Flurmp (a :: Maybe ()) :: () where
       Flurmp ('Nothing @_) = Tuple0Sym0

--- a/singletons-base/tests/compile-and-dump/Singletons/T536.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T536.golden
@@ -26,14 +26,14 @@ Singletons/T536.hs:(0,0)-(0,0): Splicing declarations
     data PMkMessageSym0 :: (Data.Singletons.~>) Symbol PMessage
       where
         PMkMessageSym0KindInference :: Data.Singletons.SameKind (Data.Singletons.Apply PMkMessageSym0 arg) (PMkMessageSym1 arg) =>
-                                       PMkMessageSym0 a0123456789876543210
-    type instance Data.Singletons.Apply @Symbol @PMessage PMkMessageSym0 a0123456789876543210 = 'PMkMessage a0123456789876543210
+                                       PMkMessageSym0 a_T536_0
+    type instance Data.Singletons.Apply @Symbol @PMessage PMkMessageSym0 a_T536_0 = 'PMkMessage a_T536_0
     instance Data.Singletons.TH.SuppressUnusedWarnings.SuppressUnusedWarnings PMkMessageSym0 where
       Data.Singletons.TH.SuppressUnusedWarnings.suppressUnusedWarnings
         = snd ((,) PMkMessageSym0KindInference ())
     type PMkMessageSym1 :: Symbol -> PMessage
-    type family PMkMessageSym1 (a0123456789876543210 :: Symbol) :: PMessage where
-      PMkMessageSym1 a0123456789876543210 = 'PMkMessage a0123456789876543210
+    type family PMkMessageSym1 (a_T536_0 :: Symbol) :: PMessage where
+      PMkMessageSym1 a_T536_0 = 'PMkMessage a_T536_0
     type SMessage :: PMessage -> Type
     data SMessage :: PMessage -> Type
       where

--- a/singletons-base/tests/compile-and-dump/Singletons/T54.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T54.golden
@@ -5,38 +5,38 @@ Singletons/T54.hs:(0,0)-(0,0): Splicing declarations
   ======>
     g :: Bool -> Bool
     g e = (case [not] of [_] -> not) e
-    type family LamCases_0123456789876543210 (e0123456789876543210 :: Bool) a_0123456789876543210 where
-      LamCases_0123456789876543210 e '[_] = NotSym0
-    data LamCases_0123456789876543210Sym0 (e0123456789876543210 :: Bool) a_01234567898765432100123456789876543210
+    type family LamCases_Singletons_T54_1 (e0 :: Bool) a_Singletons_T54_2 where
+      LamCases_Singletons_T54_1 e '[_] = NotSym0
+    data LamCases_Singletons_T54_1Sym0 (e0 :: Bool) a_Singletons_T54_2
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 e0123456789876543210) arg) (LamCases_0123456789876543210Sym1 e0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 e0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 e0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 e0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 e0123456789876543210) where
+        LamCases_Singletons_T54_1Sym0KindInference :: SameKind (Apply (LamCases_Singletons_T54_1Sym0 e0) arg) (LamCases_Singletons_T54_1Sym1 e0 arg) =>
+                                                      LamCases_Singletons_T54_1Sym0 e0 a_Singletons_T54_2
+    type instance Apply @_ @_ (LamCases_Singletons_T54_1Sym0 e0) a_Singletons_T54_2 = LamCases_Singletons_T54_1 e0 a_Singletons_T54_2
+    instance SuppressUnusedWarnings (LamCases_Singletons_T54_1Sym0 e0) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (e0123456789876543210 :: Bool) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 e0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 e0123456789876543210 a_01234567898765432100123456789876543210
+        = snd ((,) LamCases_Singletons_T54_1Sym0KindInference ())
+    type family LamCases_Singletons_T54_1Sym1 (e0 :: Bool) a_Singletons_T54_2 where
+      LamCases_Singletons_T54_1Sym1 e0 a_Singletons_T54_2 = LamCases_Singletons_T54_1 e0 a_Singletons_T54_2
     type GSym0 :: (~>) Bool Bool
     data GSym0 :: (~>) Bool Bool
       where
         GSym0KindInference :: SameKind (Apply GSym0 arg) (GSym1 arg) =>
-                              GSym0 a0123456789876543210
-    type instance Apply @Bool @Bool GSym0 a0123456789876543210 = G a0123456789876543210
+                              GSym0 a_Singletons_T54_0
+    type instance Apply @Bool @Bool GSym0 a_Singletons_T54_0 = G a_Singletons_T54_0
     instance SuppressUnusedWarnings GSym0 where
       suppressUnusedWarnings = snd ((,) GSym0KindInference ())
     type GSym1 :: Bool -> Bool
-    type family GSym1 (a0123456789876543210 :: Bool) :: Bool where
-      GSym1 a0123456789876543210 = G a0123456789876543210
+    type family GSym1 (a_Singletons_T54_0 :: Bool) :: Bool where
+      GSym1 a_Singletons_T54_0 = G a_Singletons_T54_0
     type G :: Bool -> Bool
     type family G (a :: Bool) :: Bool where
-      G e = Apply (Apply (LamCases_0123456789876543210Sym0 e) (Apply (Apply (:@#@$) NotSym0) NilSym0)) e
+      G e = Apply (Apply (LamCases_Singletons_T54_1Sym0 e) (Apply (Apply (:@#@$) NotSym0) NilSym0)) e
     sG :: (forall (t :: Bool). Sing t -> Sing (G t :: Bool) :: Type)
     sG (sE :: Sing e)
       = applySing
           (applySing
              (singFun1
-                @(LamCases_0123456789876543210Sym0 e)
+                @(LamCases_Singletons_T54_1Sym0 e)
                 (\cases (SCons _ SNil) -> singFun1 @NotSym0 sNot))
              (applySing
                 (applySing (singFun2 @(:@#@$) SCons) (singFun1 @NotSym0 sNot))

--- a/singletons-base/tests/compile-and-dump/Singletons/T555.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T555.golden
@@ -13,31 +13,29 @@ Singletons/T555.hs:(0,0)-(0,0): Splicing declarations
     type QuaternionSym0 :: MyPropKind
     type family QuaternionSym0 :: MyPropKind where
       QuaternionSym0 = Quaternion
-    type TFHelper_0123456789876543210 :: MyPropKind
-                                         -> MyPropKind -> Bool
-    type family TFHelper_0123456789876543210 (a :: MyPropKind) (a :: MyPropKind) :: Bool where
-      TFHelper_0123456789876543210 Location Location = TrueSym0
-      TFHelper_0123456789876543210 Location Quaternion = FalseSym0
-      TFHelper_0123456789876543210 Quaternion Location = FalseSym0
-      TFHelper_0123456789876543210 Quaternion Quaternion = TrueSym0
+    type TFHelper_T555_1 :: MyPropKind -> MyPropKind -> Bool
+    type family TFHelper_T555_1 (a :: MyPropKind) (a :: MyPropKind) :: Bool where
+      TFHelper_T555_1 Location Location = TrueSym0
+      TFHelper_T555_1 Location Quaternion = FalseSym0
+      TFHelper_T555_1 Quaternion Location = FalseSym0
+      TFHelper_T555_1 Quaternion Quaternion = TrueSym0
     instance PEq MyPropKind where
-      type (==) a a = TFHelper_0123456789876543210 a a
-    type Compare_0123456789876543210 :: MyPropKind
-                                        -> MyPropKind -> Ordering
-    type family Compare_0123456789876543210 (a :: MyPropKind) (a :: MyPropKind) :: Ordering where
-      Compare_0123456789876543210 Location Location = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
-      Compare_0123456789876543210 Quaternion Quaternion = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
-      Compare_0123456789876543210 Location Quaternion = LTSym0
-      Compare_0123456789876543210 Quaternion Location = GTSym0
+      type (==) a a = TFHelper_T555_1 a a
+    type Compare_T555_4 :: MyPropKind -> MyPropKind -> Ordering
+    type family Compare_T555_4 (a :: MyPropKind) (a :: MyPropKind) :: Ordering where
+      Compare_T555_4 Location Location = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
+      Compare_T555_4 Quaternion Quaternion = Apply (Apply (Apply FoldlSym0 (<>@#@$)) EQSym0) NilSym0
+      Compare_T555_4 Location Quaternion = LTSym0
+      Compare_T555_4 Quaternion Location = GTSym0
     instance POrd MyPropKind where
-      type Compare a a = Compare_0123456789876543210 a a
-    type ShowsPrec_0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural
-                                          -> MyPropKind -> Symbol -> Symbol
-    type family ShowsPrec_0123456789876543210 (a :: GHC.Internal.Bignum.Natural.Natural) (a :: MyPropKind) (a :: Symbol) :: Symbol where
-      ShowsPrec_0123456789876543210 _ Location a_0123456789876543210 = Apply (Apply ShowStringSym0 "Location") a_0123456789876543210
-      ShowsPrec_0123456789876543210 _ Quaternion a_0123456789876543210 = Apply (Apply ShowStringSym0 "Quaternion") a_0123456789876543210
+      type Compare a a = Compare_T555_4 a a
+    type ShowsPrec_T555_7 :: GHC.Internal.Bignum.Natural.Natural
+                             -> MyPropKind -> Symbol -> Symbol
+    type family ShowsPrec_T555_7 (a :: GHC.Internal.Bignum.Natural.Natural) (a :: MyPropKind) (a :: Symbol) :: Symbol where
+      ShowsPrec_T555_7 _ Location a_T555_8 = Apply (Apply ShowStringSym0 "Location") a_T555_8
+      ShowsPrec_T555_7 _ Quaternion a_T555_9 = Apply (Apply ShowStringSym0 "Quaternion") a_T555_9
     instance PShow MyPropKind where
-      type ShowsPrec a a a = ShowsPrec_0123456789876543210 a a a
+      type ShowsPrec a a a = ShowsPrec_T555_7 a a a
     data SMyPropKind :: MyPropKind -> Type
       where
         SLocation :: SMyPropKind (Location :: MyPropKind)
@@ -70,22 +68,16 @@ Singletons/T555.hs:(0,0)-(0,0): Splicing declarations
       sCompare SLocation SQuaternion = SLT
       sCompare SQuaternion SLocation = SGT
     instance SShow MyPropKind where
-      sShowsPrec
-        _
-        SLocation
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+      sShowsPrec _ SLocation (sA_T555_8 :: Sing a_T555_8)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "Location"))
-            sA_0123456789876543210
-      sShowsPrec
-        _
-        SQuaternion
-        (sA_0123456789876543210 :: Sing a_0123456789876543210)
+            sA_T555_8
+      sShowsPrec _ SQuaternion (sA_T555_9 :: Sing a_T555_9)
         = applySing
             (applySing
                (singFun2 @ShowStringSym0 sShowString) (sing :: Sing "Quaternion"))
-            sA_0123456789876543210
+            sA_T555_9
     instance SDecide MyPropKind where
       (%~) SLocation SLocation = Proved Refl
       (%~) SLocation SQuaternion = Disproved (\case)

--- a/singletons-base/tests/compile-and-dump/Singletons/T563.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T563.golden
@@ -10,13 +10,13 @@ Singletons/T563.hs:(0,0)-(0,0): Splicing declarations
     data MkFooSym0 :: (~>) Bool Foo
       where
         MkFooSym0KindInference :: SameKind (Apply MkFooSym0 arg) (MkFooSym1 arg) =>
-                                  MkFooSym0 a0123456789876543210
-    type instance Apply @Bool @Foo MkFooSym0 a0123456789876543210 = MkFoo a0123456789876543210
+                                  MkFooSym0 a_T563_0
+    type instance Apply @Bool @Foo MkFooSym0 a_T563_0 = MkFoo a_T563_0
     instance SuppressUnusedWarnings MkFooSym0 where
       suppressUnusedWarnings = snd ((,) MkFooSym0KindInference ())
     type MkFooSym1 :: Bool -> Foo
-    type family MkFooSym1 (a0123456789876543210 :: Bool) :: Foo where
-      MkFooSym1 a0123456789876543210 = MkFoo a0123456789876543210
+    type family MkFooSym1 (a_T563_0 :: Bool) :: Foo where
+      MkFooSym1 a_T563_0 = MkFoo a_T563_0
     data SFoo :: Foo -> Type
       where
         SMkFoo :: forall (n :: Bool). (Sing n) -> SFoo (MkFoo n :: Foo)
@@ -42,20 +42,19 @@ Singletons/T563.hs:(0,0)-(0,0): Splicing declarations
     data UnFoo'Sym0 :: (~>) Foo Bool
       where
         UnFoo'Sym0KindInference :: SameKind (Apply UnFoo'Sym0 arg) (UnFoo'Sym1 arg) =>
-                                   UnFoo'Sym0 a0123456789876543210
-    type instance Apply @Foo @Bool UnFoo'Sym0 a0123456789876543210 = UnFoo' a0123456789876543210
+                                   UnFoo'Sym0 a_T563_2
+    type instance Apply @Foo @Bool UnFoo'Sym0 a_T563_2 = UnFoo' a_T563_2
     instance SuppressUnusedWarnings UnFoo'Sym0 where
       suppressUnusedWarnings = snd ((,) UnFoo'Sym0KindInference ())
     type UnFoo'Sym1 :: Foo -> Bool
-    type family UnFoo'Sym1 (a0123456789876543210 :: Foo) :: Bool where
-      UnFoo'Sym1 a0123456789876543210 = UnFoo' a0123456789876543210
+    type family UnFoo'Sym1 (a_T563_2 :: Foo) :: Bool where
+      UnFoo'Sym1 a_T563_2 = UnFoo' a_T563_2
     type UnFoo' :: Foo -> Bool
     type family UnFoo' (a :: Foo) :: Bool where
-      UnFoo' a_0123456789876543210 = Apply UnFooSym0 a_0123456789876543210
+      UnFoo' a_T563_1 = Apply UnFooSym0 a_T563_1
     sUnFoo' ::
       (forall (t :: Foo). Sing t -> Sing (UnFoo' t :: Bool) :: Type)
-    sUnFoo' (sA_0123456789876543210 :: Sing a_0123456789876543210)
-      = applySing sUnFoo sA_0123456789876543210
+    sUnFoo' (sA_T563_1 :: Sing a_T563_1) = applySing sUnFoo sA_T563_1
     instance SingI (UnFoo'Sym0 :: (~>) Foo Bool) where
       sing = singFun1 @UnFoo'Sym0 sUnFoo'
 Singletons/T563.hs:0:0: error: [GHC-76037]

--- a/singletons-base/tests/compile-and-dump/Singletons/T571.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T571.golden
@@ -9,13 +9,13 @@ Singletons/T571.hs:(0,0)-(0,0): Splicing declarations
     data FSym0 :: (~>) a a
       where
         FSym0KindInference :: SameKind (Apply FSym0 arg) (FSym1 arg) =>
-                              FSym0 a0123456789876543210
-    type instance Apply @a @a FSym0 a0123456789876543210 = F a0123456789876543210
+                              FSym0 a_T571_0
+    type instance Apply @a @a FSym0 a_T571_0 = F a_T571_0
     instance SuppressUnusedWarnings FSym0 where
       suppressUnusedWarnings = snd ((,) FSym0KindInference ())
     type FSym1 :: a -> a
-    type family FSym1 @a (a0123456789876543210 :: a) :: a where
-      FSym1 a0123456789876543210 = F a0123456789876543210
+    type family FSym1 @a (a_T571_0 :: a) :: a where
+      FSym1 a_T571_0 = F a_T571_0
     type F :: a -> a
     type family F @a (a :: a) :: a where
       F x = x
@@ -34,21 +34,21 @@ Singletons/T571.hs:(0,0)-(0,0): Splicing declarations
     data GSym0 :: (~>) ((~>) a a) ((~>) a a)
       where
         GSym0KindInference :: SameKind (Apply GSym0 arg) (GSym1 arg) =>
-                              GSym0 a0123456789876543210
-    type instance Apply @((~>) a a) @((~>) a a) GSym0 a0123456789876543210 = GSym1 a0123456789876543210
+                              GSym0 a_T571_1
+    type instance Apply @((~>) a a) @((~>) a a) GSym0 a_T571_1 = GSym1 a_T571_1
     instance SuppressUnusedWarnings GSym0 where
       suppressUnusedWarnings = snd ((,) GSym0KindInference ())
     type GSym1 :: (~>) a a -> (~>) a a
-    data GSym1 (a0123456789876543210 :: (~>) a a) :: (~>) a a
+    data GSym1 (a_T571_1 :: (~>) a a) :: (~>) a a
       where
-        GSym1KindInference :: SameKind (Apply (GSym1 a0123456789876543210) arg) (GSym2 a0123456789876543210 arg) =>
-                              GSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @a @a (GSym1 a0123456789876543210) a0123456789876543210 = G a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (GSym1 a0123456789876543210) where
+        GSym1KindInference :: SameKind (Apply (GSym1 a_T571_1) arg) (GSym2 a_T571_1 arg) =>
+                              GSym1 a_T571_1 a_T571_2
+    type instance Apply @a @a (GSym1 a_T571_1) a_T571_2 = G a_T571_1 a_T571_2
+    instance SuppressUnusedWarnings (GSym1 a_T571_1) where
       suppressUnusedWarnings = snd ((,) GSym1KindInference ())
     type GSym2 :: (~>) a a -> a -> a
-    type family GSym2 @a (a0123456789876543210 :: (~>) a a) (a0123456789876543210 :: a) :: a where
-      GSym2 a0123456789876543210 a0123456789876543210 = G a0123456789876543210 a0123456789876543210
+    type family GSym2 @a (a_T571_1 :: (~>) a a) (a_T571_2 :: a) :: a where
+      GSym2 a_T571_1 a_T571_2 = G a_T571_1 a_T571_2
     type G :: (~>) a a -> a -> a
     type family G @a (a :: (~>) a a) (a :: a) :: a where
       G f x = Apply f x

--- a/singletons-base/tests/compile-and-dump/Singletons/T581.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T581.golden
@@ -50,135 +50,127 @@ Singletons/T581.hs:(0,0)-(0,0): Splicing declarations
     data M1Sym0 :: (~>) a (Maybe (a, b))
       where
         M1Sym0KindInference :: SameKind (Apply M1Sym0 arg) (M1Sym1 arg) =>
-                               M1Sym0 a0123456789876543210
+                               M1Sym0 a_T581_0
     type instance Apply @a @(Maybe (a,
-                                    b)) M1Sym0 a0123456789876543210 = M1 a0123456789876543210
+                                    b)) M1Sym0 a_T581_0 = M1 a_T581_0
     instance SuppressUnusedWarnings M1Sym0 where
       suppressUnusedWarnings = snd ((,) M1Sym0KindInference ())
     type M1Sym1 :: forall a b. a -> Maybe (a, b)
-    type family M1Sym1 @a @b (a0123456789876543210 :: a) :: Maybe (a,
-                                                                   b) where
-      M1Sym1 a0123456789876543210 = M1 a0123456789876543210
-    type M1_0123456789876543210 :: forall a b. a -> Maybe (a, b)
-    type family M1_0123456789876543210 @a @b (a :: a) :: Maybe (a,
-                                                                b) where
-      M1_0123456789876543210 @a @b (_ :: a) = NothingSym0 :: Maybe (a, b)
+    type family M1Sym1 @a @b (a_T581_0 :: a) :: Maybe (a, b) where
+      M1Sym1 a_T581_0 = M1 a_T581_0
+    type M1_T581_1 :: forall a b. a -> Maybe (a, b)
+    type family M1_T581_1 @a @b (a :: a) :: Maybe (a, b) where
+      M1_T581_1 @a @b (_ :: a) = NothingSym0 :: Maybe (a, b)
     class PC1 a where
       type family M1 (arg :: a) :: Maybe (a, b)
-      type M1 a = M1_0123456789876543210 a
+      type M1 a = M1_T581_1 a
     type M2Sym0 :: forall b a. (~>) b (Maybe a)
     data M2Sym0 :: (~>) b (Maybe a)
       where
         M2Sym0KindInference :: SameKind (Apply M2Sym0 arg) (M2Sym1 arg) =>
-                               M2Sym0 a0123456789876543210
-    type instance Apply @b @(Maybe a) M2Sym0 a0123456789876543210 = M2 a0123456789876543210
+                               M2Sym0 a_T581_3
+    type instance Apply @b @(Maybe a) M2Sym0 a_T581_3 = M2 a_T581_3
     instance SuppressUnusedWarnings M2Sym0 where
       suppressUnusedWarnings = snd ((,) M2Sym0KindInference ())
     type M2Sym1 :: forall b a. b -> Maybe a
-    type family M2Sym1 @b @a (a0123456789876543210 :: b) :: Maybe a where
-      M2Sym1 a0123456789876543210 = M2 a0123456789876543210
-    type M2_0123456789876543210 :: forall a b. b -> Maybe a
-    type family M2_0123456789876543210 @a @b (a :: b) :: Maybe a where
-      M2_0123456789876543210 @a @b (_ :: b) = NothingSym0 :: Maybe a
+    type family M2Sym1 @b @a (a_T581_3 :: b) :: Maybe a where
+      M2Sym1 a_T581_3 = M2 a_T581_3
+    type M2_T581_4 :: forall a b. b -> Maybe a
+    type family M2_T581_4 @a @b (a :: b) :: Maybe a where
+      M2_T581_4 @a @b (_ :: b) = NothingSym0 :: Maybe a
     class PC2 a where
       type family M2 (arg :: b) :: Maybe a
-      type M2 a = M2_0123456789876543210 a
+      type M2 a = M2_T581_4 a
     type M3Sym0 :: forall a b. (~>) a ((~>) b (a, b))
     data M3Sym0 :: (~>) a ((~>) b (a, b))
       where
         M3Sym0KindInference :: SameKind (Apply M3Sym0 arg) (M3Sym1 arg) =>
-                               M3Sym0 a0123456789876543210
+                               M3Sym0 a_T581_6
     type instance Apply @a @((~>) b (a,
-                                     b)) M3Sym0 a0123456789876543210 = M3Sym1 a0123456789876543210
+                                     b)) M3Sym0 a_T581_6 = M3Sym1 a_T581_6
     instance SuppressUnusedWarnings M3Sym0 where
       suppressUnusedWarnings = snd ((,) M3Sym0KindInference ())
     type M3Sym1 :: forall a b. a -> (~>) b (a, b)
-    data M3Sym1 (a0123456789876543210 :: a) :: (~>) b (a, b)
+    data M3Sym1 (a_T581_6 :: a) :: (~>) b (a, b)
       where
-        M3Sym1KindInference :: SameKind (Apply (M3Sym1 a0123456789876543210) arg) (M3Sym2 a0123456789876543210 arg) =>
-                               M3Sym1 a0123456789876543210 a0123456789876543210
+        M3Sym1KindInference :: SameKind (Apply (M3Sym1 a_T581_6) arg) (M3Sym2 a_T581_6 arg) =>
+                               M3Sym1 a_T581_6 a_T581_7
     type instance Apply @b @(a,
-                             b) (M3Sym1 a0123456789876543210) a0123456789876543210 = M3 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (M3Sym1 a0123456789876543210) where
+                             b) (M3Sym1 a_T581_6) a_T581_7 = M3 a_T581_6 a_T581_7
+    instance SuppressUnusedWarnings (M3Sym1 a_T581_6) where
       suppressUnusedWarnings = snd ((,) M3Sym1KindInference ())
     type M3Sym2 :: forall a b. a -> b -> (a, b)
-    type family M3Sym2 @a @b (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: (a,
-                                                                                         b) where
-      M3Sym2 a0123456789876543210 a0123456789876543210 = M3 a0123456789876543210 a0123456789876543210
-    type M3_0123456789876543210 :: forall a b. a -> b -> (a, b)
-    type family M3_0123456789876543210 @a @b (a :: a) (a :: b) :: (a,
-                                                                   b) where
-      M3_0123456789876543210 @a @b (x :: a) (y :: b) = Apply (Apply Tuple2Sym0 x) y :: (a,
-                                                                                        b)
+    type family M3Sym2 @a @b (a_T581_6 :: a) (a_T581_7 :: b) :: (a,
+                                                                 b) where
+      M3Sym2 a_T581_6 a_T581_7 = M3 a_T581_6 a_T581_7
+    type M3_T581_8 :: forall a b. a -> b -> (a, b)
+    type family M3_T581_8 @a @b (a :: a) (a :: b) :: (a, b) where
+      M3_T581_8 @a @b (x :: a) (y :: b) = Apply (Apply Tuple2Sym0 x) y :: (a,
+                                                                           b)
     class PC3 a where
       type family M3 (arg :: a) (arg :: b) :: (a, b)
-      type M3 a a = M3_0123456789876543210 a a
-    type M1_0123456789876543210 :: forall a b. [a] -> Maybe ([a], b)
-    type family M1_0123456789876543210 @a @b (a :: [a]) :: Maybe ([a],
-                                                                  b) where
-      M1_0123456789876543210 @a @b (_ :: [a]) = NothingSym0 :: Maybe ([a],
-                                                                      b)
+      type M3 a a = M3_T581_8 a a
+    type M1_T581_11 :: forall a b. [a] -> Maybe ([a], b)
+    type family M1_T581_11 @a @b (a :: [a]) :: Maybe ([a], b) where
+      M1_T581_11 @a @b (_ :: [a]) = NothingSym0 :: Maybe ([a], b)
     instance PC1 [a] where
-      type M1 a = M1_0123456789876543210 a
-    type M2_0123456789876543210 :: forall a b. b -> Maybe [a]
-    type family M2_0123456789876543210 @a @b (a :: b) :: Maybe [a] where
-      M2_0123456789876543210 @a @b (_ :: b) = NothingSym0 :: Maybe [a]
+      type M1 a = M1_T581_11 a
+    type M2_T581_13 :: forall a b. b -> Maybe [a]
+    type family M2_T581_13 @a @b (a :: b) :: Maybe [a] where
+      M2_T581_13 @a @b (_ :: b) = NothingSym0 :: Maybe [a]
     instance PC2 [a] where
-      type M2 a = M2_0123456789876543210 a
-    type M2_0123456789876543210 :: forall a b. b -> Maybe (Maybe a)
-    type family M2_0123456789876543210 @a @b (a :: b) :: Maybe (Maybe a) where
-      M2_0123456789876543210 @a @b (_ :: b) = NothingSym0 :: Maybe (Maybe a)
+      type M2 a = M2_T581_13 a
+    type M2_T581_15 :: forall a b. b -> Maybe (Maybe a)
+    type family M2_T581_15 @a @b (a :: b) :: Maybe (Maybe a) where
+      M2_T581_15 @a @b (_ :: b) = NothingSym0 :: Maybe (Maybe a)
     instance PC2 (Maybe a) where
-      type M2 a = M2_0123456789876543210 a
-    type family LamCases_0123456789876543210 a0123456789876543210 (x0123456789876543210 :: Maybe a0123456789876543210) (y0123456789876543210 :: b0123456789876543210) a_0123456789876543210 where
-      LamCases_0123456789876543210 a x y xx = xx :: a
-    data LamCases_0123456789876543210Sym0 a0123456789876543210 (x0123456789876543210 :: Maybe a0123456789876543210) (y0123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210
+      type M2 a = M2_T581_15 a
+    type family LamCases_T581_20 a0 (x1 :: Maybe a0) (y3 :: b2) a_T581_21 where
+      LamCases_T581_20 a x y xx = xx :: a
+    data LamCases_T581_20Sym0 a0 (x1 :: Maybe a0) (y3 :: b2) a_T581_21
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 a0123456789876543210 x0123456789876543210 y0123456789876543210) arg) (LamCases_0123456789876543210Sym1 a0123456789876543210 x0123456789876543210 y0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a0123456789876543210 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 a0123456789876543210 x0123456789876543210 y0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a0123456789876543210 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 a0123456789876543210 x0123456789876543210 y0123456789876543210) where
+        LamCases_T581_20Sym0KindInference :: SameKind (Apply (LamCases_T581_20Sym0 a0 x1 y3) arg) (LamCases_T581_20Sym1 a0 x1 y3 arg) =>
+                                             LamCases_T581_20Sym0 a0 x1 y3 a_T581_21
+    type instance Apply @_ @_ (LamCases_T581_20Sym0 a0 x1 y3) a_T581_21 = LamCases_T581_20 a0 x1 y3 a_T581_21
+    instance SuppressUnusedWarnings (LamCases_T581_20Sym0 a0 x1 y3) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 a0123456789876543210 (x0123456789876543210 :: Maybe a0123456789876543210) (y0123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a0123456789876543210 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a0123456789876543210 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
-    type M3_0123456789876543210 :: forall a b. Maybe a
-                                               -> b -> (Maybe a, b)
-    type family M3_0123456789876543210 @a @b (a :: Maybe a) (a :: b) :: (Maybe a,
-                                                                         b) where
-      M3_0123456789876543210 @a @b (x :: Maybe a) (y :: b) = Apply (Apply Tuple2Sym0 (Apply (Apply FmapSym0 (LamCases_0123456789876543210Sym0 a x y)) x)) y
+        = snd ((,) LamCases_T581_20Sym0KindInference ())
+    type family LamCases_T581_20Sym1 a0 (x1 :: Maybe a0) (y3 :: b2) a_T581_21 where
+      LamCases_T581_20Sym1 a0 x1 y3 a_T581_21 = LamCases_T581_20 a0 x1 y3 a_T581_21
+    type M3_T581_17 :: forall a b. Maybe a -> b -> (Maybe a, b)
+    type family M3_T581_17 @a @b (a :: Maybe a) (a :: b) :: (Maybe a,
+                                                             b) where
+      M3_T581_17 @a @b (x :: Maybe a) (y :: b) = Apply (Apply Tuple2Sym0 (Apply (Apply FmapSym0 (LamCases_T581_20Sym0 a x y)) x)) y
     instance PC3 (Maybe a) where
-      type M3 a a = M3_0123456789876543210 a a
-    type family LamCases_0123456789876543210 a0123456789876543210 (x0123456789876543210 :: [a0123456789876543210]) (y0123456789876543210 :: b0123456789876543210) a_0123456789876543210 where
-      LamCases_0123456789876543210 a x y xx = xx :: a
-    data LamCases_0123456789876543210Sym0 a0123456789876543210 (x0123456789876543210 :: [a0123456789876543210]) (y0123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210
+      type M3 a a = M3_T581_17 a a
+    type family LamCases_T581_25 a0 (x1 :: [a0]) (y3 :: b2) a_T581_26 where
+      LamCases_T581_25 a x y xx = xx :: a
+    data LamCases_T581_25Sym0 a0 (x1 :: [a0]) (y3 :: b2) a_T581_26
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 a0123456789876543210 x0123456789876543210 y0123456789876543210) arg) (LamCases_0123456789876543210Sym1 a0123456789876543210 x0123456789876543210 y0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a0123456789876543210 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 a0123456789876543210 x0123456789876543210 y0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a0123456789876543210 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 a0123456789876543210 x0123456789876543210 y0123456789876543210) where
+        LamCases_T581_25Sym0KindInference :: SameKind (Apply (LamCases_T581_25Sym0 a0 x1 y3) arg) (LamCases_T581_25Sym1 a0 x1 y3 arg) =>
+                                             LamCases_T581_25Sym0 a0 x1 y3 a_T581_26
+    type instance Apply @_ @_ (LamCases_T581_25Sym0 a0 x1 y3) a_T581_26 = LamCases_T581_25 a0 x1 y3 a_T581_26
+    instance SuppressUnusedWarnings (LamCases_T581_25Sym0 a0 x1 y3) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 a0123456789876543210 (x0123456789876543210 :: [a0123456789876543210]) (y0123456789876543210 :: b0123456789876543210) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a0123456789876543210 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a0123456789876543210 x0123456789876543210 y0123456789876543210 a_01234567898765432100123456789876543210
-    type M3_0123456789876543210 :: forall a b. [a] -> b -> ([a], b)
-    type family M3_0123456789876543210 @a @b (a :: [a]) (a :: b) :: ([a],
-                                                                     b) where
-      M3_0123456789876543210 @a @b (x :: [a]) (y :: b) = Apply (Apply Tuple2Sym0 (Apply (Apply FmapSym0 (LamCases_0123456789876543210Sym0 a x y)) x)) y
+        = snd ((,) LamCases_T581_25Sym0KindInference ())
+    type family LamCases_T581_25Sym1 a0 (x1 :: [a0]) (y3 :: b2) a_T581_26 where
+      LamCases_T581_25Sym1 a0 x1 y3 a_T581_26 = LamCases_T581_25 a0 x1 y3 a_T581_26
+    type M3_T581_22 :: forall a b. [a] -> b -> ([a], b)
+    type family M3_T581_22 @a @b (a :: [a]) (a :: b) :: ([a], b) where
+      M3_T581_22 @a @b (x :: [a]) (y :: b) = Apply (Apply Tuple2Sym0 (Apply (Apply FmapSym0 (LamCases_T581_25Sym0 a x y)) x)) y
     instance PC3 [a] where
-      type M3 a a = M3_0123456789876543210 a a
+      type M3 a a = M3_T581_22 a a
     class SC1 a where
       sM1 :: forall b (t :: a). Sing t -> Sing (M1 t :: Maybe (a, b))
       default sM1 ::
-                forall b (t :: a). ((M1 t :: Maybe (a, b))
-                                    ~ M1_0123456789876543210 t) =>
+                forall b (t :: a). ((M1 t :: Maybe (a, b)) ~ M1_T581_1 t) =>
                                    Sing t -> Sing (M1 t :: Maybe (a, b))
       sM1 _ = SNothing :: Sing (NothingSym0 :: Maybe (a, b))
     class SC2 a where
       sM2 :: (forall (t :: b). Sing t -> Sing (M2 t :: Maybe a) :: Type)
       default sM2 ::
                 (forall (t :: b).
-                 ((M2 t :: Maybe a) ~ M2_0123456789876543210 t) =>
+                 ((M2 t :: Maybe a) ~ M2_T581_4 t) =>
                  Sing t -> Sing (M2 t :: Maybe a) :: Type)
       sM2 _ = SNothing :: Sing (NothingSym0 :: Maybe a)
     class SC3 a where
@@ -186,8 +178,7 @@ Singletons/T581.hs:(0,0)-(0,0): Splicing declarations
         forall b (t :: a) (t :: b). Sing t
                                     -> Sing t -> Sing (M3 t t :: (a, b))
       default sM3 ::
-                forall b (t :: a) (t :: b). ((M3 t t :: (a, b))
-                                             ~ M3_0123456789876543210 t t) =>
+                forall b (t :: a) (t :: b). ((M3 t t :: (a, b)) ~ M3_T581_8 t t) =>
                                             Sing t -> Sing t -> Sing (M3 t t :: (a, b))
       sM3 (sX :: Sing x) (sY :: Sing y)
         = applySing (applySing (singFun2 @Tuple2Sym0 STuple2) sX) sY ::
@@ -213,7 +204,7 @@ Singletons/T581.hs:(0,0)-(0,0): Splicing declarations
                   (applySing
                      (singFun2 @FmapSym0 sFmap)
                      (singFun1
-                        @(LamCases_0123456789876543210Sym0 a x y)
+                        @(LamCases_T581_20Sym0 a x y)
                         (\cases (sXx :: Sing xx) -> sXx :: Sing (xx :: a))))
                   sX))
             sY
@@ -226,7 +217,7 @@ Singletons/T581.hs:(0,0)-(0,0): Splicing declarations
                   (applySing
                      (singFun2 @FmapSym0 sFmap)
                      (singFun1
-                        @(LamCases_0123456789876543210Sym0 a x y)
+                        @(LamCases_T581_25Sym0 a x y)
                         (\cases (sXx :: Sing xx) -> sXx :: Sing (xx :: a))))
                   sX))
             sY

--- a/singletons-base/tests/compile-and-dump/Singletons/T582.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T582.golden
@@ -32,89 +32,89 @@ Singletons/T582.hs:(0,0)-(0,0): Splicing declarations
     data BarSym0 :: (~>) a ((~>) a a)
       where
         BarSym0KindInference :: SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
-                                BarSym0 a0123456789876543210
-    type instance Apply @a @((~>) a a) BarSym0 a0123456789876543210 = BarSym1 a0123456789876543210
+                                BarSym0 a_T582_0
+    type instance Apply @a @((~>) a a) BarSym0 a_T582_0 = BarSym1 a_T582_0
     instance SuppressUnusedWarnings BarSym0 where
       suppressUnusedWarnings = snd ((,) BarSym0KindInference ())
     infixl 4 type `BarSym0`
     type BarSym1 :: a -> (~>) a a
-    data BarSym1 (a0123456789876543210 :: a) :: (~>) a a
+    data BarSym1 (a_T582_0 :: a) :: (~>) a a
       where
-        BarSym1KindInference :: SameKind (Apply (BarSym1 a0123456789876543210) arg) (BarSym2 a0123456789876543210 arg) =>
-                                BarSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @a @a (BarSym1 a0123456789876543210) a0123456789876543210 = Bar a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (BarSym1 a0123456789876543210) where
+        BarSym1KindInference :: SameKind (Apply (BarSym1 a_T582_0) arg) (BarSym2 a_T582_0 arg) =>
+                                BarSym1 a_T582_0 a_T582_1
+    type instance Apply @a @a (BarSym1 a_T582_0) a_T582_1 = Bar a_T582_0 a_T582_1
+    instance SuppressUnusedWarnings (BarSym1 a_T582_0) where
       suppressUnusedWarnings = snd ((,) BarSym1KindInference ())
     infixl 4 type `BarSym1`
     type BarSym2 :: a -> a -> a
-    type family BarSym2 @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: a where
-      BarSym2 a0123456789876543210 a0123456789876543210 = Bar a0123456789876543210 a0123456789876543210
+    type family BarSym2 @a (a_T582_0 :: a) (a_T582_1 :: a) :: a where
+      BarSym2 a_T582_0 a_T582_1 = Bar a_T582_0 a_T582_1
     infixl 4 type `BarSym2`
     type (!!!@#@$) :: (~>) a ((~>) a a)
     data (!!!@#@$) :: (~>) a ((~>) a a)
       where
         (:!!!@#@$###) :: SameKind (Apply (!!!@#@$) arg) ((!!!@#@$$) arg) =>
-                         (!!!@#@$) a0123456789876543210
-    type instance Apply @a @((~>) a a) (!!!@#@$) a0123456789876543210 = (!!!@#@$$) a0123456789876543210
+                         (!!!@#@$) a_T582_2
+    type instance Apply @a @((~>) a a) (!!!@#@$) a_T582_2 = (!!!@#@$$) a_T582_2
     instance SuppressUnusedWarnings (!!!@#@$) where
       suppressUnusedWarnings = snd ((,) (:!!!@#@$###) ())
     infixl 4 type !!!@#@$
     type (!!!@#@$$) :: a -> (~>) a a
-    data (!!!@#@$$) (a0123456789876543210 :: a) :: (~>) a a
+    data (!!!@#@$$) (a_T582_2 :: a) :: (~>) a a
       where
-        (:!!!@#@$$###) :: SameKind (Apply ((!!!@#@$$) a0123456789876543210) arg) ((!!!@#@$$$) a0123456789876543210 arg) =>
-                          (!!!@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @a @a ((!!!@#@$$) a0123456789876543210) a0123456789876543210 = (!!!) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((!!!@#@$$) a0123456789876543210) where
+        (:!!!@#@$$###) :: SameKind (Apply ((!!!@#@$$) a_T582_2) arg) ((!!!@#@$$$) a_T582_2 arg) =>
+                          (!!!@#@$$) a_T582_2 a_T582_3
+    type instance Apply @a @a ((!!!@#@$$) a_T582_2) a_T582_3 = (!!!) a_T582_2 a_T582_3
+    instance SuppressUnusedWarnings ((!!!@#@$$) a_T582_2) where
       suppressUnusedWarnings = snd ((,) (:!!!@#@$$###) ())
     infixl 4 type !!!@#@$$
     type (!!!@#@$$$) :: a -> a -> a
-    type family (!!!@#@$$$) @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: a where
-      (!!!@#@$$$) a0123456789876543210 a0123456789876543210 = (!!!) a0123456789876543210 a0123456789876543210
+    type family (!!!@#@$$$) @a (a_T582_2 :: a) (a_T582_3 :: a) :: a where
+      (!!!@#@$$$) a_T582_2 a_T582_3 = (!!!) a_T582_2 a_T582_3
     infixl 4 type !!!@#@$$$
     type (%%%@#@$) :: (~>) a ((~>) a a)
     data (%%%@#@$) :: (~>) a ((~>) a a)
       where
         (:%%%@#@$###) :: SameKind (Apply (%%%@#@$) arg) ((%%%@#@$$) arg) =>
-                         (%%%@#@$) a0123456789876543210
-    type instance Apply @a @((~>) a a) (%%%@#@$) a0123456789876543210 = (%%%@#@$$) a0123456789876543210
+                         (%%%@#@$) a_T582_4
+    type instance Apply @a @((~>) a a) (%%%@#@$) a_T582_4 = (%%%@#@$$) a_T582_4
     instance SuppressUnusedWarnings (%%%@#@$) where
       suppressUnusedWarnings = snd ((,) (:%%%@#@$###) ())
     infixl 4 type %%%@#@$
     type (%%%@#@$$) :: a -> (~>) a a
-    data (%%%@#@$$) (a0123456789876543210 :: a) :: (~>) a a
+    data (%%%@#@$$) (a_T582_4 :: a) :: (~>) a a
       where
-        (:%%%@#@$$###) :: SameKind (Apply ((%%%@#@$$) a0123456789876543210) arg) ((%%%@#@$$$) a0123456789876543210 arg) =>
-                          (%%%@#@$$) a0123456789876543210 a0123456789876543210
-    type instance Apply @a @a ((%%%@#@$$) a0123456789876543210) a0123456789876543210 = (%%%) a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings ((%%%@#@$$) a0123456789876543210) where
+        (:%%%@#@$$###) :: SameKind (Apply ((%%%@#@$$) a_T582_4) arg) ((%%%@#@$$$) a_T582_4 arg) =>
+                          (%%%@#@$$) a_T582_4 a_T582_5
+    type instance Apply @a @a ((%%%@#@$$) a_T582_4) a_T582_5 = (%%%) a_T582_4 a_T582_5
+    instance SuppressUnusedWarnings ((%%%@#@$$) a_T582_4) where
       suppressUnusedWarnings = snd ((,) (:%%%@#@$$###) ())
     infixl 4 type %%%@#@$$
     type (%%%@#@$$$) :: a -> a -> a
-    type family (%%%@#@$$$) @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: a where
-      (%%%@#@$$$) a0123456789876543210 a0123456789876543210 = (%%%) a0123456789876543210 a0123456789876543210
+    type family (%%%@#@$$$) @a (a_T582_4 :: a) (a_T582_5 :: a) :: a where
+      (%%%@#@$$$) a_T582_4 a_T582_5 = (%%%) a_T582_4 a_T582_5
     infixl 4 type %%%@#@$$$
     type FooSym0 :: (~>) a ((~>) a a)
     data FooSym0 :: (~>) a ((~>) a a)
       where
         FooSym0KindInference :: SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
-                                FooSym0 a0123456789876543210
-    type instance Apply @a @((~>) a a) FooSym0 a0123456789876543210 = FooSym1 a0123456789876543210
+                                FooSym0 a_T582_6
+    type instance Apply @a @((~>) a a) FooSym0 a_T582_6 = FooSym1 a_T582_6
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings = snd ((,) FooSym0KindInference ())
     infixl 4 type `FooSym0`
     type FooSym1 :: a -> (~>) a a
-    data FooSym1 (a0123456789876543210 :: a) :: (~>) a a
+    data FooSym1 (a_T582_6 :: a) :: (~>) a a
       where
-        FooSym1KindInference :: SameKind (Apply (FooSym1 a0123456789876543210) arg) (FooSym2 a0123456789876543210 arg) =>
-                                FooSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @a @a (FooSym1 a0123456789876543210) a0123456789876543210 = Foo a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (FooSym1 a0123456789876543210) where
+        FooSym1KindInference :: SameKind (Apply (FooSym1 a_T582_6) arg) (FooSym2 a_T582_6 arg) =>
+                                FooSym1 a_T582_6 a_T582_7
+    type instance Apply @a @a (FooSym1 a_T582_6) a_T582_7 = Foo a_T582_6 a_T582_7
+    instance SuppressUnusedWarnings (FooSym1 a_T582_6) where
       suppressUnusedWarnings = snd ((,) FooSym1KindInference ())
     infixl 4 type `FooSym1`
     type FooSym2 :: a -> a -> a
-    type family FooSym2 @a (a0123456789876543210 :: a) (a0123456789876543210 :: a) :: a where
-      FooSym2 a0123456789876543210 a0123456789876543210 = Foo a0123456789876543210 a0123456789876543210
+    type family FooSym2 @a (a_T582_6 :: a) (a_T582_7 :: a) :: a where
+      FooSym2 a_T582_6 a_T582_7 = Foo a_T582_6 a_T582_7
     infixl 4 type `FooSym2`
     type (%%%) :: a -> a -> a
     type family (%%%) @a (a :: a) (a :: a) :: a where

--- a/singletons-base/tests/compile-and-dump/Singletons/T585.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T585.golden
@@ -9,21 +9,21 @@ Singletons/T585.hs:(0,0)-(0,0): Splicing declarations
     data KonstSym0 :: (~>) a ((~>) b a)
       where
         KonstSym0KindInference :: SameKind (Apply KonstSym0 arg) (KonstSym1 arg) =>
-                                  KonstSym0 a0123456789876543210
-    type instance Apply @a @((~>) b a) KonstSym0 a0123456789876543210 = KonstSym1 a0123456789876543210
+                                  KonstSym0 a_T585_0
+    type instance Apply @a @((~>) b a) KonstSym0 a_T585_0 = KonstSym1 a_T585_0
     instance SuppressUnusedWarnings KonstSym0 where
       suppressUnusedWarnings = snd ((,) KonstSym0KindInference ())
     type KonstSym1 :: forall a {b}. a -> (~>) b a
-    data KonstSym1 (a0123456789876543210 :: a) :: (~>) b a
+    data KonstSym1 (a_T585_0 :: a) :: (~>) b a
       where
-        KonstSym1KindInference :: SameKind (Apply (KonstSym1 a0123456789876543210) arg) (KonstSym2 a0123456789876543210 arg) =>
-                                  KonstSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @b @a (KonstSym1 a0123456789876543210) a0123456789876543210 = Konst a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (KonstSym1 a0123456789876543210) where
+        KonstSym1KindInference :: SameKind (Apply (KonstSym1 a_T585_0) arg) (KonstSym2 a_T585_0 arg) =>
+                                  KonstSym1 a_T585_0 a_T585_1
+    type instance Apply @b @a (KonstSym1 a_T585_0) a_T585_1 = Konst a_T585_0 a_T585_1
+    instance SuppressUnusedWarnings (KonstSym1 a_T585_0) where
       suppressUnusedWarnings = snd ((,) KonstSym1KindInference ())
     type KonstSym2 :: forall a {b}. a -> b -> a
-    type family KonstSym2 @a (a0123456789876543210 :: a) (a0123456789876543210 :: b) :: a where
-      KonstSym2 a0123456789876543210 a0123456789876543210 = Konst a0123456789876543210 a0123456789876543210
+    type family KonstSym2 @a (a_T585_0 :: a) (a_T585_1 :: b) :: a where
+      KonstSym2 a_T585_0 a_T585_1 = Konst a_T585_0 a_T585_1
     type Konst :: forall a {b}. a -> b -> a
     type family Konst @a (a :: a) (a :: b) :: a where
       Konst @a (x :: a) (_ :: b) = x

--- a/singletons-base/tests/compile-and-dump/Singletons/T78.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T78.golden
@@ -13,13 +13,13 @@ Singletons/T78.hs:(0,0)-(0,0): Splicing declarations
     data FooSym0 :: (~>) (Maybe Bool) Bool
       where
         FooSym0KindInference :: SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
-                                FooSym0 a0123456789876543210
-    type instance Apply @(Maybe Bool) @Bool FooSym0 a0123456789876543210 = Foo a0123456789876543210
+                                FooSym0 a_Singletons_T78_0
+    type instance Apply @(Maybe Bool) @Bool FooSym0 a_Singletons_T78_0 = Foo a_Singletons_T78_0
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings = snd ((,) FooSym0KindInference ())
     type FooSym1 :: Maybe Bool -> Bool
-    type family FooSym1 (a0123456789876543210 :: Maybe Bool) :: Bool where
-      FooSym1 a0123456789876543210 = Foo a0123456789876543210
+    type family FooSym1 (a_Singletons_T78_0 :: Maybe Bool) :: Bool where
+      FooSym1 a_Singletons_T78_0 = Foo a_Singletons_T78_0
     type Foo :: Maybe Bool -> Bool
     type family Foo (a :: Maybe Bool) :: Bool where
       Foo ('Just 'False) = FalseSym0

--- a/singletons-base/tests/compile-and-dump/Singletons/T89.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/T89.golden
@@ -10,30 +10,28 @@ Singletons/T89.hs:0:0:: Splicing declarations
     type FooSym0 :: Foo
     type family FooSym0 :: Foo where
       FooSym0 = Foo
-    type family LamCases_0123456789876543210 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_0123456789876543210 where
-      LamCases_0123456789876543210 n 'True = FooSym0
-      LamCases_0123456789876543210 n 'False = Apply ErrorSym0 (FromString "toEnum: bad argument")
-    data LamCases_0123456789876543210Sym0 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_01234567898765432100123456789876543210
+    type family LamCases_T89_2 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_T89_3 where
+      LamCases_T89_2 n 'True = FooSym0
+      LamCases_T89_2 n 'False = Apply ErrorSym0 (FromString "toEnum: bad argument")
+    data LamCases_T89_2Sym0 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_T89_3
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 n0123456789876543210) arg) (LamCases_0123456789876543210Sym1 n0123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 n0123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 n0123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 n0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 n0123456789876543210) where
+        LamCases_T89_2Sym0KindInference :: SameKind (Apply (LamCases_T89_2Sym0 n0) arg) (LamCases_T89_2Sym1 n0 arg) =>
+                                           LamCases_T89_2Sym0 n0 a_T89_3
+    type instance Apply @_ @_ (LamCases_T89_2Sym0 n0) a_T89_3 = LamCases_T89_2 n0 a_T89_3
+    instance SuppressUnusedWarnings (LamCases_T89_2Sym0 n0) where
       suppressUnusedWarnings
-        = snd ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (n0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 n0123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 n0123456789876543210 a_01234567898765432100123456789876543210
-    type ToEnum_0123456789876543210 :: GHC.Internal.Bignum.Natural.Natural
-                                       -> Foo
-    type family ToEnum_0123456789876543210 (a :: GHC.Internal.Bignum.Natural.Natural) :: Foo where
-      ToEnum_0123456789876543210 n = Apply (LamCases_0123456789876543210Sym0 n) (Apply (Apply (==@#@$) n) (FromInteger 0))
-    type FromEnum_0123456789876543210 :: Foo
-                                         -> GHC.Internal.Bignum.Natural.Natural
-    type family FromEnum_0123456789876543210 (a :: Foo) :: GHC.Internal.Bignum.Natural.Natural where
-      FromEnum_0123456789876543210 Foo = FromInteger 0
+        = snd ((,) LamCases_T89_2Sym0KindInference ())
+    type family LamCases_T89_2Sym1 (n0 :: GHC.Internal.Bignum.Natural.Natural) a_T89_3 where
+      LamCases_T89_2Sym1 n0 a_T89_3 = LamCases_T89_2 n0 a_T89_3
+    type ToEnum_T89_0 :: GHC.Internal.Bignum.Natural.Natural -> Foo
+    type family ToEnum_T89_0 (a :: GHC.Internal.Bignum.Natural.Natural) :: Foo where
+      ToEnum_T89_0 n = Apply (LamCases_T89_2Sym0 n) (Apply (Apply (==@#@$) n) (FromInteger 0))
+    type FromEnum_T89_4 :: Foo -> GHC.Internal.Bignum.Natural.Natural
+    type family FromEnum_T89_4 (a :: Foo) :: GHC.Internal.Bignum.Natural.Natural where
+      FromEnum_T89_4 Foo = FromInteger 0
     instance PEnum Foo where
-      type ToEnum a = ToEnum_0123456789876543210 a
-      type FromEnum a = FromEnum_0123456789876543210 a
+      type ToEnum a = ToEnum_T89_0 a
+      type FromEnum a = FromEnum_T89_4 a
     data SFoo :: Foo -> Type where SFoo :: SFoo (Foo :: Foo)
     type instance Sing @Foo = SFoo
     instance SingKind Foo where
@@ -44,7 +42,7 @@ Singletons/T89.hs:0:0:: Splicing declarations
       sToEnum (sN :: Sing n)
         = applySing
             (singFun1
-               @(LamCases_0123456789876543210Sym0 n)
+               @(LamCases_T89_2Sym0 n)
                (\cases
                   STrue -> SFoo
                   SFalse

--- a/singletons-base/tests/compile-and-dump/Singletons/TopLevelPatterns.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/TopLevelPatterns.golden
@@ -15,23 +15,23 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
     data BarSym0 :: (~>) Bool ((~>) Bool Foo)
       where
         BarSym0KindInference :: SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
-                                BarSym0 a0123456789876543210
-    type instance Apply @Bool @((~>) Bool Foo) BarSym0 a0123456789876543210 = BarSym1 a0123456789876543210
+                                BarSym0 a_Singletons_TopLevelPatterns_0
+    type instance Apply @Bool @((~>) Bool Foo) BarSym0 a_Singletons_TopLevelPatterns_0 = BarSym1 a_Singletons_TopLevelPatterns_0
     instance SuppressUnusedWarnings BarSym0 where
       suppressUnusedWarnings
         = GHC.Internal.Data.Tuple.snd ((,) BarSym0KindInference ())
     type BarSym1 :: Bool -> (~>) Bool Foo
-    data BarSym1 (a0123456789876543210 :: Bool) :: (~>) Bool Foo
+    data BarSym1 (a_Singletons_TopLevelPatterns_0 :: Bool) :: (~>) Bool Foo
       where
-        BarSym1KindInference :: SameKind (Apply (BarSym1 a0123456789876543210) arg) (BarSym2 a0123456789876543210 arg) =>
-                                BarSym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @Bool @Foo (BarSym1 a0123456789876543210) a0123456789876543210 = Bar a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (BarSym1 a0123456789876543210) where
+        BarSym1KindInference :: SameKind (Apply (BarSym1 a_Singletons_TopLevelPatterns_0) arg) (BarSym2 a_Singletons_TopLevelPatterns_0 arg) =>
+                                BarSym1 a_Singletons_TopLevelPatterns_0 a_Singletons_TopLevelPatterns_1
+    type instance Apply @Bool @Foo (BarSym1 a_Singletons_TopLevelPatterns_0) a_Singletons_TopLevelPatterns_1 = Bar a_Singletons_TopLevelPatterns_0 a_Singletons_TopLevelPatterns_1
+    instance SuppressUnusedWarnings (BarSym1 a_Singletons_TopLevelPatterns_0) where
       suppressUnusedWarnings
         = GHC.Internal.Data.Tuple.snd ((,) BarSym1KindInference ())
     type BarSym2 :: Bool -> Bool -> Foo
-    type family BarSym2 (a0123456789876543210 :: Bool) (a0123456789876543210 :: Bool) :: Foo where
-      BarSym2 a0123456789876543210 a0123456789876543210 = Bar a0123456789876543210 a0123456789876543210
+    type family BarSym2 (a_Singletons_TopLevelPatterns_0 :: Bool) (a_Singletons_TopLevelPatterns_1 :: Bool) :: Foo where
+      BarSym2 a_Singletons_TopLevelPatterns_0 a_Singletons_TopLevelPatterns_1 = Bar a_Singletons_TopLevelPatterns_0 a_Singletons_TopLevelPatterns_1
     data SBool :: Bool -> Type
       where
         SFalse :: SBool (False :: Bool)
@@ -112,245 +112,245 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
     l :: Bool
     m :: Bool
     [l, m] = [not True, id False]
-    type family LamCases_0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 '[_,
-                                     y_0123456789876543210] = y_0123456789876543210
-    data LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
+    type family LamCases_Singletons_TopLevelPatterns_14 a_Singletons_TopLevelPatterns_15 where
+      LamCases_Singletons_TopLevelPatterns_14 '[_,
+                                                y_Singletons_TopLevelPatterns_13] = y_Singletons_TopLevelPatterns_13
+    data LamCases_Singletons_TopLevelPatterns_14Sym0 a_Singletons_TopLevelPatterns_15
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply LamCases_0123456789876543210Sym0 arg) (LamCases_0123456789876543210Sym1 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings LamCases_0123456789876543210Sym0 where
+        LamCases_Singletons_TopLevelPatterns_14Sym0KindInference :: SameKind (Apply LamCases_Singletons_TopLevelPatterns_14Sym0 arg) (LamCases_Singletons_TopLevelPatterns_14Sym1 arg) =>
+                                                                    LamCases_Singletons_TopLevelPatterns_14Sym0 a_Singletons_TopLevelPatterns_15
+    type instance Apply @_ @_ LamCases_Singletons_TopLevelPatterns_14Sym0 a_Singletons_TopLevelPatterns_15 = LamCases_Singletons_TopLevelPatterns_14 a_Singletons_TopLevelPatterns_15
+    instance SuppressUnusedWarnings LamCases_Singletons_TopLevelPatterns_14Sym0 where
       suppressUnusedWarnings
         = GHC.Internal.Data.Tuple.snd
-            ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 '[y_0123456789876543210,
-                                     _] = y_0123456789876543210
-    data LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
+            ((,) LamCases_Singletons_TopLevelPatterns_14Sym0KindInference ())
+    type family LamCases_Singletons_TopLevelPatterns_14Sym1 a_Singletons_TopLevelPatterns_15 where
+      LamCases_Singletons_TopLevelPatterns_14Sym1 a_Singletons_TopLevelPatterns_15 = LamCases_Singletons_TopLevelPatterns_14 a_Singletons_TopLevelPatterns_15
+    type family LamCases_Singletons_TopLevelPatterns_16 a_Singletons_TopLevelPatterns_17 where
+      LamCases_Singletons_TopLevelPatterns_16 '[y_Singletons_TopLevelPatterns_12,
+                                                _] = y_Singletons_TopLevelPatterns_12
+    data LamCases_Singletons_TopLevelPatterns_16Sym0 a_Singletons_TopLevelPatterns_17
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply LamCases_0123456789876543210Sym0 arg) (LamCases_0123456789876543210Sym1 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings LamCases_0123456789876543210Sym0 where
+        LamCases_Singletons_TopLevelPatterns_16Sym0KindInference :: SameKind (Apply LamCases_Singletons_TopLevelPatterns_16Sym0 arg) (LamCases_Singletons_TopLevelPatterns_16Sym1 arg) =>
+                                                                    LamCases_Singletons_TopLevelPatterns_16Sym0 a_Singletons_TopLevelPatterns_17
+    type instance Apply @_ @_ LamCases_Singletons_TopLevelPatterns_16Sym0 a_Singletons_TopLevelPatterns_17 = LamCases_Singletons_TopLevelPatterns_16 a_Singletons_TopLevelPatterns_17
+    instance SuppressUnusedWarnings LamCases_Singletons_TopLevelPatterns_16Sym0 where
       suppressUnusedWarnings
         = GHC.Internal.Data.Tuple.snd
-            ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 ('Bar _ y_0123456789876543210) = y_0123456789876543210
-    data LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
+            ((,) LamCases_Singletons_TopLevelPatterns_16Sym0KindInference ())
+    type family LamCases_Singletons_TopLevelPatterns_16Sym1 a_Singletons_TopLevelPatterns_17 where
+      LamCases_Singletons_TopLevelPatterns_16Sym1 a_Singletons_TopLevelPatterns_17 = LamCases_Singletons_TopLevelPatterns_16 a_Singletons_TopLevelPatterns_17
+    type family LamCases_Singletons_TopLevelPatterns_18 a_Singletons_TopLevelPatterns_19 where
+      LamCases_Singletons_TopLevelPatterns_18 ('Bar _ y_Singletons_TopLevelPatterns_10) = y_Singletons_TopLevelPatterns_10
+    data LamCases_Singletons_TopLevelPatterns_18Sym0 a_Singletons_TopLevelPatterns_19
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply LamCases_0123456789876543210Sym0 arg) (LamCases_0123456789876543210Sym1 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings LamCases_0123456789876543210Sym0 where
+        LamCases_Singletons_TopLevelPatterns_18Sym0KindInference :: SameKind (Apply LamCases_Singletons_TopLevelPatterns_18Sym0 arg) (LamCases_Singletons_TopLevelPatterns_18Sym1 arg) =>
+                                                                    LamCases_Singletons_TopLevelPatterns_18Sym0 a_Singletons_TopLevelPatterns_19
+    type instance Apply @_ @_ LamCases_Singletons_TopLevelPatterns_18Sym0 a_Singletons_TopLevelPatterns_19 = LamCases_Singletons_TopLevelPatterns_18 a_Singletons_TopLevelPatterns_19
+    instance SuppressUnusedWarnings LamCases_Singletons_TopLevelPatterns_18Sym0 where
       suppressUnusedWarnings
         = GHC.Internal.Data.Tuple.snd
-            ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 a_0123456789876543210 where
-      LamCases_0123456789876543210 ('Bar y_0123456789876543210 _) = y_0123456789876543210
-    data LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
+            ((,) LamCases_Singletons_TopLevelPatterns_18Sym0KindInference ())
+    type family LamCases_Singletons_TopLevelPatterns_18Sym1 a_Singletons_TopLevelPatterns_19 where
+      LamCases_Singletons_TopLevelPatterns_18Sym1 a_Singletons_TopLevelPatterns_19 = LamCases_Singletons_TopLevelPatterns_18 a_Singletons_TopLevelPatterns_19
+    type family LamCases_Singletons_TopLevelPatterns_20 a_Singletons_TopLevelPatterns_21 where
+      LamCases_Singletons_TopLevelPatterns_20 ('Bar y_Singletons_TopLevelPatterns_9 _) = y_Singletons_TopLevelPatterns_9
+    data LamCases_Singletons_TopLevelPatterns_20Sym0 a_Singletons_TopLevelPatterns_21
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply LamCases_0123456789876543210Sym0 arg) (LamCases_0123456789876543210Sym1 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings LamCases_0123456789876543210Sym0 where
+        LamCases_Singletons_TopLevelPatterns_20Sym0KindInference :: SameKind (Apply LamCases_Singletons_TopLevelPatterns_20Sym0 arg) (LamCases_Singletons_TopLevelPatterns_20Sym1 arg) =>
+                                                                    LamCases_Singletons_TopLevelPatterns_20Sym0 a_Singletons_TopLevelPatterns_21
+    type instance Apply @_ @_ LamCases_Singletons_TopLevelPatterns_20Sym0 a_Singletons_TopLevelPatterns_21 = LamCases_Singletons_TopLevelPatterns_20 a_Singletons_TopLevelPatterns_21
+    instance SuppressUnusedWarnings LamCases_Singletons_TopLevelPatterns_20Sym0 where
       suppressUnusedWarnings
         = GHC.Internal.Data.Tuple.snd
-            ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (a_01234567898765432100123456789876543210 :: Bool) a_0123456789876543210 where
-      LamCases_0123456789876543210 a_0123456789876543210 '(_,
-                                                           y_0123456789876543210) = y_0123456789876543210
-    data LamCases_0123456789876543210Sym0 (a_01234567898765432100123456789876543210 :: Bool) a_01234567898765432100123456789876543210
+            ((,) LamCases_Singletons_TopLevelPatterns_20Sym0KindInference ())
+    type family LamCases_Singletons_TopLevelPatterns_20Sym1 a_Singletons_TopLevelPatterns_21 where
+      LamCases_Singletons_TopLevelPatterns_20Sym1 a_Singletons_TopLevelPatterns_21 = LamCases_Singletons_TopLevelPatterns_20 a_Singletons_TopLevelPatterns_21
+    type family LamCases_Singletons_TopLevelPatterns_24 (a_Singletons_TopLevelPatterns_220 :: Bool) a_Singletons_TopLevelPatterns_25 where
+      LamCases_Singletons_TopLevelPatterns_24 a_Singletons_TopLevelPatterns_22 '(_,
+                                                                                 y_Singletons_TopLevelPatterns_7) = y_Singletons_TopLevelPatterns_7
+    data LamCases_Singletons_TopLevelPatterns_24Sym0 (a_Singletons_TopLevelPatterns_220 :: Bool) a_Singletons_TopLevelPatterns_25
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210) where
+        LamCases_Singletons_TopLevelPatterns_24Sym0KindInference :: SameKind (Apply (LamCases_Singletons_TopLevelPatterns_24Sym0 a_Singletons_TopLevelPatterns_220) arg) (LamCases_Singletons_TopLevelPatterns_24Sym1 a_Singletons_TopLevelPatterns_220 arg) =>
+                                                                    LamCases_Singletons_TopLevelPatterns_24Sym0 a_Singletons_TopLevelPatterns_220 a_Singletons_TopLevelPatterns_25
+    type instance Apply @_ @_ (LamCases_Singletons_TopLevelPatterns_24Sym0 a_Singletons_TopLevelPatterns_220) a_Singletons_TopLevelPatterns_25 = LamCases_Singletons_TopLevelPatterns_24 a_Singletons_TopLevelPatterns_220 a_Singletons_TopLevelPatterns_25
+    instance SuppressUnusedWarnings (LamCases_Singletons_TopLevelPatterns_24Sym0 a_Singletons_TopLevelPatterns_220) where
       suppressUnusedWarnings
         = GHC.Internal.Data.Tuple.snd
-            ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (a_01234567898765432100123456789876543210 :: Bool) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (a_01234567898765432100123456789876543210 :: Bool) a_0123456789876543210 where
-      LamCases_0123456789876543210 a_0123456789876543210 '(y_0123456789876543210,
-                                                           _) = y_0123456789876543210
-    data LamCases_0123456789876543210Sym0 (a_01234567898765432100123456789876543210 :: Bool) a_01234567898765432100123456789876543210
+            ((,) LamCases_Singletons_TopLevelPatterns_24Sym0KindInference ())
+    type family LamCases_Singletons_TopLevelPatterns_24Sym1 (a_Singletons_TopLevelPatterns_220 :: Bool) a_Singletons_TopLevelPatterns_25 where
+      LamCases_Singletons_TopLevelPatterns_24Sym1 a_Singletons_TopLevelPatterns_220 a_Singletons_TopLevelPatterns_25 = LamCases_Singletons_TopLevelPatterns_24 a_Singletons_TopLevelPatterns_220 a_Singletons_TopLevelPatterns_25
+    type family LamCases_Singletons_TopLevelPatterns_28 (a_Singletons_TopLevelPatterns_260 :: Bool) a_Singletons_TopLevelPatterns_29 where
+      LamCases_Singletons_TopLevelPatterns_28 a_Singletons_TopLevelPatterns_26 '(y_Singletons_TopLevelPatterns_6,
+                                                                                 _) = y_Singletons_TopLevelPatterns_6
+    data LamCases_Singletons_TopLevelPatterns_28Sym0 (a_Singletons_TopLevelPatterns_260 :: Bool) a_Singletons_TopLevelPatterns_29
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210) where
+        LamCases_Singletons_TopLevelPatterns_28Sym0KindInference :: SameKind (Apply (LamCases_Singletons_TopLevelPatterns_28Sym0 a_Singletons_TopLevelPatterns_260) arg) (LamCases_Singletons_TopLevelPatterns_28Sym1 a_Singletons_TopLevelPatterns_260 arg) =>
+                                                                    LamCases_Singletons_TopLevelPatterns_28Sym0 a_Singletons_TopLevelPatterns_260 a_Singletons_TopLevelPatterns_29
+    type instance Apply @_ @_ (LamCases_Singletons_TopLevelPatterns_28Sym0 a_Singletons_TopLevelPatterns_260) a_Singletons_TopLevelPatterns_29 = LamCases_Singletons_TopLevelPatterns_28 a_Singletons_TopLevelPatterns_260 a_Singletons_TopLevelPatterns_29
+    instance SuppressUnusedWarnings (LamCases_Singletons_TopLevelPatterns_28Sym0 a_Singletons_TopLevelPatterns_260) where
       suppressUnusedWarnings
         = GHC.Internal.Data.Tuple.snd
-            ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (a_01234567898765432100123456789876543210 :: Bool) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (a_01234567898765432100123456789876543210 :: Bool) a_0123456789876543210 where
-      LamCases_0123456789876543210 a_0123456789876543210 '[_,
-                                                           y_0123456789876543210] = y_0123456789876543210
-    data LamCases_0123456789876543210Sym0 (a_01234567898765432100123456789876543210 :: Bool) a_01234567898765432100123456789876543210
+            ((,) LamCases_Singletons_TopLevelPatterns_28Sym0KindInference ())
+    type family LamCases_Singletons_TopLevelPatterns_28Sym1 (a_Singletons_TopLevelPatterns_260 :: Bool) a_Singletons_TopLevelPatterns_29 where
+      LamCases_Singletons_TopLevelPatterns_28Sym1 a_Singletons_TopLevelPatterns_260 a_Singletons_TopLevelPatterns_29 = LamCases_Singletons_TopLevelPatterns_28 a_Singletons_TopLevelPatterns_260 a_Singletons_TopLevelPatterns_29
+    type family LamCases_Singletons_TopLevelPatterns_32 (a_Singletons_TopLevelPatterns_300 :: Bool) a_Singletons_TopLevelPatterns_33 where
+      LamCases_Singletons_TopLevelPatterns_32 a_Singletons_TopLevelPatterns_30 '[_,
+                                                                                 y_Singletons_TopLevelPatterns_4] = y_Singletons_TopLevelPatterns_4
+    data LamCases_Singletons_TopLevelPatterns_32Sym0 (a_Singletons_TopLevelPatterns_300 :: Bool) a_Singletons_TopLevelPatterns_33
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210) where
+        LamCases_Singletons_TopLevelPatterns_32Sym0KindInference :: SameKind (Apply (LamCases_Singletons_TopLevelPatterns_32Sym0 a_Singletons_TopLevelPatterns_300) arg) (LamCases_Singletons_TopLevelPatterns_32Sym1 a_Singletons_TopLevelPatterns_300 arg) =>
+                                                                    LamCases_Singletons_TopLevelPatterns_32Sym0 a_Singletons_TopLevelPatterns_300 a_Singletons_TopLevelPatterns_33
+    type instance Apply @_ @_ (LamCases_Singletons_TopLevelPatterns_32Sym0 a_Singletons_TopLevelPatterns_300) a_Singletons_TopLevelPatterns_33 = LamCases_Singletons_TopLevelPatterns_32 a_Singletons_TopLevelPatterns_300 a_Singletons_TopLevelPatterns_33
+    instance SuppressUnusedWarnings (LamCases_Singletons_TopLevelPatterns_32Sym0 a_Singletons_TopLevelPatterns_300) where
       suppressUnusedWarnings
         = GHC.Internal.Data.Tuple.snd
-            ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (a_01234567898765432100123456789876543210 :: Bool) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type family LamCases_0123456789876543210 (a_01234567898765432100123456789876543210 :: Bool) a_0123456789876543210 where
-      LamCases_0123456789876543210 a_0123456789876543210 '[y_0123456789876543210,
-                                                           _] = y_0123456789876543210
-    data LamCases_0123456789876543210Sym0 (a_01234567898765432100123456789876543210 :: Bool) a_01234567898765432100123456789876543210
+            ((,) LamCases_Singletons_TopLevelPatterns_32Sym0KindInference ())
+    type family LamCases_Singletons_TopLevelPatterns_32Sym1 (a_Singletons_TopLevelPatterns_300 :: Bool) a_Singletons_TopLevelPatterns_33 where
+      LamCases_Singletons_TopLevelPatterns_32Sym1 a_Singletons_TopLevelPatterns_300 a_Singletons_TopLevelPatterns_33 = LamCases_Singletons_TopLevelPatterns_32 a_Singletons_TopLevelPatterns_300 a_Singletons_TopLevelPatterns_33
+    type family LamCases_Singletons_TopLevelPatterns_36 (a_Singletons_TopLevelPatterns_340 :: Bool) a_Singletons_TopLevelPatterns_37 where
+      LamCases_Singletons_TopLevelPatterns_36 a_Singletons_TopLevelPatterns_34 '[y_Singletons_TopLevelPatterns_3,
+                                                                                 _] = y_Singletons_TopLevelPatterns_3
+    data LamCases_Singletons_TopLevelPatterns_36Sym0 (a_Singletons_TopLevelPatterns_340 :: Bool) a_Singletons_TopLevelPatterns_37
       where
-        LamCases_0123456789876543210Sym0KindInference :: SameKind (Apply (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210) arg) (LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 arg) =>
-                                                         LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    type instance Apply @_ @_ (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210) a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
-    instance SuppressUnusedWarnings (LamCases_0123456789876543210Sym0 a_01234567898765432100123456789876543210) where
+        LamCases_Singletons_TopLevelPatterns_36Sym0KindInference :: SameKind (Apply (LamCases_Singletons_TopLevelPatterns_36Sym0 a_Singletons_TopLevelPatterns_340) arg) (LamCases_Singletons_TopLevelPatterns_36Sym1 a_Singletons_TopLevelPatterns_340 arg) =>
+                                                                    LamCases_Singletons_TopLevelPatterns_36Sym0 a_Singletons_TopLevelPatterns_340 a_Singletons_TopLevelPatterns_37
+    type instance Apply @_ @_ (LamCases_Singletons_TopLevelPatterns_36Sym0 a_Singletons_TopLevelPatterns_340) a_Singletons_TopLevelPatterns_37 = LamCases_Singletons_TopLevelPatterns_36 a_Singletons_TopLevelPatterns_340 a_Singletons_TopLevelPatterns_37
+    instance SuppressUnusedWarnings (LamCases_Singletons_TopLevelPatterns_36Sym0 a_Singletons_TopLevelPatterns_340) where
       suppressUnusedWarnings
         = GHC.Internal.Data.Tuple.snd
-            ((,) LamCases_0123456789876543210Sym0KindInference ())
-    type family LamCases_0123456789876543210Sym1 (a_01234567898765432100123456789876543210 :: Bool) a_01234567898765432100123456789876543210 where
-      LamCases_0123456789876543210Sym1 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210 = LamCases_0123456789876543210 a_01234567898765432100123456789876543210 a_01234567898765432100123456789876543210
+            ((,) LamCases_Singletons_TopLevelPatterns_36Sym0KindInference ())
+    type family LamCases_Singletons_TopLevelPatterns_36Sym1 (a_Singletons_TopLevelPatterns_340 :: Bool) a_Singletons_TopLevelPatterns_37 where
+      LamCases_Singletons_TopLevelPatterns_36Sym1 a_Singletons_TopLevelPatterns_340 a_Singletons_TopLevelPatterns_37 = LamCases_Singletons_TopLevelPatterns_36 a_Singletons_TopLevelPatterns_340 a_Singletons_TopLevelPatterns_37
     type MSym0 :: Bool
     type family MSym0 :: Bool where
       MSym0 = M
     type LSym0 :: Bool
     type family LSym0 :: Bool where
       LSym0 = L
-    type family X_0123456789876543210Sym0 where
-      X_0123456789876543210Sym0 = X_0123456789876543210
+    type family X_Singletons_TopLevelPatterns_11Sym0 where
+      X_Singletons_TopLevelPatterns_11Sym0 = X_Singletons_TopLevelPatterns_11
     type KSym0 :: Bool
     type family KSym0 :: Bool where
       KSym0 = K
     type JSym0 :: Bool
     type family JSym0 :: Bool where
       JSym0 = J
-    type family X_0123456789876543210Sym0 where
-      X_0123456789876543210Sym0 = X_0123456789876543210
+    type family X_Singletons_TopLevelPatterns_8Sym0 where
+      X_Singletons_TopLevelPatterns_8Sym0 = X_Singletons_TopLevelPatterns_8
     type ISym0 :: (~>) Bool Bool
     data ISym0 :: (~>) Bool Bool
       where
         ISym0KindInference :: SameKind (Apply ISym0 arg) (ISym1 arg) =>
-                              ISym0 a0123456789876543210
-    type instance Apply @Bool @Bool ISym0 a0123456789876543210 = I a0123456789876543210
+                              ISym0 a_Singletons_TopLevelPatterns_23
+    type instance Apply @Bool @Bool ISym0 a_Singletons_TopLevelPatterns_23 = I a_Singletons_TopLevelPatterns_23
     instance SuppressUnusedWarnings ISym0 where
       suppressUnusedWarnings
         = GHC.Internal.Data.Tuple.snd ((,) ISym0KindInference ())
     type ISym1 :: Bool -> Bool
-    type family ISym1 (a0123456789876543210 :: Bool) :: Bool where
-      ISym1 a0123456789876543210 = I a0123456789876543210
+    type family ISym1 (a_Singletons_TopLevelPatterns_23 :: Bool) :: Bool where
+      ISym1 a_Singletons_TopLevelPatterns_23 = I a_Singletons_TopLevelPatterns_23
     type HSym0 :: (~>) Bool Bool
     data HSym0 :: (~>) Bool Bool
       where
         HSym0KindInference :: SameKind (Apply HSym0 arg) (HSym1 arg) =>
-                              HSym0 a0123456789876543210
-    type instance Apply @Bool @Bool HSym0 a0123456789876543210 = H a0123456789876543210
+                              HSym0 a_Singletons_TopLevelPatterns_27
+    type instance Apply @Bool @Bool HSym0 a_Singletons_TopLevelPatterns_27 = H a_Singletons_TopLevelPatterns_27
     instance SuppressUnusedWarnings HSym0 where
       suppressUnusedWarnings
         = GHC.Internal.Data.Tuple.snd ((,) HSym0KindInference ())
     type HSym1 :: Bool -> Bool
-    type family HSym1 (a0123456789876543210 :: Bool) :: Bool where
-      HSym1 a0123456789876543210 = H a0123456789876543210
-    type family X_0123456789876543210Sym0 where
-      X_0123456789876543210Sym0 = X_0123456789876543210
+    type family HSym1 (a_Singletons_TopLevelPatterns_27 :: Bool) :: Bool where
+      HSym1 a_Singletons_TopLevelPatterns_27 = H a_Singletons_TopLevelPatterns_27
+    type family X_Singletons_TopLevelPatterns_5Sym0 where
+      X_Singletons_TopLevelPatterns_5Sym0 = X_Singletons_TopLevelPatterns_5
     type GSym0 :: (~>) Bool Bool
     data GSym0 :: (~>) Bool Bool
       where
         GSym0KindInference :: SameKind (Apply GSym0 arg) (GSym1 arg) =>
-                              GSym0 a0123456789876543210
-    type instance Apply @Bool @Bool GSym0 a0123456789876543210 = G a0123456789876543210
+                              GSym0 a_Singletons_TopLevelPatterns_31
+    type instance Apply @Bool @Bool GSym0 a_Singletons_TopLevelPatterns_31 = G a_Singletons_TopLevelPatterns_31
     instance SuppressUnusedWarnings GSym0 where
       suppressUnusedWarnings
         = GHC.Internal.Data.Tuple.snd ((,) GSym0KindInference ())
     type GSym1 :: Bool -> Bool
-    type family GSym1 (a0123456789876543210 :: Bool) :: Bool where
-      GSym1 a0123456789876543210 = G a0123456789876543210
+    type family GSym1 (a_Singletons_TopLevelPatterns_31 :: Bool) :: Bool where
+      GSym1 a_Singletons_TopLevelPatterns_31 = G a_Singletons_TopLevelPatterns_31
     type FSym0 :: (~>) Bool Bool
     data FSym0 :: (~>) Bool Bool
       where
         FSym0KindInference :: SameKind (Apply FSym0 arg) (FSym1 arg) =>
-                              FSym0 a0123456789876543210
-    type instance Apply @Bool @Bool FSym0 a0123456789876543210 = F a0123456789876543210
+                              FSym0 a_Singletons_TopLevelPatterns_35
+    type instance Apply @Bool @Bool FSym0 a_Singletons_TopLevelPatterns_35 = F a_Singletons_TopLevelPatterns_35
     instance SuppressUnusedWarnings FSym0 where
       suppressUnusedWarnings
         = GHC.Internal.Data.Tuple.snd ((,) FSym0KindInference ())
     type FSym1 :: Bool -> Bool
-    type family FSym1 (a0123456789876543210 :: Bool) :: Bool where
-      FSym1 a0123456789876543210 = F a0123456789876543210
-    type family X_0123456789876543210Sym0 where
-      X_0123456789876543210Sym0 = X_0123456789876543210
+    type family FSym1 (a_Singletons_TopLevelPatterns_35 :: Bool) :: Bool where
+      FSym1 a_Singletons_TopLevelPatterns_35 = F a_Singletons_TopLevelPatterns_35
+    type family X_Singletons_TopLevelPatterns_2Sym0 where
+      X_Singletons_TopLevelPatterns_2Sym0 = X_Singletons_TopLevelPatterns_2
     type family False_Sym0 where
       False_Sym0 = False_
     type NotSym0 :: (~>) Bool Bool
     data NotSym0 :: (~>) Bool Bool
       where
         NotSym0KindInference :: SameKind (Apply NotSym0 arg) (NotSym1 arg) =>
-                                NotSym0 a0123456789876543210
-    type instance Apply @Bool @Bool NotSym0 a0123456789876543210 = Not a0123456789876543210
+                                NotSym0 a_Singletons_TopLevelPatterns_38
+    type instance Apply @Bool @Bool NotSym0 a_Singletons_TopLevelPatterns_38 = Not a_Singletons_TopLevelPatterns_38
     instance SuppressUnusedWarnings NotSym0 where
       suppressUnusedWarnings
         = GHC.Internal.Data.Tuple.snd ((,) NotSym0KindInference ())
     type NotSym1 :: Bool -> Bool
-    type family NotSym1 (a0123456789876543210 :: Bool) :: Bool where
-      NotSym1 a0123456789876543210 = Not a0123456789876543210
+    type family NotSym1 (a_Singletons_TopLevelPatterns_38 :: Bool) :: Bool where
+      NotSym1 a_Singletons_TopLevelPatterns_38 = Not a_Singletons_TopLevelPatterns_38
     type IdSym0 :: (~>) a a
     data IdSym0 :: (~>) a a
       where
         IdSym0KindInference :: SameKind (Apply IdSym0 arg) (IdSym1 arg) =>
-                               IdSym0 a0123456789876543210
-    type instance Apply @a @a IdSym0 a0123456789876543210 = Id a0123456789876543210
+                               IdSym0 a_Singletons_TopLevelPatterns_39
+    type instance Apply @a @a IdSym0 a_Singletons_TopLevelPatterns_39 = Id a_Singletons_TopLevelPatterns_39
     instance SuppressUnusedWarnings IdSym0 where
       suppressUnusedWarnings
         = GHC.Internal.Data.Tuple.snd ((,) IdSym0KindInference ())
     type IdSym1 :: a -> a
-    type family IdSym1 @a (a0123456789876543210 :: a) :: a where
-      IdSym1 a0123456789876543210 = Id a0123456789876543210
+    type family IdSym1 @a (a_Singletons_TopLevelPatterns_39 :: a) :: a where
+      IdSym1 a_Singletons_TopLevelPatterns_39 = Id a_Singletons_TopLevelPatterns_39
     type OtherwiseSym0 :: Bool
     type family OtherwiseSym0 :: Bool where
       OtherwiseSym0 = Otherwise
     type M :: Bool
     type family M :: Bool where
-      M = Apply LamCases_0123456789876543210Sym0 X_0123456789876543210Sym0
+      M = Apply LamCases_Singletons_TopLevelPatterns_14Sym0 X_Singletons_TopLevelPatterns_11Sym0
     type L :: Bool
     type family L :: Bool where
-      L = Apply LamCases_0123456789876543210Sym0 X_0123456789876543210Sym0
-    type family X_0123456789876543210 where
-      X_0123456789876543210 = Apply (Apply (:@#@$) (Apply NotSym0 TrueSym0)) (Apply (Apply (:@#@$) (Apply IdSym0 FalseSym0)) NilSym0)
+      L = Apply LamCases_Singletons_TopLevelPatterns_16Sym0 X_Singletons_TopLevelPatterns_11Sym0
+    type family X_Singletons_TopLevelPatterns_11 where
+      X_Singletons_TopLevelPatterns_11 = Apply (Apply (:@#@$) (Apply NotSym0 TrueSym0)) (Apply (Apply (:@#@$) (Apply IdSym0 FalseSym0)) NilSym0)
     type K :: Bool
     type family K :: Bool where
-      K = Apply LamCases_0123456789876543210Sym0 X_0123456789876543210Sym0
+      K = Apply LamCases_Singletons_TopLevelPatterns_18Sym0 X_Singletons_TopLevelPatterns_8Sym0
     type J :: Bool
     type family J :: Bool where
-      J = Apply LamCases_0123456789876543210Sym0 X_0123456789876543210Sym0
-    type family X_0123456789876543210 where
-      X_0123456789876543210 = Apply (Apply BarSym0 TrueSym0) (Apply HSym0 FalseSym0)
+      J = Apply LamCases_Singletons_TopLevelPatterns_20Sym0 X_Singletons_TopLevelPatterns_8Sym0
+    type family X_Singletons_TopLevelPatterns_8 where
+      X_Singletons_TopLevelPatterns_8 = Apply (Apply BarSym0 TrueSym0) (Apply HSym0 FalseSym0)
     type I :: Bool -> Bool
     type family I (a :: Bool) :: Bool where
-      I a_0123456789876543210 = Apply (Apply (LamCases_0123456789876543210Sym0 a_0123456789876543210) X_0123456789876543210Sym0) a_0123456789876543210
+      I a_Singletons_TopLevelPatterns_22 = Apply (Apply (LamCases_Singletons_TopLevelPatterns_24Sym0 a_Singletons_TopLevelPatterns_22) X_Singletons_TopLevelPatterns_5Sym0) a_Singletons_TopLevelPatterns_22
     type H :: Bool -> Bool
     type family H (a :: Bool) :: Bool where
-      H a_0123456789876543210 = Apply (Apply (LamCases_0123456789876543210Sym0 a_0123456789876543210) X_0123456789876543210Sym0) a_0123456789876543210
-    type family X_0123456789876543210 where
-      X_0123456789876543210 = Apply (Apply Tuple2Sym0 FSym0) GSym0
+      H a_Singletons_TopLevelPatterns_26 = Apply (Apply (LamCases_Singletons_TopLevelPatterns_28Sym0 a_Singletons_TopLevelPatterns_26) X_Singletons_TopLevelPatterns_5Sym0) a_Singletons_TopLevelPatterns_26
+    type family X_Singletons_TopLevelPatterns_5 where
+      X_Singletons_TopLevelPatterns_5 = Apply (Apply Tuple2Sym0 FSym0) GSym0
     type G :: Bool -> Bool
     type family G (a :: Bool) :: Bool where
-      G a_0123456789876543210 = Apply (Apply (LamCases_0123456789876543210Sym0 a_0123456789876543210) X_0123456789876543210Sym0) a_0123456789876543210
+      G a_Singletons_TopLevelPatterns_30 = Apply (Apply (LamCases_Singletons_TopLevelPatterns_32Sym0 a_Singletons_TopLevelPatterns_30) X_Singletons_TopLevelPatterns_2Sym0) a_Singletons_TopLevelPatterns_30
     type F :: Bool -> Bool
     type family F (a :: Bool) :: Bool where
-      F a_0123456789876543210 = Apply (Apply (LamCases_0123456789876543210Sym0 a_0123456789876543210) X_0123456789876543210Sym0) a_0123456789876543210
-    type family X_0123456789876543210 where
-      X_0123456789876543210 = Apply (Apply (:@#@$) NotSym0) (Apply (Apply (:@#@$) IdSym0) NilSym0)
+      F a_Singletons_TopLevelPatterns_34 = Apply (Apply (LamCases_Singletons_TopLevelPatterns_36Sym0 a_Singletons_TopLevelPatterns_34) X_Singletons_TopLevelPatterns_2Sym0) a_Singletons_TopLevelPatterns_34
+    type family X_Singletons_TopLevelPatterns_2 where
+      X_Singletons_TopLevelPatterns_2 = Apply (Apply (:@#@$) NotSym0) (Apply (Apply (:@#@$) IdSym0) NilSym0)
     type family False_ where
       False_ = FalseSym0
     type Not :: Bool -> Bool
@@ -365,16 +365,20 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
       Otherwise = TrueSym0
     sM :: (Sing (M :: Bool) :: Type)
     sL :: (Sing (L :: Bool) :: Type)
-    sX_0123456789876543210 :: Sing @_ X_0123456789876543210
+    sX_Singletons_TopLevelPatterns_11 ::
+      Sing @_ X_Singletons_TopLevelPatterns_11
     sK :: (Sing (K :: Bool) :: Type)
     sJ :: (Sing (J :: Bool) :: Type)
-    sX_0123456789876543210 :: Sing @_ X_0123456789876543210
+    sX_Singletons_TopLevelPatterns_8 ::
+      Sing @_ X_Singletons_TopLevelPatterns_8
     sI :: (forall (t :: Bool). Sing t -> Sing (I t :: Bool) :: Type)
     sH :: (forall (t :: Bool). Sing t -> Sing (H t :: Bool) :: Type)
-    sX_0123456789876543210 :: Sing @_ X_0123456789876543210
+    sX_Singletons_TopLevelPatterns_5 ::
+      Sing @_ X_Singletons_TopLevelPatterns_5
     sG :: (forall (t :: Bool). Sing t -> Sing (G t :: Bool) :: Type)
     sF :: (forall (t :: Bool). Sing t -> Sing (F t :: Bool) :: Type)
-    sX_0123456789876543210 :: Sing @_ X_0123456789876543210
+    sX_Singletons_TopLevelPatterns_2 ::
+      Sing @_ X_Singletons_TopLevelPatterns_2
     sFalse_ :: Sing @_ False_
     sNot ::
       (forall (t :: Bool). Sing t -> Sing (Not t :: Bool) :: Type)
@@ -383,23 +387,23 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
     sM
       = applySing
           (singFun1
-             @LamCases_0123456789876543210Sym0
+             @LamCases_Singletons_TopLevelPatterns_14Sym0
              (\cases
                 (SCons _
-                       (SCons (sY_0123456789876543210 :: Sing y_0123456789876543210)
+                       (SCons (sY_Singletons_TopLevelPatterns_13 :: Sing y_Singletons_TopLevelPatterns_13)
                               SNil))
-                  -> sY_0123456789876543210))
-          sX_0123456789876543210
+                  -> sY_Singletons_TopLevelPatterns_13))
+          sX_Singletons_TopLevelPatterns_11
     sL
       = applySing
           (singFun1
-             @LamCases_0123456789876543210Sym0
+             @LamCases_Singletons_TopLevelPatterns_16Sym0
              (\cases
-                (SCons (sY_0123456789876543210 :: Sing y_0123456789876543210)
+                (SCons (sY_Singletons_TopLevelPatterns_12 :: Sing y_Singletons_TopLevelPatterns_12)
                        (SCons _ SNil))
-                  -> sY_0123456789876543210))
-          sX_0123456789876543210
-    sX_0123456789876543210
+                  -> sY_Singletons_TopLevelPatterns_12))
+          sX_Singletons_TopLevelPatterns_11
+    sX_Singletons_TopLevelPatterns_11
       = applySing
           (applySing
              (singFun2 @(:@#@$) SCons)
@@ -412,71 +416,79 @@ Singletons/TopLevelPatterns.hs:(0,0)-(0,0): Splicing declarations
     sK
       = applySing
           (singFun1
-             @LamCases_0123456789876543210Sym0
+             @LamCases_Singletons_TopLevelPatterns_18Sym0
              (\cases
-                (SBar _ (sY_0123456789876543210 :: Sing y_0123456789876543210))
-                  -> sY_0123456789876543210))
-          sX_0123456789876543210
+                (SBar _
+                      (sY_Singletons_TopLevelPatterns_10 :: Sing y_Singletons_TopLevelPatterns_10))
+                  -> sY_Singletons_TopLevelPatterns_10))
+          sX_Singletons_TopLevelPatterns_8
     sJ
       = applySing
           (singFun1
-             @LamCases_0123456789876543210Sym0
+             @LamCases_Singletons_TopLevelPatterns_20Sym0
              (\cases
-                (SBar (sY_0123456789876543210 :: Sing y_0123456789876543210) _)
-                  -> sY_0123456789876543210))
-          sX_0123456789876543210
-    sX_0123456789876543210
+                (SBar (sY_Singletons_TopLevelPatterns_9 :: Sing y_Singletons_TopLevelPatterns_9)
+                      _)
+                  -> sY_Singletons_TopLevelPatterns_9))
+          sX_Singletons_TopLevelPatterns_8
+    sX_Singletons_TopLevelPatterns_8
       = applySing
           (applySing (singFun2 @BarSym0 SBar) STrue)
           (applySing (singFun1 @HSym0 sH) SFalse)
-    sI (sA_0123456789876543210 :: Sing a_0123456789876543210)
+    sI
+      (sA_Singletons_TopLevelPatterns_22 :: Sing a_Singletons_TopLevelPatterns_22)
       = applySing
           (applySing
              (singFun1
-                @(LamCases_0123456789876543210Sym0 a_0123456789876543210)
+                @(LamCases_Singletons_TopLevelPatterns_24Sym0 a_Singletons_TopLevelPatterns_22)
                 (\cases
-                   (STuple2 _ (sY_0123456789876543210 :: Sing y_0123456789876543210))
-                     -> sY_0123456789876543210))
-             sX_0123456789876543210)
-          sA_0123456789876543210
-    sH (sA_0123456789876543210 :: Sing a_0123456789876543210)
+                   (STuple2 _
+                            (sY_Singletons_TopLevelPatterns_7 :: Sing y_Singletons_TopLevelPatterns_7))
+                     -> sY_Singletons_TopLevelPatterns_7))
+             sX_Singletons_TopLevelPatterns_5)
+          sA_Singletons_TopLevelPatterns_22
+    sH
+      (sA_Singletons_TopLevelPatterns_26 :: Sing a_Singletons_TopLevelPatterns_26)
       = applySing
           (applySing
              (singFun1
-                @(LamCases_0123456789876543210Sym0 a_0123456789876543210)
+                @(LamCases_Singletons_TopLevelPatterns_28Sym0 a_Singletons_TopLevelPatterns_26)
                 (\cases
-                   (STuple2 (sY_0123456789876543210 :: Sing y_0123456789876543210) _)
-                     -> sY_0123456789876543210))
-             sX_0123456789876543210)
-          sA_0123456789876543210
-    sX_0123456789876543210
+                   (STuple2 (sY_Singletons_TopLevelPatterns_6 :: Sing y_Singletons_TopLevelPatterns_6)
+                            _)
+                     -> sY_Singletons_TopLevelPatterns_6))
+             sX_Singletons_TopLevelPatterns_5)
+          sA_Singletons_TopLevelPatterns_26
+    sX_Singletons_TopLevelPatterns_5
       = applySing
           (applySing (singFun2 @Tuple2Sym0 STuple2) (singFun1 @FSym0 sF))
           (singFun1 @GSym0 sG)
-    sG (sA_0123456789876543210 :: Sing a_0123456789876543210)
+    sG
+      (sA_Singletons_TopLevelPatterns_30 :: Sing a_Singletons_TopLevelPatterns_30)
       = applySing
           (applySing
              (singFun1
-                @(LamCases_0123456789876543210Sym0 a_0123456789876543210)
+                @(LamCases_Singletons_TopLevelPatterns_32Sym0 a_Singletons_TopLevelPatterns_30)
                 (\cases
                    (SCons _
-                          (SCons (sY_0123456789876543210 :: Sing y_0123456789876543210)
+                          (SCons (sY_Singletons_TopLevelPatterns_4 :: Sing y_Singletons_TopLevelPatterns_4)
                                  SNil))
-                     -> sY_0123456789876543210))
-             sX_0123456789876543210)
-          sA_0123456789876543210
-    sF (sA_0123456789876543210 :: Sing a_0123456789876543210)
+                     -> sY_Singletons_TopLevelPatterns_4))
+             sX_Singletons_TopLevelPatterns_2)
+          sA_Singletons_TopLevelPatterns_30
+    sF
+      (sA_Singletons_TopLevelPatterns_34 :: Sing a_Singletons_TopLevelPatterns_34)
       = applySing
           (applySing
              (singFun1
-                @(LamCases_0123456789876543210Sym0 a_0123456789876543210)
+                @(LamCases_Singletons_TopLevelPatterns_36Sym0 a_Singletons_TopLevelPatterns_34)
                 (\cases
-                   (SCons (sY_0123456789876543210 :: Sing y_0123456789876543210)
+                   (SCons (sY_Singletons_TopLevelPatterns_3 :: Sing y_Singletons_TopLevelPatterns_3)
                           (SCons _ SNil))
-                     -> sY_0123456789876543210))
-             sX_0123456789876543210)
-          sA_0123456789876543210
-    sX_0123456789876543210
+                     -> sY_Singletons_TopLevelPatterns_3))
+             sX_Singletons_TopLevelPatterns_2)
+          sA_Singletons_TopLevelPatterns_34
+    sX_Singletons_TopLevelPatterns_2
       = applySing
           (applySing (singFun2 @(:@#@$) SCons) (singFun1 @NotSym0 sNot))
           (applySing

--- a/singletons-base/tests/compile-and-dump/Singletons/TypeAbstractions.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/TypeAbstractions.golden
@@ -53,38 +53,38 @@ Singletons/TypeAbstractions.hs:(0,0)-(0,0): Splicing declarations
       TF @j _ @k _ = (j, k)
     type TS :: forall j. j -> forall k. k -> Type
     type TS @j (a :: j) @k (b :: k) = (j, k)
-    data TSSym0 :: (~>) j0123456789876543210 ((~>) k0123456789876543210 Type)
+    data TSSym0 :: (~>) j0 ((~>) k1 Type)
       where
         TSSym0KindInference :: SameKind (Apply TSSym0 arg) (TSSym1 arg) =>
-                               TSSym0 e0123456789876543210
-    type instance Apply @j0123456789876543210 @((~>) k0123456789876543210 Type) TSSym0 e0123456789876543210 = TSSym1 e0123456789876543210
+                               TSSym0 e_TypeAbstractions_0
+    type instance Apply @j0 @((~>) k1 Type) TSSym0 e_TypeAbstractions_0 = TSSym1 e_TypeAbstractions_0
     instance SuppressUnusedWarnings TSSym0 where
       suppressUnusedWarnings = snd ((,) TSSym0KindInference ())
-    data TSSym1 (e0123456789876543210 :: j0123456789876543210) :: (~>) k0123456789876543210 Type
+    data TSSym1 (e_TypeAbstractions_0 :: j0) :: (~>) k1 Type
       where
-        TSSym1KindInference :: SameKind (Apply (TSSym1 e0123456789876543210) arg) (TSSym2 e0123456789876543210 arg) =>
-                               TSSym1 e0123456789876543210 e0123456789876543210
-    type instance Apply @k0123456789876543210 @Type (TSSym1 e0123456789876543210) e0123456789876543210 = TS e0123456789876543210 e0123456789876543210
-    instance SuppressUnusedWarnings (TSSym1 e0123456789876543210) where
+        TSSym1KindInference :: SameKind (Apply (TSSym1 e_TypeAbstractions_0) arg) (TSSym2 e_TypeAbstractions_0 arg) =>
+                               TSSym1 e_TypeAbstractions_0 e_TypeAbstractions_1
+    type instance Apply @k1 @Type (TSSym1 e_TypeAbstractions_0) e_TypeAbstractions_1 = TS e_TypeAbstractions_0 e_TypeAbstractions_1
+    instance SuppressUnusedWarnings (TSSym1 e_TypeAbstractions_0) where
       suppressUnusedWarnings = snd ((,) TSSym1KindInference ())
-    type family TSSym2 (e0123456789876543210 :: j0123456789876543210) (e0123456789876543210 :: k0123456789876543210) :: Type where
-      TSSym2 e0123456789876543210 e0123456789876543210 = TS e0123456789876543210 e0123456789876543210
-    data TFSym0 :: (~>) j0123456789876543210 ((~>) k0123456789876543210 Type)
+    type family TSSym2 (e_TypeAbstractions_0 :: j0) (e_TypeAbstractions_1 :: k1) :: Type where
+      TSSym2 e_TypeAbstractions_0 e_TypeAbstractions_1 = TS e_TypeAbstractions_0 e_TypeAbstractions_1
+    data TFSym0 :: (~>) j0 ((~>) k1 Type)
       where
         TFSym0KindInference :: SameKind (Apply TFSym0 arg) (TFSym1 arg) =>
-                               TFSym0 e0123456789876543210
-    type instance Apply @j0123456789876543210 @((~>) k0123456789876543210 Type) TFSym0 e0123456789876543210 = TFSym1 e0123456789876543210
+                               TFSym0 e_TypeAbstractions_2
+    type instance Apply @j0 @((~>) k1 Type) TFSym0 e_TypeAbstractions_2 = TFSym1 e_TypeAbstractions_2
     instance SuppressUnusedWarnings TFSym0 where
       suppressUnusedWarnings = snd ((,) TFSym0KindInference ())
-    data TFSym1 (e0123456789876543210 :: j0123456789876543210) :: (~>) k0123456789876543210 Type
+    data TFSym1 (e_TypeAbstractions_2 :: j0) :: (~>) k1 Type
       where
-        TFSym1KindInference :: SameKind (Apply (TFSym1 e0123456789876543210) arg) (TFSym2 e0123456789876543210 arg) =>
-                               TFSym1 e0123456789876543210 e0123456789876543210
-    type instance Apply @k0123456789876543210 @Type (TFSym1 e0123456789876543210) e0123456789876543210 = TF e0123456789876543210 e0123456789876543210
-    instance SuppressUnusedWarnings (TFSym1 e0123456789876543210) where
+        TFSym1KindInference :: SameKind (Apply (TFSym1 e_TypeAbstractions_2) arg) (TFSym2 e_TypeAbstractions_2 arg) =>
+                               TFSym1 e_TypeAbstractions_2 e_TypeAbstractions_3
+    type instance Apply @k1 @Type (TFSym1 e_TypeAbstractions_2) e_TypeAbstractions_3 = TF e_TypeAbstractions_2 e_TypeAbstractions_3
+    instance SuppressUnusedWarnings (TFSym1 e_TypeAbstractions_2) where
       suppressUnusedWarnings = snd ((,) TFSym1KindInference ())
-    type family TFSym2 (e0123456789876543210 :: j0123456789876543210) (e0123456789876543210 :: k0123456789876543210) :: Type where
-      TFSym2 e0123456789876543210 e0123456789876543210 = TF e0123456789876543210 e0123456789876543210
+    type family TFSym2 (e_TypeAbstractions_2 :: j0) (e_TypeAbstractions_3 :: k1) :: Type where
+      TFSym2 e_TypeAbstractions_2 e_TypeAbstractions_3 = TF e_TypeAbstractions_2 e_TypeAbstractions_3
     type MkD1Sym0 :: forall j
                             k
                             (a :: j)
@@ -92,23 +92,23 @@ Singletons/TypeAbstractions.hs:(0,0)-(0,0): Splicing declarations
     data MkD1Sym0 :: (~>) (Proxy a) ((~>) (Proxy b) (D1 @j @k a b))
       where
         MkD1Sym0KindInference :: SameKind (Apply MkD1Sym0 arg) (MkD1Sym1 arg) =>
-                                 MkD1Sym0 a0123456789876543210
-    type instance Apply @(Proxy a) @((~>) (Proxy b) (D1 @j @k a b)) MkD1Sym0 a0123456789876543210 = MkD1Sym1 a0123456789876543210
+                                 MkD1Sym0 a_TypeAbstractions_4
+    type instance Apply @(Proxy a) @((~>) (Proxy b) (D1 @j @k a b)) MkD1Sym0 a_TypeAbstractions_4 = MkD1Sym1 a_TypeAbstractions_4
     instance SuppressUnusedWarnings MkD1Sym0 where
       suppressUnusedWarnings = snd ((,) MkD1Sym0KindInference ())
     type MkD1Sym1 :: forall j k (a :: j) (b :: k). Proxy a
                                                    -> (~>) (Proxy b) (D1 @j @k a b)
-    data MkD1Sym1 (a0123456789876543210 :: Proxy a) :: (~>) (Proxy b) (D1 @j @k a b)
+    data MkD1Sym1 (a_TypeAbstractions_4 :: Proxy a) :: (~>) (Proxy b) (D1 @j @k a b)
       where
-        MkD1Sym1KindInference :: SameKind (Apply (MkD1Sym1 a0123456789876543210) arg) (MkD1Sym2 a0123456789876543210 arg) =>
-                                 MkD1Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Proxy b) @(D1 @j @k a b) (MkD1Sym1 a0123456789876543210) a0123456789876543210 = MkD1 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (MkD1Sym1 a0123456789876543210) where
+        MkD1Sym1KindInference :: SameKind (Apply (MkD1Sym1 a_TypeAbstractions_4) arg) (MkD1Sym2 a_TypeAbstractions_4 arg) =>
+                                 MkD1Sym1 a_TypeAbstractions_4 a_TypeAbstractions_5
+    type instance Apply @(Proxy b) @(D1 @j @k a b) (MkD1Sym1 a_TypeAbstractions_4) a_TypeAbstractions_5 = MkD1 a_TypeAbstractions_4 a_TypeAbstractions_5
+    instance SuppressUnusedWarnings (MkD1Sym1 a_TypeAbstractions_4) where
       suppressUnusedWarnings = snd ((,) MkD1Sym1KindInference ())
     type MkD1Sym2 :: forall j k (a :: j) (b :: k). Proxy a
                                                    -> Proxy b -> D1 @j @k a b
-    type family MkD1Sym2 @j @k @(a :: j) @(b :: k) (a0123456789876543210 :: Proxy a) (a0123456789876543210 :: Proxy b) :: D1 @j @k a b where
-      MkD1Sym2 a0123456789876543210 a0123456789876543210 = MkD1 a0123456789876543210 a0123456789876543210
+    type family MkD1Sym2 @j @k @(a :: j) @(b :: k) (a_TypeAbstractions_4 :: Proxy a) (a_TypeAbstractions_5 :: Proxy b) :: D1 @j @k a b where
+      MkD1Sym2 a_TypeAbstractions_4 a_TypeAbstractions_5 = MkD1 a_TypeAbstractions_4 a_TypeAbstractions_5
     type MkD2Sym0 :: forall x
                             y
                             (a :: x)
@@ -116,23 +116,23 @@ Singletons/TypeAbstractions.hs:(0,0)-(0,0): Splicing declarations
     data MkD2Sym0 :: (~>) (Proxy a) ((~>) (Proxy b) (D2 @x @y a b))
       where
         MkD2Sym0KindInference :: SameKind (Apply MkD2Sym0 arg) (MkD2Sym1 arg) =>
-                                 MkD2Sym0 a0123456789876543210
-    type instance Apply @(Proxy a) @((~>) (Proxy b) (D2 @x @y a b)) MkD2Sym0 a0123456789876543210 = MkD2Sym1 a0123456789876543210
+                                 MkD2Sym0 a_TypeAbstractions_6
+    type instance Apply @(Proxy a) @((~>) (Proxy b) (D2 @x @y a b)) MkD2Sym0 a_TypeAbstractions_6 = MkD2Sym1 a_TypeAbstractions_6
     instance SuppressUnusedWarnings MkD2Sym0 where
       suppressUnusedWarnings = snd ((,) MkD2Sym0KindInference ())
     type MkD2Sym1 :: forall x y (a :: x) (b :: y). Proxy a
                                                    -> (~>) (Proxy b) (D2 @x @y a b)
-    data MkD2Sym1 (a0123456789876543210 :: Proxy a) :: (~>) (Proxy b) (D2 @x @y a b)
+    data MkD2Sym1 (a_TypeAbstractions_6 :: Proxy a) :: (~>) (Proxy b) (D2 @x @y a b)
       where
-        MkD2Sym1KindInference :: SameKind (Apply (MkD2Sym1 a0123456789876543210) arg) (MkD2Sym2 a0123456789876543210 arg) =>
-                                 MkD2Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Proxy b) @(D2 @x @y a b) (MkD2Sym1 a0123456789876543210) a0123456789876543210 = MkD2 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (MkD2Sym1 a0123456789876543210) where
+        MkD2Sym1KindInference :: SameKind (Apply (MkD2Sym1 a_TypeAbstractions_6) arg) (MkD2Sym2 a_TypeAbstractions_6 arg) =>
+                                 MkD2Sym1 a_TypeAbstractions_6 a_TypeAbstractions_7
+    type instance Apply @(Proxy b) @(D2 @x @y a b) (MkD2Sym1 a_TypeAbstractions_6) a_TypeAbstractions_7 = MkD2 a_TypeAbstractions_6 a_TypeAbstractions_7
+    instance SuppressUnusedWarnings (MkD2Sym1 a_TypeAbstractions_6) where
       suppressUnusedWarnings = snd ((,) MkD2Sym1KindInference ())
     type MkD2Sym2 :: forall x y (a :: x) (b :: y). Proxy a
                                                    -> Proxy b -> D2 @x @y a b
-    type family MkD2Sym2 @x @y @(a :: x) @(b :: y) (a0123456789876543210 :: Proxy a) (a0123456789876543210 :: Proxy b) :: D2 @x @y a b where
-      MkD2Sym2 a0123456789876543210 a0123456789876543210 = MkD2 a0123456789876543210 a0123456789876543210
+    type family MkD2Sym2 @x @y @(a :: x) @(b :: y) (a_TypeAbstractions_6 :: Proxy a) (a_TypeAbstractions_7 :: Proxy b) :: D2 @x @y a b where
+      MkD2Sym2 a_TypeAbstractions_6 a_TypeAbstractions_7 = MkD2 a_TypeAbstractions_6 a_TypeAbstractions_7
     type MkD3Sym0 :: forall j
                             (a :: j)
                             k
@@ -140,34 +140,34 @@ Singletons/TypeAbstractions.hs:(0,0)-(0,0): Splicing declarations
     data MkD3Sym0 :: (~>) (Proxy a) ((~>) (Proxy b) (D3 @j a @k b))
       where
         MkD3Sym0KindInference :: SameKind (Apply MkD3Sym0 arg) (MkD3Sym1 arg) =>
-                                 MkD3Sym0 a0123456789876543210
-    type instance Apply @(Proxy a) @((~>) (Proxy b) (D3 @j a @k b)) MkD3Sym0 a0123456789876543210 = MkD3Sym1 a0123456789876543210
+                                 MkD3Sym0 a_TypeAbstractions_8
+    type instance Apply @(Proxy a) @((~>) (Proxy b) (D3 @j a @k b)) MkD3Sym0 a_TypeAbstractions_8 = MkD3Sym1 a_TypeAbstractions_8
     instance SuppressUnusedWarnings MkD3Sym0 where
       suppressUnusedWarnings = snd ((,) MkD3Sym0KindInference ())
     type MkD3Sym1 :: forall j (a :: j) k (b :: k). Proxy a
                                                    -> (~>) (Proxy b) (D3 @j a @k b)
-    data MkD3Sym1 (a0123456789876543210 :: Proxy a) :: (~>) (Proxy b) (D3 @j a @k b)
+    data MkD3Sym1 (a_TypeAbstractions_8 :: Proxy a) :: (~>) (Proxy b) (D3 @j a @k b)
       where
-        MkD3Sym1KindInference :: SameKind (Apply (MkD3Sym1 a0123456789876543210) arg) (MkD3Sym2 a0123456789876543210 arg) =>
-                                 MkD3Sym1 a0123456789876543210 a0123456789876543210
-    type instance Apply @(Proxy b) @(D3 @j a @k b) (MkD3Sym1 a0123456789876543210) a0123456789876543210 = MkD3 a0123456789876543210 a0123456789876543210
-    instance SuppressUnusedWarnings (MkD3Sym1 a0123456789876543210) where
+        MkD3Sym1KindInference :: SameKind (Apply (MkD3Sym1 a_TypeAbstractions_8) arg) (MkD3Sym2 a_TypeAbstractions_8 arg) =>
+                                 MkD3Sym1 a_TypeAbstractions_8 a_TypeAbstractions_9
+    type instance Apply @(Proxy b) @(D3 @j a @k b) (MkD3Sym1 a_TypeAbstractions_8) a_TypeAbstractions_9 = MkD3 a_TypeAbstractions_8 a_TypeAbstractions_9
+    instance SuppressUnusedWarnings (MkD3Sym1 a_TypeAbstractions_8) where
       suppressUnusedWarnings = snd ((,) MkD3Sym1KindInference ())
     type MkD3Sym2 :: forall j (a :: j) k (b :: k). Proxy a
                                                    -> Proxy b -> D3 @j a @k b
-    type family MkD3Sym2 @j @(a :: j) @k @(b :: k) (a0123456789876543210 :: Proxy a) (a0123456789876543210 :: Proxy b) :: D3 @j a @k b where
-      MkD3Sym2 a0123456789876543210 a0123456789876543210 = MkD3 a0123456789876543210 a0123456789876543210
+    type family MkD3Sym2 @j @(a :: j) @k @(b :: k) (a_TypeAbstractions_8 :: Proxy a) (a_TypeAbstractions_9 :: Proxy b) :: D3 @j a @k b where
+      MkD3Sym2 a_TypeAbstractions_8 a_TypeAbstractions_9 = MkD3 a_TypeAbstractions_8 a_TypeAbstractions_9
     type MkD4Sym0 :: forall (a :: Type). (~>) a (D4 @a)
     data MkD4Sym0 :: (~>) a (D4 @a)
       where
         MkD4Sym0KindInference :: SameKind (Apply MkD4Sym0 arg) (MkD4Sym1 arg) =>
-                                 MkD4Sym0 a0123456789876543210
-    type instance Apply @a @(D4 @a) MkD4Sym0 a0123456789876543210 = MkD4 a0123456789876543210
+                                 MkD4Sym0 a_TypeAbstractions_10
+    type instance Apply @a @(D4 @a) MkD4Sym0 a_TypeAbstractions_10 = MkD4 a_TypeAbstractions_10
     instance SuppressUnusedWarnings MkD4Sym0 where
       suppressUnusedWarnings = snd ((,) MkD4Sym0KindInference ())
     type MkD4Sym1 :: forall (a :: Type). a -> D4 @a
-    type family MkD4Sym1 @(a :: Type) (a0123456789876543210 :: a) :: D4 @a where
-      MkD4Sym1 a0123456789876543210 = MkD4 a0123456789876543210
+    type family MkD4Sym1 @(a :: Type) (a_TypeAbstractions_10 :: a) :: D4 @a where
+      MkD4Sym1 a_TypeAbstractions_10 = MkD4 a_TypeAbstractions_10
     type Meth1Sym0 :: forall j
                              k
                              (a :: j)
@@ -175,13 +175,13 @@ Singletons/TypeAbstractions.hs:(0,0)-(0,0): Splicing declarations
     data Meth1Sym0 :: (~>) (Proxy a) (Proxy b)
       where
         Meth1Sym0KindInference :: SameKind (Apply Meth1Sym0 arg) (Meth1Sym1 arg) =>
-                                  Meth1Sym0 a0123456789876543210
-    type instance Apply @(Proxy a) @(Proxy b) Meth1Sym0 a0123456789876543210 = Meth1 a0123456789876543210
+                                  Meth1Sym0 a_TypeAbstractions_11
+    type instance Apply @(Proxy a) @(Proxy b) Meth1Sym0 a_TypeAbstractions_11 = Meth1 a_TypeAbstractions_11
     instance SuppressUnusedWarnings Meth1Sym0 where
       suppressUnusedWarnings = snd ((,) Meth1Sym0KindInference ())
     type Meth1Sym1 :: forall j k (a :: j) (b :: k). Proxy a -> Proxy b
-    type family Meth1Sym1 @j @k @(a :: j) @(b :: k) (a0123456789876543210 :: Proxy a) :: Proxy b where
-      Meth1Sym1 a0123456789876543210 = Meth1 a0123456789876543210
+    type family Meth1Sym1 @j @k @(a :: j) @(b :: k) (a_TypeAbstractions_11 :: Proxy a) :: Proxy b where
+      Meth1Sym1 a_TypeAbstractions_11 = Meth1 a_TypeAbstractions_11
     type PC1 :: forall j k. j -> k -> Constraint
     class PC1 @j @k (a :: j) (b :: k) where
       type family Meth1 (arg :: Proxy a) :: Proxy b
@@ -192,13 +192,13 @@ Singletons/TypeAbstractions.hs:(0,0)-(0,0): Splicing declarations
     data Meth2Sym0 :: (~>) (Proxy a) (Proxy b)
       where
         Meth2Sym0KindInference :: SameKind (Apply Meth2Sym0 arg) (Meth2Sym1 arg) =>
-                                  Meth2Sym0 a0123456789876543210
-    type instance Apply @(Proxy a) @(Proxy b) Meth2Sym0 a0123456789876543210 = Meth2 a0123456789876543210
+                                  Meth2Sym0 a_TypeAbstractions_12
+    type instance Apply @(Proxy a) @(Proxy b) Meth2Sym0 a_TypeAbstractions_12 = Meth2 a_TypeAbstractions_12
     instance SuppressUnusedWarnings Meth2Sym0 where
       suppressUnusedWarnings = snd ((,) Meth2Sym0KindInference ())
     type Meth2Sym1 :: forall x y (a :: x) (b :: y). Proxy a -> Proxy b
-    type family Meth2Sym1 @x @y @(a :: x) @(b :: y) (a0123456789876543210 :: Proxy a) :: Proxy b where
-      Meth2Sym1 a0123456789876543210 = Meth2 a0123456789876543210
+    type family Meth2Sym1 @x @y @(a :: x) @(b :: y) (a_TypeAbstractions_12 :: Proxy a) :: Proxy b where
+      Meth2Sym1 a_TypeAbstractions_12 = Meth2 a_TypeAbstractions_12
     type PC2 :: forall j k. j -> k -> Constraint
     class PC2 @x @y (a :: x) (b :: y) where
       type family Meth2 (arg :: Proxy a) :: Proxy b
@@ -209,13 +209,13 @@ Singletons/TypeAbstractions.hs:(0,0)-(0,0): Splicing declarations
     data Meth3Sym0 :: (~>) (Proxy a) (Proxy b)
       where
         Meth3Sym0KindInference :: SameKind (Apply Meth3Sym0 arg) (Meth3Sym1 arg) =>
-                                  Meth3Sym0 a0123456789876543210
-    type instance Apply @(Proxy a) @(Proxy b) Meth3Sym0 a0123456789876543210 = Meth3 a0123456789876543210
+                                  Meth3Sym0 a_TypeAbstractions_13
+    type instance Apply @(Proxy a) @(Proxy b) Meth3Sym0 a_TypeAbstractions_13 = Meth3 a_TypeAbstractions_13
     instance SuppressUnusedWarnings Meth3Sym0 where
       suppressUnusedWarnings = snd ((,) Meth3Sym0KindInference ())
     type Meth3Sym1 :: forall j (a :: j) k (b :: k). Proxy a -> Proxy b
-    type family Meth3Sym1 @j @(a :: j) @k @(b :: k) (a0123456789876543210 :: Proxy a) :: Proxy b where
-      Meth3Sym1 a0123456789876543210 = Meth3 a0123456789876543210
+    type family Meth3Sym1 @j @(a :: j) @k @(b :: k) (a_TypeAbstractions_13 :: Proxy a) :: Proxy b where
+      Meth3Sym1 a_TypeAbstractions_13 = Meth3 a_TypeAbstractions_13
     type PC3 :: forall j. j -> forall k. k -> Constraint
     class PC3 @j (a :: j) @k (b :: k) where
       type family Meth3 (arg :: Proxy a) :: Proxy b

--- a/singletons-base/tests/compile-and-dump/Singletons/Undef.golden
+++ b/singletons-base/tests/compile-and-dump/Singletons/Undef.golden
@@ -13,40 +13,40 @@ Singletons/Undef.hs:(0,0)-(0,0): Splicing declarations
     data BarSym0 :: (~>) Bool Bool
       where
         BarSym0KindInference :: SameKind (Apply BarSym0 arg) (BarSym1 arg) =>
-                                BarSym0 a0123456789876543210
-    type instance Apply @Bool @Bool BarSym0 a0123456789876543210 = Bar a0123456789876543210
+                                BarSym0 a_Singletons_Undef_1
+    type instance Apply @Bool @Bool BarSym0 a_Singletons_Undef_1 = Bar a_Singletons_Undef_1
     instance SuppressUnusedWarnings BarSym0 where
       suppressUnusedWarnings = snd ((,) BarSym0KindInference ())
     type BarSym1 :: Bool -> Bool
-    type family BarSym1 (a0123456789876543210 :: Bool) :: Bool where
-      BarSym1 a0123456789876543210 = Bar a0123456789876543210
+    type family BarSym1 (a_Singletons_Undef_1 :: Bool) :: Bool where
+      BarSym1 a_Singletons_Undef_1 = Bar a_Singletons_Undef_1
     type FooSym0 :: (~>) Bool Bool
     data FooSym0 :: (~>) Bool Bool
       where
         FooSym0KindInference :: SameKind (Apply FooSym0 arg) (FooSym1 arg) =>
-                                FooSym0 a0123456789876543210
-    type instance Apply @Bool @Bool FooSym0 a0123456789876543210 = Foo a0123456789876543210
+                                FooSym0 a_Singletons_Undef_3
+    type instance Apply @Bool @Bool FooSym0 a_Singletons_Undef_3 = Foo a_Singletons_Undef_3
     instance SuppressUnusedWarnings FooSym0 where
       suppressUnusedWarnings = snd ((,) FooSym0KindInference ())
     type FooSym1 :: Bool -> Bool
-    type family FooSym1 (a0123456789876543210 :: Bool) :: Bool where
-      FooSym1 a0123456789876543210 = Foo a0123456789876543210
+    type family FooSym1 (a_Singletons_Undef_3 :: Bool) :: Bool where
+      FooSym1 a_Singletons_Undef_3 = Foo a_Singletons_Undef_3
     type Bar :: Bool -> Bool
     type family Bar (a :: Bool) :: Bool where
-      Bar a_0123456789876543210 = Apply (Apply ErrorSym0 "urk") a_0123456789876543210
+      Bar a_Singletons_Undef_0 = Apply (Apply ErrorSym0 "urk") a_Singletons_Undef_0
     type Foo :: Bool -> Bool
     type family Foo (a :: Bool) :: Bool where
-      Foo a_0123456789876543210 = Apply UndefinedSym0 a_0123456789876543210
+      Foo a_Singletons_Undef_2 = Apply UndefinedSym0 a_Singletons_Undef_2
     sBar ::
       (forall (t :: Bool). Sing t -> Sing (Bar t :: Bool) :: Type)
     sFoo ::
       (forall (t :: Bool). Sing t -> Sing (Foo t :: Bool) :: Type)
-    sBar (sA_0123456789876543210 :: Sing a_0123456789876543210)
+    sBar (sA_Singletons_Undef_0 :: Sing a_Singletons_Undef_0)
       = applySing
           (applySing (singFun1 @ErrorSym0 sError) (sing :: Sing "urk"))
-          sA_0123456789876543210
-    sFoo (sA_0123456789876543210 :: Sing a_0123456789876543210)
-      = applySing sUndefined sA_0123456789876543210
+          sA_Singletons_Undef_0
+    sFoo (sA_Singletons_Undef_2 :: Sing a_Singletons_Undef_2)
+      = applySing sUndefined sA_Singletons_Undef_2
     instance SingI (BarSym0 :: (~>) Bool Bool) where
       sing = singFun1 @BarSym0 sBar
     instance SingI (FooSym0 :: (~>) Bool Bool) where

--- a/singletons-th/CHANGES.md
+++ b/singletons-th/CHANGES.md
@@ -1,6 +1,12 @@
 Changelog for the `singletons-th` project
 =========================================
 
+next [????.??.??]
+-----------------
+* The unique names that `singletons-th` generates are now deterministic. This
+  should not affect the public-facing API portions of the TH-generated code,
+  but the resulting Haddocks should be a bit more compact and readable.
+
 3.5.1 [2026.01.10]
 ------------------
 * Require building with GHC 9.14.

--- a/singletons-th/src/Data/Singletons/TH/Options.hs
+++ b/singletons-th/src/Data/Singletons/TH/Options.hs
@@ -88,8 +88,8 @@ data Options = Options
     -- ^ Given the name of the original, unrefined value, produces the name of
     --   the promoted equivalent of the value. This is used for both top-level
     --   and @let@-bound names, and the difference is encoded in the
-    --   @'Maybe' 'Int'@ argument. If promoting a top-level name, the argument
-    --   is 'Nothing'. If promoting a @let@-bound name, the argument is
+    --   @'Maybe' 'UniqueCounter'@ argument. If promoting a top-level name, the
+    --   argument is 'Nothing'. If promoting a @let@-bound name, the argument is
     --   @Just idx@, where @idx@ is a deterministic counter that can be used
     --   to distinguish the name from other local definitions of the same name
     --   (e.g., if two functions both use @let x = ... in x@).

--- a/singletons-th/src/Data/Singletons/TH/Options.hs
+++ b/singletons-th/src/Data/Singletons/TH/Options.hs
@@ -84,13 +84,13 @@ data Options = Options
   , promotedClassName :: Name -> Name
     -- ^ Given the name of the original, unrefined class, produces the name of
     --   the promoted equivalent of the class.
-  , promotedValueName :: Name -> Maybe Uniq -> Name
+  , promotedValueName :: Name -> Maybe UniqueCounter -> Name
     -- ^ Given the name of the original, unrefined value, produces the name of
     --   the promoted equivalent of the value. This is used for both top-level
     --   and @let@-bound names, and the difference is encoded in the
-    --   @'Maybe' 'Uniq'@ argument. If promoting a top-level name, the argument
+    --   @'Maybe' 'Int'@ argument. If promoting a top-level name, the argument
     --   is 'Nothing'. If promoting a @let@-bound name, the argument is
-    --   @Just uniq@, where @uniq@ is a globally unique number that can be used
+    --   @Just idx@, where @idx@ is a deterministic counter that can be used
     --   to distinguish the name from other local definitions of the same name
     --   (e.g., if two functions both use @let x = ... in x@).
   , singledDataTypeName :: Name -> Name
@@ -150,9 +150,9 @@ promotedTopLevelValueName :: Options -> Name -> Name
 promotedTopLevelValueName opts name = promotedValueName opts name Nothing
 
 -- | Given the name of the original, unrefined, @let@-bound value and its
--- globally unique number, produces the name of the promoted equivalent of the
--- value.
-promotedLetBoundValueName :: Options -> Name -> Uniq -> Name
+-- deterministic identifier, produces the name of the promoted equivalent of
+-- the value.
+promotedLetBoundValueName :: Options -> Name -> UniqueCounter -> Name
 promotedLetBoundValueName opts name = promotedValueName opts name . Just
 
 -- | Given the original name of a function (term- or type-level), produces a
@@ -203,11 +203,11 @@ withOptions opts (OptionsM x) = runReaderT x opts
 -- Used when a value name appears in a pattern context.
 -- Works only for proper variables (lower-case names).
 --
--- If the Maybe Uniq argument is Nothing, then the name is top-level (and
+-- If the Maybe 'UniqueCounter' argument is Nothing, then the name is top-level (and
 -- thus globally unique on its own).
--- If the Maybe Uniq argument is `Just uniq`, then the name is let-bound and
--- should use `uniq` to make the promoted name globally unique.
-promoteValNameLhs :: Name -> Maybe Uniq -> Name
+-- If the Maybe 'UniqueCounter' argument is `Just idx`, then the name is let-bound and
+-- should use `idx` to make the promoted name unique within the generated code.
+promoteValNameLhs :: Name -> Maybe UniqueCounter -> Name
 promoteValNameLhs n mb_let_uniq
     -- We can't promote promote idenitifers beginning with underscores to
     -- type names, so we work around the issue by prepending "US" at the
@@ -218,8 +218,27 @@ promoteValNameLhs n mb_let_uniq
   | otherwise
   = mkName $ toUpcaseStr pres n
   where
-    pres = maybe noPrefix (uniquePrefixes "Let" "<<<") mb_let_uniq
+    pres = maybe noPrefix deterministicPrefixes mb_let_uniq
     (alpha, _) = pres
+    deterministicPrefixes (UniqueCounter idx) =
+      let suffix = show idx
+          symSuffix = map digitToSymbol suffix in
+      ("Let" ++ suffix, "<<<" ++ symSuffix)
+
+    -- Symbolic names can't contain numbers, so we convert the numeric suffix
+    -- into suitable characters.
+    digitToSymbol :: Char -> Char
+    digitToSymbol '0' = '!'
+    digitToSymbol '1' = '#'
+    digitToSymbol '2' = '$'
+    digitToSymbol '3' = '%'
+    digitToSymbol '4' = '&'
+    digitToSymbol '5' = '*'
+    digitToSymbol '6' = '+'
+    digitToSymbol '7' = '.'
+    digitToSymbol '8' = '/'
+    digitToSymbol '9' = '='
+    digitToSymbol c   = c
 
 -- generates type-level symbol for a given name. Int parameter represents
 -- saturation: 0 - no parameters passed to the symbol, 1 - one parameter

--- a/singletons-th/src/Data/Singletons/TH/Promote.hs
+++ b/singletons-th/src/Data/Singletons/TH/Promote.hs
@@ -1010,7 +1010,7 @@ data LetDecRHSSort
 promoteLetDecRHS :: LetDecRHSSort
                  -> OMap Name DType      -- local type env't
                  -> OMap Name Fixity     -- local fixity env't
-                 -> Maybe UniqueCounter       -- let-binding identifier (if locally bound)
+                 -> Maybe UniqueCounter  -- let-binding identifier (if locally bound)
                  -> Name                 -- name of the thing being promoted
                  -> ULetDecRHS           -- body of the thing
                  -> PrM ( [DDec]        -- promoted type family dec, plus the
@@ -1585,7 +1585,8 @@ dTypeFamilyHead_with_locals tf_nm local_vars arg_tvbs res_sig =
     Nothing
   where
     -- We take care to only apply `noExactTyVars` to the local variables and not
-    -- to any of the argument/result types. The latter are more likely to appear in haddocks.
+    -- to any of the argument/result types. The latter are more likely to appear
+    -- in Haddocks.
     local_vars' = noExactTyVars local_vars
 
     -- Ensure that all references to local_nms are substituted away.

--- a/singletons-th/src/Data/Singletons/TH/Promote.hs
+++ b/singletons-th/src/Data/Singletons/TH/Promote.hs
@@ -10,7 +10,7 @@ type level. It is an internal module to the singletons-th package.
 module Data.Singletons.TH.Promote where
 
 import Language.Haskell.TH hiding ( Q, cxt )
-import Language.Haskell.TH.Syntax ( NameSpace(..), Quasi(..), Uniq )
+import Language.Haskell.TH.Syntax ( NameSpace(..), Quasi(..) )
 import Language.Haskell.TH.Desugar
 import qualified Language.Haskell.TH.Desugar.OMap.Strict as OMap
 import Language.Haskell.TH.Desugar.OMap.Strict (OMap)
@@ -206,7 +206,7 @@ promoteDecs raw_decls = do
   mapM_ (promoteInstanceDec orig_meth_sigs cls_tvbs_map) insts
 
 -- curious about ALetDecEnv? See the LetDecEnv module for an explanation.
-promoteLetDecs :: Maybe Uniq -- let-binding unique (if locally bound)
+promoteLetDecs :: Maybe UniqueCounter -- let-binding identifier (if locally bound)
                -> [DLetDec] -> PrM ([LetBind], ALetDecEnv)
 promoteLetDecs mb_let_uniq decls = do
   opts <- getOptions
@@ -865,7 +865,7 @@ substitute in the kinds of the instance itself to determine the kinds of
 promoted method implementations like MHelper2.
 -}
 
-promoteLetDecEnv :: Maybe Uniq -> ULetDecEnv -> PrM ([DDec], ALetDecEnv)
+promoteLetDecEnv :: Maybe UniqueCounter -> ULetDecEnv -> PrM ([DDec], ALetDecEnv)
 promoteLetDecEnv mb_let_uniq (LetDecEnv { lde_defns = value_env
                                         , lde_types = type_env
                                         , lde_infix = fix_env }) = do
@@ -893,7 +893,7 @@ promoteLetDecEnv mb_let_uniq (LetDecEnv { lde_defns = value_env
 
 -- Promote a fixity declaration.
 promoteInfixDecl :: forall q. OptionsMonad q
-                 => Maybe Uniq -> Name -> Fixity
+                 => Maybe UniqueCounter -> Name -> Fixity
                  -> NamespaceSpecifier
                     -- The namespace specifier for the fixity declaration. We
                     -- only pass this for the sake of checking if we need to
@@ -1010,7 +1010,7 @@ data LetDecRHSSort
 promoteLetDecRHS :: LetDecRHSSort
                  -> OMap Name DType      -- local type env't
                  -> OMap Name Fixity     -- local fixity env't
-                 -> Maybe Uniq           -- let-binding unique (if locally bound)
+                 -> Maybe UniqueCounter       -- let-binding identifier (if locally bound)
                  -> Name                 -- name of the thing being promoted
                  -> ULetDecRHS           -- body of the thing
                  -> PrM ( [DDec]        -- promoted type family dec, plus the
@@ -1337,8 +1337,8 @@ Note that we do not bind @b here. The `dtvbSpecsToBndrVis` function is
 responsible for filtering out inferred type variable binders.
 -}
 
-promoteClause :: Maybe Uniq
-                 -- ^ Let-binding unique (if locally bound)
+promoteClause :: Maybe UniqueCounter
+                 -- ^ Let-binding identifier (if locally bound)
               -> Name
                  -- ^ Name of the function being promoted
               -> Maybe LetDecRHSKindInfo
@@ -1472,8 +1472,8 @@ promoteExp (DLamCasesE clauses) = do
           all_locals
   pure (prom_lam_cases, ADLamCasesE num_args prom_lam_cases ann_clauses)
 promoteExp (DLetE decs exp) = do
-  unique <- qNewUnique
-  (binds, ann_env) <- promoteLetDecs (Just unique) decs
+  letId <- nextUnique
+  (binds, ann_env) <- promoteLetDecs (Just letId) decs
   (exp', ann_exp) <- letBind binds $ promoteExp exp
   return (exp', ADLetE ann_env ann_exp)
 promoteExp (DSigE exp ty) = do
@@ -1525,8 +1525,8 @@ promoteLitPat lit =
 -- Data.Singletons.TH.Promote.Monad.) Otherwise, it will include any local
 -- variables that it closes over as explicit arguments.
 promoteLetDecName ::
-     Maybe Uniq
-     -- ^ Let-binding unique (if locally bound)
+     Maybe UniqueCounter
+     -- ^ Let-binding identifier (if locally bound)
   -> Name
      -- ^ Name of the function being promoted
   -> Maybe LetDecRHSKindInfo
@@ -1565,7 +1565,7 @@ promoteLetDecName mb_let_uniq name m_ldrki all_locals = do
   pure $ applyDType (DConT proName) type_args
 
 -- Construct a 'DTypeFamilyHead' that closes over some local variables. We
--- apply `noExactName` to each local variable to avoid GHC#11812.
+-- apply `noExactTyVars` to each local variable to avoid GHC#11812.
 -- See also Note [Pitfalls of NameU/NameL] in Data.Singletons.TH.Util.
 dTypeFamilyHead_with_locals ::
      Name
@@ -1585,9 +1585,7 @@ dTypeFamilyHead_with_locals tf_nm local_vars arg_tvbs res_sig =
     Nothing
   where
     -- We take care to only apply `noExactTyVars` to the local variables and not
-    -- to any of the argument/result types. The latter are much more likely to
-    -- show up in the Haddocks, and `noExactTyVars` produces incredibly long
-    -- Names that are much harder to read in the rendered Haddocks.
+    -- to any of the argument/result types. The latter are more likely to appear in haddocks.
     local_vars' = noExactTyVars local_vars
 
     -- Ensure that all references to local_nms are substituted away.

--- a/singletons-th/src/Data/Singletons/TH/Promote/Defun.hs
+++ b/singletons-th/src/Data/Singletons/TH/Promote/Defun.hs
@@ -298,7 +298,7 @@ defunctionalize name m_fixity defun_ki = do
     defun_fallback locals tvbs' m_res' = do
       opts <- getOptions
       extra_name <- qNewName "arg"
-      -- Use noExactTyVars below to avoid GHC#11812.
+      -- Use deterministic names below to avoid GHC#11812.
       -- See also Note [Pitfalls of NameU/NameL] in Data.Singletons.TH.Util.
       let (locals', tvbs_no_exact, m_res_no_exact) =
             runFreshen $ do

--- a/singletons-th/src/Data/Singletons/TH/Promote/Defun.hs
+++ b/singletons-th/src/Data/Singletons/TH/Promote/Defun.hs
@@ -205,9 +205,9 @@ defunctionalize name m_fixity defun_ki = do
       opts <- getOptions
       extra_name <- qNewName "arg"
       let sak_arg_n = length sak_arg_kis
-      -- Use noExactName below to avoid GHC#17537.
+      -- Use deterministic names below to avoid GHC#17537.
       -- See also Note [Pitfalls of NameU/NameL] in Data.Singletons.TH.Util.
-      arg_names <- replicateM sak_arg_n (noExactName <$> qNewName "a")
+      arg_names <- replicateM sak_arg_n (newUniqueName "a")
 
       let -- The inner loop. @go n arg_nks res_nks@ returns @(res_k, decls)@.
           -- Using one particular example:
@@ -300,8 +300,13 @@ defunctionalize name m_fixity defun_ki = do
       extra_name <- qNewName "arg"
       -- Use noExactTyVars below to avoid GHC#11812.
       -- See also Note [Pitfalls of NameU/NameL] in Data.Singletons.TH.Util.
-      let locals' = noExactTyVars locals
-      (tvbs, m_res) <- eta_expand (noExactTyVars tvbs') (noExactTyVars m_res')
+      let (locals', tvbs_no_exact, m_res_no_exact) =
+            runFreshen $ do
+              locals'' <- traverse freshenTyVarsM locals
+              tvbs''   <- traverse freshenTyVarsM tvbs'
+              m_res''  <- traverse freshenTyVarsM m_res'
+              pure (locals'', tvbs'', m_res'')
+      (tvbs, m_res) <- eta_expand tvbs_no_exact m_res_no_exact
 
       let tvbs_n = length tvbs
 
@@ -456,10 +461,10 @@ defunctionalize name m_fixity defun_ki = do
       case vfa of
         DVisFADep tvb -> pure (BndrReq <$ tvb)
         DVisFAAnon k  -> (\n -> DKindedTV n BndrReq k) <$>
-                           -- Use noExactName below to avoid GHC#19743.
+                           -- Use deterministic names below to avoid GHC#19743.
                            -- See also Note [Pitfalls of NameU/NameL]
                            -- in Data.Singletons.TH.Util.
-                           (noExactName <$> qNewName "e")
+                           (newUniqueName "e")
 
     mk_fix_decl :: Name -> Fixity -> DDec
     mk_fix_decl n f = DLetDec $ DInfixD f TypeNamespaceSpecifier n

--- a/singletons-th/src/Data/Singletons/TH/Util.hs
+++ b/singletons-th/src/Data/Singletons/TH/Util.hs
@@ -7,7 +7,10 @@ This file contains helper functions internal to the singletons-th package.
 Users of the package should not need to consult this file.
 -}
 
-module Data.Singletons.TH.Util ( module Data.Singletons.TH.Util, UniqueCounter(..) ) where
+module Data.Singletons.TH.Util
+  ( module Data.Singletons.TH.Util
+  , UniqueCounter(..)
+  ) where
 
 import Prelude hiding ( exp, foldl, concat, mapM, any, pred )
 import Language.Haskell.TH ( pprint )
@@ -384,23 +387,28 @@ filterInvisTvbArgs (DFAForalls tele args) =
     DForallVis   _     -> res
     DForallInvis tvbs' -> tvbs' ++ res
 
--- | Change all unique Names with a NameU or NameL namespace to non-unique Names
--- by performing a syb-based traversal. See Note [Pitfalls of NameU/NameL] for
--- why this is useful.
+-- | Change all unique 'Name's with a 'NameU' or 'NameL' namespace to non-unique
+-- 'Name's by performing a syb-based traversal. See @Note [Pitfalls of
+-- NameU/NameL]@ for why this is useful.
 --
--- Each variable encountered during the traversal will be given a fresh non-unique Name
--- which is the variable OccName followed by an incrementing counter.
--- For example: x0 y1 z2 x3 etc
+-- Each variable encountered during the traversal will be given a fresh
+-- non-unique 'Name' which is the variable OccName followed by an incrementing
+-- counter. For example: @x0@, @y1@, @z2@, @x3@, etc.
 --
--- Each call to `noExactTyVars` starts producing names from 0, so
+-- Each call to 'noExactTyVars' starts producing names from @0@. As a result,
+-- if you call 'noExactTyVars' in two different locations, then there is no
+-- guarantee that the 'Name's used in one location will be distinct from the
+-- other location. It is the responsibility of the caller to ensure that this
+-- does not result in name clashes.
 noExactTyVars :: Data a => a -> a
 noExactTyVars = runFreshen . freshenTyVarsM
 
--- | This function performs an SYB traversal and replaces `Name`s with a fresh name,
--- and substitutes the fresh name for all other occurences of the name in the expression.
+-- | This function performs an SYB traversal and replaces `Name`s with a fresh
+-- name, and substitutes the fresh name for all other occurences of the name in
+-- the expression.
 --
--- The scope of 'freshenTyVarsM' is indicated by executing the stateful computation using
--- `runFreshen`.
+-- The scope of 'freshenTyVarsM' is indicated by executing the stateful
+-- computation using 'runFreshen'.
 freshenTyVarsM :: Data a => a -> State FreshenState a
 freshenTyVarsM = everywhereM freshenTyVarsStep
   where
@@ -435,17 +443,22 @@ freshenTyVarsM = everywhereM freshenTyVarsStep
       n' <- freshenName n
       pure LocalVar { lvName = n', lvKind = mbKind }
 
+-- | The state maintained by 'freshenTyVarsM'.
 data FreshenState = FreshenState
-  { fsNextId   :: !Int
+  { fsNextId    :: !Int
   , fsRenamings :: Map Name Name
   }
 
+-- | The initial state for 'freshenTyVarsM': identifiers will start from @0@,
+-- and no renamings will have yet occurred.
 initialFreshenState :: FreshenState
 initialFreshenState = FreshenState 0 Map.empty
 
+-- | Run a stateful computation that involves 'FreshenState'.
 runFreshen :: State FreshenState a -> a
 runFreshen = (`evalState` initialFreshenState)
 
+-- | Create a fresh name and update the 'FreshenState' accordingly.
 freshenName :: Name -> State FreshenState Name
 freshenName n@(Name (OccName occ) ns) =
   case ns of

--- a/singletons-th/src/Data/Singletons/TH/Util.hs
+++ b/singletons-th/src/Data/Singletons/TH/Util.hs
@@ -7,7 +7,7 @@ This file contains helper functions internal to the singletons-th package.
 Users of the package should not need to consult this file.
 -}
 
-module Data.Singletons.TH.Util where
+module Data.Singletons.TH.Util ( module Data.Singletons.TH.Util, UniqueCounter(..) ) where
 
 import Prelude hiding ( exp, foldl, concat, mapM, any, pred )
 import Language.Haskell.TH ( pprint )
@@ -19,6 +19,7 @@ import Control.Monad ( liftM, unless, when )
 import Control.Monad.Except ( ExceptT, runExceptT, MonadError(..) )
 import Control.Monad.IO.Class ( MonadIO )
 import Control.Monad.Reader ( MonadReader(..), Reader, ReaderT(..) )
+import Control.Monad.State.Strict ( State, evalState, get, modify' )
 import Control.Monad.Trans ( MonadTrans )
 import Control.Monad.Writer ( MonadWriter(..), WriterT(..), execWriterT )
 import qualified Data.Map as Map
@@ -38,14 +39,6 @@ qReportWarning = qReport False
 -- like reportError, but generalized to any Quasi
 qReportError :: Quasi q => String -> q ()
 qReportError = qReport True
-
--- | Generate a new Unique
-qNewUnique :: DsMonad q => q Uniq
-qNewUnique = do
-  Name _ flav <- qNewName "x"
-  case flav of
-    NameU n -> return n
-    _       -> error "Internal error: `qNewName` didn't return a NameU"
 
 checkForRep :: Quasi q => [Name] -> q ()
 checkForRep names =
@@ -168,31 +161,6 @@ tailNameStr str =
   case str of
     (_:cs) -> cs
     [] -> error "tailNameStr: Expected non-empty string"
-
--- convert a number into both alphanumeric and symoblic forms
-uniquePrefixes :: String   -- alphanumeric prefix
-               -> String   -- symbolic prefix
-               -> Uniq
-               -> (String, String)  -- (alphanum, symbolic)
-uniquePrefixes alpha symb n = (alpha ++ n_str, symb ++ convert n_str)
-  where
-    n_str = show n
-
-    convert [] = []
-    convert (d : ds) =
-      let d' = case d of
-                 '0' -> '!'
-                 '1' -> '#'
-                 '2' -> '$'
-                 '3' -> '%'
-                 '4' -> '&'
-                 '5' -> '*'
-                 '6' -> '+'
-                 '7' -> '.'
-                 '8' -> '/'
-                 '9' -> '>'
-                 _   -> error "non-digit in show #"
-      in d' : convert ds
 
 -- extract the kind from a TyVarBndr
 extractTvbKind :: DTyVarBndr flag -> Maybe DKind
@@ -416,44 +384,86 @@ filterInvisTvbArgs (DFAForalls tele args) =
     DForallVis   _     -> res
     DForallInvis tvbs' -> tvbs' ++ res
 
--- Change all unique Names with a NameU or NameL namespace to non-unique Names
+-- | Change all unique Names with a NameU or NameL namespace to non-unique Names
 -- by performing a syb-based traversal. See Note [Pitfalls of NameU/NameL] for
 -- why this is useful.
+--
+-- Each variable encountered during the traversal will be given a fresh non-unique Name
+-- which is the variable OccName followed by an incrementing counter.
+-- For example: x0 y1 z2 x3 etc
+--
+-- Each call to `noExactTyVars` starts producing names from 0, so
 noExactTyVars :: Data a => a -> a
-noExactTyVars = everywhere go
+noExactTyVars = runFreshen . freshenTyVarsM
+
+-- | This function performs an SYB traversal and replaces `Name`s with a fresh name,
+-- and substitutes the fresh name for all other occurences of the name in the expression.
+--
+-- The scope of 'freshenTyVarsM' is indicated by executing the stateful computation using
+-- `runFreshen`.
+freshenTyVarsM :: Data a => a -> State FreshenState a
+freshenTyVarsM = everywhereM freshenTyVarsStep
   where
-    go :: Data a => a -> a
-    go = mkT (fix_tvb @Specificity)
-      `extT` fix_tvb @()
-      `extT` fix_tvb @BndrVis
-      `extT` fix_ty
-      `extT` fix_inj_ann
-      `extT` fix_local_var
+    freshenTyVarsStep :: Data a => a -> State FreshenState a
+    freshenTyVarsStep = mkM (fix_tvb @Specificity)
+      `extM` fix_tvb @()
+      `extM` fix_tvb @BndrVis
+      `extM` fix_ty
+      `extM` fix_inj_ann
+      `extM` fix_local_var
 
-    fix_tvb :: Typeable flag => DTyVarBndr flag -> DTyVarBndr flag
-    fix_tvb (DPlainTV n f)    = DPlainTV (noExactName n) f
-    fix_tvb (DKindedTV n f k) = DKindedTV (noExactName n) f k
+    fix_tvb :: Typeable flag => DTyVarBndr flag -> State FreshenState (DTyVarBndr flag)
+    fix_tvb (DPlainTV n f) = do
+      n' <- freshenName n
+      pure (DPlainTV n' f)
+    fix_tvb (DKindedTV n f k) = do
+      n' <- freshenName n
+      pure (DKindedTV n' f k)
 
-    fix_ty (DVarT n)           = DVarT (noExactName n)
-    fix_ty ty                  = ty
+    fix_ty :: DType -> State FreshenState DType
+    fix_ty (DVarT n) = DVarT <$> freshenName n
+    fix_ty ty        = pure ty
 
-    fix_inj_ann (InjectivityAnn lhs rhs)
-      = InjectivityAnn (noExactName lhs) (map noExactName rhs)
+    fix_inj_ann :: InjectivityAnn -> State FreshenState InjectivityAnn
+    fix_inj_ann (InjectivityAnn lhs rhs) = do
+      lhs' <- freshenName lhs
+      rhs' <- traverse freshenName rhs
+      pure (InjectivityAnn lhs' rhs')
 
-    fix_local_var :: LocalVar -> LocalVar
-    fix_local_var (LocalVar { lvName = n, lvKind =  mbKind })
-      = LocalVar { lvName = noExactName n, lvKind = mbKind }
+    fix_local_var :: LocalVar -> State FreshenState LocalVar
+    fix_local_var (LocalVar { lvName = n, lvKind = mbKind }) = do
+      n' <- freshenName n
+      pure LocalVar { lvName = n', lvKind = mbKind }
 
--- Changes a unique Name with a NameU or NameL namespace to a non-unique Name.
--- See Note [Pitfalls of NameU/NameL] for why this is useful.
-noExactName :: Name -> Name
-noExactName n@(Name (OccName occ) ns) =
+data FreshenState = FreshenState
+  { fsNextId   :: !Int
+  , fsRenamings :: Map Name Name
+  }
+
+initialFreshenState :: FreshenState
+initialFreshenState = FreshenState 0 Map.empty
+
+runFreshen :: State FreshenState a -> a
+runFreshen = (`evalState` initialFreshenState)
+
+freshenName :: Name -> State FreshenState Name
+freshenName n@(Name (OccName occ) ns) =
   case ns of
-    NameU unique -> mk_name unique
-    NameL unique -> mk_name unique
-    _            -> n
+    NameU _ -> allocate occ
+    NameL _ -> allocate occ
+    _       -> pure n
   where
-    mk_name unique = mkName (occ ++ show unique)
+    allocate occStr = do
+      FreshenState { fsNextId = next, fsRenamings = renamings } <- get
+      case Map.lookup n renamings of
+        Just n' -> pure n'
+        Nothing -> do
+          let newOccName = mkName (occStr ++ show next)
+          modify' $ \s -> s { fsNextId = next + 1
+                            , fsRenamings = Map.insert n newOccName renamings
+                            }
+          pure newOccName
+
 
 {-
 Note [Pitfalls of NameU/NameL]
@@ -507,24 +517,26 @@ the equation for `G`, and once more in the type variable binder in
 `type family LetG x_456`. The last of these scopes in particular is enough to
 confuse GHC in some situations and trigger GHC#11812.
 
-Our workaround is to apply the `noExactName` function to such names, which
-converts any Names with NameU/NameL namespaces into non-unique Names with
-longer OccNames. For instance, `noExactName x_456` will return a non-unique
-Name with the OccName `x456`. We use `noExactName` when generating `LetG` so
+Our workaround is to apply the `freshenName` function (via `freshenTyVarsM`) to
+such names, which converts any Names with NameU/NameL namespaces into
+non-unique Names. In each freshening-scope, all variables encountered are given
+an incrementing unique name. For example, `x_456` will
+return a non-unique Name with the OccName `x0`. We use this renamer when
+generating `LetG` so
 that it will instead be:
 
-    type family LetG x456 where
-      LetG x_456 = x_456
+    type family LetG x0 where
+      LetG x0 = x0
 
-Here, `x456` is a non-unique Name, and `x_456` is a Unique name. Thankfully,
+Here, `x0` is a non-unique Name, and `x_456` is a Unique name. Thankfully,
 this is sufficient to work around GHC#11812. There is still some amount of
 risk, since we are reusing `x_456` in two different type family equations (one
 for `LetG` and one for `F`), but GHC accepts this for now. We prefer to use the
-`noExactName` in as few places as possible, as using longer OccNames makes the
+this renaming machinery in as few places as possible, as using longer OccNames makes the
 Haddocks harder to read, so we will continue to reuse unique Names unless GHC
 forces us to behave differently.
 
-In addition to the type family example above, we also make use of `noExactName`
+In addition to the type family example above, we also make use of this renaming
 (as well as its cousin, `noExactTyVars`) when generating defunctionalization
 symbols, as these also require reusing Unique names in several type family and
 data type declarations. See references to this Note in the code for particular


### PR DESCRIPTION
@RyanGlScott If you had the time I would appreciate your feedback on the approach in this patch before I invest time finishing things off.




```
There are currently two sources of non-determinism when using
singletons-th.

1. Let bindings are promoted to a top-level type family named
   Let<UNIQUE>.

2. The `noExactTyVars` function shifts the unique into the OccName of a
   name in order to make distinct occnames.

Now there are two mechanisms to provide deterministic names in these two
cases.

1. The PrM monad carries an incrementing counter in order to uniquely
   name each top-level Let. Any name created by `newUniqueName` now uses
   this global counter.

2. For the names which require local uniqueness, `noExactTyVars` carries
   its own counter and renaming in order to substitute fresh names into
   a local scope.

Fixes https://github.com/goldfirere/singletons/issues/628
```

